### PR TITLE
Fall back to official arXiv RSS

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -41,6 +41,21 @@ sources:
     # timestamp is submission time, while announcements pause on weekends.
     overlap_hours: 120
     request_delay_seconds: 3
+    # GitHub-hosted runners are routinely rate-limited by the Atom API's
+    # shared-IP quota. Use official category RSS feeds and filter locally.
+    # Atom parsing remains available for deployments with a stable egress IP.
+    atom_enabled: false
+    rss_categories: [cs.AI, cs.CL, cs.CV]
+    rss_keywords:
+      - benchmark
+      - evaluation
+      - evaluator
+      - leaderboard
+      - dataset
+      - test set
+      - data contamination
+      - benchmark leakage
+      - data quality
     queries:
       - 'all:"large language model" AND (all:benchmark OR all:evaluation)'
       - '(all:benchmark OR all:dataset) AND (cat:cs.AI OR cat:cs.CL OR cat:cs.CV)'

--- a/src/benchmark_radar/pipeline.py
+++ b/src/benchmark_radar/pipeline.py
@@ -210,13 +210,17 @@ def run_pipeline(
         if source_config.get("enabled", True) and source_config.get("required", False)
     }
     required_health = {source.source: source for source in health if source.source in required}
-    unavailable_required = sorted(
-        source
-        for source in required
-        if source not in required_health
-        or not required_health[source].ok
-        or required_health[source].item_count == 0
-    )
+    unavailable_required = []
+    for source in sorted(required):
+        source_health = required_health.get(source)
+        if source_health is None:
+            unavailable_required.append(f"{source} was not checked")
+        elif not source_health.ok:
+            unavailable_required.append(
+                f"{source} failed" + (f" ({source_health.error})" if source_health.error else "")
+            )
+        elif source_health.item_count == 0:
+            unavailable_required.append(f"{source} returned no records")
     if unavailable_required:
         raise RuntimeError(
             "Required discovery sources failed or returned no records: "

--- a/src/benchmark_radar/sources.py
+++ b/src/benchmark_radar/sources.py
@@ -5,6 +5,7 @@ import re
 import time
 import xml.etree.ElementTree as ET
 from datetime import UTC, datetime, timedelta
+from email.utils import parsedate_to_datetime
 from typing import Any
 
 from .describe import github_summary, huggingface_summary
@@ -18,6 +19,85 @@ def _date(value: str | None) -> datetime:
     return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
 
 
+def _arxiv_source_id(value: str) -> str:
+    identifier = value.rsplit("/", 1)[-1].replace("oai:arXiv.org:", "")
+    return re.sub(r"v\d+$", "", identifier)
+
+
+def _fetch_arxiv_rss(
+    config: dict[str, Any],
+    *,
+    overlap_since: datetime,
+    limit: int,
+) -> list[RadarItem]:
+    namespaces = {
+        "arxiv": "http://arxiv.org/schemas/atom",
+        "dc": "http://purl.org/dc/elements/1.1/",
+    }
+    keywords = [
+        str(keyword).casefold()
+        for keyword in config.get(
+            "rss_keywords",
+            [
+                "benchmark",
+                "evaluation",
+                "leaderboard",
+                "dataset",
+                "test set",
+                "data contamination",
+                "benchmark leakage",
+                "data quality",
+            ],
+        )
+    ]
+    found: dict[str, RadarItem] = {}
+    for category in config.get("rss_categories", ["cs.AI", "cs.CL", "cs.CV"]):
+        root = ET.fromstring(get_text(f"https://rss.arxiv.org/rss/{category}"))
+        for entry in root.findall("./channel/item"):
+            title = " ".join((entry.findtext("title") or "").split())
+            description = " ".join((entry.findtext("description") or "").split())
+            if keywords and not any(
+                keyword in f"{title} {description}".casefold() for keyword in keywords
+            ):
+                continue
+            published_text = entry.findtext("pubDate")
+            if not published_text:
+                continue
+            published = parsedate_to_datetime(published_text).astimezone(UTC)
+            if published < overlap_since:
+                continue
+            url = (entry.findtext("link") or "").replace("http:", "https:")
+            guid = entry.findtext("guid") or url
+            source_id = _arxiv_source_id(guid)
+            if not source_id or not url:
+                continue
+            announce_type = (
+                entry.findtext("arxiv:announce_type", namespaces=namespaces) or ""
+            ).casefold()
+            summary = (
+                description.split("Abstract:", 1)[-1].strip()
+                if "Abstract:" in description
+                else description
+            )
+            creators = entry.findtext("dc:creator", namespaces=namespaces) or ""
+            found[source_id] = RadarItem(
+                source="arXiv",
+                source_id=source_id,
+                title=title,
+                url=url,
+                published_at=published,
+                updated_at=published,
+                summary=summary,
+                event_kind="updated" if announce_type == "replace" else "released",
+                authors=[author.strip() for author in creators.split(",") if author.strip()],
+            )
+    return sorted(
+        found.values(),
+        key=lambda item: (item.updated_at or item.published_at, item.source_id),
+        reverse=True,
+    )[:limit]
+
+
 def fetch_arxiv(config: dict[str, Any], since: datetime, limit: int) -> list[RadarItem]:
     namespace = {"atom": "http://www.w3.org/2005/Atom"}
     found: dict[str, RadarItem] = {}
@@ -28,46 +108,72 @@ def fetch_arxiv(config: dict[str, Any], since: datetime, limit: int) -> list[Rad
     overlap_since = since - timedelta(hours=int(config.get("overlap_hours", 120)))
     queries = config.get("queries", [])
     request_delay = float(config.get("request_delay_seconds", 3))
-    for query_index, query in enumerate(queries):
-        if query_index and request_delay > 0:
-            time.sleep(request_delay)
-        xml = get_text(
-            "https://export.arxiv.org/api/query",
-            params={
-                "search_query": query,
-                "start": 0,
-                "max_results": limit,
-                "sortBy": "submittedDate",
-                "sortOrder": "descending",
-            },
+    atom_error: Exception | None = None
+    if config.get("atom_enabled", True):
+        try:
+            for query_index, query in enumerate(queries):
+                if query_index and request_delay > 0:
+                    time.sleep(request_delay)
+                xml = get_text(
+                    "https://export.arxiv.org/api/query",
+                    params={
+                        "search_query": query,
+                        "start": 0,
+                        "max_results": limit,
+                        "sortBy": "submittedDate",
+                        "sortOrder": "descending",
+                    },
+                )
+                root = ET.fromstring(xml)
+                for entry in root.findall("atom:entry", namespace):
+                    published = _date(entry.findtext("atom:published", namespaces=namespace))
+                    updated = _date(entry.findtext("atom:updated", namespaces=namespace))
+                    if max(published, updated) < overlap_since:
+                        continue
+                    url = (entry.findtext("atom:id", namespaces=namespace) or "").replace(
+                        "http:", "https:"
+                    )
+                    source_id = _arxiv_source_id(url)
+                    title = " ".join(
+                        (entry.findtext("atom:title", namespaces=namespace) or "").split()
+                    )
+                    summary = " ".join(
+                        (entry.findtext("atom:summary", namespaces=namespace) or "").split()
+                    )
+                    authors = [
+                        name.text or ""
+                        for name in entry.findall("atom:author/atom:name", namespace)
+                        if name.text
+                    ]
+                    found[source_id] = RadarItem(
+                        source="arXiv",
+                        source_id=source_id,
+                        title=title,
+                        url=url,
+                        published_at=published,
+                        updated_at=updated,
+                        summary=summary,
+                        event_kind="updated" if updated > published else "released",
+                        authors=authors,
+                    )
+        except Exception as error:
+            atom_error = error
+
+    if atom_error or not found:
+        rss_items = _fetch_arxiv_rss(
+            config,
+            overlap_since=overlap_since,
+            limit=limit,
         )
-        root = ET.fromstring(xml)
-        for entry in root.findall("atom:entry", namespace):
-            published = _date(entry.findtext("atom:published", namespaces=namespace))
-            updated = _date(entry.findtext("atom:updated", namespaces=namespace))
-            if max(published, updated) < overlap_since:
-                continue
-            url = (entry.findtext("atom:id", namespaces=namespace) or "").replace("http:", "https:")
-            source_id = url.rsplit("/", 1)[-1].split("v", 1)[0]
-            title = " ".join((entry.findtext("atom:title", namespaces=namespace) or "").split())
-            summary = " ".join((entry.findtext("atom:summary", namespaces=namespace) or "").split())
-            authors = [
-                name.text or ""
-                for name in entry.findall("atom:author/atom:name", namespace)
-                if name.text
-            ]
-            found[source_id] = RadarItem(
-                source="arXiv",
-                source_id=source_id,
-                title=title,
-                url=url,
-                published_at=published,
-                updated_at=updated,
-                summary=summary,
-                event_kind="updated" if updated > published else "released",
-                authors=authors,
-            )
-    return list(found.values())
+        if rss_items:
+            return rss_items
+        if atom_error:
+            raise atom_error
+    return sorted(
+        found.values(),
+        key=lambda item: (item.updated_at or item.published_at, item.source_id),
+        reverse=True,
+    )[:limit]
 
 
 def fetch_huggingface(config: dict[str, Any], since: datetime, limit: int) -> list[RadarItem]:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -108,7 +108,10 @@ def test_every_required_source_must_return_records(monkeypatch):
         "sources": {"required_fixture": {"enabled": True, "required": True}},
     }
 
-    with pytest.raises(RuntimeError, match="required_fixture"):
+    with pytest.raises(
+        RuntimeError,
+        match="required_fixture returned no records",
+    ):
         run_pipeline(config, datetime(2026, 7, 27, tzinfo=UTC))
 
 

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime
+from urllib.error import HTTPError
 
 from benchmark_radar.sources import fetch_arxiv
 
@@ -13,6 +14,24 @@ ARXIV_XML = """\
     <author><name>Radar Author</name></author>
   </entry>
 </feed>
+"""
+
+ARXIV_RSS = """\
+<rss xmlns:arxiv="http://arxiv.org/schemas/atom"
+     xmlns:dc="http://purl.org/dc/elements/1.1/" version="2.0">
+  <channel>
+    <item>
+      <title>Fallback evaluation benchmark</title>
+      <link>https://arxiv.org/abs/2607.54321</link>
+      <description>arXiv:2607.54321v1 Announce Type: new
+Abstract: A benchmark recovered from the official category feed.</description>
+      <guid isPermaLink="false">oai:arXiv.org:2607.54321v1</guid>
+      <pubDate>Mon, 27 Jul 2026 00:00:00 -0400</pubDate>
+      <arxiv:announce_type>new</arxiv:announce_type>
+      <dc:creator>Radar Author, Second Author</dc:creator>
+    </item>
+  </channel>
+</rss>
 """
 
 
@@ -42,3 +61,51 @@ def test_arxiv_uses_overlap_and_updated_timestamp(monkeypatch):
     assert items[0].published_at == datetime(2026, 7, 23, 18, tzinfo=UTC)
     assert items[0].updated_at == datetime(2026, 7, 26, 18, tzinfo=UTC)
     assert items[0].event_kind == "updated"
+
+
+def test_arxiv_falls_back_to_official_rss_when_atom_is_rate_limited(monkeypatch):
+    def fake_get_text(url, params=None):
+        if url == "https://export.arxiv.org/api/query":
+            raise HTTPError(url, 429, "Too Many Requests", {}, None)
+        assert url == "https://rss.arxiv.org/rss/cs.AI"
+        return ARXIV_RSS
+
+    monkeypatch.setattr("benchmark_radar.sources.get_text", fake_get_text)
+
+    items = fetch_arxiv(
+        {
+            "queries": ["all:benchmark"],
+            "rss_categories": ["cs.AI"],
+            "rss_keywords": ["benchmark"],
+        },
+        datetime(2026, 7, 25, 12, tzinfo=UTC),
+        10,
+    )
+
+    assert len(items) == 1
+    assert items[0].source_id == "2607.54321"
+    assert items[0].published_at == datetime(2026, 7, 27, 4, tzinfo=UTC)
+    assert items[0].authors == ["Radar Author", "Second Author"]
+    assert items[0].event_kind == "released"
+
+
+def test_arxiv_can_use_official_rss_as_primary(monkeypatch):
+    def fake_get_text(url, params=None):
+        assert url == "https://rss.arxiv.org/rss/cs.AI"
+        assert params is None
+        return ARXIV_RSS
+
+    monkeypatch.setattr("benchmark_radar.sources.get_text", fake_get_text)
+
+    items = fetch_arxiv(
+        {
+            "atom_enabled": False,
+            "queries": ["must not be requested"],
+            "rss_categories": ["cs.AI"],
+            "rss_keywords": ["benchmark"],
+        },
+        datetime(2026, 7, 25, 12, tzinfo=UTC),
+        10,
+    )
+
+    assert [item.source_id for item in items] == ["2607.54321"]


### PR DESCRIPTION
## Root cause

The controlled post-merge Daily Radar run failed before persistence because arXiv was required and returned no records. Direct inspection showed the Atom endpoint returning HTTP 429 or timing out from shared hosted-runner IPs, while the official arXiv category RSS endpoints were healthy.

Failed run: https://github.com/ktwu01/benchmark-radar/actions/runs/30323063835

## Fix

- Use official `rss.arxiv.org` category feeds as the production path on GitHub-hosted runners and filter relevant benchmark/evaluation/data records locally.
- Retain the Atom parser—including `updated` handling—for deployments with stable egress that explicitly enable it.
- Preserve stable arXiv IDs, announcement timestamps, update/release event kinds, authors, overlap filtering, and the per-source cap.
- Keep `required: true` strict. Required-source failures now identify whether a source failed or returned zero records.
- Add coverage for both HTTP-429 fallback and RSS-primary operation.

## Validation

- `ruff check .`
- `ruff format --check .`
- `pytest -q` — 41 passed
- Live official RSS collection — 60 relevant arXiv records
- Isolated full collector run — 30 ranked evidence, 18 attention, arXiv healthy with 60 raw records, two-day dashboard generated
- `git diff --check`

OpenAlex and Brave remain separately blocked by absent repository API-key secrets; this change does not mask those optional-source health failures.