### PR TITLE
Persist snapshots outside protected main

### DIFF
--- a/.github/workflows/daily-radar.yml
+++ b/.github/workflows/daily-radar.yml
@@ -29,6 +29,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - name: Restore snapshot history
+        run: |
+          git fetch --depth=1 origin radar-data:refs/remotes/origin/radar-data
+          git archive origin/radar-data data/snapshots | tar -x
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
@@ -60,7 +64,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: main
+          ref: radar-data
       - name: Download validated snapshot
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -81,7 +85,7 @@ jobs:
             exit 0
           fi
           git commit -m "Record daily radar snapshot [skip ci]"
-          git push origin HEAD:main
+          git push origin HEAD:radar-data
 
   publish-issue:
     needs: [build-report, persist-snapshot]
@@ -132,6 +136,10 @@ jobs:
         with:
           ref: main
           persist-credentials: false
+      - name: Restore snapshot history
+        run: |
+          git fetch --depth=1 origin radar-data:refs/remotes/origin/radar-data
+          git archive origin/radar-data data/snapshots | tar -x
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,6 +27,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - name: Restore snapshot history
+        run: |
+          git fetch --depth=1 origin radar-data:refs/remotes/origin/radar-data
+          git archive origin/radar-data data/snapshots | tar -x
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Outputs:
 - `data/snapshots/YYYY-MM-DD.json`: versioned, idempotent UTC snapshot
 - `site/data/radar.json`: deterministic browser-ready history
 
+Automation keeps the growing corpus on the public `radar-data` branch so the protected
+`main` branch remains pull-request-only. Dashboard builds restore that history before
+validation and deployment.
+
 Rebuild the dashboard data without collecting again:
 
 ```bash


### PR DESCRIPTION
## What changed

- restore accumulated snapshots from the public `radar-data` branch before collection and Pages builds
- persist generated daily snapshots back to `radar-data`
- keep protected `main` pull-request-only
- document the corpus branch

## Why

The repository ruleset requires reviewed, signed changes on `main`, so the scheduled collector must not push generated data there. A dedicated public data branch preserves durable daily automation without weakening the code-protection policy.

## Validation

- `ruff check .`
- `ruff format --check .`
- `pytest -q` — 15 passed
- local `git archive origin/radar-data data/snapshots | tar -x`
- deterministic `benchmark-radar rebuild`
- workflow YAML parse