### PR TITLE
Ignore local development artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ build/
 .env
 out/
 
+.gstack/
+.DS_Store


### PR DESCRIPTION
## What changed

- Ignore `.gstack/` local workflow state.
- Ignore macOS `.DS_Store` metadata.

## Why

These files are local development artifacts and should not appear as untracked repository changes.

## Validation

- `git diff --check -- .gitignore`
- Change is limited to `.gitignore`.