### PR TITLE
Publish the whole corpus, add per-domain trends, and cut the verbose chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,23 @@ pytest -q
 Edit [`config.yml`](config.yml) to change the lookback, threshold, queries, taxonomy, and
 report size. Copy `.env.example` to `.env` only for local use; never commit credentials.
 
+Record volume is controlled by three separate keys, so the daily Issue stays readable
+without discarding the corpus behind it:
+
+| Key | Effect |
+|---|---|
+| `max_items_per_source` | Upper bound on records fetched from each source |
+| `report_limit` | Records scored, snapshotted, and published to the dashboard |
+| `issue_item_limit` | Records written into the daily Issue body |
+
+Every run records its own drop-off (`fetched → deduplicated → qualified → published`) in
+the snapshot and at the top of the Issue, so the gap between what a source returned and
+what was published is always auditable.
+
+The `watchlist` block pins named artifacts, matched on title and source id by word
+boundary. A hit is routed to the top and labelled with a one-line note; it never changes
+a score, so the ranking stays explainable.
+
 Optional repository secrets:
 
 ```text

--- a/README.md
+++ b/README.md
@@ -99,6 +99,15 @@ Every run records its own drop-off (`fetched → deduplicated → qualified → 
 the snapshot and at the top of the Issue, so the gap between what a source returned and
 what was published is always auditable.
 
+GitHub search is rate-limited to 10 requests per minute without a token and 30 with one,
+so pagination is bounded by `sources.github.max_requests` and spaced by
+`request_delay_seconds`. Both default by whether `GITHUB_TOKEN` is present; raising
+`max_items_per_source` well beyond the defaults on a tokenless run risks a 403.
+
+Trend comparisons only run between snapshots collected under the same `report_limit`.
+Changing the cap lifts every count at once, and reporting that as domain momentum would
+present a change in collection policy as a change in the field.
+
 The `watchlist` block pins named artifacts, matched on title and source id by word
 boundary. A hit is routed to the top and labelled with a one-line note; it never changes
 a score, so the ranking stays explainable.

--- a/config.yml
+++ b/config.yml
@@ -1,7 +1,13 @@
 radar:
   lookback_hours: 48
-  max_items_per_source: 60
-  report_limit: 30
+  # Sources routinely return several hundred rows a day. The previous 60/30
+  # pair discarded most of them before anyone could see them, so the dashboard
+  # claimed "228 found" while publishing 8 GitHub records.
+  max_items_per_source: 300
+  # Cap the daily Issue, not the corpus: the snapshot and dashboard keep every
+  # scored record, and only the Markdown digest is truncated to this many.
+  report_limit: 300
+  issue_item_limit: 40
   minimum_score: 2.0
 
 taxonomy:
@@ -32,6 +38,28 @@ taxonomy:
     - data provenance
     - annotation quality
     - benchmark leakage
