### PR TITLE
Simplify the Today dashboard

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -46,7 +46,14 @@ function formatDate(value, options = { dateStyle: "long" }) {
 
 function shorten(value, max = 190) {
   if (!value) return "";
-  return value.length > max ? `${value.slice(0, max).trim()}…` : value;
+  const normalized = value.trim();
+  if (normalized.length <= max) return normalized;
+  const candidate = normalized.slice(0, max - 1).trimEnd();
+  const lastSpace = candidate.lastIndexOf(" ");
+  const cutoff = lastSpace >= Math.floor(max * 0.6)
+    ? candidate.slice(0, lastSpace)
+    : candidate;
+  return `${cutoff.replace(/[,:;.!?-]+$/, "")}…`;
 }
 
 function option(value, label, selected = false) {
@@ -186,37 +193,6 @@ function renderToday() {
   if (!day) return;
   state.todayDate = day.date;
   byId("today-date").value = day.date;
-  byId("scan-count").textContent = day.item_count;
-  byId("briefing-date").textContent = formatDate(day.date);
-
-  const reporting = day.health.filter((entry) => entry.ok);
-  const failed = day.health.filter((entry) => !entry.ok);
-  const represented = new Set(day.items.map((item) => item.source)).size;
-  byId("briefing-copy").textContent = failed.length
-    ? `${reporting.length} of ${day.health.length} configured sources reported; ${failed.length} failed and contributed nothing. Comparisons should be read with that limitation.`
-    : "All configured sources reported successfully for this scan.";
-  replaceChildren(byId("briefing-stats"), [
-    definition("Window start", formatDate(day.since, { dateStyle: "medium" })),
-    definition("Sources reporting", `${reporting.length}/${day.health.length}`),
-    definition("Sources in results", represented),
-    definition("Categories", Object.keys(day.category_counts).length),
-  ]);
-
-  const distribution = Object.entries(day.category_counts).sort((a, b) => b[1] - a[1]);
-  const distributionMax = Math.max(1, ...distribution.map(([, count]) => count));
-  replaceChildren(
-    byId("scan-distribution"),
-    distribution.map(([category, count], index) => {
-      const fill = element("span", { className: "spark-fill" });
-      fill.style.width = `${Math.max(4, (count / distributionMax) * 100)}%`;
-      fill.style.setProperty("--bar-color", categoryColor(category, index));
-      return element("div", { className: "spark-row" }, [
-        element("span", { className: "spark-label", text: category.replaceAll("_", " ") }),
-        element("span", { className: "spark-track" }, [fill]),
-        element("span", { className: "spark-count", text: String(count) }),
-      ]);
-    }),
-  );
 
   byId("today-count").textContent = `${day.item_count} records`;
   replaceChildren(
@@ -224,7 +200,6 @@ function renderToday() {
     day.items.map((item, index) => signalCard(item, index)),
   );
 
-  byId("health-summary").textContent = `${reporting.length}/${day.health.length} reporting`;
   replaceChildren(
     byId("health-list"),
     day.health.map((entry) => {

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -268,15 +268,10 @@ h1 {
   padding-top: clamp(1.75rem, 3vw, 2.75rem);
 }
 
-#today-view .view-heading {
+.today-toolbar {
+  display: flex;
+  justify-content: flex-end;
   margin-bottom: clamp(1.25rem, 2vw, 1.75rem);
-}
-
-#today-heading {
-  max-width: none;
-  font-size: clamp(1.8rem, 3vw, 2.6rem);
-  line-height: 1;
-  white-space: nowrap;
 }
 
 h2 {
@@ -311,121 +306,6 @@ input {
   font-size: 0.9rem;
   letter-spacing: normal;
   text-transform: none;
-}
-
-.today-overview {
-  display: grid;
-  grid-template-columns: minmax(230px, 270px) minmax(0, 1fr);
-  margin-bottom: 2rem;
-  border: 1px solid var(--ink);
-  background: var(--panel);
-  box-shadow: var(--shadow);
-}
-
-.scan-readout {
-  display: flex;
-  flex-direction: column;
-  padding: clamp(1.1rem, 2vw, 1.4rem);
-  background: #eef2f4;
-}
-
-.scan-readout .eyebrow {
-  margin-bottom: 0.25rem;
-}
-
-.scan-readout > strong {
-  font-family: var(--display);
-  font-size: 3.25rem;
-  line-height: 0.95;
-  letter-spacing: -0.02em;
-}
-
-.scan-distribution {
-  display: grid;
-  gap: 0.4rem;
-  margin-top: auto;
-  padding-top: 1rem;
-}
-
-.spark-row {
-  display: grid;
-  grid-template-columns: 5.5rem minmax(0, 1fr) 1.6rem;
-  gap: 0.5rem;
-  align-items: center;
-}
-
-.spark-track {
-  height: 8px;
-  background: #dfe5e8;
-}
-
-.spark-fill {
-  display: block;
-  height: 100%;
-  background: var(--bar-color, var(--blue));
-}
-
-.spark-count {
-  color: var(--ink);
-  font-family: var(--display);
-  font-size: 0.8rem;
-  line-height: 1;
-  text-align: right;
-}
-
-.spark-label {
-  color: var(--muted);
-  font-family: var(--utility);
-  font-size: 0.55rem;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
-.briefing {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  padding: clamp(1.1rem, 2vw, 1.5rem);
-  border-left: 1px solid var(--ink);
-}
-
-.briefing h2 {
-  margin-bottom: 0.45rem;
-  font-size: clamp(1.35rem, 2vw, 1.7rem);
-}
-
-.briefing > p:not(.eyebrow) {
-  max-width: 650px;
-  margin-bottom: 0;
-  color: var(--muted);
-  font-size: 0.95rem;
-}
-
-.briefing-stats {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.9rem 2.25rem;
-  margin: 1rem 0 0;
-  padding-top: 0.9rem;
-  border-top: 1px solid var(--line);
-}
-
-.briefing-stats div {
-  display: grid;
-}
-
-.briefing-stats dt {
-  color: var(--muted);
-  font-family: var(--utility);
-  font-size: 0.65rem;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-}
-
-.briefing-stats dd {
-  margin: 0;
-  font-family: var(--display);
-  font-size: 1.35rem;
 }
 
 .content-grid {
@@ -532,12 +412,15 @@ input {
 
 .score {
   align-self: center;
+  justify-self: end;
+  width: 170px;
 }
 
 .score-value {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr auto;
   align-items: baseline;
-  justify-content: space-between;
+  width: 100%;
   font-family: var(--display);
 }
 
@@ -547,14 +430,17 @@ input {
 }
 
 .score-value span {
+  justify-self: end;
   color: var(--muted);
   font-family: var(--utility);
   font-size: 0.65rem;
 }
 
 .score-track {
+  width: 100%;
   height: 6px;
   margin-top: 0.35rem;
+  overflow: hidden;
   border: 1px solid var(--line);
   background: transparent;
 }
@@ -1086,26 +972,13 @@ footer {
     font-size: clamp(1.7rem, 7vw, 2.3rem);
   }
 
-  #today-heading {
-    font-size: clamp(1.6rem, 6.5vw, 2.1rem);
-    white-space: normal;
-  }
-
-  .today-overview {
-    grid-template-columns: 1fr;
-  }
-
-  .briefing {
-    border-top: 1px solid var(--ink);
-    border-left: 0;
-  }
-
   .signal-card {
     grid-template-columns: 36px minmax(0, 1fr);
   }
 
   .score {
     grid-column: 2;
+    justify-self: start;
     max-width: 180px;
   }
 

--- a/site/index.html
+++ b/site/index.html
@@ -38,30 +38,12 @@
     </nav>
 
     <main id="main-content" tabindex="-1">
-      <section class="view" id="today-view" aria-labelledby="today-heading">
-        <header class="view-heading">
-          <div>
-            <p class="eyebrow">Daily field note</p>
-            <h1 id="today-heading">What entered the field?</h1>
-          </div>
+      <section class="view" id="today-view" aria-label="Today">
+        <div class="today-toolbar">
           <label class="date-control">
             Scan date
             <select id="today-date"></select>
           </label>
-        </header>
-
-        <div class="today-overview">
-          <div class="scan-readout">
-            <p class="eyebrow">Ranked signals</p>
-            <strong id="scan-count">—</strong>
-            <div class="scan-distribution" id="scan-distribution" aria-label="Signals by category"></div>
-          </div>
-          <div class="briefing">
-            <p class="eyebrow">Observation window</p>
-            <h2 id="briefing-date">Awaiting data</h2>
-            <p id="briefing-copy">Loading the latest validated daily snapshot.</p>
-            <dl class="briefing-stats" id="briefing-stats"></dl>
-          </div>
         </div>
 
         <div class="content-grid">
@@ -74,8 +56,7 @@
           </div>
           <aside class="health-panel" aria-labelledby="health-heading">
             <div class="section-title">
-              <h2 id="health-heading">Source health</h2>
-              <span id="health-summary"></span>
+              <h2 id="health-heading">Sources</h2>
             </div>
             <ul id="health-list"></ul>
           </aside>

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -32,6 +32,25 @@ def test_site_has_accessible_landmarks_and_views():
     assert {"today-view", "trends-view", "explorer-view", "main-content"} <= parser.ids
 
 
+def test_today_view_keeps_one_signal_summary_and_one_source_status():
+    html = Path("site/index.html").read_text(encoding="utf-8")
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    assert html.count("Ranked signals") == 1
+    assert "Daily field note" not in html
+    assert "What entered the field?" not in html
+    assert "today-overview" not in html
+    assert "Sources in results" not in script
+    assert "health-summary" not in html
+
+
+def test_summaries_truncate_at_a_word_boundary():
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    assert 'const lastSpace = candidate.lastIndexOf(" ");' in script
+    assert "candidate.slice(0, lastSpace)" in script
+
+
 def test_site_does_not_render_source_content_as_html():
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## What changed

- remove the duplicate Today overview, category breakdown, observation window, and redundant source counts
- remove the decorative “Daily field note / What entered the field?” heading
- keep one ranked-record count and one source-status surface
- truncate summaries at a word boundary
- make the priority value and score track share the exact same width

## Why

The Today view repeated the same record, category, date, and source information in several places. This made the page feel heavier than the data warranted and pushed the ranked results down.

## Impact

The page now opens directly on the ranked feed, exposes more records above the fold, and keeps source failures visible in the source panel without repeating them in the hero area.

## Validation

- `PYTHONPATH=src python3 -m pytest -q` — 19 passed
- `node --check site/assets/app.js`
- `git diff --check`
- real-browser desktop and 390px mobile checks: 30 cards rendered, no horizontal overflow, score label/value/track widths all 170px, and truncation ends on a complete word

Closes #15