+
+# Named artifacts worth surfacing whenever they move, regardless of where the
+# generic score places them. A watchlist hit is a routing decision, not a
+# quality claim: it pins the record to the top of the digest and labels why.
+watchlist:
+  - name: PaperBench
+    aliases: [paperbench, "paper bench"]
+    note: OpenAI benchmark for replicating ML research papers end to end.
+  - name: MLE-bench
+    aliases: [mlebench, "mle-bench", "mle bench"]
+    note: OpenAI benchmark scoring agents on Kaggle-style ML engineering tasks.
+  - name: MLE-Marathon
+    aliases: ["mle-marathon", "mle marathon", mlemarathon]
+    note: Long-running variant of the MLE engineering benchmark family.
+  - name: PostRainBench
+    aliases: [postrainbench, "postrain bench", "post-rain bench"]
+    note: Benchmark for post-processing precipitation and rainfall prediction.
+  # "long horizon" alone appears in the abstract of most agent papers, so the
+  # aliases require the benchmark noun to keep this from matching everything.
+  - name: Long-Horizon Bench
+    aliases: ["long horizon bench", "long horizon benchmark", longhorizonbench]
+    note: Evaluations targeting extended multi-step agent execution.
 
 sources:
   arxiv:

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -304,9 +304,12 @@ function deltaText(value) {
 function domainCard(category, trend, index) {
   const swatch = element("span", { className: "legend-swatch" });
   swatch.style.setProperty("--swatch", categoryColor(category, index));
-  const delta = Number(trend.delta || 0);
+  // A null delta means the previous scan used a different report limit, so the
+  // two counts are not comparable and no change is claimed.
+  const comparable = trend.delta !== null && trend.delta !== undefined;
+  const delta = comparable ? Number(trend.delta) : 0;
   const rows = [
-    ["vs previous scan", deltaText(delta)],
+    ["vs previous scan", comparable ? deltaText(delta) : "not comparable"],
     [
       "recent daily average",
       trend.baseline === null || trend.baseline === undefined
@@ -322,7 +325,7 @@ function domainCard(category, trend, index) {
   return element(
     "article",
     {
-      className: `domain-card${delta > 0 ? " is-up" : delta < 0 ? " is-down" : ""}`,
+      className: `domain-card${!comparable ? "" : delta > 0 ? " is-up" : delta < 0 ? " is-down" : ""}`,
     },
     [
       element("div", { className: "domain-head" }, [
@@ -861,17 +864,20 @@ async function initialize() {
     renderExplorer();
     setView(state.view, false);
     const latest = dailySnapshot(state.data.latest_date);
-    const degraded = latest.ingest_health.filter(
-      (entry) => !entry.ok || entry.item_count === 0,
+    // A source that succeeded with zero records is not down: empty and failed
+    // are distinct states everywhere else, so only failures are called out.
+    const failed = latest.ingest_health.filter((entry) => !entry.ok).length;
+    const empty = latest.ingest_health.filter(
+      (entry) => entry.ok && entry.item_count === 0,
     ).length;
     // Report what the reader gets, and mention plumbing only when it broke.
     byId("status-copy").textContent =
       `${formatDate(latest.date, { dateStyle: "medium" })} · ${latest.evidence_count} records` +
-      (degraded ? ` · ${degraded} source${degraded === 1 ? "" : "s"} down` : "");
+      (failed ? ` · ${failed} source${failed === 1 ? "" : "s"} failed` : "");
     byId("feed-status").textContent =
       `${latest.evidence_count} ranked evidence · ${latest.attention.active_count} persisted attention`;
     byId("run-status").querySelector(".status-light").classList.add(
-      degraded === 0 ? "ok" : "warning",
+      failed === 0 && empty === 0 ? "ok" : "warning",
     );
     byId("build-meta").textContent = `Updated ${formatDate(state.data.generated_at, {
       dateStyle: "medium",

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -141,6 +141,9 @@ function scoreBlock(item) {
 
 function pillBar(item) {
   const pills = [
+    ...(item.watchlist
+      ? [element("span", { className: "pill pill-watchlist", text: `★ ${item.watchlist}` })]
+      : []),
     element("span", { className: "pill pill-source", text: item.source }),
     element("span", { className: "pill pill-event", text: item.event_kind }),
     ...(item.categories || []).map((category) =>
@@ -159,6 +162,11 @@ function signalCard(item, index) {
     attrs: { href: item.url, target: "_blank", rel: "noopener noreferrer" },
   });
   const body = [pillBar(item), element("h3", {}, [title])];
+  // The watchlist note is the one line explaining why this artifact is
+  // tracked by name, so it leads ahead of the upstream description.
+  if (item.watchlist && item.watchlist_note) {
+    body.push(element("p", { className: "signal-tldr", text: item.watchlist_note }));
+  }
   // An absent description is reported as absent. Filling the gap with a
   // generated sentence would restate the pills above and tell the reader
   // nothing about the artifact.
@@ -288,6 +296,73 @@ function renderToday() {
   writeUrl();
 }
 
+function deltaText(value) {
+  if (!value) return "no change";
+  return value > 0 ? `+${value}` : String(value);
+}
+
+function domainCard(category, trend, index) {
+  const swatch = element("span", { className: "legend-swatch" });
+  swatch.style.setProperty("--swatch", categoryColor(category, index));
+  const delta = Number(trend.delta || 0);
+  const rows = [
+    ["vs previous scan", deltaText(delta)],
+    [
+      "recent daily average",
+      trend.baseline === null || trend.baseline === undefined
+        ? "not enough history"
+        : Number(trend.baseline).toFixed(2),
+    ],
+    ["cumulative", Number(trend.cumulative || 0).toLocaleString()],
+  ];
+  if (trend.momentum !== null && trend.momentum !== undefined) {
+    const percent = Math.round(Number(trend.momentum) * 100);
+    rows.splice(2, 0, ["vs its average", `${percent > 0 ? "+" : ""}${percent}%`]);
+  }
+  return element(
+    "article",
+    {
+      className: `domain-card${delta > 0 ? " is-up" : delta < 0 ? " is-down" : ""}`,
+    },
+    [
+      element("div", { className: "domain-head" }, [
+        swatch,
+        element("h3", { text: category.replaceAll("_", " ") }),
+      ]),
+      element("p", { className: "domain-count", text: String(trend.count ?? 0) }),
+      element(
+        "dl",
+        { className: "domain-stats" },
+        rows.flatMap(([label, value]) => [
+          element("dt", { text: label }),
+          element("dd", { text: value }),
+        ]),
+      ),
+    ],
+  );
+}
+
+function renderDomainMetrics(day) {
+  const grid = byId("domain-grid");
+  if (!grid) return;
+  const trends = day.category_trends || {};
+  const entries = Object.entries(trends).sort(
+    (a, b) => (b[1].count || 0) - (a[1].count || 0) || a[0].localeCompare(b[0]),
+  );
+  byId("domain-date").textContent = formatDate(day.date, { dateStyle: "medium" });
+  replaceChildren(
+    grid,
+    entries.length
+      ? entries.map(([category, trend], index) => domainCard(category, trend, index))
+      : [
+          element("p", {
+            className: "empty-state",
+            text: "No categorized records in this scan.",
+          }),
+        ],
+  );
+}
+
 function renderTrends() {
   const categories = state.data.facets.categories;
   replaceChildren(
@@ -310,6 +385,7 @@ function renderTrends() {
       })(),
     ],
   );
+  renderDomainMetrics(state.data.days[state.data.days.length - 1]);
   const dayCount = state.data.days.length;
   const trendMessage = byId("trend-message");
   const trendChart = byId("trend-chart");
@@ -329,8 +405,14 @@ function renderTrends() {
     const evidenceDelta = latest.evidence_count - previous.evidence_count;
     const attentionDelta = latest.attention.active_count - previous.attention.active_count;
     const direction = (value) => (value > 0 ? `up ${value}` : value < 0 ? `down ${Math.abs(value)}` : "flat");
+    const movers = Object.entries(latest.category_trends || {})
+      .filter(([, trend]) => trend.delta)
+      .sort((a, b) => Math.abs(b[1].delta) - Math.abs(a[1].delta))
+      .slice(0, 2)
+      .map(([category, trend]) => `${category.replaceAll("_", " ")} ${deltaText(trend.delta)}`);
     trendMessage.textContent =
-      `Compared with ${previous.date}, surfaced evidence is ${direction(evidenceDelta)} and active attention is ${direction(attentionDelta)}.`;
+      `Compared with ${previous.date}, surfaced evidence is ${direction(evidenceDelta)} and active attention is ${direction(attentionDelta)}.` +
+      (movers.length ? ` Biggest domain moves: ${movers.join(", ")}.` : "");
     trendChart.hidden = false;
   }
   const maxTotal = Math.max(
@@ -428,10 +510,9 @@ function countMapText(values) {
 }
 
 function healthSummary(entries) {
-  const nonempty = entries.filter((entry) => entry.ok && entry.item_count > 0).length;
-  const empty = entries.filter((entry) => entry.ok && entry.item_count === 0).length;
-  const failed = entries.filter((entry) => !entry.ok).length;
-  return `${nonempty} nonempty · ${empty} empty · ${failed} failed`;
+  const total = entries.length;
+  const healthy = entries.filter((entry) => entry.ok && entry.item_count > 0).length;
+  return healthy === total ? "all ok" : `${healthy}/${total} ok`;
 }
 
 function allObservations() {
@@ -724,9 +805,35 @@ function bindEvents() {
   });
 }
 
+const REPO_SLUG = "ktwu01/benchmark-radar";
+
+function setBadgeCount(id, value) {
+  const node = byId(id)?.querySelector("[data-count]");
+  if (node) node.textContent = Number(value || 0).toLocaleString();
+}
+
+async function renderRepoBadges() {
+  // Counts are decoration: the badges link out and stay usable if this fails,
+  // so a rate-limited API must never surface as an error state.
+  try {
+    const response = await fetch(`https://api.github.com/repos/${REPO_SLUG}`, {
+      headers: { Accept: "application/vnd.github+json" },
+    });
+    if (!response.ok) return;
+    const repo = await response.json();
+    setBadgeCount("badge-stars", repo.stargazers_count);
+    setBadgeCount("badge-forks", repo.forks_count);
+    setBadgeCount("badge-issues", repo.open_issues_count);
+  } catch (error) {
+    console.debug("Repository badge counts unavailable", error);
+  }
+}
+
 async function initialize() {
   readUrl();
   bindEvents();
+  // Independent of the data file, so badges still render on an error state.
+  renderRepoBadges();
   try {
     const response = await fetch("data/radar.json", { cache: "no-store" });
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
@@ -754,25 +861,22 @@ async function initialize() {
     renderExplorer();
     setView(state.view, false);
     const latest = dailySnapshot(state.data.latest_date);
-    const nonempty = latest.ingest_health.filter(
-      (entry) => entry.ok && entry.item_count > 0,
+    const degraded = latest.ingest_health.filter(
+      (entry) => !entry.ok || entry.item_count === 0,
     ).length;
-    const empty = latest.ingest_health.filter(
-      (entry) => entry.ok && entry.item_count === 0,
-    ).length;
-    const failed = latest.ingest_health.filter((entry) => !entry.ok).length;
+    // Report what the reader gets, and mention plumbing only when it broke.
     byId("status-copy").textContent =
-      `Latest ${latest.date} · ${nonempty} nonempty · ${empty} empty · ${failed} failed`;
+      `${formatDate(latest.date, { dateStyle: "medium" })} · ${latest.evidence_count} records` +
+      (degraded ? ` · ${degraded} source${degraded === 1 ? "" : "s"} down` : "");
     byId("feed-status").textContent =
       `${latest.evidence_count} ranked evidence · ${latest.attention.active_count} persisted attention`;
     byId("run-status").querySelector(".status-light").classList.add(
-      empty === 0 && failed === 0 ? "ok" : "warning",
+      degraded === 0 ? "ok" : "warning",
     );
-    byId("build-meta").textContent =
-      `Schema ${state.data.schema_version} · Build ${formatDate(state.data.generated_at, {
-        dateStyle: "medium",
-        timeStyle: "short",
-      })} UTC`;
+    byId("build-meta").textContent = `Updated ${formatDate(state.data.generated_at, {
+      dateStyle: "medium",
+      timeStyle: "short",
+    })} UTC`;
   } catch (error) {
     document.querySelectorAll(".view").forEach((section) => {
       section.hidden = true;

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -366,6 +366,10 @@ function renderDomainMetrics(day) {
   );
 }
 
+function sameReportLimit(a, b) {
+  return (a.selection || {}).report_limit === (b.selection || {}).report_limit;
+}
+
 function renderTrends() {
   const categories = state.data.facets.categories;
   replaceChildren(
@@ -399,8 +403,12 @@ function renderTrends() {
       `Baseline: ${only.evidence_count} evidence records and ${only.attention.active_count} active attention signals.`;
     trendChart.hidden = true;
   } else if (dayCount === 2) {
-    trendMessage.textContent =
-      "Two snapshots are available. The chart shows the first comparable daily change; broader trend language begins with three snapshots.";
+    trendMessage.textContent = sameReportLimit(
+      state.data.days[1],
+      state.data.days[0],
+    )
+      ? "Two snapshots are available. The chart shows the first comparable daily change; broader trend language begins with three snapshots."
+      : "Two snapshots are available, but they used different report limits, so the change between them is not comparable.";
     trendChart.hidden = false;
   } else {
     const latest = state.data.days[dayCount - 1];
@@ -408,8 +416,7 @@ function renderTrends() {
     // Raising the report limit lifts every count at once. Announcing that as
     // movement would report a collection-policy change as a change in field,
     // so the same gate the domain cards use applies to this sentence.
-    const comparable =
-      (latest.selection || {}).report_limit === (previous.selection || {}).report_limit;
+    const comparable = sameReportLimit(latest, previous);
     if (comparable) {
       const evidenceDelta = latest.evidence_count - previous.evidence_count;
       const attentionDelta = latest.attention.active_count - previous.attention.active_count;

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -405,17 +405,28 @@ function renderTrends() {
   } else {
     const latest = state.data.days[dayCount - 1];
     const previous = state.data.days[dayCount - 2];
-    const evidenceDelta = latest.evidence_count - previous.evidence_count;
-    const attentionDelta = latest.attention.active_count - previous.attention.active_count;
-    const direction = (value) => (value > 0 ? `up ${value}` : value < 0 ? `down ${Math.abs(value)}` : "flat");
-    const movers = Object.entries(latest.category_trends || {})
-      .filter(([, trend]) => trend.delta)
-      .sort((a, b) => Math.abs(b[1].delta) - Math.abs(a[1].delta))
-      .slice(0, 2)
-      .map(([category, trend]) => `${category.replaceAll("_", " ")} ${deltaText(trend.delta)}`);
-    trendMessage.textContent =
-      `Compared with ${previous.date}, surfaced evidence is ${direction(evidenceDelta)} and active attention is ${direction(attentionDelta)}.` +
-      (movers.length ? ` Biggest domain moves: ${movers.join(", ")}.` : "");
+    // Raising the report limit lifts every count at once. Announcing that as
+    // movement would report a collection-policy change as a change in field,
+    // so the same gate the domain cards use applies to this sentence.
+    const comparable =
+      (latest.selection || {}).report_limit === (previous.selection || {}).report_limit;
+    if (comparable) {
+      const evidenceDelta = latest.evidence_count - previous.evidence_count;
+      const attentionDelta = latest.attention.active_count - previous.attention.active_count;
+      const direction = (value) => (value > 0 ? `up ${value}` : value < 0 ? `down ${Math.abs(value)}` : "flat");
+      const movers = Object.entries(latest.category_trends || {})
+        .filter(([, trend]) => trend.delta)
+        .sort((a, b) => Math.abs(b[1].delta) - Math.abs(a[1].delta))
+        .slice(0, 2)
+        .map(([category, trend]) => `${category.replaceAll("_", " ")} ${deltaText(trend.delta)}`);
+      trendMessage.textContent =
+        `Compared with ${previous.date}, surfaced evidence is ${direction(evidenceDelta)} and active attention is ${direction(attentionDelta)}.` +
+        (movers.length ? ` Biggest domain moves: ${movers.join(", ")}.` : "");
+    } else {
+      trendMessage.textContent =
+        `${latest.date} used a different report limit than ${previous.date}, so the two scans ` +
+        "are not directly comparable. Counts are shown without a change figure.";
+    }
     trendChart.hidden = false;
   }
   const maxTotal = Math.max(
@@ -513,9 +524,13 @@ function countMapText(values) {
 }
 
 function healthSummary(entries) {
+  // A source that returned nothing still succeeded. Only a failure is not ok,
+  // and an empty run is reported alongside rather than counted as a fault.
   const total = entries.length;
-  const healthy = entries.filter((entry) => entry.ok && entry.item_count > 0).length;
-  return healthy === total ? "all ok" : `${healthy}/${total} ok`;
+  const ok = entries.filter((entry) => entry.ok).length;
+  const empty = entries.filter((entry) => entry.ok && entry.item_count === 0).length;
+  const base = ok === total ? "all ok" : `${ok}/${total} ok`;
+  return empty ? `${base} · ${empty} empty` : base;
 }
 
 function allObservations() {
@@ -826,7 +841,19 @@ async function renderRepoBadges() {
     const repo = await response.json();
     setBadgeCount("badge-stars", repo.stargazers_count);
     setBadgeCount("badge-forks", repo.forks_count);
-    setBadgeCount("badge-issues", repo.open_issues_count);
+    // open_issues_count includes pull requests, so a badge labelled "Issues"
+    // built from it overstates the count and disagrees with the page it links
+    // to. Ask search for issues only, and leave the badge blank if that fails
+    // rather than showing the inflated number.
+    const issues = await fetch(
+      `https://api.github.com/search/issues?q=${encodeURIComponent(
+        `repo:${REPO_SLUG} is:issue is:open`,
+      )}&per_page=1`,
+      { headers: { Accept: "application/vnd.github+json" } },
+    );
+    if (issues.ok) {
+      setBadgeCount("badge-issues", (await issues.json()).total_count);
+    }
   } catch (error) {
     console.debug("Repository badge counts unavailable", error);
   }

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -192,6 +192,47 @@ th {
   box-shadow: 0 0 0 4px rgb(220 99 63 / 14%);
 }
 
+.masthead-end {
+  display: flex;
+  gap: 0.7rem;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.repo-badges {
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+}
+
+.repo-badge {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  padding: 0.32rem 0.6rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--ink);
+  font-family: var(--utility);
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: border-color 120ms ease, background 120ms ease;
+}
+
+.repo-badge:hover,
+.repo-badge:focus-visible {
+  border-color: var(--ink);
+  background: var(--panel);
+}
+
+.repo-badge-count {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+}
+
 .view-nav {
   display: flex;
   align-items: stretch;
@@ -426,6 +467,19 @@ input {
   color: var(--blue-deep);
 }
 
+.pill-watchlist {
+  border-color: var(--gold);
+  background: rgb(201 147 39 / 12%);
+  color: #7d5c14;
+  font-weight: 700;
+}
+
+/* The one line saying why a tracked artifact matters, ahead of upstream prose. */
+.signal-tldr {
+  margin-bottom: 0.35rem;
+  font-weight: 600;
+}
+
 .signal-why {
   margin-bottom: 0;
   color: var(--muted);
@@ -547,6 +601,7 @@ input {
 }
 
 .trend-panel,
+.domain-panel,
 .ledger,
 .method-note,
 .filter-panel {
@@ -556,8 +611,80 @@ input {
 }
 
 .trend-panel,
+.domain-panel,
 .ledger {
   padding: clamp(1.25rem, 3vw, 2rem);
+}
+
+.domain-panel {
+  margin-bottom: clamp(1.25rem, 3vw, 2rem);
+}
+
+.domain-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  margin-top: 1rem;
+}
+
+.domain-card {
+  padding: 1rem;
+  border: 1px solid var(--line);
+  border-top: 3px solid var(--line);
+  background: var(--canvas);
+}
+
+.domain-card.is-up {
+  border-top-color: var(--sea);
+}
+
+.domain-card.is-down {
+  border-top-color: var(--orange);
+}
+
+.domain-head {
+  display: flex;
+  gap: 0.45rem;
+  align-items: center;
+}
+
+.domain-head h3 {
+  margin: 0;
+  font-family: var(--utility);
+  font-size: 0.72rem;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.domain-count {
+  margin: 0.35rem 0 0.65rem;
+  font-family: var(--display);
+  font-size: 2.4rem;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+
+.domain-stats {
+  display: grid;
+  gap: 0.15rem 0.75rem;
+  grid-template-columns: 1fr auto;
+  margin: 0;
+}
+
+.domain-stats dt {
+  color: var(--muted);
+  font-family: var(--utility);
+  font-size: 0.62rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.domain-stats dd {
+  margin: 0;
+  font-family: var(--utility);
+  font-size: 0.72rem;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
 }
 
 .legend {
@@ -1000,6 +1127,21 @@ footer {
 
   .run-status {
     display: none;
+  }
+
+  /* Keep the badges reachable on narrow screens, but drop the word so the
+     icon and count still fit beside the wordmark. */
+  .repo-badge-label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+  }
+
+  .repo-badge {
+    padding-inline: 0.5rem;
   }
 
   .view-nav {

--- a/site/index.html
+++ b/site/index.html
@@ -19,14 +19,48 @@
         <span class="brand-mark" aria-hidden="true">
           <span></span>
         </span>
-        <span>
-          <strong>Benchmark Radar</strong>
-          <small>Evidence log / UTC</small>
-        </span>
+        <strong>Benchmark Radar</strong>
       </a>
-      <div class="run-status" id="run-status" role="status">
-        <span class="status-light" aria-hidden="true"></span>
-        <span id="status-copy">Loading latest scan</span>
+      <div class="masthead-end">
+        <div class="run-status" id="run-status" role="status">
+          <span class="status-light" aria-hidden="true"></span>
+          <span id="status-copy">Loading latest scan</span>
+        </div>
+        <div class="repo-badges" id="repo-badges" aria-label="Repository activity">
+          <a
+            class="repo-badge"
+            id="badge-stars"
+            href="https://github.com/ktwu01/benchmark-radar/stargazers"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <span aria-hidden="true">★</span>
+            <span class="repo-badge-label">Stars</span>
+            <span class="repo-badge-count" data-count>—</span>
+          </a>
+          <a
+            class="repo-badge"
+            id="badge-forks"
+            href="https://github.com/ktwu01/benchmark-radar/forks"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <span aria-hidden="true">⑂</span>
+            <span class="repo-badge-label">Forks</span>
+            <span class="repo-badge-count" data-count>—</span>
+          </a>
+          <a
+            class="repo-badge"
+            id="badge-issues"
+            href="https://github.com/ktwu01/benchmark-radar/issues"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <span aria-hidden="true">◎</span>
+            <span class="repo-badge-label">Issues</span>
+            <span class="repo-badge-count" data-count>—</span>
+          </a>
+        </div>
       </div>
     </header>
 
@@ -57,9 +91,7 @@
               <h2>Attention signals</h2>
               <span id="today-attention-count"></span>
             </div>
-            <p class="section-note">
-              Public activity is persisted with this UTC snapshot and is never quality-scored.
-            </p>
+            <p class="section-note">Public activity, not quality-scored.</p>
             <div class="explorer-list" id="today-attention-list"></div>
           </div>
           <aside class="health-panel" aria-labelledby="health-heading">
@@ -79,6 +111,18 @@
           </div>
           <p class="heading-note">Counts describe discovery volume, not scientific quality.</p>
         </header>
+
+        <div class="domain-panel">
+          <div class="section-title">
+            <h2 id="domain-heading">New by domain</h2>
+            <span id="domain-date"></span>
+          </div>
+          <p class="section-note">
+            Records surfaced in each domain on the selected scan, against its own recent daily
+            average.
+          </p>
+          <div class="domain-grid" id="domain-grid" aria-labelledby="domain-heading"></div>
+        </div>
 
         <div class="trend-panel">
           <div class="section-title">
@@ -189,8 +233,7 @@
     </dialog>
 
     <footer>
-      <p>Automated discovery and triage—not an endorsement.</p>
-      <p id="build-meta">Schema — · Build —</p>
+      <p id="build-meta">Updated —</p>
     </footer>
   </body>
 </html>

--- a/src/benchmark_radar/cli.py
+++ b/src/benchmark_radar/cli.py
@@ -60,8 +60,13 @@ def main() -> None:
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.json_output.parent.mkdir(parents=True, exist_ok=True)
     dashboard_url = config.get("publish", {}).get("dashboard_url")
+    issue_item_limit = config.get("radar", {}).get("issue_item_limit")
     args.output.write_text(
-        render_markdown(run, dashboard_url=dashboard_url),
+        render_markdown(
+            run,
+            dashboard_url=dashboard_url,
+            issue_item_limit=int(issue_item_limit) if issue_item_limit else None,
+        ),
         encoding="utf-8",
     )
     args.json_output.write_text(
@@ -77,6 +82,7 @@ def main() -> None:
                     health.to_dict() for health in [*run.health, *run.attention_ingest_health]
                 ],
                 "producer_health": [health.to_dict() for health in run.producer_health],
+                "selection": run.selection,
             },
             indent=2,
             ensure_ascii=False,

--- a/src/benchmark_radar/models.py
+++ b/src/benchmark_radar/models.py
@@ -27,6 +27,10 @@ class RadarItem:
     adoption_score: float = 0.0
     total_score: float = 0.0
     rationale: list[str] = field(default_factory=list)
+    # Set when the record matches a named artifact on the configured
+    # watchlist. Routing metadata only: it never alters a score.
+    watchlist: str | None = None
+    watchlist_note: str = ""
 
     @property
     def canonical_key(self) -> str:
@@ -107,3 +111,6 @@ class RadarRun:
     attention_ingest_health: list[SourceHealth] = field(default_factory=list)
     producer_health: list[ProducerHealth] = field(default_factory=list)
     discovery_state: dict[str, Any] = field(default_factory=dict)
+    # Per-stage record counts (fetched → deduplicated → scored → qualified →
+    # published) so the gap between "228 found" and what ships is visible.
+    selection: dict[str, Any] = field(default_factory=dict)

--- a/src/benchmark_radar/pipeline.py
+++ b/src/benchmark_radar/pipeline.py
@@ -110,6 +110,45 @@ def score_item(
     return item
 
 
+def apply_watchlist(
+    items: list[RadarItem],
+    watchlist: list[dict[str, Any]],
+) -> list[RadarItem]:
+    """Tag records naming an artifact the reader always wants to see.
+
+    Only the title and source id are matched. A watchlisted name mentioned in
+    passing inside an abstract describes related work, not a release of that
+    artifact, so including the summary pinned unrelated papers to the top.
+    Matching is on word boundaries for the same reason: a bare substring made
+    "long horizon" swallow every agent paper that used the phrase.
+
+    This marks and routes the record only; it never edits a score, so the
+    published ranking stays explainable.
+    """
+    if not watchlist:
+        return items
+    for item in items:
+        haystack = f"{item.title} {item.source_id}".casefold()
+        for entry in watchlist:
+            name = str(entry.get("name") or "").strip()
+            aliases = [str(alias).casefold() for alias in entry.get("aliases") or []]
+            terms = [alias for alias in [*aliases, name.casefold()] if alias]
+            # Hyphens, spaces and underscores are interchangeable separators
+            # so "mle-bench", "mle bench" and "mle_bench" all match one alias.
+            patterns = [
+                r"(?<![0-9a-z])"
+                + r"[\s_-]*".join(re.escape(part) for part in re.split(r"[\s_-]+", term) if part)
+                + r"(?![0-9a-z])"
+                for term in terms
+            ]
+            if any(re.search(pattern, haystack) for pattern in patterns):
+                item.watchlist = name or terms[0]
+                item.watchlist_note = str(entry.get("note") or "").strip()
+                item.rationale.append(f"Watchlist: {item.watchlist}")
+                break
+    return items
+
+
 BOILERPLATE_THRESHOLD = 3
 
 
@@ -226,16 +265,38 @@ def run_pipeline(
             "Required discovery sources failed or returned no records: "
             + ", ".join(unavailable_required)
         )
+    fetched_count = len(items)
     unique = deduplicate(items)
-    scored = [score_item(item, config["taxonomy"], now) for item in unique]
+    scored = apply_watchlist(
+        [score_item(item, config["taxonomy"], now) for item in unique],
+        config.get("watchlist") or [],
+    )
     selected = [
         item
         for item in scored
-        if item.total_score >= float(settings["minimum_score"]) and item.categories
+        # A watchlist hit is published even when the generic score or taxonomy
+        # would have dropped it: the reader asked for these by name.
+        if item.watchlist
+        or (item.total_score >= float(settings["minimum_score"]) and item.categories)
     ]
-    selected.sort(key=lambda item: (item.total_score, item.published_at), reverse=True)
+    selected.sort(
+        key=lambda item: (bool(item.watchlist), item.total_score, item.published_at),
+        reverse=True,
+    )
     published = selected[: int(settings["report_limit"])]
     assert_no_boilerplate_summaries(published)
+    # The dashboard previously showed "228 found" beside 8 published records
+    # with nothing to explain the gap. Persist each stage so the drop-off is
+    # auditable rather than looking like lost data.
+    selection = {
+        "fetched": fetched_count,
+        "deduplicated": len(unique),
+        "scored": len(scored),
+        "qualified": len(selected),
+        "published": len(published),
+        "minimum_score": float(settings["minimum_score"]),
+        "report_limit": int(settings["report_limit"]),
+    }
     attention, attention_health, producer_health, attention_state = fetch_attention_feeds(
         config.get("attention") or {},
         observed_at=now,
@@ -250,6 +311,7 @@ def run_pipeline(
         attention=attention,
         attention_ingest_health=attention_health,
         producer_health=producer_health,
+        selection=selection,
         discovery_state={
             **discovery_state,
             "attention": attention_state,

--- a/src/benchmark_radar/pipeline.py
+++ b/src/benchmark_radar/pipeline.py
@@ -215,6 +215,10 @@ def run_pipeline(
     limit = int(settings["max_items_per_source"])
     items: list[RadarItem] = []
     health: list[SourceHealth] = []
+    # Counted before arXiv overlap suppression, so this always agrees with the
+    # per-source health table rather than silently excluding repeat records.
+    fetched_count = 0
+    suppressed_count = 0
     discovery_state = deepcopy((previous_snapshot or {}).get("discovery_state") or {})
     for source_name, source_config in config["sources"].items():
         if not source_config.get("enabled", True):
@@ -222,15 +226,16 @@ def run_pipeline(
         fetcher = SOURCE_FETCHERS[source_name]
         try:
             fetched = fetcher(source_config, since, limit)
+            fetched_count += len(fetched)
             health.append(SourceHealth(source=source_name, ok=True, item_count=len(fetched)))
             if source_name == "arxiv":
-                items.extend(
-                    _apply_arxiv_discovery_state(
-                        fetched,
-                        now=now,
-                        state=discovery_state,
-                    )
+                changed = _apply_arxiv_discovery_state(
+                    fetched,
+                    now=now,
+                    state=discovery_state,
                 )
+                suppressed_count += len(fetched) - len(changed)
+                items.extend(changed)
             else:
                 for item in fetched:
                     item.discovered_at = now
@@ -265,7 +270,6 @@ def run_pipeline(
             "Required discovery sources failed or returned no records: "
             + ", ".join(unavailable_required)
         )
-    fetched_count = len(items)
     unique = deduplicate(items)
     scored = apply_watchlist(
         [score_item(item, config["taxonomy"], now) for item in unique],
@@ -290,9 +294,19 @@ def run_pipeline(
     # auditable rather than looking like lost data.
     selection = {
         "fetched": fetched_count,
+        # arXiv records already seen in a previous run, dropped before dedupe.
+        "suppressed_as_seen": suppressed_count,
         "deduplicated": len(unique),
         "scored": len(scored),
         "qualified": len(selected),
+        # Qualified purely by a watchlist match, so the threshold wording in
+        # the report stays true for the records that did clear the bar.
+        "watchlisted": sum(
+            1
+            for item in selected
+            if item.watchlist
+            and not (item.total_score >= float(settings["minimum_score"]) and item.categories)
+        ),
         "published": len(published),
         "minimum_score": float(settings["minimum_score"]),
         "report_limit": int(settings["report_limit"]),

--- a/src/benchmark_radar/report.py
+++ b/src/benchmark_radar/report.py
@@ -109,14 +109,24 @@ def render_markdown(
     )
     if run.selection:
         selection = run.selection
+        watchlisted = int(selection.get("watchlisted") or 0)
+        # Watchlist hits bypass the threshold on purpose, so they are named
+        # separately rather than folded into the "scored at or above" claim.
+        qualified = (
+            f"**{selection.get('qualified', 0)}** qualified "
+            f"(at or above {selection.get('minimum_score', 0):g}"
+            + (f", plus {watchlisted} by watchlist" if watchlisted else "")
+            + ")"
+        )
+        suppressed = int(selection.get("suppressed_as_seen") or 0)
         lines.extend(
             [
                 "- Selection: "
                 f"**{selection.get('fetched', 0)}** fetched → "
-                f"**{selection.get('deduplicated', 0)}** after dedupe → "
-                f"**{selection.get('qualified', 0)}** scored at or above "
-                f"{selection.get('minimum_score', 0):g} → "
-                f"**{selection.get('published', 0)}** published",
+                + (f"**{suppressed}** already seen → " if suppressed else "")
+                + f"**{selection.get('deduplicated', 0)}** after dedupe → "
+                + qualified
+                + f" → **{selection.get('published', 0)}** published",
                 "",
             ]
         )

--- a/src/benchmark_radar/report.py
+++ b/src/benchmark_radar/report.py
@@ -110,12 +110,14 @@ def render_markdown(
     if run.selection:
         selection = run.selection
         watchlisted = int(selection.get("watchlisted") or 0)
-        # Watchlist hits bypass the threshold on purpose, so they are named
-        # separately rather than folded into the "scored at or above" claim.
+        # Watchlist hits bypass the threshold on purpose and are already inside
+        # `qualified`, so subtract them before claiming how many cleared the
+        # bar. Otherwise a lone bypass reads as "1 qualified (at or above 99)".
+        by_threshold = int(selection.get("qualified", 0)) - watchlisted
         qualified = (
             f"**{selection.get('qualified', 0)}** qualified "
-            f"(at or above {selection.get('minimum_score', 0):g}"
-            + (f", plus {watchlisted} by watchlist" if watchlisted else "")
+            f"({by_threshold} at or above {selection.get('minimum_score', 0):g}"
+            + (f", {watchlisted} by watchlist" if watchlisted else "")
             + ")"
         )
         suppressed = int(selection.get("suppressed_as_seen") or 0)

--- a/src/benchmark_radar/report.py
+++ b/src/benchmark_radar/report.py
@@ -17,13 +17,16 @@ def _item_block(index: int, item: RadarItem) -> str:
     authors = ", ".join(item.authors[:4])
     if len(item.authors) > 4:
         authors += " et al."
+    marker = f"⭐ {_escape(item.watchlist)} · " if item.watchlist else ""
     lines = [
         f"### {index}. [{_escape(item.title)}]({item.url})",
         "",
-        f"**{item.source} · {item.event_kind} · {category} · "
+        f"**{marker}{item.source} · {item.event_kind} · {category} · "
         f"priority {item.total_score:.2f}/4.00**",
         "",
     ]
+    if item.watchlist and item.watchlist_note:
+        lines.extend([f"> {_escape(item.watchlist_note)}", ""])
     if item.summary:
         summary = _escape(item.summary)
         lines.extend([summary[:700] + ("…" if len(summary) > 700 else ""), ""])
@@ -51,7 +54,12 @@ def _item_block(index: int, item: RadarItem) -> str:
     return "\n".join(lines)
 
 
-def render_markdown(run: RadarRun, dashboard_url: str | None = None) -> str:
+def render_markdown(
+    run: RadarRun,
+    dashboard_url: str | None = None,
+    *,
+    issue_item_limit: int | None = None,
+) -> str:
     date = run.generated_at.astimezone(UTC).date().isoformat()
     category_counts = Counter(category for item in run.items for category in item.categories)
     source_counts = Counter(item.source for item in run.items)
@@ -99,10 +107,48 @@ def render_markdown(run: RadarRun, dashboard_url: str | None = None) -> str:
             "",
         ]
     )
+    if run.selection:
+        selection = run.selection
+        lines.extend(
+            [
+                "- Selection: "
+                f"**{selection.get('fetched', 0)}** fetched → "
+                f"**{selection.get('deduplicated', 0)}** after dedupe → "
+                f"**{selection.get('qualified', 0)}** scored at or above "
+                f"{selection.get('minimum_score', 0):g} → "
+                f"**{selection.get('published', 0)}** published",
+                "",
+            ]
+        )
+    tracked = [item for item in run.items if item.watchlist]
+    if tracked:
+        lines.extend(["## Watchlist", ""])
+        for item in tracked:
+            note = f" {_escape(item.watchlist_note)}" if item.watchlist_note else ""
+            lines.append(
+                f"- **{_escape(item.watchlist)}** — [{_escape(item.title)}]({item.url}) "
+                f"({item.source} · {item.event_kind}).{note}"
+            )
+        lines.append("")
     if run.items:
-        lines.extend(["## Today's signals", ""])
-        for index, item in enumerate(run.items, start=1):
+        # GitHub Issue bodies have a hard size limit, so the digest is
+        # truncated while the snapshot and dashboard keep every record.
+        shown = run.items[:issue_item_limit] if issue_item_limit else run.items
+        heading = "## Today's signals"
+        if len(shown) < len(run.items):
+            heading += f" (top {len(shown)} of {len(run.items)})"
+        lines.extend([heading, ""])
+        for index, item in enumerate(shown, start=1):
             lines.append(_item_block(index, item))
+        if len(shown) < len(run.items):
+            remaining = len(run.items) - len(shown)
+            link = f"[the dashboard]({dashboard_url})" if dashboard_url else "the dashboard"
+            lines.extend(
+                [
+                    f"_{remaining} further ranked records are published to {link}._",
+                    "",
+                ]
+            )
     else:
         lines.extend(
             [

--- a/src/benchmark_radar/snapshots.py
+++ b/src/benchmark_radar/snapshots.py
@@ -300,22 +300,37 @@ def _attach_category_trends(days: list[dict[str, Any]]) -> None:
     "How many benchmarks landed today" is only half the question; the other
     half is which domain moved and by how much. Every figure here is a count of
     surfaced records, never a quality judgement.
+
+    Only snapshots collected under the same report limit are compared. Raising
+    the cap lifts every count at once, and presenting that as domain momentum
+    would report a change in collection policy as a change in the field.
     """
     cumulative: Counter[str] = Counter()
     for index, day in enumerate(days):
         counts = day["category_counts"]
-        previous = days[index - 1]["category_counts"] if index else {}
-        window = days[max(0, index - TREND_BASELINE_DAYS) : index]
+        limit = (day.get("selection") or {}).get("report_limit")
+        comparable = [
+            entry
+            for entry in days[max(0, index - TREND_BASELINE_DAYS) : index]
+            if (entry.get("selection") or {}).get("report_limit") == limit
+        ]
+        prior_day = days[index - 1] if index else None
+        if (
+            prior_day is not None
+            and (prior_day.get("selection") or {}).get("report_limit") != limit
+        ):
+            prior_day = None
+        previous = prior_day["category_counts"] if prior_day else {}
         trends = {}
         for category in sorted({*counts, *previous}):
             count = counts.get(category, 0)
-            prior = previous.get(category, 0)
-            history = [entry["category_counts"].get(category, 0) for entry in window]
+            history = [entry["category_counts"].get(category, 0) for entry in comparable]
             baseline = round(sum(history) / len(history), 2) if history else None
+            prior = previous.get(category, 0) if prior_day else None
             trends[category] = {
                 "count": count,
                 "previous": prior,
-                "delta": count - prior,
+                "delta": None if prior is None else count - prior,
                 "baseline": baseline,
                 # Momentum compares today with its own recent average, so a
                 # category is judged against its normal volume, not the corpus.
@@ -323,6 +338,7 @@ def _attach_category_trends(days: list[dict[str, Any]]) -> None:
                     round((count - baseline) / baseline, 2) if baseline not in (None, 0) else None
                 ),
                 "cumulative": cumulative[category] + count,
+                "comparable": prior_day is not None,
             }
         cumulative.update(counts)
         day["category_trends"] = trends

--- a/src/benchmark_radar/snapshots.py
+++ b/src/benchmark_radar/snapshots.py
@@ -304,10 +304,22 @@ def _attach_category_trends(days: list[dict[str, Any]]) -> None:
     Only snapshots collected under the same report limit are compared. Raising
     the cap lifts every count at once, and presenting that as domain momentum
     would report a change in collection policy as a change in the field.
+
+    Cumulative figures count distinct artifacts, not sightings. The scan window
+    overlaps by design and only arXiv suppresses repeats, so summing daily
+    counts would re-count the same repository every day it stayed in range and
+    grow steadily while nothing new was found.
     """
-    cumulative: Counter[str] = Counter()
+    seen: dict[str, set[str]] = {}
+    seen_any: set[str] = set()
     for index, day in enumerate(days):
         counts = day["category_counts"]
+        for record in day["evidence_items"]:
+            identity = f"{record['source']}:{record['source_id']}".lower()
+            seen_any.add(identity)
+            for category in record["categories"]:
+                seen.setdefault(category, set()).add(identity)
+        cumulative = Counter({category: len(ids) for category, ids in seen.items()})
         limit = (day.get("selection") or {}).get("report_limit")
         comparable = [
             entry
@@ -337,15 +349,14 @@ def _attach_category_trends(days: list[dict[str, Any]]) -> None:
                 "momentum": (
                     round((count - baseline) / baseline, 2) if baseline not in (None, 0) else None
                 ),
-                "cumulative": cumulative[category] + count,
+                # Distinct artifacts seen in this category up to and including
+                # today, so a repository lingering in the window counts once.
+                "cumulative": cumulative[category],
                 "comparable": prior_day is not None,
             }
-        cumulative.update(counts)
         day["category_trends"] = trends
         day["cumulative_category_counts"] = dict(sorted(cumulative.items()))
-        day["cumulative_evidence_count"] = sum(
-            entry["evidence_count"] for entry in days[: index + 1]
-        )
+        day["cumulative_evidence_count"] = len(seen_any)
 
 
 def dashboard_data(snapshots: list[dict[str, Any]]) -> dict[str, Any]:

--- a/src/benchmark_radar/snapshots.py
+++ b/src/benchmark_radar/snapshots.py
@@ -36,6 +36,7 @@ def snapshot_for_run(run: RadarRun) -> dict[str, Any]:
             health.to_dict() for health in [*run.health, *run.attention_ingest_health]
         ],
         "producer_health": [health.to_dict() for health in run.producer_health],
+        "selection": run.selection,
         "discovery_state": run.discovery_state,
     }
 
@@ -230,6 +231,9 @@ def validate_snapshot(snapshot: dict[str, Any], *, source: str = "snapshot") -> 
     _validate_health(snapshot["producer_health"], source=source, field="producer_health")
     if not isinstance(snapshot["discovery_state"], dict):
         raise SnapshotError(f"{source}: discovery_state must be an object")
+    # Optional: snapshots written before per-stage counts were tracked stay valid.
+    if "selection" in snapshot and not isinstance(snapshot["selection"], dict):
+        raise SnapshotError(f"{source}: selection must be an object")
 
 
 def normalize_snapshot(snapshot: dict[str, Any], *, source: str = "snapshot") -> dict[str, Any]:
@@ -287,6 +291,47 @@ def load_snapshots(snapshot_dir: Path) -> list[dict[str, Any]]:
     return snapshots
 
 
+TREND_BASELINE_DAYS = 7
+
+
+def _attach_category_trends(days: list[dict[str, Any]]) -> None:
+    """Add per-category deltas, baselines and cumulative totals to each day.
+
+    "How many benchmarks landed today" is only half the question; the other
+    half is which domain moved and by how much. Every figure here is a count of
+    surfaced records, never a quality judgement.
+    """
+    cumulative: Counter[str] = Counter()
+    for index, day in enumerate(days):
+        counts = day["category_counts"]
+        previous = days[index - 1]["category_counts"] if index else {}
+        window = days[max(0, index - TREND_BASELINE_DAYS) : index]
+        trends = {}
+        for category in sorted({*counts, *previous}):
+            count = counts.get(category, 0)
+            prior = previous.get(category, 0)
+            history = [entry["category_counts"].get(category, 0) for entry in window]
+            baseline = round(sum(history) / len(history), 2) if history else None
+            trends[category] = {
+                "count": count,
+                "previous": prior,
+                "delta": count - prior,
+                "baseline": baseline,
+                # Momentum compares today with its own recent average, so a
+                # category is judged against its normal volume, not the corpus.
+                "momentum": (
+                    round((count - baseline) / baseline, 2) if baseline not in (None, 0) else None
+                ),
+                "cumulative": cumulative[category] + count,
+            }
+        cumulative.update(counts)
+        day["category_trends"] = trends
+        day["cumulative_category_counts"] = dict(sorted(cumulative.items()))
+        day["cumulative_evidence_count"] = sum(
+            entry["evidence_count"] for entry in days[: index + 1]
+        )
+
+
 def dashboard_data(snapshots: list[dict[str, Any]]) -> dict[str, Any]:
     days: list[dict[str, Any]] = []
     categories: set[str] = set()
@@ -333,8 +378,10 @@ def dashboard_data(snapshots: list[dict[str, Any]]) -> dict[str, Any]:
                 },
                 "ingest_health": snapshot["ingest_health"],
                 "producer_health": snapshot["producer_health"],
+                "selection": snapshot.get("selection") or {},
             }
         )
+    _attach_category_trends(days)
     return {
         "schema_version": SCHEMA_VERSION,
         "latest_date": days[-1]["date"] if days else None,

--- a/src/benchmark_radar/sources.py
+++ b/src/benchmark_radar/sources.py
@@ -229,8 +229,21 @@ def fetch_github(config: dict[str, Any], since: datetime, limit: int) -> list[Ra
     # until the query is exhausted or the per-source limit is reached.
     page_size = 100
     max_pages = max(1, -(-limit // page_size))
-    for query in config.get("queries", []):
+    # Search is rate-limited to 10 requests/minute unauthenticated and 30
+    # authenticated. Paging every query to exhaustion can exceed that and
+    # trip a 403, which fails a required source and aborts the whole run, so
+    # bound the total requests and space them out when running tokenless.
+    queries = list(config.get("queries", []))
+    budget = int(config.get("max_requests", 30 if token else 8))
+    delay = float(config.get("request_delay_seconds", 0 if token else 6.5))
+    requests_made = 0
+    for query in queries:
         for page in range(1, max_pages + 1):
+            if requests_made >= budget:
+                break
+            if requests_made and delay > 0:
+                time.sleep(delay)
+            requests_made += 1
             payload = get_json(
                 "https://api.github.com/search/repositories",
                 params={
@@ -262,8 +275,10 @@ def fetch_github(config: dict[str, Any], since: datetime, limit: int) -> list[Ra
                     },
                     raw=row,
                 )
-            if len(rows) < min(limit, page_size):
+            if len(rows) < min(limit, page_size) or len(found) >= limit:
                 break
+        if requests_made >= budget or len(found) >= limit:
+            break
     return list(found.values())
 
 

--- a/src/benchmark_radar/sources.py
+++ b/src/benchmark_radar/sources.py
@@ -190,6 +190,8 @@ def fetch_huggingface(config: dict[str, Any], since: datetime, limit: int) -> li
                     "full": "true",
                 },
             )
+            if not isinstance(rows, list):
+                continue
             for row in rows:
                 changed = _date(row.get("lastModified") or row.get("createdAt"))
                 if changed < since:
@@ -222,36 +224,46 @@ def fetch_github(config: dict[str, Any], since: datetime, limit: int) -> list[Ra
     headers = {"Authorization": f"Bearer {token}"} if token else {}
     found: dict[str, RadarItem] = {}
     date_filter = since.date().isoformat()
+    # The search API returns at most 100 rows per request, so a bare
+    # `per_page=limit` silently truncates any query that matches more. Page
+    # until the query is exhausted or the per-source limit is reached.
+    page_size = 100
+    max_pages = max(1, -(-limit // page_size))
     for query in config.get("queries", []):
-        payload = get_json(
-            "https://api.github.com/search/repositories",
-            params={
-                "q": f"{query} pushed:>={date_filter}",
-                "sort": "updated",
-                "order": "desc",
-                "per_page": min(limit, 100),
-            },
-            headers=headers,
-        )
-        for row in payload.get("items", []):
-            changed = _date(row.get("pushed_at") or row.get("updated_at"))
-            if changed < since:
-                continue
-            full_name = row["full_name"]
-            found[full_name] = RadarItem(
-                source="GitHub",
-                source_id=full_name,
-                title=full_name,
-                url=row["html_url"],
-                published_at=changed,
-                summary=github_summary(row),
-                event_kind=("released" if _date(row.get("created_at")) >= since else "updated"),
-                metrics={
-                    "stars": float(row.get("stargazers_count") or 0),
-                    "forks": float(row.get("forks_count") or 0),
+        for page in range(1, max_pages + 1):
+            payload = get_json(
+                "https://api.github.com/search/repositories",
+                params={
+                    "q": f"{query} pushed:>={date_filter}",
+                    "sort": "updated",
+                    "order": "desc",
+                    "per_page": min(limit, page_size),
+                    "page": page,
                 },
-                raw=row,
+                headers=headers,
             )
+            rows = payload.get("items", [])
+            for row in rows:
+                changed = _date(row.get("pushed_at") or row.get("updated_at"))
+                if changed < since:
+                    continue
+                full_name = row["full_name"]
+                found[full_name] = RadarItem(
+                    source="GitHub",
+                    source_id=full_name,
+                    title=full_name,
+                    url=row["html_url"],
+                    published_at=changed,
+                    summary=github_summary(row),
+                    event_kind=("released" if _date(row.get("created_at")) >= since else "updated"),
+                    metrics={
+                        "stars": float(row.get("stargazers_count") or 0),
+                        "forks": float(row.get("forks_count") or 0),
+                    },
+                    raw=row,
+                )
+            if len(rows) < min(limit, page_size):
+                break
     return list(found.values())
 
 

--- a/src/benchmark_radar/sources.py
+++ b/src/benchmark_radar/sources.py
@@ -237,10 +237,17 @@ def fetch_github(config: dict[str, Any], since: datetime, limit: int) -> list[Ra
     budget = int(config.get("max_requests", 30 if token else 8))
     delay = float(config.get("request_delay_seconds", 0 if token else 6.5))
     requests_made = 0
-    for query in queries:
-        for page in range(1, max_pages + 1):
-            if requests_made >= budget:
-                break
+    # Page round-robin rather than query-by-query. Draining the first query to
+    # the source limit would spend the whole budget on it and never issue the
+    # evaluation, dataset and contamination searches at all, quietly dropping
+    # entire topics from the scan.
+    exhausted: set[int] = set()
+    for page in range(1, max_pages + 1):
+        if len(exhausted) == len(queries):
+            break
+        for index, query in enumerate(queries):
+            if index in exhausted or requests_made >= budget:
+                continue
             if requests_made and delay > 0:
                 time.sleep(delay)
             requests_made += 1
@@ -275,9 +282,9 @@ def fetch_github(config: dict[str, Any], since: datetime, limit: int) -> list[Ra
                     },
                     raw=row,
                 )
-            if len(rows) < min(limit, page_size) or len(found) >= limit:
-                break
-        if requests_made >= budget or len(found) >= limit:
+            if len(rows) < min(limit, page_size):
+                exhausted.add(index)
+        if requests_made >= budget:
             break
     return list(found.values())
 

--- a/src/benchmark_radar/sources.py
+++ b/src/benchmark_radar/sources.py
@@ -286,7 +286,10 @@ def fetch_github(config: dict[str, Any], since: datetime, limit: int) -> list[Ra
                 exhausted.add(index)
         if requests_made >= budget:
             break
-    return list(found.values())
+    # Round-robin can overshoot the per-source cap on its final sweep, since
+    # every query contributes before the total is known. Trim to the most
+    # recently active repositories so `max_items_per_source` stays honest.
+    return sorted(found.values(), key=lambda item: item.published_at, reverse=True)[:limit]
 
 
 def fetch_openalex(config: dict[str, Any], since: datetime, limit: int) -> list[RadarItem]:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -197,6 +197,69 @@ def test_selection_counts_expose_the_published_gap(monkeypatch):
     assert len(run.items) == 2
 
 
+def test_funnel_counts_suppressed_arxiv_records_as_fetched(monkeypatch):
+    # Source health counts these as fetched, so the funnel must agree rather
+    # than reporting zero for a source that plainly returned records.
+    seen = item(source_id="2607.12345", updated_at=datetime(2026, 7, 26, 18, tzinfo=UTC))
+    monkeypatch.setitem(
+        __import__("benchmark_radar.pipeline", fromlist=["SOURCE_FETCHERS"]).SOURCE_FETCHERS,
+        "arxiv",
+        lambda config, since, limit: [seen],
+    )
+    config = {
+        "radar": {
+            "lookback_hours": 48,
+            "max_items_per_source": 10,
+            "report_limit": 10,
+            "minimum_score": 0,
+        },
+        "taxonomy": {"benchmark": ["benchmark"]},
+        "sources": {"arxiv": {"enabled": True, "required": True}},
+    }
+    previous = {
+        "discovery_state": {
+            "arxiv": {
+                "2607.12345": {
+                    "discovered_at": "2026-07-26T19:00:00+00:00",
+                    "last_activity_at": "2026-07-26T18:00:00+00:00",
+                }
+            }
+        }
+    }
+
+    run = run_pipeline(config, datetime(2026, 7, 27, tzinfo=UTC), previous_snapshot=previous)
+
+    assert run.items == []
+    assert run.health[0].item_count == 1
+    assert run.selection["fetched"] == 1
+    assert run.selection["suppressed_as_seen"] == 1
+
+
+def test_funnel_names_watchlist_bypasses_separately(monkeypatch):
+    tracked = item(title="mlebench release", summary="", source="GitHub", source_id="o/mlebench")
+    monkeypatch.setitem(
+        __import__("benchmark_radar.pipeline", fromlist=["SOURCE_FETCHERS"]).SOURCE_FETCHERS,
+        "github",
+        lambda config, since, limit: [tracked],
+    )
+    config = {
+        "radar": {
+            "lookback_hours": 48,
+            "max_items_per_source": 10,
+            "report_limit": 10,
+            "minimum_score": 99,
+        },
+        "taxonomy": {"benchmark": ["benchmark"]},
+        "sources": {"github": {"enabled": True, "required": True}},
+        "watchlist": WATCHLIST,
+    }
+
+    run = run_pipeline(config, datetime(2026, 7, 27, tzinfo=UTC))
+
+    assert run.selection["qualified"] == 1
+    assert run.selection["watchlisted"] == 1
+
+
 def test_every_required_source_must_return_records(monkeypatch):
     def empty_fetcher(config, since, limit):
         return []

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -4,6 +4,7 @@ import pytest
 
 from benchmark_radar.models import RadarItem
 from benchmark_radar.pipeline import (
+    apply_watchlist,
     assert_no_boilerplate_summaries,
     canonical_url,
     deduplicate,
@@ -11,6 +12,11 @@ from benchmark_radar.pipeline import (
     run_pipeline,
     score_item,
 )
+
+WATCHLIST = [
+    {"name": "MLE-bench", "aliases": ["mlebench", "mle-bench"], "note": "ML engineering tasks."},
+    {"name": "PaperBench", "aliases": ["paperbench"], "note": "Paper replication."},
+]
 
 
 def item(**overrides):
@@ -86,6 +92,109 @@ def test_boilerplate_summary_cannot_earn_relevance():
         datetime(2026, 7, 27, 1, tzinfo=UTC),
     )
     assert "dataset" not in bare.categories
+
+
+def test_watchlist_matches_aliases_across_fields():
+    by_title = item(title="PaperBench: replicating research")
+    by_source_id = item(source="GitHub", source_id="openai/mle-bench", title="openai/mle-bench")
+    unrelated = item(title="An unrelated corpus release")
+
+    tagged = apply_watchlist([by_title, by_source_id, unrelated], WATCHLIST)
+
+    assert [record.watchlist for record in tagged] == ["PaperBench", "MLE-bench", None]
+    assert tagged[0].watchlist_note == "Paper replication."
+    assert "Watchlist: PaperBench" in tagged[0].rationale
+
+
+def test_watchlist_ignores_passing_mentions_in_the_summary():
+    # A watchlisted name inside an abstract is related work, not a release.
+    mention = item(
+        title="A survey of agent evaluation practice",
+        summary="We compare against PaperBench and other suites.",
+    )
+
+    assert apply_watchlist([mention], WATCHLIST)[0].watchlist is None
+
+
+def test_watchlist_matches_on_word_boundaries_and_separators():
+    spaced = item(title="MLE bench results", source_id="a/b")
+    underscored = item(title="mle_bench harness", source_id="a/c")
+    embedded = item(title="Nonmlebenchmarking of models", source_id="a/d")
+
+    tagged = apply_watchlist([spaced, underscored, embedded], WATCHLIST)
+
+    assert [record.watchlist for record in tagged] == ["MLE-bench", "MLE-bench", None]
+
+
+def test_watchlist_does_not_alter_scores():
+    taxonomy = {"benchmark": ["benchmark"]}
+    scored = score_item(item(title="PaperBench"), taxonomy, datetime(2026, 7, 27, tzinfo=UTC))
+    before = scored.total_score
+
+    apply_watchlist([scored], WATCHLIST)
+
+    assert scored.watchlist == "PaperBench"
+    assert scored.total_score == before
+
+
+def test_watchlist_record_publishes_below_threshold(monkeypatch):
+    # Named artifacts are published even when the generic score would drop them.
+    tracked = item(title="mlebench release", summary="", source="GitHub", source_id="o/mlebench")
+    monkeypatch.setitem(
+        __import__("benchmark_radar.pipeline", fromlist=["SOURCE_FETCHERS"]).SOURCE_FETCHERS,
+        "github",
+        lambda config, since, limit: [tracked],
+    )
+    config = {
+        "radar": {
+            "lookback_hours": 48,
+            "max_items_per_source": 10,
+            "report_limit": 10,
+            "minimum_score": 99,
+        },
+        "taxonomy": {"benchmark": ["benchmark"]},
+        "sources": {"github": {"enabled": True, "required": True}},
+        "watchlist": WATCHLIST,
+    }
+
+    run = run_pipeline(config, datetime(2026, 7, 27, tzinfo=UTC))
+
+    assert [record.watchlist for record in run.items] == ["MLE-bench"]
+
+
+def test_selection_counts_expose_the_published_gap(monkeypatch):
+    records = [
+        item(
+            source="GitHub",
+            source_id=f"org/repo{index}",
+            title=f"A distinct benchmark repository number {index}",
+            url=f"https://github.com/org/repo{index}",
+            summary=f"Benchmark suite number {index} for language model evaluation.",
+        )
+        for index in range(5)
+    ]
+    monkeypatch.setitem(
+        __import__("benchmark_radar.pipeline", fromlist=["SOURCE_FETCHERS"]).SOURCE_FETCHERS,
+        "github",
+        lambda config, since, limit: records,
+    )
+    config = {
+        "radar": {
+            "lookback_hours": 48,
+            "max_items_per_source": 10,
+            "report_limit": 2,
+            "minimum_score": 0,
+        },
+        "taxonomy": {"benchmark": ["benchmark"]},
+        "sources": {"github": {"enabled": True, "required": True}},
+    }
+
+    run = run_pipeline(config, datetime(2026, 7, 27, tzinfo=UTC))
+
+    assert run.selection["fetched"] == 5
+    assert run.selection["qualified"] == 5
+    assert run.selection["published"] == 2
+    assert len(run.items) == 2
 
 
 def test_every_required_source_must_return_records(monkeypatch):

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -31,6 +31,65 @@ def test_report_contains_evidence_and_health():
     assert "Source health" in report
 
 
+def _record(index: int, **overrides) -> RadarItem:
+    values = {
+        "source": "GitHub",
+        "source_id": f"org/repo{index}",
+        "title": f"Benchmark suite {index}",
+        "url": f"https://github.com/org/repo{index}",
+        "published_at": datetime(2026, 7, 27, tzinfo=UTC),
+        "categories": ["benchmark"],
+        "total_score": 3.0,
+    }
+    values.update(overrides)
+    return RadarItem(**values)
+
+
+def _run(items) -> RadarRun:
+    return RadarRun(
+        generated_at=datetime(2026, 7, 27, tzinfo=UTC),
+        since=datetime(2026, 7, 25, tzinfo=UTC),
+        items=items,
+        health=[],
+    )
+
+
+def test_report_leads_with_watchlist_hits():
+    tracked = _record(1, watchlist="MLE-bench", watchlist_note="ML engineering tasks.")
+
+    report = render_markdown(_run([tracked, _record(2)]))
+
+    assert "## Watchlist" in report
+    assert "**MLE-bench**" in report
+    assert "ML engineering tasks." in report
+
+
+def test_report_truncates_the_issue_but_states_the_true_total():
+    records = [_record(index) for index in range(10)]
+
+    report = render_markdown(_run(records), issue_item_limit=3)
+
+    assert "## Today's signals (top 3 of 10)" in report
+    assert "7 further ranked records" in report
+    assert "Benchmark suite 9" not in report
+
+
+def test_report_shows_the_selection_funnel():
+    run = _run([_record(1)])
+    run.selection = {
+        "fetched": 316,
+        "deduplicated": 300,
+        "qualified": 120,
+        "published": 30,
+        "minimum_score": 2.0,
+    }
+
+    report = render_markdown(run)
+
+    assert "**316** fetched" in report
+    assert "**30** published" in report
+
+
 def test_report_links_to_date_filtered_dashboard():
     run = RadarRun(
         generated_at=datetime(2026, 7, 27, tzinfo=UTC),

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -90,6 +90,17 @@ def test_report_shows_the_selection_funnel():
     assert "**30** published" in report
 
 
+def test_funnel_excludes_watchlist_bypasses_from_the_threshold_count():
+    # A lone bypass must not read as "1 qualified (at or above 99)": nothing
+    # met the threshold, so the two counts are reported separately.
+    run = _run([_record(1, watchlist="MLE-bench")])
+    run.selection = {"fetched": 5, "qualified": 1, "watchlisted": 1, "minimum_score": 99}
+
+    report = render_markdown(run)
+
+    assert "**1** qualified (0 at or above 99, 1 by watchlist)" in report
+
+
 def test_report_links_to_date_filtered_dashboard():
     run = RadarRun(
         generated_at=datetime(2026, 7, 27, tzinfo=UTC),

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -150,13 +150,49 @@ def test_dashboard_reports_per_category_deltas_and_cumulative(tmp_path):
 
     first, second = data["days"]
     assert first["category_trends"]["benchmark"]["count"] == 1
-    assert first["category_trends"]["benchmark"]["delta"] == 1
+    # Nothing precedes the first scan, so no change is claimed.
+    assert first["category_trends"]["benchmark"]["delta"] is None
     assert first["category_trends"]["benchmark"]["baseline"] is None
     # Day two matches day one, so the domain is flat but the total accumulates.
     assert second["category_trends"]["benchmark"]["delta"] == 0
     assert second["category_trends"]["benchmark"]["baseline"] == 1.0
     assert second["category_trends"]["benchmark"]["cumulative"] == 2
     assert second["cumulative_evidence_count"] == 2
+
+
+def test_trends_do_not_compare_across_a_report_limit_change(tmp_path):
+    # Raising the cap lifts every count at once. Reporting that as domain
+    # momentum would present a collection-policy change as a change in field.
+    snapshot_dir = tmp_path / "snapshots"
+    narrow = radar_run(26)
+    narrow.selection = {"report_limit": 30}
+    wide = radar_run(27)
+    wide.selection = {"report_limit": 300}
+    write_snapshot(narrow, snapshot_dir)
+    write_snapshot(wide, snapshot_dir)
+
+    data = rebuild_dashboard(snapshot_dir, tmp_path / "radar.json")
+
+    after = data["days"][1]["category_trends"]["benchmark"]
+    assert after["delta"] is None
+    assert after["baseline"] is None
+    assert after["comparable"] is False
+    # Cumulative totals still accrue: they describe the corpus, not a rate.
+    assert after["cumulative"] == 2
+
+
+def test_trends_compare_snapshots_sharing_a_report_limit(tmp_path):
+    snapshot_dir = tmp_path / "snapshots"
+    for day in (26, 27):
+        run = radar_run(day)
+        run.selection = {"report_limit": 300}
+        write_snapshot(run, snapshot_dir)
+
+    data = rebuild_dashboard(snapshot_dir, tmp_path / "radar.json")
+
+    after = data["days"][1]["category_trends"]["benchmark"]
+    assert after["delta"] == 0
+    assert after["comparable"] is True
 
 
 def test_selection_counts_round_trip_through_the_snapshot(tmp_path):

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -141,6 +141,43 @@ def test_rebuild_is_deterministic(tmp_path):
     assert first["days"][0]["attention"]["active_count"] == 1
 
 
+def test_dashboard_reports_per_category_deltas_and_cumulative(tmp_path):
+    snapshot_dir = tmp_path / "snapshots"
+    write_snapshot(radar_run(26), snapshot_dir)
+    write_snapshot(radar_run(27), snapshot_dir)
+
+    data = rebuild_dashboard(snapshot_dir, tmp_path / "radar.json")
+
+    first, second = data["days"]
+    assert first["category_trends"]["benchmark"]["count"] == 1
+    assert first["category_trends"]["benchmark"]["delta"] == 1
+    assert first["category_trends"]["benchmark"]["baseline"] is None
+    # Day two matches day one, so the domain is flat but the total accumulates.
+    assert second["category_trends"]["benchmark"]["delta"] == 0
+    assert second["category_trends"]["benchmark"]["baseline"] == 1.0
+    assert second["category_trends"]["benchmark"]["cumulative"] == 2
+    assert second["cumulative_evidence_count"] == 2
+
+
+def test_selection_counts_round_trip_through_the_snapshot(tmp_path):
+    run = radar_run(27)
+    run.selection = {"fetched": 300, "published": 30, "minimum_score": 2.0}
+
+    snapshot = snapshot_for_run(run)
+    validate_snapshot(snapshot)
+
+    write_snapshot(run, tmp_path / "snapshots")
+    data = rebuild_dashboard(tmp_path / "snapshots", tmp_path / "radar.json")
+    assert data["days"][-1]["selection"]["fetched"] == 300
+
+
+def test_snapshots_without_selection_stay_valid():
+    snapshot = snapshot_for_run(radar_run())
+    snapshot.pop("selection")
+
+    validate_snapshot(snapshot)
+
+
 def test_validation_rejects_missing_item_fields():
     snapshot = snapshot_for_run(radar_run())
     del snapshot["evidence_items"][0]["event_kind"]

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -160,6 +160,25 @@ def test_dashboard_reports_per_category_deltas_and_cumulative(tmp_path):
     assert second["cumulative_evidence_count"] == 2
 
 
+def test_cumulative_counts_artifacts_once_across_overlapping_windows(tmp_path):
+    # The scan window overlaps by design, so the same repository appears on
+    # adjacent days. Summing daily counts would grow the total while nothing
+    # new was actually discovered.
+    snapshot_dir = tmp_path / "snapshots"
+    for day in (26, 27):
+        run = radar_run(day)
+        # Same artifact identity on both days.
+        run.items[0].source_id = "2607.0001"
+        run.items[0].url = "https://arxiv.org/abs/2607.0001"
+        write_snapshot(run, snapshot_dir)
+
+    data = rebuild_dashboard(snapshot_dir, tmp_path / "radar.json")
+
+    second = data["days"][1]
+    assert second["category_trends"]["benchmark"]["cumulative"] == 1
+    assert second["cumulative_evidence_count"] == 1
+
+
 def test_trends_do_not_compare_across_a_report_limit_change(tmp_path):
     # Raising the cap lifts every count at once. Reporting that as domain
     # momentum would present a collection-policy change as a change in field.

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -210,3 +210,25 @@ def test_github_spaces_unauthenticated_requests(monkeypatch):
     )
 
     assert delays and all(delay > 0 for delay in delays)
+
+
+def test_github_pages_round_robin_so_no_query_is_skipped(monkeypatch):
+    # Draining the first query to the source limit spent the whole budget on
+    # it and never issued the other configured searches, dropping whole topics.
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setattr("benchmark_radar.sources.time.sleep", lambda seconds: None)
+    queried = []
+
+    def fake_get_json(url, params=None, headers=None):
+        queried.append(params["q"].split(" pushed")[0])
+        return {"items": [_github_row(offset) for offset in range(100)]}
+
+    monkeypatch.setattr("benchmark_radar.sources.get_json", fake_get_json)
+
+    fetch_github(
+        {"queries": ["alpha", "beta", "gamma"], "max_requests": 3},
+        datetime(2026, 7, 25, 12, tzinfo=UTC),
+        300,
+    )
+
+    assert sorted(queried) == ["alpha", "beta", "gamma"]

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -232,3 +232,28 @@ def test_github_pages_round_robin_so_no_query_is_skipped(monkeypatch):
     )
 
     assert sorted(queried) == ["alpha", "beta", "gamma"]
+
+
+def test_github_respects_the_per_source_limit_after_round_robin(monkeypatch):
+    # Every query contributes before the running total is known, so the final
+    # sweep can overshoot; the cap must still hold for the returned records.
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setattr("benchmark_radar.sources.time.sleep", lambda seconds: None)
+    monkeypatch.setattr(
+        "benchmark_radar.sources.get_json",
+        lambda url, params=None, headers=None: {
+            "items": [
+                # Unique across query and page so nothing dedupes away.
+                _github_row(ord(params["q"][0]) * 100_000 + params["page"] * 1000 + offset)
+                for offset in range(100)
+            ]
+        },
+    )
+
+    items = fetch_github(
+        {"queries": ["alpha", "beta", "gamma"], "max_requests": 9},
+        datetime(2026, 7, 25, 12, tzinfo=UTC),
+        150,
+    )
+
+    assert len(items) == 150

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,7 +1,7 @@
 from datetime import UTC, datetime
 from urllib.error import HTTPError
 
-from benchmark_radar.sources import fetch_arxiv
+from benchmark_radar.sources import fetch_arxiv, fetch_github
 
 ARXIV_XML = """\
 <feed xmlns="http://www.w3.org/2005/Atom">
@@ -109,3 +109,58 @@ def test_arxiv_can_use_official_rss_as_primary(monkeypatch):
     )
 
     assert [item.source_id for item in items] == ["2607.54321"]
+
+
+def _github_row(index: int) -> dict:
+    return {
+        "full_name": f"org/repo{index}",
+        "html_url": f"https://github.com/org/repo{index}",
+        "pushed_at": "2026-07-27T00:00:00Z",
+        "created_at": "2026-07-27T00:00:00Z",
+        "description": f"Benchmark suite {index}",
+        "stargazers_count": index,
+        "forks_count": 0,
+    }
+
+
+def test_github_pages_past_the_hundred_row_search_limit(monkeypatch):
+    # The search API caps a response at 100 rows, so a single request silently
+    # dropped everything beyond it whenever a query matched more.
+    requested_pages = []
+
+    def fake_get_json(url, params=None, headers=None):
+        requested_pages.append(params["page"])
+        start = (params["page"] - 1) * 100
+        if start >= 150:
+            return {"items": []}
+        return {"items": [_github_row(start + offset) for offset in range(min(100, 150 - start))]}
+
+    monkeypatch.setattr("benchmark_radar.sources.get_json", fake_get_json)
+
+    items = fetch_github(
+        {"queries": ["benchmark"]},
+        datetime(2026, 7, 25, 12, tzinfo=UTC),
+        300,
+    )
+
+    assert requested_pages == [1, 2]
+    assert len(items) == 150
+
+
+def test_github_stops_paging_once_a_page_is_short(monkeypatch):
+    calls = []
+
+    def fake_get_json(url, params=None, headers=None):
+        calls.append(params["page"])
+        return {"items": [_github_row(0)]}
+
+    monkeypatch.setattr("benchmark_radar.sources.get_json", fake_get_json)
+
+    items = fetch_github(
+        {"queries": ["benchmark"]},
+        datetime(2026, 7, 25, 12, tzinfo=UTC),
+        300,
+    )
+
+    assert calls == [1]
+    assert len(items) == 1

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -126,6 +126,7 @@ def _github_row(index: int) -> dict:
 def test_github_pages_past_the_hundred_row_search_limit(monkeypatch):
     # The search API caps a response at 100 rows, so a single request silently
     # dropped everything beyond it whenever a query matched more.
+    monkeypatch.setattr("benchmark_radar.sources.time.sleep", lambda seconds: None)
     requested_pages = []
 
     def fake_get_json(url, params=None, headers=None):
@@ -148,6 +149,7 @@ def test_github_pages_past_the_hundred_row_search_limit(monkeypatch):
 
 
 def test_github_stops_paging_once_a_page_is_short(monkeypatch):
+    monkeypatch.setattr("benchmark_radar.sources.time.sleep", lambda seconds: None)
     calls = []
 
     def fake_get_json(url, params=None, headers=None):
@@ -164,3 +166,47 @@ def test_github_stops_paging_once_a_page_is_short(monkeypatch):
 
     assert calls == [1]
     assert len(items) == 1
+
+
+def test_github_bounds_total_requests_when_unauthenticated(monkeypatch):
+    # Search allows ~10 requests/minute without a token. Paging every query to
+    # exhaustion tripped a 403, which fails a required source and aborts the run.
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setattr("benchmark_radar.sources.time.sleep", lambda seconds: None)
+    calls = []
+
+    def fake_get_json(url, params=None, headers=None):
+        calls.append(params["page"])
+        # Rows repeat across queries, so the per-source limit is never reached
+        # and only the request budget can stop the walk.
+        return {"items": [_github_row(offset) for offset in range(100)]}
+
+    monkeypatch.setattr("benchmark_radar.sources.get_json", fake_get_json)
+
+    fetch_github(
+        {"queries": ["a", "b", "c", "d"], "max_requests": 8},
+        datetime(2026, 7, 25, 12, tzinfo=UTC),
+        1000,
+    )
+
+    assert len(calls) == 8
+
+
+def test_github_spaces_unauthenticated_requests(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    delays = []
+    monkeypatch.setattr("benchmark_radar.sources.time.sleep", delays.append)
+    monkeypatch.setattr(
+        "benchmark_radar.sources.get_json",
+        lambda url, params=None, headers=None: {
+            "items": [_github_row(offset) for offset in range(100)]
+        },
+    )
+
+    fetch_github(
+        {"queries": ["a"], "max_requests": 3},
+        datetime(2026, 7, 25, 12, tzinfo=UTC),
+        300,
+    )
+
+    assert delays and all(delay > 0 for delay in delays)


### PR DESCRIPTION
Fixes the five open dashboard/pipeline issues, highest-impact first.

## Closes #26 — ~300 found, 30 published

Three independent limits were discarding records:

- GitHub search caps a response at 100 rows, but the fetcher sent one request with `per_page=limit`, so a query matching more was silently truncated (228 returned where the source held 917).
- `max_items_per_source: 60` cut each source again.
- `report_limit: 30` cut the result a third time.

`report_limit` (scored, snapshotted, published) is now separate from `issue_item_limit` (what fits in the Issue body), so the digest stays readable without throwing away the corpus. A truncated Issue states the true total and links the remainder to the dashboard.

Every run also persists its own funnel — `fetched → already seen → deduplicated → qualified → published` — so the gap between what a source returned and what shipped is auditable instead of looking like data loss. Live run: **1016 fetched → 346 qualified → 300 published**, versus 30 before.

## Closes #25 — remove verbose chrome

Dropped "Evidence log / UTC", the schema version, and the `3 nonempty · 1 empty · 2 failed` status. The header now states the date and record count, and mentions sources only when one actually failed.

## Closes #24 — clickable repo badges

Star, fork and issue badges in the masthead. The issue count comes from an issue-only search, since `open_issues_count` includes pull requests and would disagree with the page it links to. Counts are decorative: a rate-limited API leaves the links working.

## Closes #27 — per-domain quantitative metrics

New "New by domain" panel giving each category its count, change against the previous scan, its own recent daily average, momentum against that average, and a cumulative total of distinct artifacts. The trend line names the two biggest domain moves.

Two accuracy rules apply: comparisons only run between snapshots sharing a `report_limit` (raising the cap lifts every count at once, and reporting that as momentum would present a collection-policy change as a change in the field), and cumulative figures count distinct artifacts rather than sightings (the scan window overlaps, so summing daily counts grew the total while nothing new was found).

## Closes #23 — priority watchlist

A config `watchlist` pins named artifacts (PaperBench, MLE-bench, MLE-Marathon, PostRainBench, Long-Horizon Bench). A hit is routed to the top of the digest and dashboard and labelled with a one-line TL;DR.

Matching is on title and source id by word boundary, and never touches a score, so the ranking stays explainable. Both constraints came from testing: substring matching on the summary made "long horizon" pin 13 unrelated agent papers, since a name in an abstract is related work rather than a release.

## Rate limits

Paging every query to exhaustion could issue 12 back-to-back requests against a 10/minute unauthenticated quota; a 403 there fails a required source and aborts the run, and the README documents `GITHUB_TOKEN` as optional. Requests are now bounded by `max_requests`, spaced by `request_delay_seconds` (both defaulting on whether a token is present), and paged round-robin so a broad first query cannot consume the budget and skip the evaluation, dataset and contamination searches entirely.

## Test plan

- `pytest` — 65 passing, up from 41. New coverage for pagination, the request budget, round-robin fairness, the per-source cap, watchlist precision (including the negative cases), funnel counts, and trend comparability.
- `ruff check` and `ruff format --check` clean.
- Live pipeline run against the real arXiv/HF/GitHub APIs: 300 published across all three sources, funnel intact, zero watchlist false positives.
- Dashboard reviewed in a real browser (Today and Trends) at each stage.
- Regenerated scan data is deliberately excluded so this PR is code only.

Four rounds of Codex review at high reasoning effort were applied and fixed (one P1 rate-limit issue, one P1 coverage regression, and eight P2/P3 count-accuracy issues). A fifth pass was unavailable because the Codex account hit its usage limit, so the last round is self-review; the round-robin ordering and cumulative-dedupe edge cases were verified by direct execution rather than inspection alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)