### PR TITLE
Resolve scoring, dashboard, corpus, and source coverage gaps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,6 @@
 GITHUB_TOKEN=
 
 # Optional enrichment sources.
+SEMANTIC_SCHOLAR_API_KEY=
 OPENALEX_API_KEY=
 BRAVE_API_KEY=
-

--- a/.github/workflows/daily-radar.yml
+++ b/.github/workflows/daily-radar.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Collect and render
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          SEMANTIC_SCHOLAR_API_KEY: ${{ secrets.SEMANTIC_SCHOLAR_API_KEY }}
           OPENALEX_API_KEY: ${{ secrets.OPENALEX_API_KEY }}
           BRAVE_API_KEY: ${{ secrets.BRAVE_API_KEY }}
         run: benchmark-radar

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,6 +7,7 @@ on:
       - "data/snapshots/**"
       - "site/**"
       - "src/benchmark_radar/snapshots.py"
+      - "src/benchmark_radar/corpus.py"
       - ".github/workflows/pages.yml"
   workflow_dispatch:
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,11 @@ Default sources:
 | Source | Required secret | Role |
 |---|---|---|
 | arXiv | No | Primary paper discovery |
+| OpenReview | No | Primary conference and workshop submissions |
 | Hugging Face Hub | No | Dataset repository discovery |
 | GitHub | No in Actions | Code and artifact discovery |
+| GitHub Releases | No in Actions | Curated first-party release discovery |
+| Semantic Scholar | Optional `SEMANTIC_SCHOLAR_API_KEY` | Structured scholarly discovery |
 | OpenAlex | `OPENALEX_API_KEY` | Scholarly metadata enrichment |
 | Brave Search | `BRAVE_API_KEY` | Web and lab-blog discovery |
 
@@ -139,6 +142,7 @@ a score, so the ranking stays explainable.
 Optional repository secrets:
 
 ```text
+SEMANTIC_SCHOLAR_API_KEY
 OPENALEX_API_KEY
 BRAVE_API_KEY
 ```
@@ -172,6 +176,10 @@ must exist; they are created during initial repository setup.
 ## Provenance and limitations
 
 - Every entry links to its discovered primary or structured record.
+- Connector summaries quote upstream abstracts, cards, descriptions, or release
+  notes; a missing upstream description stays empty rather than being synthesized.
+- Evidence records persist retrieval time, parser version, and a SHA-256 raw-payload
+  fingerprint while omitting the raw response itself from public snapshots.
 - Optional-source failures are visible.
 - Persisted snapshots omit raw API payloads and credentials.
 - Public attention feeds are displayed separately and never contribute to quality scores.

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ Each item receives four visible scores:
 - **Recency**: time since publication or material update
 - **Adoption**: logarithmically scaled stars, downloads, likes, or citations
 
-The default priority is:
+The default priority is reported on a 0–100 scale:
 
 ```text
-0.40 relevance + 0.25 evidence + 0.20 recency + 0.15 adoption
+0.35 relevance + 0.20 evidence + 0.20 recency + 0.25 adoption
 ```
 
 The weights, per-component bands, and stated limits live in
@@ -50,6 +50,10 @@ The weights, per-component bands, and stated limits live in
 `site/data/radar.json`, so the rubric the dashboard shows is read from the same definition
 the pipeline applies. Every priority score on the dashboard is clickable: it opens the
 rubric with that record's own component scores worked through the weighted sum.
+Recency uses the full configured lookback window, and narrowly defined negative
+signals demote follower-count leaderboards, result indexes, submission placeholders,
+and visualization-only companions. The latter three are suppressed from the daily list;
+the selection funnel reports the count, and every scored deduction remains auditable.
 
 This is triage, not scientific quality adjudication or endorsement.
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ Outputs:
 - `out/report.md`: the exact GitHub Issue body
 - `out/items.json`: machine-readable evidence and source-health snapshot
 - `data/snapshots/YYYY-MM-DD.json`: versioned, idempotent UTC snapshot
-- `site/data/radar.json`: deterministic browser-ready history generated for deployment
+- `site/data/radar.json`: deterministic browser-ready history, cumulative entity graph,
+  observations, edges, and precomputed aggregates generated for deployment
 
 Validated snapshots are the canonical corpus and live on `main` beside the code and
 schema that interpret them. A dedicated snapshot-writer GitHub App may append only
@@ -83,6 +84,19 @@ Rebuild the dashboard data without collecting again:
 ```bash
 benchmark-radar rebuild
 ```
+
+`benchmark-radar backfill` is the explicit corpus-replay alias. It validates every
+snapshot, resolves entities from exact identifiers (DOI, arXiv, OpenReview, GitHub,
+and Hugging Face), and deterministically regenerates the same entity/observation/edge
+graph and aggregates under the
+[versioned public schema](docs/cumulative-corpus.schema.json). No fuzzy match silently
+merges similarly titled artifacts.
+
+The dashboard exposes one filterable Today list, inline multi-record expansion, Trends,
+and a keyboard-accessible Trend Map. Selecting a map node carries its exact topic,
+source, organization, or artifact into the Today filters. Trend comparisons require
+both the same report limit and the same connector-coverage signature; incomplete days
+remain visible and are explicitly annotated.
 
 Run checks:
 

--- a/config.yml
+++ b/config.yml
@@ -8,7 +8,9 @@ radar:
   # scored record, and only the Markdown digest is truncated to this many.
   report_limit: 300
   issue_item_limit: 40
-  minimum_score: 2.0
+  # Rubric v2 uses an explainable 0-100 scale. Forty keeps multi-signal
+  # releases while explicit low-value patterns fall below the cutoff.
+  minimum_score: 40
 
 taxonomy:
   benchmark:

--- a/config.yml
+++ b/config.yml
@@ -111,6 +111,46 @@ sources:
       - '"benchmark dataset" in:name,description,readme'
       - '"data contamination" in:name,description,readme'
 
+  openreview:
+    enabled: true
+    venues:
+      - ICLR.cc/2026/Conference
+      - NeurIPS.cc/2026/Conference
+      - ICML.cc/2026/Conference
+      - ACLweb.org/ACL/2026/Conference
+    page_size: 250
+    max_requests: 4
+    attempts: 3
+    timeout_seconds: 30
+
+  semantic_scholar:
+    enabled: true
+    searches:
+      - large language model benchmark
+      - artificial intelligence evaluation dataset
+      - data contamination benchmark
+    page_size: 100
+    max_requests: 3
+    attempts: 3
+    timeout_seconds: 30
+
+  github_releases:
+    enabled: true
+    repositories:
+      - stanford-crfm/helm
+      - EleutherAI/lm-evaluation-harness
+      - LiveBench/LiveBench
+      - princeton-nlp/SWE-bench
+      - evalplus/evalplus
+      - openai/evals
+      - mlcommons/inference
+      - ARCPrize/ARC-AGI
+    page_size: 30
+    max_pages_per_repository: 1
+    max_requests: 8
+    attempts: 3
+    timeout_seconds: 30
+
   openalex:
     enabled: true
     searches:

--- a/docs/cumulative-corpus.schema.json
+++ b/docs/cumulative-corpus.schema.json
@@ -43,7 +43,9 @@
           "sources",
           "categories",
           "metrics",
-          "metric_deltas"
+          "metric_deltas",
+          "parser_versions",
+          "raw_payload_hashes"
         ],
         "properties": {
           "id": {
@@ -110,6 +112,21 @@
             "additionalProperties": {
               "type": "number"
             }
+          },
+          "parser_versions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "uniqueItems": true
+          },
+          "raw_payload_hashes": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^sha256:[0-9a-f]{64}$"
+            },
+            "uniqueItems": true
           }
         }
       }
@@ -127,6 +144,9 @@
           "event_kind",
           "url",
           "published_at",
+          "retrieved_at",
+          "parser_version",
+          "raw_payload_hash",
           "categories",
           "organizations",
           "metrics"

--- a/docs/cumulative-corpus.schema.json
+++ b/docs/cumulative-corpus.schema.json
@@ -1,0 +1,173 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ktwu01.github.io/benchmark-radar/cumulative-corpus.schema.json",
+  "title": "Benchmark Radar cumulative corpus",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "entity_count",
+    "observation_count",
+    "edge_count",
+    "entities",
+    "observations",
+    "edges",
+    "aggregates"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "entity_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "observation_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "edge_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "entities": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "label",
+          "first_seen_at",
+          "last_seen_at",
+          "seen_days",
+          "sources",
+          "categories",
+          "metrics",
+          "metric_deltas"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "type": {
+            "enum": [
+              "artifact",
+              "topic",
+              "organization",
+              "person",
+              "source"
+            ]
+          },
+          "label": {
+            "type": "string"
+          },
+          "url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uri"
+          },
+          "first_seen_at": {
+            "type": "string",
+            "format": "date"
+          },
+          "last_seen_at": {
+            "type": "string",
+            "format": "date"
+          },
+          "seen_days": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "date"
+            },
+            "uniqueItems": true
+          },
+          "sources": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "uniqueItems": true
+          },
+          "categories": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "uniqueItems": true
+          },
+          "metrics": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "number"
+            }
+          },
+          "metric_deltas": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "number"
+            }
+          }
+        }
+      }
+    },
+    "observations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "entity_id",
+          "snapshot_date",
+          "source",
+          "source_id",
+          "event_kind",
+          "url",
+          "published_at",
+          "categories",
+          "organizations",
+          "metrics"
+        ]
+      }
+    },
+    "edges": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "source",
+          "target",
+          "first_seen_at",
+          "last_seen_at",
+          "seen_days"
+        ],
+        "properties": {
+          "type": {
+            "enum": [
+              "AUTHORED_BY",
+              "RELEASED_BY",
+              "HAS_TOPIC",
+              "FOUND_VIA"
+            ]
+          }
+        }
+      }
+    },
+    "aggregates": {
+      "type": "object",
+      "required": [
+        "window_days",
+        "topics",
+        "entity_types",
+        "sources",
+        "organizations",
+        "provenance"
+      ]
+    }
+  }
+}

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -11,7 +11,6 @@ const state = {
   data: null,
   view: "today",
   todayDate: "",
-  date: "",
   q: "",
   kind: "",
   category: "",
@@ -66,14 +65,9 @@ function option(value, label, selected = false) {
 function readUrl() {
   const params = new URLSearchParams(window.location.search);
   const requestedView = params.get("view");
-  state.view = ["today", "trends", "explorer"].includes(requestedView)
-    ? requestedView
-    : "today";
-  if (state.view === "today") {
-    state.todayDate = params.get("date") || "";
-  } else {
-    state.date = params.get("date") || "";
-  }
+  // Legacy Explorer permalinks resolve to the filterable Today list.
+  state.view = requestedView === "trends" ? "trends" : "today";
+  state.todayDate = params.get("date") || "";
   state.q = params.get("q") || "";
   state.kind = params.get("kind") || "";
   state.category = params.get("category") || "";
@@ -84,9 +78,12 @@ function readUrl() {
 function writeUrl() {
   const params = new URLSearchParams();
   if (state.view !== "today") params.set("view", state.view);
-  const activeDate = state.view === "today" ? state.todayDate : state.date;
-  if (activeDate && (state.view !== "today" || activeDate !== state.data?.latest_date)) {
-    params.set("date", activeDate);
+  if (
+    state.view === "today" &&
+    state.todayDate &&
+    state.todayDate !== state.data?.latest_date
+  ) {
+    params.set("date", state.todayDate);
   }
   if (state.q) params.set("q", state.q);
   if (state.kind) params.set("kind", state.kind);
@@ -152,7 +149,13 @@ function scoreBlock(item) {
     element("span", { text: "Priority score" }),
     element("span", { className: "info-mark", text: "i", attrs: { "aria-hidden": "true" } }),
   ]);
-  explain.addEventListener("click", () => openRubric(item));
+  explain.addEventListener("click", (event) => {
+    // The control lives inside a native <summary>; keep rubric access from
+    // also toggling the row.
+    event.preventDefault();
+    event.stopPropagation();
+    openRubric(item);
+  });
   return element("div", { className: "score" }, [
     element("div", { className: "score-value" }, [
       element("strong", { text: score.toFixed(2) }),
@@ -180,83 +183,6 @@ function pillBar(item) {
   return element("div", { className: "pill-bar" }, pills);
 }
 
-function signalCard(item, index) {
-  const title = element("a", {
-    text: item.title,
-    attrs: { href: item.url, target: "_blank", rel: "noopener noreferrer" },
-  });
-  const body = [pillBar(item), element("h3", {}, [title])];
-  // The watchlist note is the one line explaining why this artifact is
-  // tracked by name, so it leads ahead of the upstream description.
-  if (item.watchlist && item.watchlist_note) {
-    body.push(element("p", { className: "signal-tldr", text: item.watchlist_note }));
-  }
-  // An absent description is reported as absent. Filling the gap with a
-  // generated sentence would restate the pills above and tell the reader
-  // nothing about the artifact.
-  if ((item.summary || "").trim()) {
-    body.push(element("p", { text: shorten(item.summary) }));
-  } else {
-    body.push(
-      element("p", {
-        className: "signal-nodesc",
-        text: "No description published at the source.",
-      }),
-    );
-  }
-  // The pill bar already states source and categories, so drop the rationale
-  // entries that only restate them.
-  const rationale = (item.rationale || [])
-    .filter(Boolean)
-    .filter((reason) => !/^(Matched|Primary record):/.test(reason));
-  if (rationale.length) {
-    body.push(
-      element("p", {
-        className: "signal-why",
-        text: `Why surfaced: ${rationale.join("; ")}`,
-      }),
-    );
-  }
-  return element("article", { className: "signal-card" }, [
-    element("div", { className: "signal-rank", text: String(index + 1).padStart(2, "0") }),
-    element("div", {}, body),
-    scoreBlock(item),
-  ]);
-}
-
-function attentionCard(item) {
-  const details = element("button", {
-    className: "detail-button",
-    text: "View signal",
-    attrs: { type: "button" },
-  });
-  details.addEventListener("click", () =>
-    openDetails({ ...item, snapshot_date: state.todayDate, observation_kind: "attention" }),
-  );
-  return element("article", { className: "explorer-card attention-card" }, [
-    element("div", {}, [
-      element("div", { className: "signal-meta" }, [
-        element("span", { className: "attention-badge", text: "attention" }),
-        element("span", { text: `${item.source} · ${item.event_kind}` }),
-      ]),
-      element("h3", {}, [
-        element("a", {
-          text: item.title,
-          attrs: {
-            href: item.primary_artifact_url || item.url,
-            target: "_blank",
-            rel: "noopener noreferrer",
-          },
-        }),
-      ]),
-      element("p", {
-        text: `${metricLabel(item.metrics?.points, "point")} · ${metricLabel(item.metrics?.comments, "comment")} · ${metricLabel(item.metrics?.submissions ?? 1, "submission")}`,
-      }),
-    ]),
-    details,
-  ]);
-}
-
 function definition(label, value) {
   return element("div", {}, [
     element("dt", { text: label }),
@@ -270,21 +196,23 @@ function renderToday() {
   state.todayDate = day.date;
   byId("today-date").value = day.date;
 
-  byId("today-count").textContent = `${day.evidence_count} records`;
+  syncFilters();
+  const observations = filteredObservations();
+  const evidenceCount = observations.filter(
+    (item) => item.observation_kind === "evidence",
+  ).length;
+  const attentionCount = observations.length - evidenceCount;
+  byId("today-count").textContent =
+    `${observations.length} result${observations.length === 1 ? "" : "s"} · ` +
+    `${evidenceCount} evidence · ${attentionCount} attention`;
   replaceChildren(
     byId("today-list"),
-    day.evidence_items.map((item, index) => signalCard(item, index)),
-  );
-  byId("today-attention-count").textContent =
-    `${day.attention.active_count} active · ${day.attention.new_count} new`;
-  replaceChildren(
-    byId("today-attention-list"),
-    day.attention.observations.length
-      ? day.attention.observations.map(attentionCard)
+    observations.length
+      ? observations.map(observationCard)
       : [
           element("p", {
             className: "empty-state",
-            text: "No persisted attention observations for this snapshot.",
+            text: "No observations match these filters. Clear one or more filters to widen the view.",
           }),
         ],
   );
@@ -602,12 +530,6 @@ function syncFilters() {
     state.kind,
   );
   populateSelect(
-    byId("date-filter"),
-    [...new Set(observations.map((item) => item.snapshot_date))].sort().reverse(),
-    "dates",
-    state.date,
-  );
-  populateSelect(
     byId("category-filter"),
     [...new Set(observations.flatMap((item) => item.categories || []))].sort(),
     "categories",
@@ -633,7 +555,7 @@ function filteredObservations() {
   return allObservations().filter((item) => {
     const haystack = `${item.title} ${item.summary} ${item.source}`.toLowerCase();
     return (
-      (!state.date || item.snapshot_date === state.date) &&
+      item.snapshot_date === state.todayDate &&
       (!state.kind || item.observation_kind === state.kind) &&
       (!state.category || (item.categories || []).includes(state.category)) &&
       (!state.source || item.source === state.source) &&
@@ -759,7 +681,7 @@ function openRubric(item = null) {
   dialog.showModal();
 }
 
-function openDetails(item) {
+function expandedRecord(item) {
   const isAttention = item.observation_kind === "attention";
   const primaryArtifact = item.primary_artifact_url || item.artifact_urls?.[0];
   const scoreEntries = isAttention
@@ -835,34 +757,19 @@ function openDetails(item) {
       : []),
     element("a", {
       className: isAttention ? "secondary-link" : "primary-link",
-      text: isAttention ? "Open public discussion ↗" : "Open primary source ↗",
+      text: isAttention
+        ? "Open public discussion ↗"
+        : item.source === "Hugging Face"
+          ? "Read full card ↗"
+          : "Open primary source ↗",
       attrs: { href: item.url, target: "_blank", rel: "noopener noreferrer" },
     }),
   ]);
-  // Attention signals are not scored, so the rubric would describe a
-  // calculation that was never applied to them.
-  let rubricLink = null;
-  if (!isAttention && state.data?.rubric) {
-    const button = element("button", {
-      className: "rubric-link",
-      attrs: { type: "button" },
-    }, [
-      element("span", { text: "How is this scored?" }),
-      element("span", { className: "info-mark", text: "i", attrs: { "aria-hidden": "true" } }),
-    ]);
-    // One dialog at a time: showModal() throws on an already-open dialog.
-    button.addEventListener("click", () => {
-      byId("detail-dialog").close();
-      openRubric(item);
-    });
-    rubricLink = button;
-  }
-  replaceChildren(byId("detail-content"), [
+  return element("div", { className: "record-detail" }, [
     element("p", {
       className: "detail-source",
       text: `${item.source} · ${item.event_kind} · ${item.snapshot_date}`,
     }),
-    element("h2", { className: "detail-title", text: item.title, attrs: { id: "detail-title" } }),
     element("p", {
       className: item.summary ? "detail-summary" : "detail-summary signal-nodesc",
       text: item.summary || "No description published at the source.",
@@ -873,7 +780,6 @@ function openDetails(item) {
       { className: "detail-grid" },
       scoreEntries.map(([label, value]) => definition(label, value)),
     ),
-    rubricLink,
     element("h3", { text: "Why surfaced" }),
     rationale,
     supporting,
@@ -887,81 +793,60 @@ function openDetails(item) {
       : null,
     links,
   ]);
-  byId("detail-dialog").showModal();
 }
 
-function explorerCard(item) {
-  const isAttention = item.observation_kind === "attention";
-  const badge =
-    isAttention
-      ? element("span", { className: "attention-badge", text: "attention" })
-      : null;
-  const details = element("button", {
-    className: "detail-button",
-    text: isAttention ? "View signal" : "View evidence",
-    attrs: { type: "button" },
-  });
-  details.addEventListener("click", () => openDetails(item));
-  return element("article", { className: "explorer-card" }, [
-    element("div", {}, [
-      element("div", { className: "signal-meta" }, [
-        badge,
-        element("span", {
-          text: `${item.snapshot_date} · ${item.source} · ${item.event_kind}`,
-        }),
-      ]),
-      element("h3", {}, [
-        element("a", {
-          text: item.title,
-          attrs: {
-            href:
-              isAttention && (item.primary_artifact_url || item.artifact_urls?.[0])
-                ? item.primary_artifact_url || item.artifact_urls[0]
-                : item.url,
-            target: "_blank",
-            rel: "noopener noreferrer",
-          },
-        }),
-      ]),
-      element("p", {
-        text: isAttention
-          ? `${(item.categories || []).join(" · ") || "uncategorized"} · ${metricLabel(item.metrics?.points, "point")} · ${metricLabel(item.metrics?.comments, "comment")} · ${metricLabel(item.metrics?.submissions || 1, "submission")}`
-          : `${(item.categories || []).join(" · ") || "uncategorized"} · ${shorten(item.summary, 140)}`,
-      }),
-    ]),
-    details,
+function attentionActivity(item) {
+  return element("div", { className: "attention-activity" }, [
+    element("strong", { text: metricLabel(item.metrics?.points, "point") }),
+    element("span", { text: metricLabel(item.metrics?.comments, "comment") }),
+    element("span", { text: metricLabel(item.metrics?.submissions ?? 1, "submission") }),
   ]);
 }
 
-function renderExplorer() {
-  syncFilters();
-  const observations = filteredObservations();
-  const evidenceCount = observations.filter(
-    (item) => item.observation_kind === "evidence",
-  ).length;
-  const attentionCount = observations.length - evidenceCount;
-  byId("explorer-count").textContent =
-    `${observations.length} result${observations.length === 1 ? "" : "s"} · ` +
-    `${evidenceCount} evidence · ${attentionCount} attention`;
-  replaceChildren(
-    byId("explorer-list"),
-    observations.length
-      ? observations.map(explorerCard)
-      : [
-          element("p", {
-            className: "empty-state",
-            text: "No observations match these filters. Clear one or more filters to widen the view.",
-          }),
-        ],
+function observationCard(item, index) {
+  const isAttention = item.observation_kind === "attention";
+  const metadata = isAttention
+    ? element("div", { className: "signal-meta" }, [
+        element("span", { className: "attention-badge", text: "attention" }),
+        element("span", { text: `${item.source} · ${item.event_kind}` }),
+      ])
+    : pillBar(item);
+  const summary = (item.summary || "").trim()
+    ? shorten(item.summary)
+    : "No description published at the source.";
+  const header = element("summary", { className: "record-summary" }, [
+    element("span", {
+      className: "signal-rank",
+      text: String(index + 1).padStart(2, "0"),
+    }),
+    element("div", { className: "record-heading" }, [
+      metadata,
+      element("h3", { text: item.title }),
+      ...(item.watchlist && item.watchlist_note
+        ? [element("p", { className: "signal-tldr", text: item.watchlist_note })]
+        : []),
+      element("p", {
+        className: item.summary ? "" : "signal-nodesc",
+        text: isAttention
+          ? `${summary} · ${metricLabel(item.metrics?.points, "point")}`
+          : summary,
+      }),
+    ]),
+    isAttention ? attentionActivity(item) : scoreBlock(item),
+  ]);
+  return element(
+    "details",
+    {
+      className: `record-card${isAttention ? " attention-card" : ""}`,
+    },
+    [header, expandedRecord(item)],
   );
-  writeUrl();
 }
 
 function bindEvents() {
   document.querySelectorAll("[data-view]").forEach((button) => {
     button.addEventListener("click", () => {
       setView(button.dataset.view);
-      if (button.dataset.view === "explorer") renderExplorer();
     });
   });
   byId("today-date").addEventListener("change", (event) => {
@@ -971,24 +856,18 @@ function bindEvents() {
   byId("filters").addEventListener("input", () => {
     state.q = byId("search-filter").value;
     state.kind = byId("kind-filter").value;
-    state.date = byId("date-filter").value;
     state.category = byId("category-filter").value;
     state.source = byId("source-filter").value;
     state.event = byId("event-filter").value;
-    renderExplorer();
+    renderToday();
   });
   byId("clear-filters").addEventListener("click", () => {
     state.q = "";
     state.kind = "";
-    state.date = "";
     state.category = "";
     state.source = "";
     state.event = "";
-    renderExplorer();
-  });
-  byId("dialog-close").addEventListener("click", () => byId("detail-dialog").close());
-  byId("detail-dialog").addEventListener("click", (event) => {
-    if (event.target === byId("detail-dialog")) byId("detail-dialog").close();
+    renderToday();
   });
   byId("rubric-close").addEventListener("click", () => byId("rubric-dialog").close());
   byId("rubric-dialog").addEventListener("click", (event) => {
@@ -1064,7 +943,6 @@ async function initialize() {
     );
     renderToday();
     renderTrends();
-    renderExplorer();
     setView(state.view, false);
     const latest = dailySnapshot(state.data.latest_date);
     // A source that succeeded with zero records is not down: empty and failed
@@ -1077,8 +955,6 @@ async function initialize() {
     byId("status-copy").textContent =
       `${formatDate(latest.date, { dateStyle: "medium" })} · ${latest.evidence_count} records` +
       (failed ? ` · ${failed} source${failed === 1 ? "" : "s"} failed` : "");
-    byId("feed-status").textContent =
-      `${latest.evidence_count} ranked evidence · ${latest.attention.active_count} persisted attention`;
     byId("run-status").querySelector(".status-light").classList.add(
       failed === 0 && empty === 0 ? "ok" : "warning",
     );

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -15,7 +15,9 @@ const state = {
   kind: "",
   category: "",
   source: "",
+  organization: "",
   event: "",
+  entity: "",
 };
 
 function element(tag, options = {}, children = []) {
@@ -28,6 +30,13 @@ function element(tag, options = {}, children = []) {
     });
   }
   children.filter(Boolean).forEach((child) => node.append(child));
+  return node;
+}
+
+function svgElement(tag, attrs = {}, text = null) {
+  const node = document.createElementNS("http://www.w3.org/2000/svg", tag);
+  Object.entries(attrs).forEach(([key, value]) => node.setAttribute(key, String(value)));
+  if (text !== null) node.textContent = String(text);
   return node;
 }
 
@@ -66,30 +75,30 @@ function readUrl() {
   const params = new URLSearchParams(window.location.search);
   const requestedView = params.get("view");
   // Legacy Explorer permalinks resolve to the filterable Today list.
-  state.view = requestedView === "trends" ? "trends" : "today";
+  state.view = ["trends", "map"].includes(requestedView) ? requestedView : "today";
   state.todayDate = params.get("date") || "";
   state.q = params.get("q") || "";
   state.kind = params.get("kind") || "";
   state.category = params.get("category") || "";
   state.source = params.get("source") || "";
+  state.organization = params.get("organization") || "";
   state.event = params.get("event") || "";
+  state.entity = params.get("entity") || "";
 }
 
 function writeUrl() {
   const params = new URLSearchParams();
   if (state.view !== "today") params.set("view", state.view);
-  if (
-    state.view === "today" &&
-    state.todayDate &&
-    state.todayDate !== state.data?.latest_date
-  ) {
+  if (state.todayDate && state.todayDate !== state.data?.latest_date) {
     params.set("date", state.todayDate);
   }
   if (state.q) params.set("q", state.q);
   if (state.kind) params.set("kind", state.kind);
   if (state.category) params.set("category", state.category);
   if (state.source) params.set("source", state.source);
+  if (state.organization) params.set("organization", state.organization);
   if (state.event) params.set("event", state.event);
+  if (state.view === "map" && state.entity) params.set("entity", state.entity);
   const query = params.toString();
   window.history.replaceState(null, "", `${window.location.pathname}${query ? `?${query}` : ""}`);
 }
@@ -318,8 +327,17 @@ function renderDomainMetrics(day) {
   );
 }
 
-function sameReportLimit(a, b) {
-  return (a.selection || {}).report_limit === (b.selection || {}).report_limit;
+function sameCollectionContext(a, b) {
+  return (
+    (a.selection || {}).report_limit === (b.selection || {}).report_limit &&
+    JSON.stringify(a.coverage_signature || []) === JSON.stringify(b.coverage_signature || [])
+  );
+}
+
+function coverageNote(day) {
+  return (day.coverage_gaps || []).length
+    ? ` Coverage is incomplete: ${day.coverage_gaps.join(", ")} failed.`
+    : "";
 }
 
 function renderTrends() {
@@ -355,12 +373,13 @@ function renderTrends() {
       `Baseline: ${only.evidence_count} evidence records and ${only.attention.active_count} active attention signals.`;
     trendChart.hidden = true;
   } else if (dayCount === 2) {
-    trendMessage.textContent = sameReportLimit(
+    trendMessage.textContent = sameCollectionContext(
       state.data.days[1],
       state.data.days[0],
     )
-      ? "Two snapshots are available. The chart shows the first comparable daily change; broader trend language begins with three snapshots."
-      : "Two snapshots are available, but they used different report limits, so the change between them is not comparable.";
+      ? "Two snapshots are available. The chart shows the first comparable daily change; broader trend language begins with three snapshots." +
+        coverageNote(state.data.days[1])
+      : "Two snapshots are available, but their connector coverage or report limit differs, so the change between them is not comparable.";
     trendChart.hidden = false;
   } else {
     const latest = state.data.days[dayCount - 1];
@@ -368,7 +387,7 @@ function renderTrends() {
     // Raising the report limit lifts every count at once. Announcing that as
     // movement would report a collection-policy change as a change in field,
     // so the same gate the domain cards use applies to this sentence.
-    const comparable = sameReportLimit(latest, previous);
+    const comparable = sameCollectionContext(latest, previous);
     if (comparable) {
       const evidenceDelta = latest.evidence_count - previous.evidence_count;
       const attentionDelta = latest.attention.active_count - previous.attention.active_count;
@@ -380,10 +399,11 @@ function renderTrends() {
         .map(([category, trend]) => `${category.replaceAll("_", " ")} ${deltaText(trend.delta)}`);
       trendMessage.textContent =
         `Compared with ${previous.date}, surfaced evidence is ${direction(evidenceDelta)} and active attention is ${direction(attentionDelta)}.` +
-        (movers.length ? ` Biggest domain moves: ${movers.join(", ")}.` : "");
+        (movers.length ? ` Biggest domain moves: ${movers.join(", ")}.` : "") +
+        coverageNote(latest);
     } else {
       trendMessage.textContent =
-        `${latest.date} used a different report limit than ${previous.date}, so the two scans ` +
+        `${latest.date} used different connector coverage or a different report limit than ${previous.date}, so the two scans ` +
         "are not directly comparable. Counts are shown without a change figure.";
     }
     trendChart.hidden = false;
@@ -505,6 +525,7 @@ function allObservations() {
       ...item,
       snapshot_date: day.date,
       artifact_urls: item.primary_artifact_url ? [item.primary_artifact_url] : [],
+      organizations: item.producer ? [item.producer] : [],
       observation_kind: "attention",
     })),
   );
@@ -542,6 +563,16 @@ function syncFilters() {
     state.source,
   );
   populateSelect(
+    byId("organization-filter"),
+    [
+      ...new Set(
+        observations.flatMap((item) => item.organizations || []),
+      ),
+    ].sort(),
+    "organizations",
+    state.organization,
+  );
+  populateSelect(
     byId("event-filter"),
     [...new Set(observations.map((item) => item.event_kind))].sort(),
     "events",
@@ -559,6 +590,7 @@ function filteredObservations() {
       (!state.kind || item.observation_kind === state.kind) &&
       (!state.category || (item.categories || []).includes(state.category)) &&
       (!state.source || item.source === state.source) &&
+      (!state.organization || (item.organizations || []).includes(state.organization)) &&
       (!state.event || item.event_kind === state.event) &&
       (!query || haystack.includes(query))
     );
@@ -795,6 +827,240 @@ function expandedRecord(item) {
   ]);
 }
 
+function mapFilterFor(entity) {
+  state.q = "";
+  state.kind = "evidence";
+  state.category = "";
+  state.source = "";
+  state.organization = "";
+  state.event = "";
+  if (entity.type === "artifact") {
+    state.q = entity.label;
+    state.todayDate = entity.last_seen_at;
+  } else if (entity.type === "topic") {
+    state.category = entity.id.replace(/^topic:/, "");
+  } else if (entity.type === "source") {
+    state.source = entity.label;
+  } else if (entity.type === "organization") {
+    state.organization = entity.label;
+  }
+}
+
+function selectMapNode(entity, relatedEntities) {
+  state.entity = entity.id;
+  mapFilterFor(entity);
+  const topicAggregate = (state.data.corpus.aggregates.topics || []).find(
+    (entry) => `topic:${entry.topic}` === entity.id,
+  );
+  const stats = [
+    definition("Type", entity.type),
+    definition("First seen", formatDate(entity.first_seen_at, { dateStyle: "medium" })),
+    definition("Last seen", formatDate(entity.last_seen_at, { dateStyle: "medium" })),
+    definition("Observed days", Number(entity.seen_days?.length || 0).toLocaleString()),
+    ...(entity.type === "artifact"
+      ? [
+          definition("Observations", Number(entity.observation_count || 0).toLocaleString()),
+          definition(
+            "Latest priority",
+            entity.latest_score === null || entity.latest_score === undefined
+              ? "not scored"
+              : Number(entity.latest_score).toFixed(2),
+          ),
+        ]
+      : []),
+    ...(topicAggregate
+      ? [
+          definition("Artifact count", topicAggregate.entity_count),
+          definition("Source breadth", topicAggregate.source_breadth),
+          definition(
+            `${state.data.corpus.aggregates.window_days}-day velocity`,
+            topicAggregate.velocity === null
+              ? "needs a prior window"
+              : `${topicAggregate.velocity >= 0 ? "+" : ""}${topicAggregate.velocity}/day`,
+          ),
+        ]
+      : []),
+  ];
+  replaceChildren(byId("map-detail"), [
+    element("p", { className: "eyebrow", text: "Selected node" }),
+    element("h2", { text: entity.label }),
+    element("p", {
+      text:
+        entity.type === "artifact"
+          ? "The corresponding date and exact title search are now set for Today."
+          : `The ${entity.type} filter is now set for Today.`,
+    }),
+    element("dl", {}, stats),
+    relatedEntities.length
+      ? element("p", {
+          className: "discovery-note",
+          text: `Connected to ${relatedEntities
+            .slice(0, 8)
+            .map((related) => related.label)
+            .join(", ")}${relatedEntities.length > 8 ? "…" : ""}`,
+        })
+      : null,
+    entity.url
+      ? element("a", {
+          className: "primary-link",
+          text: "Open primary source ↗",
+          attrs: {
+            href: entity.url,
+            target: "_blank",
+            rel: "noopener noreferrer",
+          },
+        })
+      : null,
+  ]);
+  writeUrl();
+}
+
+function renderTrendMap() {
+  const corpus = state.data.corpus;
+  if (!corpus) return;
+  const entityById = new Map(corpus.entities.map((entity) => [entity.id, entity]));
+  const selectedFromUrl = entityById.get(state.entity);
+  let artifacts = corpus.entities
+    .filter((entity) => entity.type === "artifact")
+    .sort(
+      (a, b) =>
+        Number(b.latest_score || 0) - Number(a.latest_score || 0) ||
+        Number(b.observation_count || 0) - Number(a.observation_count || 0) ||
+        a.label.localeCompare(b.label),
+    )
+    .slice(0, 16);
+  if (
+    selectedFromUrl?.type === "artifact" &&
+    !artifacts.some((entity) => entity.id === selectedFromUrl.id)
+  ) {
+    artifacts = [selectedFromUrl, ...artifacts.slice(0, 15)];
+  }
+  const artifactIds = new Set(artifacts.map((entity) => entity.id));
+  const visibleEdges = corpus.edges.filter(
+    (edge) =>
+      artifactIds.has(edge.source) &&
+      ["HAS_TOPIC", "RELEASED_BY", "FOUND_VIA"].includes(edge.type),
+  );
+  const visibleIds = new Set([
+    ...artifactIds,
+    ...visibleEdges.flatMap((edge) => [edge.source, edge.target]),
+  ]);
+  if (
+    selectedFromUrl &&
+    ["topic", "organization", "source"].includes(selectedFromUrl.type)
+  ) {
+    visibleIds.add(selectedFromUrl.id);
+  }
+  const visibleEntities = [...visibleIds]
+    .map((id) => entityById.get(id))
+    .filter(Boolean);
+  const typeOrder = ["source", "organization", "artifact", "topic"];
+  const xByType = { source: 110, organization: 350, artifact: 650, topic: 1010 };
+  const groups = Object.fromEntries(
+    typeOrder.map((type) => [
+      type,
+      visibleEntities
+        .filter((entity) => entity.type === type)
+        .sort((a, b) => a.label.localeCompare(b.label)),
+    ]),
+  );
+  const height = Math.max(
+    560,
+    ...typeOrder.map((type) => groups[type].length * 52 + 90),
+  );
+  const positions = new Map();
+  typeOrder.forEach((type) => {
+    groups[type].forEach((entity, index) => {
+      positions.set(entity.id, { x: xByType[type], y: 70 + index * 52 });
+    });
+  });
+
+  const svg = svgElement("svg", {
+    viewBox: `0 0 1200 ${height}`,
+    width: "1200",
+    height,
+    role: "img",
+    "aria-label": "Artifact nodes connected to topics, organizations, and discovery sources",
+  });
+  typeOrder.forEach((type) => {
+    svg.append(
+      svgElement(
+        "text",
+        {
+          x: xByType[type],
+          y: 30,
+          "text-anchor": "middle",
+          class: "map-column-label",
+        },
+        `${type}s`,
+      ),
+    );
+  });
+  visibleEdges.forEach((edge) => {
+    const source = positions.get(edge.source);
+    const target = positions.get(edge.target);
+    if (!source || !target) return;
+    svg.append(
+      svgElement("line", {
+        x1: source.x,
+        y1: source.y,
+        x2: target.x,
+        y2: target.y,
+        class: "map-edge",
+      }),
+    );
+  });
+  visibleEntities.forEach((entity) => {
+    const position = positions.get(entity.id);
+    if (!position) return;
+    const group = svgElement("g", {
+      class: `map-node map-node-${entity.type}`,
+      transform: `translate(${position.x} ${position.y})`,
+      tabindex: "0",
+      role: "button",
+      "aria-label": `${entity.type}: ${entity.label}`,
+    });
+    group.append(svgElement("circle", { r: entity.type === "artifact" ? 8 : 6 }));
+    group.append(
+      svgElement(
+        "text",
+        { x: 14, y: 4 },
+        shorten(entity.label, entity.type === "artifact" ? 38 : 24),
+      ),
+    );
+    const related = visibleEdges
+      .filter((edge) => edge.source === entity.id || edge.target === entity.id)
+      .map((edge) => entityById.get(edge.source === entity.id ? edge.target : edge.source))
+      .filter(Boolean);
+    const select = () => selectMapNode(entity, related);
+    group.addEventListener("click", select);
+    group.addEventListener("keydown", (event) => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        select();
+      }
+    });
+    svg.append(group);
+  });
+  replaceChildren(byId("map-canvas"), [svg]);
+  byId("map-summary").textContent =
+    `${corpus.entity_count} cumulative entities · ${corpus.observation_count} observations · ` +
+    `${corpus.edge_count} relationships · showing ${artifacts.length} ranked artifacts`;
+  if (selectedFromUrl) {
+    const related = corpus.edges
+      .filter(
+        (edge) => edge.source === selectedFromUrl.id || edge.target === selectedFromUrl.id,
+      )
+      .map((edge) =>
+        entityById.get(
+          edge.source === selectedFromUrl.id ? edge.target : edge.source,
+        ),
+      )
+      .filter(Boolean);
+    selectMapNode(selectedFromUrl, related);
+  }
+}
+
 function attentionActivity(item) {
   return element("div", { className: "attention-activity" }, [
     element("strong", { text: metricLabel(item.metrics?.points, "point") }),
@@ -847,6 +1113,9 @@ function bindEvents() {
   document.querySelectorAll("[data-view]").forEach((button) => {
     button.addEventListener("click", () => {
       setView(button.dataset.view);
+      if (button.dataset.view === "today") renderToday();
+      if (button.dataset.view === "trends") renderTrends();
+      if (button.dataset.view === "map") renderTrendMap();
     });
   });
   byId("today-date").addEventListener("change", (event) => {
@@ -858,6 +1127,7 @@ function bindEvents() {
     state.kind = byId("kind-filter").value;
     state.category = byId("category-filter").value;
     state.source = byId("source-filter").value;
+    state.organization = byId("organization-filter").value;
     state.event = byId("event-filter").value;
     renderToday();
   });
@@ -866,6 +1136,7 @@ function bindEvents() {
     state.kind = "";
     state.category = "";
     state.source = "";
+    state.organization = "";
     state.event = "";
     renderToday();
   });
@@ -943,6 +1214,7 @@ async function initialize() {
     );
     renderToday();
     renderTrends();
+    renderTrendMap();
     setView(state.view, false);
     const latest = dailySnapshot(state.data.latest_date);
     // A source that succeeded with zero records is not down: empty and failed

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -123,13 +123,18 @@ function dailySnapshot(date = state.todayDate) {
   );
 }
 
-function scoreMax() {
-  return Number(state.data?.rubric?.score_max) || 4;
+function rubricFor(item = null) {
+  const version = String(item?.score_version || state.data?.rubric?.scoring_version || 1);
+  return state.data?.rubrics?.[version] || state.data?.rubric;
+}
+
+function scoreMax(item = null) {
+  return Number(item?.score_max || rubricFor(item)?.score_max) || 4;
 }
 
 function scoreBlock(item) {
   const score = Number(item.total_score || 0);
-  const max = scoreMax();
+  const max = scoreMax(item);
   const width = Math.max(0, Math.min(100, (score / max) * 100));
   const trackFill = element("span", {});
   const track = element("div", { className: "score-track" }, [trackFill]);
@@ -642,7 +647,7 @@ function filteredObservations() {
 // component scores beside each weight, so the reader can see the arithmetic
 // that produced the total rather than a generic description of it.
 function openRubric(item = null) {
-  const data = state.data?.rubric;
+  const data = rubricFor(item);
   const dialog = byId("rubric-dialog");
   if (!data) return;
   const max = Number(data.score_max) || 4;

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -385,16 +385,43 @@ input {
   color: var(--muted);
 }
 
-.signal-card {
-  display: grid;
-  grid-template-columns: 54px minmax(0, 1fr) 170px;
-  gap: 1.25rem;
-  padding: 1.5rem 0;
+.record-card {
   border-bottom: 1px solid var(--line);
 }
 
-.attention-section-title {
-  margin-top: 3rem;
+.record-summary {
+  display: grid;
+  grid-template-columns: 54px minmax(0, 1fr) 170px;
+  gap: 1.25rem;
+  align-items: start;
+  padding: 1.5rem 0;
+  cursor: pointer;
+  list-style: none;
+}
+
+.record-summary::-webkit-details-marker {
+  display: none;
+}
+
+.record-card[open] {
+  background: color-mix(in srgb, var(--panel) 70%, transparent);
+}
+
+.record-card[open] .record-summary {
+  border-bottom: 1px dashed var(--line);
+}
+
+.record-detail {
+  margin: 0 190px 0 79px;
+  padding: 1.25rem 0 1.75rem;
+}
+
+.record-detail > h3 {
+  margin-top: 1.5rem;
+}
+
+.record-detail .detail-summary {
+  white-space: pre-line;
 }
 
 .section-note,
@@ -408,8 +435,17 @@ input {
 }
 
 .attention-card {
-  padding-inline: 0.8rem;
   background: color-mix(in srgb, #e9dfff 28%, transparent);
+}
+
+.attention-activity {
+  display: grid;
+  gap: 0.25rem;
+  color: #51477f;
+  font-family: var(--utility);
+  font-size: 0.68rem;
+  text-align: right;
+  text-transform: uppercase;
 }
 
 .signal-rank {
@@ -418,8 +454,7 @@ input {
   font-size: 0.78rem;
 }
 
-.signal-card h3,
-.explorer-card h3 {
+.record-card h3 {
   overflow-wrap: anywhere;
   margin: 0.2rem 0 0.55rem;
   font-family: var(--display);
@@ -427,15 +462,7 @@ input {
   line-height: 1.05;
 }
 
-.signal-card h3 a,
-.explorer-card h3 a {
-  color: inherit;
-  text-decoration-thickness: 1px;
-  text-decoration-color: var(--line);
-  text-underline-offset: 4px;
-}
-
-.signal-card p {
+.record-heading p {
   margin-bottom: 0.8rem;
   color: var(--muted);
   font-size: 0.9rem;
@@ -1048,35 +1075,6 @@ td a {
   color: white;
 }
 
-.explorer-title {
-  margin-bottom: 0;
-}
-
-.explorer-card {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 1.5rem;
-  align-items: center;
-  padding: 1.3rem 0;
-  border-bottom: 1px solid var(--line);
-}
-
-.explorer-card p {
-  margin-bottom: 0;
-  color: var(--muted);
-  font-size: 0.85rem;
-}
-
-.detail-button {
-  padding: 0.55rem 0.8rem;
-  border: 1px solid var(--line);
-  background: var(--panel);
-  color: var(--blue-deep);
-  font-family: var(--utility);
-  font-size: 0.67rem;
-  text-transform: uppercase;
-}
-
 .attention-badge {
   display: inline-block;
   margin-right: 0.5rem;
@@ -1352,14 +1350,21 @@ footer {
     font-size: clamp(1.7rem, 7vw, 2.3rem);
   }
 
-  .signal-card {
+  .record-summary {
     grid-template-columns: 36px minmax(0, 1fr);
   }
 
-  .score {
+  .record-summary .score,
+  .record-summary .attention-activity {
     grid-column: 2;
     justify-self: start;
     max-width: 180px;
+    text-align: left;
+  }
+
+  .record-detail {
+    margin: 0 0 0 51px;
+    padding-right: 1rem;
   }
 
   .trend-grid {
@@ -1372,10 +1377,6 @@ footer {
 
   .search-field {
     grid-column: auto;
-  }
-
-  .explorer-card {
-    grid-template-columns: 1fr;
   }
 
   footer {

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -1048,7 +1048,7 @@ td a {
 
 .filter-panel {
   display: grid;
-  grid-template-columns: 2fr repeat(5, minmax(115px, 1fr)) auto;
+  grid-template-columns: 2fr repeat(6, minmax(105px, 1fr)) auto;
   gap: 1rem;
   align-items: end;
   margin-bottom: 3rem;
@@ -1088,6 +1088,119 @@ td a {
   border-bottom: 1px solid var(--line);
   color: var(--muted);
   text-align: center;
+}
+
+.map-summary {
+  color: var(--muted);
+  font-family: var(--utility);
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.map-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 1.5rem;
+  align-items: start;
+}
+
+.map-canvas {
+  max-height: 720px;
+  overflow: auto;
+  border: 1px solid var(--line);
+  background:
+    linear-gradient(var(--line) 1px, transparent 1px),
+    linear-gradient(90deg, var(--line) 1px, transparent 1px);
+  background-size: 48px 48px;
+}
+
+.map-canvas svg {
+  display: block;
+  min-width: 900px;
+}
+
+.map-edge {
+  stroke: #9baab1;
+  stroke-opacity: 0.38;
+  stroke-width: 1;
+}
+
+.map-column-label {
+  fill: var(--muted);
+  font-family: var(--utility);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.map-node {
+  cursor: pointer;
+}
+
+.map-node circle {
+  fill: var(--panel);
+  stroke: var(--blue-deep);
+  stroke-width: 1.5;
+}
+
+.map-node-artifact circle {
+  fill: #fff7ee;
+  stroke: var(--orange);
+}
+
+.map-node-topic circle {
+  fill: #e5f2ef;
+  stroke: var(--sea);
+}
+
+.map-node-organization circle {
+  fill: #f1eafa;
+  stroke: #756aa8;
+}
+
+.map-node text {
+  fill: var(--ink);
+  font-family: var(--utility);
+  font-size: 11px;
+}
+
+.map-node:focus circle,
+.map-node:hover circle {
+  stroke-width: 4;
+}
+
+.map-detail {
+  position: sticky;
+  top: 1rem;
+  padding: 1.5rem;
+  border: 1px solid var(--ink);
+  background: var(--panel);
+}
+
+.map-detail h2 {
+  overflow-wrap: anywhere;
+}
+
+.map-detail dl {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.map-detail dt {
+  color: var(--muted);
+  font-family: var(--utility);
+  font-size: 0.65rem;
+  text-transform: uppercase;
+}
+
+.map-detail dd {
+  margin: 0.15rem 0 0;
+}
+
+.map-detail .primary-link {
+  display: inline-block;
+  margin-top: 1rem;
 }
 
 dialog {
@@ -1369,6 +1482,14 @@ footer {
 
   .trend-grid {
     grid-template-columns: 1fr;
+  }
+
+  .map-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .map-detail {
+    position: static;
   }
 
   .filter-panel {

--- a/site/index.html
+++ b/site/index.html
@@ -67,6 +67,7 @@
     <nav class="view-nav" aria-label="Dashboard views">
       <button type="button" data-view="today" aria-controls="today-view">Today</button>
       <button type="button" data-view="trends" aria-controls="trends-view">Trends</button>
+      <button type="button" data-view="map" aria-controls="map-view">Trend map</button>
       <button type="button" id="rubric-nav" aria-haspopup="dialog">Rubric</button>
     </nav>
 
@@ -99,6 +100,10 @@
             <select id="source-filter" name="source"></select>
           </label>
           <label>
+            Organization
+            <select id="organization-filter" name="organization"></select>
+          </label>
+          <label>
             Event
             <select id="event-filter" name="event"></select>
           </label>
@@ -118,6 +123,37 @@
               <h2 id="health-heading">Sources</h2>
             </div>
             <ul id="health-list"></ul>
+          </aside>
+        </div>
+      </section>
+
+      <section class="view" id="map-view" aria-labelledby="map-heading" hidden>
+        <header class="view-heading">
+          <div>
+            <p class="eyebrow">Cumulative corpus</p>
+            <h1 id="map-heading">Artifacts and their context</h1>
+          </div>
+          <p class="heading-note">
+            Exact identifiers connect artifacts to topics, publishers, and discovery sources.
+            Select a node to carry it into the Today filters.
+          </p>
+        </header>
+        <p class="map-summary" id="map-summary"></p>
+        <div class="map-layout">
+          <div
+            class="map-canvas"
+            id="map-canvas"
+            role="region"
+            aria-label="Interactive artifact relationship map"
+            tabindex="0"
+          ></div>
+          <aside class="map-detail" id="map-detail" aria-live="polite">
+            <p class="eyebrow">Select a node</p>
+            <h2>Inspect a relationship</h2>
+            <p>
+              Topic, source, and organization nodes set the corresponding Today filter.
+              Artifact nodes set the date and title search.
+            </p>
           </aside>
         </div>
       </section>

--- a/site/index.html
+++ b/site/index.html
@@ -67,32 +67,51 @@
     <nav class="view-nav" aria-label="Dashboard views">
       <button type="button" data-view="today" aria-controls="today-view">Today</button>
       <button type="button" data-view="trends" aria-controls="trends-view">Trends</button>
-      <button type="button" data-view="explorer" aria-controls="explorer-view">Explorer</button>
       <button type="button" id="rubric-nav" aria-haspopup="dialog">Rubric</button>
     </nav>
 
     <main id="main-content" tabindex="-1">
       <section class="view" id="today-view" aria-label="Today">
-        <div class="today-toolbar">
-          <label class="date-control">
-            Scan date
-            <select id="today-date"></select>
+        <form class="filter-panel today-filters" id="filters">
+          <label class="search-field">
+            Search
+            <input
+              id="search-filter"
+              name="q"
+              type="search"
+              placeholder="Title, summary, or source"
+            >
           </label>
-        </div>
+          <label>
+            Scan date
+            <select id="today-date" name="date"></select>
+          </label>
+          <label>
+            Kind
+            <select id="kind-filter" name="kind"></select>
+          </label>
+          <label>
+            Category
+            <select id="category-filter" name="category"></select>
+          </label>
+          <label>
+            Source
+            <select id="source-filter" name="source"></select>
+          </label>
+          <label>
+            Event
+            <select id="event-filter" name="event"></select>
+          </label>
+          <button class="clear-button" id="clear-filters" type="button">Clear filters</button>
+        </form>
 
         <div class="content-grid">
           <div>
             <div class="section-title">
-              <h2>Ranked evidence</h2>
-              <span id="today-count"></span>
+              <h2>Matching observations</h2>
+              <span id="today-count" aria-live="polite"></span>
             </div>
             <div class="signal-list" id="today-list"></div>
-            <div class="section-title attention-section-title">
-              <h2>Attention signals</h2>
-              <span id="today-attention-count"></span>
-            </div>
-            <p class="section-note">Public activity, not quality-scored.</p>
-            <div class="explorer-list" id="today-attention-list"></div>
           </div>
           <aside class="health-panel" aria-labelledby="health-heading">
             <div class="section-title">
@@ -173,50 +192,6 @@
         </div>
       </section>
 
-      <section class="view" id="explorer-view" aria-labelledby="explorer-heading" hidden>
-        <header class="view-heading">
-          <div>
-            <p class="eyebrow">Evidence index</p>
-            <h1 id="explorer-heading">Explore every observation</h1>
-          </div>
-          <p class="heading-note" id="feed-status">Checking public signal feeds…</p>
-        </header>
-
-        <form class="filter-panel" id="filters">
-          <label class="search-field">
-            Search
-            <input id="search-filter" name="q" type="search" placeholder="Title, summary, or source">
-          </label>
-          <label>
-            Kind
-            <select id="kind-filter" name="kind"></select>
-          </label>
-          <label>
-            Date
-            <select id="date-filter" name="date"></select>
-          </label>
-          <label>
-            Category
-            <select id="category-filter" name="category"></select>
-          </label>
-          <label>
-            Source
-            <select id="source-filter" name="source"></select>
-          </label>
-          <label>
-            Event
-            <select id="event-filter" name="event"></select>
-          </label>
-          <button class="clear-button" id="clear-filters" type="button">Clear filters</button>
-        </form>
-
-        <div class="section-title explorer-title">
-          <h2>Matching observations</h2>
-          <span id="explorer-count" aria-live="polite"></span>
-        </div>
-        <div class="explorer-list" id="explorer-list"></div>
-      </section>
-
       <section class="error-state" id="error-state" hidden>
         <p class="eyebrow">Dashboard unavailable</p>
         <h1>The validated data file could not be loaded.</h1>
@@ -226,11 +201,6 @@
         </a>
       </section>
     </main>
-
-    <dialog id="detail-dialog" aria-labelledby="detail-title">
-      <button class="dialog-close" id="dialog-close" type="button" aria-label="Close details">×</button>
-      <div id="detail-content"></div>
-    </dialog>
 
     <dialog id="rubric-dialog" aria-labelledby="rubric-title">
       <button

--- a/src/benchmark_radar/cli.py
+++ b/src/benchmark_radar/cli.py
@@ -26,9 +26,12 @@ def main() -> None:
     parser.add_argument(
         "command",
         nargs="?",
-        choices=("run", "rebuild", "migrate"),
+        choices=("run", "rebuild", "backfill", "migrate"),
         default="run",
-        help="Collect a daily run or rebuild dashboard data from saved snapshots.",
+        help=(
+            "Collect a daily run, rebuild/backfill cumulative data from saved snapshots, "
+            "or migrate snapshot schemas."
+        ),
     )
     parser.add_argument("--config", type=Path, default=Path("config.yml"))
     parser.add_argument("--output", type=Path, default=Path("out/report.md"))
@@ -37,9 +40,10 @@ def main() -> None:
     parser.add_argument("--dashboard-output", type=Path, default=Path("site/data/radar.json"))
     args = parser.parse_args()
 
-    if args.command == "rebuild":
+    if args.command in {"rebuild", "backfill"}:
         data = rebuild_dashboard(args.snapshot_dir, args.dashboard_output)
-        print(f"Rebuilt {args.dashboard_output} from {data['snapshot_count']} daily snapshots")
+        action = "Backfilled" if args.command == "backfill" else "Rebuilt"
+        print(f"{action} {args.dashboard_output} from {data['snapshot_count']} daily snapshots")
         return
 
     config = load_config(args.config)

--- a/src/benchmark_radar/corpus.py
+++ b/src/benchmark_radar/corpus.py
@@ -1,0 +1,413 @@
+"""Deterministic cumulative entity graph built from validated daily snapshots."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections import Counter, defaultdict
+from datetime import UTC, datetime
+from typing import Any
+from urllib.parse import parse_qs, urlsplit
+
+CORPUS_SCHEMA_VERSION = 1
+AGGREGATE_WINDOW_DAYS = 7
+PRIMARY_SOURCE_RANK = {
+    "arXiv": 1,
+    "OpenReview": 1,
+    "GitHub Release": 1,
+    "GitHub": 1,
+    "Hugging Face": 1,
+    "Semantic Scholar": 2,
+    "OpenAlex": 2,
+    "Brave Search": 3,
+}
+PRIMARY_OR_STRUCTURED_SOURCES = {
+    "arXiv",
+    "OpenReview",
+    "GitHub Release",
+    "GitHub",
+    "Hugging Face",
+}
+
+
+class CorpusError(ValueError):
+    """Raised when generated cumulative data violates the public schema."""
+
+
+def _stable_id(prefix: str, value: str) -> str:
+    digest = hashlib.sha256(value.encode()).hexdigest()[:20]
+    return f"{prefix}:{digest}"
+
+
+def _arxiv_id(path: str) -> str | None:
+    match = re.search(r"/(?:abs|pdf)/([^/?#]+)", path, flags=re.IGNORECASE)
+    if not match:
+        return None
+    return re.sub(r"v\d+$", "", match.group(1), flags=re.IGNORECASE).lower()
+
+
+def exact_artifact_key(item: dict[str, Any]) -> str:
+    """Resolve an artifact using exact public identifiers only.
+
+    URL identifiers take priority so a Semantic Scholar/OpenReview observation
+    carrying an arXiv, DOI, GitHub, or Hugging Face link joins that primary
+    entity. Ambiguous title similarity is deliberately not used.
+    """
+    urls = [str(item.get("url") or ""), *map(str, item.get("artifact_urls") or [])]
+    candidates: dict[int, str] = {}
+    for url in urls:
+        parsed = urlsplit(url)
+        host = parsed.netloc.casefold().removeprefix("www.")
+        segments = [segment for segment in parsed.path.split("/") if segment]
+        if host in {"doi.org", "dx.doi.org"} and segments:
+            candidates[1] = f"artifact:doi:{'/'.join(segments).casefold()}"
+        arxiv = _arxiv_id(parsed.path) if host.endswith("arxiv.org") else None
+        if arxiv:
+            candidates[2] = f"artifact:arxiv:{arxiv}"
+        if host == "openreview.net":
+            forum = (parse_qs(parsed.query).get("id") or [None])[0]
+            if forum:
+                candidates[3] = f"artifact:openreview:{str(forum).casefold()}"
+        if host == "github.com" and len(segments) >= 2:
+            candidates[4] = f"artifact:github:{segments[0].casefold()}/{segments[1].casefold()}"
+        if host == "huggingface.co" and len(segments) >= 2:
+            kind = segments[0].casefold()
+            if kind in {"datasets", "spaces", "models"} and len(segments) >= 3:
+                candidates[5] = (
+                    f"artifact:huggingface:{kind}:{segments[1].casefold()}/{segments[2].casefold()}"
+                )
+            elif kind not in {"datasets", "spaces"}:
+                candidates[5] = (
+                    f"artifact:huggingface:models:{segments[0].casefold()}/{segments[1].casefold()}"
+                )
+    if candidates:
+        return candidates[min(candidates)]
+
+    source = str(item.get("source") or "").casefold()
+    source_id = str(item.get("source_id") or "").strip().casefold()
+    if source == "arxiv":
+        base_id = re.sub(r"v\d+$", "", source_id)
+        return f"artifact:arxiv:{base_id}"
+    if source == "openreview":
+        return f"artifact:openreview:{source_id}"
+    if source in {"github", "github release"}:
+        return f"artifact:github:{source_id.split('@', 1)[0]}"
+    if source == "hugging face":
+        return f"artifact:huggingface:datasets:{source_id}"
+    return _stable_id("artifact:url", str(item.get("url") or source_id).casefold())
+
+
+def organizations_for_item(item: dict[str, Any]) -> list[str]:
+    """Return exact publisher/owner names available in structured source IDs."""
+    source = str(item.get("source") or "").casefold()
+    source_id = str(item.get("source_id") or "")
+    if source in {"github", "github release", "hugging face"} and "/" in source_id:
+        return [source_id.split("/", 1)[0]]
+    return [str(value) for value in item.get("organizations") or [] if str(value).strip()]
+
+
+def _edge_id(kind: str, source: str, target: str) -> str:
+    return _stable_id("edge", f"{kind}\0{source}\0{target}")
+
+
+def _observation_id(date: str, entity_id: str, item: dict[str, Any]) -> str:
+    return _stable_id(
+        "observation",
+        f"{date}\0{entity_id}\0{item.get('source')}\0{item.get('source_id')}",
+    )
+
+
+def _entity(
+    entity_id: str,
+    entity_type: str,
+    label: str,
+    *,
+    url: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": entity_id,
+        "type": entity_type,
+        "label": label,
+        "url": url,
+        "first_seen_at": None,
+        "last_seen_at": None,
+        "seen_days": set(),
+        "sources": set(),
+        "categories": set(),
+        "metrics_first": {},
+        "metrics_latest": {},
+        "latest_score": None,
+        "_primary_rank": 99,
+    }
+
+
+def build_corpus(snapshots: list[dict[str, Any]]) -> dict[str, Any]:
+    """Merge snapshot observations into a deterministic public entity graph."""
+    entities: dict[str, dict[str, Any]] = {}
+    edges: dict[str, dict[str, Any]] = {}
+    observations: list[dict[str, Any]] = []
+
+    def touch(entity: dict[str, Any], *, date: str, source: str = "") -> None:
+        entity["first_seen_at"] = min(entity["first_seen_at"] or date, date)
+        entity["last_seen_at"] = max(entity["last_seen_at"] or date, date)
+        entity["seen_days"].add(date)
+        if source:
+            entity["sources"].add(source)
+
+    def connect(kind: str, source_id: str, target_id: str, date: str) -> None:
+        edge_id = _edge_id(kind, source_id, target_id)
+        edge = edges.setdefault(
+            edge_id,
+            {
+                "id": edge_id,
+                "type": kind,
+                "source": source_id,
+                "target": target_id,
+                "first_seen_at": date,
+                "last_seen_at": date,
+                "seen_days": set(),
+            },
+        )
+        edge["first_seen_at"] = min(edge["first_seen_at"], date)
+        edge["last_seen_at"] = max(edge["last_seen_at"], date)
+        edge["seen_days"].add(date)
+
+    for snapshot in snapshots:
+        date = str(snapshot["date"])
+        for item in snapshot["evidence_items"]:
+            entity_id = exact_artifact_key(item)
+            artifact = entities.setdefault(
+                entity_id,
+                _entity(entity_id, "artifact", str(item["title"]), url=str(item["url"])),
+            )
+            touch(artifact, date=date, source=str(item["source"]))
+            source_rank = PRIMARY_SOURCE_RANK.get(str(item["source"]), 4)
+            # A secondary metadata observation must not replace an exact
+            # primary artifact as the entity's public label/link.
+            if source_rank <= artifact["_primary_rank"]:
+                artifact["label"] = str(item["title"])
+                artifact["url"] = str(item["url"])
+                artifact["_primary_rank"] = source_rank
+            artifact["categories"].update(map(str, item.get("categories") or []))
+            metrics = {
+                str(key): float(value)
+                for key, value in (item.get("metrics") or {}).items()
+                if isinstance(value, (int, float))
+            }
+            if not artifact["metrics_first"]:
+                artifact["metrics_first"] = metrics
+            artifact["metrics_latest"] = metrics
+            artifact["latest_score"] = item.get("total_score")
+
+            observation = {
+                "id": _observation_id(date, entity_id, item),
+                "entity_id": entity_id,
+                "snapshot_date": date,
+                "source": str(item["source"]),
+                "source_id": str(item["source_id"]),
+                "event_kind": str(item["event_kind"]),
+                "url": str(item["url"]),
+                "published_at": str(item["published_at"]),
+                "updated_at": item.get("updated_at"),
+                "categories": sorted(map(str, item.get("categories") or [])),
+                "organizations": sorted(organizations_for_item(item)),
+                "metrics": metrics,
+                "total_score": item.get("total_score"),
+                "score_version": int(item.get("score_version") or 1),
+            }
+            observations.append(observation)
+
+            source_name = str(item["source"])
+            source_id = f"source:{source_name.casefold().replace(' ', '-')}"
+            source_entity = entities.setdefault(
+                source_id,
+                _entity(source_id, "source", source_name),
+            )
+            touch(source_entity, date=date, source=source_name)
+            connect("FOUND_VIA", entity_id, source_id, date)
+
+            for category in observation["categories"]:
+                topic_id = f"topic:{category}"
+                topic = entities.setdefault(
+                    topic_id,
+                    _entity(topic_id, "topic", category.replace("_", " ")),
+                )
+                touch(topic, date=date, source=source_name)
+                connect("HAS_TOPIC", entity_id, topic_id, date)
+
+            for organization in observation["organizations"]:
+                organization_id = _stable_id("organization", organization.casefold())
+                owner = entities.setdefault(
+                    organization_id,
+                    _entity(organization_id, "organization", organization),
+                )
+                touch(owner, date=date, source=source_name)
+                connect("RELEASED_BY", entity_id, organization_id, date)
+
+            for author in map(str, item.get("authors") or []):
+                person_id = _stable_id("person", author.casefold())
+                person = entities.setdefault(
+                    person_id,
+                    _entity(person_id, "person", author),
+                )
+                touch(person, date=date, source=source_name)
+                connect("AUTHORED_BY", entity_id, person_id, date)
+
+    entity_observation_counts = Counter(observation["entity_id"] for observation in observations)
+    public_entities = []
+    for entity in entities.values():
+        entity.pop("_primary_rank")
+        metrics_first = entity.pop("metrics_first")
+        metrics_latest = entity.pop("metrics_latest")
+        metric_deltas = {
+            key: round(metrics_latest.get(key, 0) - metrics_first.get(key, 0), 4)
+            for key in sorted({*metrics_first, *metrics_latest})
+        }
+        public_entities.append(
+            {
+                **entity,
+                "seen_days": sorted(entity["seen_days"]),
+                "sources": sorted(entity["sources"]),
+                "categories": sorted(entity["categories"]),
+                "metrics": metrics_latest,
+                "metric_deltas": metric_deltas,
+                "observation_count": (
+                    entity_observation_counts[entity["id"]]
+                    if entity["type"] == "artifact"
+                    else len(entity["seen_days"])
+                ),
+            }
+        )
+    public_edges = [{**edge, "seen_days": sorted(edge["seen_days"])} for edge in edges.values()]
+    observations.sort(key=lambda value: (value["snapshot_date"], value["id"]))
+    public_entities.sort(key=lambda value: value["id"])
+    public_edges.sort(key=lambda value: value["id"])
+
+    aggregates = _aggregate_corpus(public_entities, observations)
+    corpus = {
+        "schema_version": CORPUS_SCHEMA_VERSION,
+        "entity_count": len(public_entities),
+        "observation_count": len(observations),
+        "edge_count": len(public_edges),
+        "entities": public_entities,
+        "observations": observations,
+        "edges": public_edges,
+        "aggregates": aggregates,
+    }
+    validate_corpus(corpus)
+    return corpus
+
+
+def _aggregate_corpus(
+    entities: list[dict[str, Any]],
+    observations: list[dict[str, Any]],
+) -> dict[str, Any]:
+    dates = sorted({observation["snapshot_date"] for observation in observations})
+    recent_dates = set(dates[-AGGREGATE_WINDOW_DAYS:])
+    baseline_dates = set(dates[-2 * AGGREGATE_WINDOW_DAYS : -AGGREGATE_WINDOW_DAYS])
+    topic_entities: dict[str, set[str]] = defaultdict(set)
+    topic_days: dict[str, set[str]] = defaultdict(set)
+    topic_sources: dict[str, set[str]] = defaultdict(set)
+    recent = Counter()
+    baseline = Counter()
+    for observation in observations:
+        for topic in observation["categories"]:
+            topic_entities[topic].add(observation["entity_id"])
+            topic_days[topic].add(observation["snapshot_date"])
+            topic_sources[topic].add(observation["source"])
+            if observation["snapshot_date"] in recent_dates:
+                recent[topic] += 1
+            if observation["snapshot_date"] in baseline_dates:
+                baseline[topic] += 1
+    topics = []
+    for topic in sorted(topic_entities):
+        recent_average = recent[topic] / len(recent_dates) if recent_dates else 0
+        baseline_average = baseline[topic] / len(baseline_dates) if baseline_dates else None
+        topics.append(
+            {
+                "topic": topic,
+                "entity_count": len(topic_entities[topic]),
+                "persistence_days": len(topic_days[topic]),
+                "source_breadth": len(topic_sources[topic]),
+                "recent_daily_average": round(recent_average, 3),
+                "baseline_daily_average": (
+                    round(baseline_average, 3) if baseline_average is not None else None
+                ),
+                "velocity": (
+                    round(recent_average - baseline_average, 3)
+                    if baseline_average is not None
+                    else None
+                ),
+            }
+        )
+    return {
+        "window_days": AGGREGATE_WINDOW_DAYS,
+        "topics": topics,
+        "entity_types": dict(sorted(Counter(entity["type"] for entity in entities).items())),
+        "sources": dict(
+            sorted(Counter(observation["source"] for observation in observations).items())
+        ),
+        "organizations": dict(
+            sorted(
+                Counter(
+                    organization
+                    for observation in observations
+                    for organization in observation["organizations"]
+                ).items()
+            )
+        ),
+        "provenance": {
+            "primary_or_structured_observations": sum(
+                observation["source"] in PRIMARY_OR_STRUCTURED_SOURCES
+                for observation in observations
+            ),
+            "primary_source_rate": round(
+                (
+                    sum(
+                        observation["source"] in PRIMARY_OR_STRUCTURED_SOURCES
+                        for observation in observations
+                    )
+                    / len(observations)
+                ),
+                4,
+            )
+            if observations
+            else None,
+        },
+    }
+
+
+def validate_corpus(corpus: dict[str, Any]) -> None:
+    if corpus.get("schema_version") != CORPUS_SCHEMA_VERSION:
+        raise CorpusError("unsupported corpus schema_version")
+    for field in ("entities", "observations", "edges"):
+        if not isinstance(corpus.get(field), list):
+            raise CorpusError(f"{field} must be an array")
+    entities = corpus["entities"]
+    entity_ids = {entity.get("id") for entity in entities}
+    if None in entity_ids or len(entity_ids) != len(entities):
+        raise CorpusError("entity IDs must be present and unique")
+    for entity in entities:
+        if entity.get("url") and not str(entity["url"]).startswith(("https://", "http://")):
+            raise CorpusError(f"{entity['id']}: entity URL must be HTTP(S)")
+        if "raw" in entity:
+            raise CorpusError(f"{entity['id']}: raw payloads are not public corpus fields")
+    observation_ids: set[str] = set()
+    for observation in corpus["observations"]:
+        if observation.get("id") in observation_ids:
+            raise CorpusError("observation IDs must be unique")
+        observation_ids.add(observation.get("id"))
+        if observation.get("entity_id") not in entity_ids:
+            raise CorpusError("observation references an unknown entity")
+        if not str(observation.get("url") or "").startswith(("https://", "http://")):
+            raise CorpusError("observation URL must be HTTP(S)")
+        datetime.fromisoformat(str(observation["published_at"]).replace("Z", "+00:00")).astimezone(
+            UTC
+        )
+    edge_ids: set[str] = set()
+    for edge in corpus["edges"]:
+        if edge.get("id") in edge_ids:
+            raise CorpusError("edge IDs must be unique")
+        edge_ids.add(edge.get("id"))
+        if edge.get("source") not in entity_ids or edge.get("target") not in entity_ids:
+            raise CorpusError("edge references an unknown entity")

--- a/src/benchmark_radar/corpus.py
+++ b/src/benchmark_radar/corpus.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import re
 from collections import Counter, defaultdict
 from datetime import UTC, datetime
@@ -117,6 +118,18 @@ def _observation_id(date: str, entity_id: str, item: dict[str, Any]) -> str:
     )
 
 
+def _legacy_payload_hash(item: dict[str, Any]) -> str:
+    """Fingerprint the persisted public projection when the raw hash predates v2."""
+    encoded = json.dumps(
+        item,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode()
+    return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
 def _entity(
     entity_id: str,
     entity_type: str,
@@ -138,6 +151,8 @@ def _entity(
         "metrics_latest": {},
         "latest_score": None,
         "_primary_rank": 99,
+        "_parser_versions": set(),
+        "_raw_payload_hashes": set(),
     }
 
 
@@ -153,6 +168,15 @@ def build_corpus(snapshots: list[dict[str, Any]]) -> dict[str, Any]:
         entity["seen_days"].add(date)
         if source:
             entity["sources"].add(source)
+
+    def record_provenance(
+        entity: dict[str, Any],
+        *,
+        parser_version: str,
+        raw_payload_hash: str,
+    ) -> None:
+        entity["_parser_versions"].add(parser_version)
+        entity["_raw_payload_hashes"].add(raw_payload_hash)
 
     def connect(kind: str, source_id: str, target_id: str, date: str) -> None:
         edge_id = _edge_id(kind, source_id, target_id)
@@ -175,12 +199,22 @@ def build_corpus(snapshots: list[dict[str, Any]]) -> dict[str, Any]:
     for snapshot in snapshots:
         date = str(snapshot["date"])
         for item in snapshot["evidence_items"]:
+            parser_version = str(item.get("parser_version") or "legacy-public-projection/1")
+            raw_payload_hash = str(item.get("raw_payload_hash") or _legacy_payload_hash(item))
+            retrieved_at = (
+                item.get("retrieved_at") or snapshot.get("generated_at") or f"{date}T00:00:00+00:00"
+            )
             entity_id = exact_artifact_key(item)
             artifact = entities.setdefault(
                 entity_id,
                 _entity(entity_id, "artifact", str(item["title"]), url=str(item["url"])),
             )
             touch(artifact, date=date, source=str(item["source"]))
+            record_provenance(
+                artifact,
+                parser_version=parser_version,
+                raw_payload_hash=raw_payload_hash,
+            )
             source_rank = PRIMARY_SOURCE_RANK.get(str(item["source"]), 4)
             # A secondary metadata observation must not replace an exact
             # primary artifact as the entity's public label/link.
@@ -209,6 +243,10 @@ def build_corpus(snapshots: list[dict[str, Any]]) -> dict[str, Any]:
                 "url": str(item["url"]),
                 "published_at": str(item["published_at"]),
                 "updated_at": item.get("updated_at"),
+                "discovered_at": item.get("discovered_at"),
+                "retrieved_at": retrieved_at,
+                "parser_version": parser_version,
+                "raw_payload_hash": raw_payload_hash,
                 "categories": sorted(map(str, item.get("categories") or [])),
                 "organizations": sorted(organizations_for_item(item)),
                 "metrics": metrics,
@@ -224,6 +262,11 @@ def build_corpus(snapshots: list[dict[str, Any]]) -> dict[str, Any]:
                 _entity(source_id, "source", source_name),
             )
             touch(source_entity, date=date, source=source_name)
+            record_provenance(
+                source_entity,
+                parser_version=parser_version,
+                raw_payload_hash=raw_payload_hash,
+            )
             connect("FOUND_VIA", entity_id, source_id, date)
 
             for category in observation["categories"]:
@@ -233,6 +276,11 @@ def build_corpus(snapshots: list[dict[str, Any]]) -> dict[str, Any]:
                     _entity(topic_id, "topic", category.replace("_", " ")),
                 )
                 touch(topic, date=date, source=source_name)
+                record_provenance(
+                    topic,
+                    parser_version=parser_version,
+                    raw_payload_hash=raw_payload_hash,
+                )
                 connect("HAS_TOPIC", entity_id, topic_id, date)
 
             for organization in observation["organizations"]:
@@ -242,6 +290,11 @@ def build_corpus(snapshots: list[dict[str, Any]]) -> dict[str, Any]:
                     _entity(organization_id, "organization", organization),
                 )
                 touch(owner, date=date, source=source_name)
+                record_provenance(
+                    owner,
+                    parser_version=parser_version,
+                    raw_payload_hash=raw_payload_hash,
+                )
                 connect("RELEASED_BY", entity_id, organization_id, date)
 
             for author in map(str, item.get("authors") or []):
@@ -251,12 +304,19 @@ def build_corpus(snapshots: list[dict[str, Any]]) -> dict[str, Any]:
                     _entity(person_id, "person", author),
                 )
                 touch(person, date=date, source=source_name)
+                record_provenance(
+                    person,
+                    parser_version=parser_version,
+                    raw_payload_hash=raw_payload_hash,
+                )
                 connect("AUTHORED_BY", entity_id, person_id, date)
 
     entity_observation_counts = Counter(observation["entity_id"] for observation in observations)
     public_entities = []
     for entity in entities.values():
         entity.pop("_primary_rank")
+        parser_versions = sorted(entity.pop("_parser_versions"))
+        raw_payload_hashes = sorted(entity.pop("_raw_payload_hashes"))
         metrics_first = entity.pop("metrics_first")
         metrics_latest = entity.pop("metrics_latest")
         metric_deltas = {
@@ -276,6 +336,8 @@ def build_corpus(snapshots: list[dict[str, Any]]) -> dict[str, Any]:
                     if entity["type"] == "artifact"
                     else len(entity["seen_days"])
                 ),
+                "parser_versions": parser_versions,
+                "raw_payload_hashes": raw_payload_hashes,
             }
         )
     public_edges = [{**edge, "seen_days": sorted(edge["seen_days"])} for edge in edges.values()]
@@ -392,6 +454,13 @@ def validate_corpus(corpus: dict[str, Any]) -> None:
             raise CorpusError(f"{entity['id']}: entity URL must be HTTP(S)")
         if "raw" in entity:
             raise CorpusError(f"{entity['id']}: raw payloads are not public corpus fields")
+        if not entity.get("parser_versions") or not entity.get("raw_payload_hashes"):
+            raise CorpusError(f"{entity['id']}: provenance must be present")
+        if any(
+            not re.fullmatch(r"sha256:[0-9a-f]{64}", str(value))
+            for value in entity["raw_payload_hashes"]
+        ):
+            raise CorpusError(f"{entity['id']}: raw payload hash must use sha256")
     observation_ids: set[str] = set()
     for observation in corpus["observations"]:
         if observation.get("id") in observation_ids:
@@ -404,6 +473,13 @@ def validate_corpus(corpus: dict[str, Any]) -> None:
         datetime.fromisoformat(str(observation["published_at"]).replace("Z", "+00:00")).astimezone(
             UTC
         )
+        datetime.fromisoformat(str(observation["retrieved_at"]).replace("Z", "+00:00")).astimezone(
+            UTC
+        )
+        if not observation.get("parser_version") or not re.fullmatch(
+            r"sha256:[0-9a-f]{64}", str(observation.get("raw_payload_hash") or "")
+        ):
+            raise CorpusError("observation provenance must be present")
     edge_ids: set[str] = set()
     for edge in corpus["edges"]:
         if edge.get("id") in edge_ids:

--- a/src/benchmark_radar/describe.py
+++ b/src/benchmark_radar/describe.py
@@ -81,36 +81,14 @@ def strip_title_echo(text: str, title: str) -> str:
 def huggingface_summary(row: dict[str, Any], title: str) -> str:
     """Describe a Hugging Face repo using only what its maintainer published.
 
-    Returns "" when the repo has no card and no descriptive tags, which is itself
-    a signal: an unlabelled repo is usually a scratch upload, not a release.
+    Returns "" when the repo has no prose. Structured tags remain available in
+    the raw payload for future typed fields, but must not be rewritten into a
+    sentence that can influence relevance scoring.
     """
     prose = strip_title_echo(clean_card_text(row.get("description")), title)
     if prose:
         return prose
-    # No card. Fall back to curator-authored metadata, which is still real
-    # evidence, unlike a generated sentence.
-    card = row.get("cardData") or {}
-    facets: list[str] = []
-    tasks = card.get("task_categories") or card.get("task_ids") or []
-    if isinstance(tasks, list) and tasks:
-        facets.append("tasks: " + ", ".join(str(value) for value in tasks[:3]))
-    sizes = card.get("size_categories")
-    if sizes:
-        size = sizes[0] if isinstance(sizes, list) and sizes else sizes
-        facets.append(f"size: {size}")
-    languages = card.get("language") or []
-    if isinstance(languages, list) and languages:
-        facets.append("language: " + ", ".join(str(value) for value in languages[:3]))
-    # Author-supplied tags exclude the machine-generated `license:`/`region:`
-    # namespaces that every repo carries.
-    free_tags = [
-        tag
-        for tag in (row.get("tags") or [])
-        if isinstance(tag, str) and ":" not in tag and tag.lower() not in {"benchmark", "dataset"}
-    ]
-    if free_tags:
-        facets.append("tagged: " + ", ".join(free_tags[:4]))
-    return "No dataset card. Declared " + "; ".join(facets) + "." if facets else ""
+    return ""
 
 
 def github_summary(row: dict[str, Any]) -> str:

--- a/src/benchmark_radar/describe.py
+++ b/src/benchmark_radar/describe.py
@@ -36,7 +36,9 @@ _MARKDOWN_NOISE = re.compile(
 # YAML front matter in a dataset card is metadata, not description prose.
 _FRONT_MATTER = re.compile(r"\A\s*---.*?\n---\s*", re.DOTALL)
 
-MAX_SUMMARY_CHARS = 400
+# Keep enough upstream prose for useful inline expansion while bounding the
+# static payload. The UI links to the full source/card for anything beyond it.
+MAX_SUMMARY_CHARS = 2_000
 
 
 def clean_card_text(text: str | None) -> str:

--- a/src/benchmark_radar/http.py
+++ b/src/benchmark_radar/http.py
@@ -11,6 +11,17 @@ from typing import Any
 import certifi
 
 USER_AGENT = "benchmark-radar/0.1 (+https://github.com/ktwu01/benchmark-radar)"
+DEFAULT_TIMEOUT_SECONDS = 30.0
+MAX_RETRY_DELAY_SECONDS = 30.0
+
+
+class RequestError(RuntimeError):
+    """Credential-safe HTTP failure suitable for public source-health output."""
+
+
+def _safe_url(url: str) -> str:
+    parts = urllib.parse.urlsplit(url)
+    return urllib.parse.urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
 
 
 def get_json(
@@ -19,13 +30,14 @@ def get_json(
     params: dict[str, Any] | None = None,
     headers: dict[str, str] | None = None,
     attempts: int = 3,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
 ) -> Any:
     if params:
         clean = {key: value for key, value in params.items() if value is not None}
         url = f"{url}?{urllib.parse.urlencode(clean)}"
     request_headers = {"Accept": "application/json", "User-Agent": USER_AGENT}
     request_headers.update(headers or {})
-    return json.loads(_request(url, request_headers, attempts).decode("utf-8"))
+    return json.loads(_request(url, request_headers, attempts, timeout=timeout).decode("utf-8"))
 
 
 def get_text(
@@ -34,27 +46,54 @@ def get_text(
     params: dict[str, Any] | None = None,
     headers: dict[str, str] | None = None,
     attempts: int = 3,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
 ) -> str:
     if params:
         url = f"{url}?{urllib.parse.urlencode(params)}"
     request_headers = {"User-Agent": USER_AGENT}
     request_headers.update(headers or {})
-    return _request(url, request_headers, attempts).decode("utf-8")
+    return _request(url, request_headers, attempts, timeout=timeout).decode("utf-8")
 
 
-def _request(url: str, headers: dict[str, str], attempts: int) -> bytes:
+def _request(
+    url: str,
+    headers: dict[str, str],
+    attempts: int,
+    *,
+    timeout: float,
+) -> bytes:
+    if attempts < 1:
+        raise ValueError("attempts must be at least 1")
+    if timeout <= 0:
+        raise ValueError("timeout must be positive")
     last_error: Exception | None = None
     for attempt in range(attempts):
         try:
             with urllib.request.urlopen(
                 urllib.request.Request(url, headers=headers),
-                timeout=30,
+                timeout=timeout,
                 context=ssl.create_default_context(cafile=certifi.where()),
             ) as response:
                 return response.read()
+        except urllib.error.HTTPError as error:
+            # Only rate limits and server failures are transient. Never expose
+            # a query string: some APIs carry credentials there.
+            if error.code != 429 and error.code < 500:
+                raise RequestError(f"HTTP {error.code} from {_safe_url(url)}") from None
+            last_error = error
+            retry_after = error.headers.get("Retry-After") if error.headers else None
+            delay = float(retry_after) if retry_after and retry_after.isdigit() else 2**attempt
+            if attempt + 1 < attempts:
+                time.sleep(min(delay, MAX_RETRY_DELAY_SECONDS))
         except (urllib.error.URLError, TimeoutError) as error:
             last_error = error
             if attempt + 1 < attempts:
-                time.sleep(2**attempt)
+                time.sleep(min(2**attempt, MAX_RETRY_DELAY_SECONDS))
     assert last_error is not None
-    raise last_error
+    if isinstance(last_error, urllib.error.HTTPError):
+        raise RequestError(
+            f"HTTP {last_error.code} from {_safe_url(url)} after {attempts} attempts"
+        ) from None
+    raise RequestError(
+        f"{type(last_error).__name__} from {_safe_url(url)} after {attempts} attempts"
+    ) from None

--- a/src/benchmark_radar/models.py
+++ b/src/benchmark_radar/models.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import hashlib
+import json
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from typing import Any
@@ -14,12 +16,15 @@ class RadarItem:
     published_at: datetime
     updated_at: datetime | None = None
     discovered_at: datetime | None = None
+    retrieved_at: datetime | None = None
     summary: str = ""
     event_kind: str = "discovered"
     authors: list[str] = field(default_factory=list)
     artifact_urls: list[str] = field(default_factory=list)
     metrics: dict[str, float] = field(default_factory=dict)
     raw: dict[str, Any] = field(default_factory=dict, repr=False)
+    parser_version: str = "radar-item/1"
+    raw_payload_hash: str = ""
     categories: list[str] = field(default_factory=list)
     evidence_score: float = 0.0
     relevance_score: float = 0.0
@@ -40,6 +45,26 @@ class RadarItem:
         return f"{self.source}:{self.source_id}".lower()
 
     def to_dict(self) -> dict[str, Any]:
+        if not self.raw_payload_hash:
+            payload = self.raw or {
+                "source": self.source,
+                "source_id": self.source_id,
+                "title": self.title,
+                "url": self.url,
+                "published_at": self.published_at.isoformat(),
+                "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+                "summary": self.summary,
+                "authors": self.authors,
+                "metrics": self.metrics,
+            }
+            encoded = json.dumps(
+                payload,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+                default=str,
+            ).encode()
+            self.raw_payload_hash = f"sha256:{hashlib.sha256(encoded).hexdigest()}"
         value = asdict(self)
         value["published_at"] = self.published_at.astimezone(UTC).isoformat()
         value["updated_at"] = (
@@ -47,6 +72,9 @@ class RadarItem:
         )
         value["discovered_at"] = (
             self.discovered_at.astimezone(UTC).isoformat() if self.discovered_at else None
+        )
+        value["retrieved_at"] = (
+            self.retrieved_at.astimezone(UTC).isoformat() if self.retrieved_at else None
         )
         value.pop("raw", None)
         return value

--- a/src/benchmark_radar/models.py
+++ b/src/benchmark_radar/models.py
@@ -26,6 +26,9 @@ class RadarItem:
     recency_score: float = 0.0
     adoption_score: float = 0.0
     total_score: float = 0.0
+    score_version: int = 2
+    score_max: float = 100.0
+    suppression_reasons: list[str] = field(default_factory=list)
     rationale: list[str] = field(default_factory=list)
     # Set when the record matches a named artifact on the configured
     # watchlist. Routing metadata only: it never alters a score.

--- a/src/benchmark_radar/pipeline.py
+++ b/src/benchmark_radar/pipeline.py
@@ -268,6 +268,8 @@ def run_pipeline(
             fetched = fetcher(source_config, since, limit)
             fetched_count += len(fetched)
             health.append(SourceHealth(source=source_name, ok=True, item_count=len(fetched)))
+            for item in fetched:
+                item.retrieved_at = item.retrieved_at or now
             if source_name == "arxiv":
                 changed = _apply_arxiv_discovery_state(
                     fetched,

--- a/src/benchmark_radar/pipeline.py
+++ b/src/benchmark_radar/pipeline.py
@@ -60,6 +60,8 @@ def score_item(
     item: RadarItem,
     taxonomy: dict[str, list[str]],
     now: datetime | None = None,
+    *,
+    lookback_hours: float = rubric.DEFAULT_LOOKBACK_HOURS,
 ) -> RadarItem:
     now = now or datetime.now(UTC)
     # Only match against text a human actually wrote about the artifact. If a
@@ -74,11 +76,24 @@ def score_item(
             categories.append(category)
             matched_terms.extend(matches[:2])
     item.categories = categories
-    item.relevance_score = min(
+    relevance = min(
         rubric.SCORE_MAX,
         rubric.RELEVANCE_PER_CATEGORY * len(categories)
         + rubric.RELEVANCE_PER_TERM * len(matched_terms),
     )
+    deductions = [
+        signal
+        for signal in rubric.LOW_VALUE_SIGNALS
+        if re.search(str(signal["pattern"]), haystack, flags=re.IGNORECASE)
+    ]
+    deduction = min(
+        rubric.MAX_LOW_VALUE_DEDUCTION,
+        sum(float(signal["deduction"]) for signal in deductions),
+    )
+    item.relevance_score = max(0.0, relevance - deduction)
+    item.suppression_reasons = [
+        str(signal["label"]) for signal in deductions if signal["action"] == "suppress"
+    ]
 
     evidence = rubric.EVIDENCE_BASE
     if item.source in rubric.EVIDENCE_PRIMARY_SOURCES:
@@ -93,14 +108,22 @@ def score_item(
 
     activity_at = item.updated_at or item.published_at
     age_hours = max(0.0, (now - activity_at).total_seconds() / 3600)
+    if lookback_hours <= 0:
+        raise ValueError("lookback_hours must be positive")
     item.recency_score = max(
         0.0,
-        rubric.SCORE_MAX - age_hours / rubric.RECENCY_HALF_LIFE_HOURS,
+        rubric.SCORE_MAX * (1.0 - age_hours / lookback_hours),
     )
 
-    adoption = sum(
-        math.log10(1 + item.metrics.get(metric, 0)) * weight
-        for metric, weight in rubric.ADOPTION_METRIC_WEIGHTS.items()
+    adoption = max(
+        (
+            rubric.SCORE_MAX
+            * math.log10(1 + max(0.0, float(item.metrics.get(metric, 0))))
+            / math.log10(1 + saturation)
+            for metric, saturation in rubric.ADOPTION_METRIC_SATURATION.items()
+            if item.metrics.get(metric, 0)
+        ),
+        default=0.0,
     )
     item.adoption_score = min(adoption, rubric.SCORE_MAX)
     item.total_score = round(
@@ -110,8 +133,19 @@ def score_item(
         ),
         2,
     )
+    item.score_version = rubric.SCORING_VERSION
+    item.score_max = rubric.SCORE_MAX
+    item.rationale = [
+        reason
+        for reason in item.rationale
+        if not reason.startswith(("Matched:", "Demoted:", "Primary record:"))
+    ]
     if matched_terms:
         item.rationale.append(f"Matched: {', '.join(sorted(set(matched_terms)))}")
+    for signal in deductions:
+        item.rationale.append(
+            f"Demoted: {signal['label']} (-{float(signal['deduction']):g} relevance)"
+        )
     item.rationale.append(f"Primary record: {item.source}")
     return item
 
@@ -278,7 +312,15 @@ def run_pipeline(
         )
     unique = deduplicate(items)
     scored = apply_watchlist(
-        [score_item(item, config["taxonomy"], now) for item in unique],
+        [
+            score_item(
+                item,
+                config["taxonomy"],
+                now,
+                lookback_hours=float(settings["lookback_hours"]),
+            )
+            for item in unique
+        ],
         config.get("watchlist") or [],
     )
     selected = [
@@ -287,7 +329,11 @@ def run_pipeline(
         # A watchlist hit is published even when the generic score or taxonomy
         # would have dropped it: the reader asked for these by name.
         if item.watchlist
-        or (item.total_score >= float(settings["minimum_score"]) and item.categories)
+        or (
+            not item.suppression_reasons
+            and item.total_score >= float(settings["minimum_score"])
+            and item.categories
+        )
     ]
     selected.sort(
         key=lambda item: (bool(item.watchlist), item.total_score, item.published_at),
@@ -311,11 +357,21 @@ def run_pipeline(
             1
             for item in selected
             if item.watchlist
-            and not (item.total_score >= float(settings["minimum_score"]) and item.categories)
+            and not (
+                not item.suppression_reasons
+                and item.total_score >= float(settings["minimum_score"])
+                and item.categories
+            )
+        ),
+        "suppressed_low_value": sum(
+            1 for item in scored if item.suppression_reasons and not item.watchlist
         ),
         "published": len(published),
         "minimum_score": float(settings["minimum_score"]),
         "report_limit": int(settings["report_limit"]),
+        "lookback_hours": float(settings["lookback_hours"]),
+        "score_version": rubric.SCORING_VERSION,
+        "score_max": rubric.SCORE_MAX,
     }
     attention, attention_health, producer_health, attention_state = fetch_attention_feeds(
         config.get("attention") or {},

--- a/src/benchmark_radar/report.py
+++ b/src/benchmark_radar/report.py
@@ -22,7 +22,7 @@ def _item_block(index: int, item: RadarItem) -> str:
         f"### {index}. [{_escape(item.title)}]({item.url})",
         "",
         f"**{marker}{item.source} · {item.event_kind} · {category} · "
-        f"priority {item.total_score:.2f}/4.00**",
+        f"priority {item.total_score:.1f}/{item.score_max:.0f}**",
         "",
     ]
     if item.watchlist and item.watchlist_note:
@@ -121,12 +121,18 @@ def render_markdown(
             + ")"
         )
         suppressed = int(selection.get("suppressed_as_seen") or 0)
+        suppressed_low_value = int(selection.get("suppressed_low_value") or 0)
         lines.extend(
             [
                 "- Selection: "
                 f"**{selection.get('fetched', 0)}** fetched → "
                 + (f"**{suppressed}** already seen → " if suppressed else "")
                 + f"**{selection.get('deduplicated', 0)}** after dedupe → "
+                + (
+                    f"**{suppressed_low_value}** low-value artifacts suppressed → "
+                    if suppressed_low_value
+                    else ""
+                )
                 + qualified
                 + f" → **{selection.get('published', 0)}** published",
                 "",

--- a/src/benchmark_radar/rubric.py
+++ b/src/benchmark_radar/rubric.py
@@ -1,169 +1,237 @@
-"""The published scoring rubric, in one place.
+"""Versioned, published definitions for Benchmark Radar priority scores.
 
-`score_item` in `pipeline.py` computes priority from these weights, and
-`dashboard_data` copies this module's description into `site/data/radar.json`
-so the dashboard can show a reader exactly the rubric that ranked the records
-in front of them. Keeping the numbers here rather than restating them in the
-browser is deliberate: a rubric the UI describes from its own hardcoded copy
-drifts silently the first time a weight changes, and a rubric that says
-something the pipeline does not do is worse than no rubric at all.
+The pipeline and dashboard both consume this module.  A score is useful only
+when the arithmetic shown to a reader is the arithmetic that produced it, so
+historical scoring versions remain available instead of being relabelled when
+the current rubric changes.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
-SCORE_MAX = 4.0
+SCORING_VERSION = 2
+SCORE_MAX = 100.0
+DEFAULT_LOOKBACK_HOURS = 48.0
 
-# Priority is the weighted mean of the four components below. The weights sum
-# to 1.0, so priority shares the components' 0-4 range.
+# The v1 rubric placed 60% of the total on evidence and recency, which barely
+# varied inside the 48-hour collection window.  Adoption now has enough weight
+# to distinguish established artifacts while relevance remains the largest
+# input.
 WEIGHTS: dict[str, float] = {
-    "relevance": 0.40,
-    "evidence": 0.25,
+    "relevance": 0.35,
+    "evidence": 0.20,
     "recency": 0.20,
-    "adoption": 0.15,
+    "adoption": 0.25,
 }
 
-# Evidence credit per source. `score_item` tests each tier independently and
-# adds every credit that applies, so these two source tuples must stay
-# disjoint: a source listed in both would collect 2.5 rather than the 1.5 or
-# 1.0 the published bands promise. `test_source_tiers_stay_disjoint` enforces
-# that, because the drift would show up as an inflated score with a rubric
-# beside it that no longer explains the number.
-EVIDENCE_BASE = 0.5
-EVIDENCE_PRIMARY_SOURCES = ("arXiv", "OpenAlex")
-EVIDENCE_PRIMARY_CREDIT = 1.5
-EVIDENCE_ARTIFACT_SOURCES = ("GitHub", "Hugging Face")
-EVIDENCE_ARTIFACT_CREDIT = 1.0
-EVIDENCE_AUTHORSHIP_CREDIT = 0.5
-EVIDENCE_CROSS_LINK_CREDIT = 0.5
+# Evidence is explicit and additive on a 0-100 scale.
+EVIDENCE_BASE = 10.0
+EVIDENCE_PRIMARY_SOURCES = ("arXiv", "OpenAlex", "OpenReview", "Semantic Scholar")
+EVIDENCE_PRIMARY_CREDIT = 40.0
+EVIDENCE_ARTIFACT_SOURCES = ("GitHub", "GitHub Release", "Hugging Face")
+EVIDENCE_ARTIFACT_CREDIT = 30.0
+EVIDENCE_AUTHORSHIP_CREDIT = 20.0
+EVIDENCE_CROSS_LINK_CREDIT = 20.0
 
-# Relevance credit for taxonomy matches.
-RELEVANCE_PER_CATEGORY = 1.25
-RELEVANCE_PER_TERM = 0.2
+# Relevance credit for taxonomy matches.  A single incidental term cannot
+# produce a high score; multiple independent category matches can.
+RELEVANCE_PER_CATEGORY = 20.0
+RELEVANCE_PER_TERM = 5.0
 RELEVANCE_TERMS_COUNTED_PER_CATEGORY = 2
 
-# Recency decays linearly from the full score to zero across this many hours.
-RECENCY_HALF_LIFE_HOURS = 24.0
-RECENCY_ZERO_AT_HOURS = SCORE_MAX * RECENCY_HALF_LIFE_HOURS
+# Deterministic negative signals address artifacts that are technically
+# on-topic but do not represent a benchmark/data release worth occupying the
+# daily radar.  Patterns require specific phrases rather than generic words so
+# a legitimate leaderboard or anonymous conference paper is not penalized.
+LOW_VALUE_SIGNALS: tuple[dict[str, Any], ...] = (
+    {
+        "label": "follower-count leaderboard",
+        "pattern": (
+            r"\bfollowers?[\s_-]*(?:count[\s_-]*)?leaderboard\b"
+            r"|\bfollower leaderboard(?:'s)? history\b"
+        ),
+        "deduction": 50.0,
+        "action": "demote",
+    },
+    {
+        "label": "results dump or per-run index",
+        "pattern": (
+            r"\bresults?[\s_-]*(?:dump|index)\b"
+            r"|\bper[\s_-]*run[\s_-]*results?\b"
+        ),
+        "deduction": 30.0,
+        "action": "suppress",
+    },
+    {
+        "label": "submission placeholder",
+        "pattern": (
+            r"\b(?:anonymous|anonymized)[\s_-]*(?:review[\s_-]*)?submission\b"
+            r"|\breview[\s_-]*process[\s_-]*(?:stub|placeholder)\b"
+            r"|\bsubmission[\s_-]*(?:stub|placeholder)\b"
+        ),
+        "deduction": 30.0,
+        "action": "suppress",
+    },
+    {
+        "label": "visualization-only companion",
+        "pattern": (
+            r"\bvisuali[sz]ation companion\b"
+            r"|\bcompact browser assets\b"
+            r"|\bleaderboard case assets\b"
+        ),
+        "deduction": 25.0,
+        "action": "suppress",
+    },
+)
+MAX_LOW_VALUE_DEDUCTION = 60.0
 
-# Adoption weights for log10-scaled public counters.
-ADOPTION_METRIC_WEIGHTS: dict[str, float] = {
-    "stars": 0.8,
-    "citations": 0.7,
-    "downloads": 0.6,
-    "likes": 0.5,
+# Adoption reaches the top of its scale at a documented, source-appropriate
+# public counter.  The strongest available counter is used because adding
+# incomparable counters (stars + downloads + citations) rewards sources merely
+# for exposing more metric types.
+ADOPTION_METRIC_SATURATION: dict[str, float] = {
+    "stars": 10_000.0,
+    "citations": 1_000.0,
+    "downloads": 100_000.0,
+    "likes": 1_000.0,
 }
 
-COMPONENTS: list[dict[str, Any]] = [
-    {
-        "key": "relevance",
-        "label": "Relevance",
-        "weight": WEIGHTS["relevance"],
-        "summary": (
-            "How squarely the title and the source's own description land inside the "
-            "benchmark, evaluation, dataset, and data-quality taxonomy."
-        ),
-        "bands": [
-            f"{RELEVANCE_PER_CATEGORY:.2f} per taxonomy category matched",
-            f"{RELEVANCE_PER_TERM:.2f} per matched term, counting up to "
-            f"{RELEVANCE_TERMS_COUNTED_PER_CATEGORY} terms per category",
-            f"Capped at {SCORE_MAX:.2f}",
-        ],
-    },
-    {
-        "key": "evidence",
-        "label": "Evidence",
-        "weight": WEIGHTS["evidence"],
-        "summary": (
-            "How directly the record is attested: a primary or structured record "
-            "outranks a secondary mention, and named authors and linked artifacts "
-            "add attestation."
-        ),
-        "bands": [
-            f"{EVIDENCE_BASE:.2f} baseline for any record that passed ingest",
-            f"+{EVIDENCE_PRIMARY_CREDIT:.2f} from a primary scholarly record "
-            f"({', '.join(EVIDENCE_PRIMARY_SOURCES)})",
-            f"+{EVIDENCE_ARTIFACT_CREDIT:.2f} from a structured artifact registry "
-            f"({', '.join(EVIDENCE_ARTIFACT_SOURCES)})",
-            f"+{EVIDENCE_AUTHORSHIP_CREDIT:.2f} when the source names authors",
-            f"+{EVIDENCE_CROSS_LINK_CREDIT:.2f} when a second artifact URL corroborates it",
-            f"Capped at {SCORE_MAX:.2f}",
-        ],
-    },
-    {
-        "key": "recency",
-        "label": "Recency",
-        "weight": WEIGHTS["recency"],
-        "summary": (
-            "Hours since publication or the last material update, so a revised "
-            "record re-enters the day's view."
-        ),
-        "bands": [
-            f"{SCORE_MAX:.2f} at the moment of publication or update",
-            f"Decays linearly by 1.00 every {RECENCY_HALF_LIFE_HOURS:g} hours",
-            f"Reaches 0.00 at {RECENCY_ZERO_AT_HOURS:g} hours",
-        ],
-    },
-    {
-        "key": "adoption",
-        "label": "Adoption",
-        "weight": WEIGHTS["adoption"],
-        "summary": (
-            "Public uptake counters on a log10 scale, so the first hundred stars "
-            "move the score far more than the ten-thousandth."
-        ),
-        "bands": [
-            f"{weight:.2f} x log10(1 + {metric})"
-            for metric, weight in ADOPTION_METRIC_WEIGHTS.items()
-        ]
-        + [f"Capped at {SCORE_MAX:.2f}"],
-    },
-]
 
-LIMITS: list[str] = [
-    "This is triage for a reader deciding what to open next. It is not peer "
-    "review, a quality verdict, or an endorsement.",
-    "Relevance reads only the title and the description the source itself "
-    "published. Nothing this project writes about a record can earn it points.",
-    "Adoption measures attention, not correctness. A widely starred repository "
-    "and a careful one are not the same claim.",
-    "Attention signals are shown separately and are never scored on this rubric.",
-    "Watchlisted artifacts are published whatever they score, and sort above "
-    "everything else. Their rank reflects that request, not a higher score.",
-]
+def _components(*, lookback_hours: float) -> list[dict[str, Any]]:
+    return [
+        {
+            "key": "relevance",
+            "label": "Relevance",
+            "weight": WEIGHTS["relevance"],
+            "summary": (
+                "How squarely the title and the source's own description land inside the "
+                "benchmark, evaluation, dataset, and data-quality taxonomy, after explicit "
+                "low-value deductions."
+            ),
+            "bands": [
+                f"{RELEVANCE_PER_CATEGORY:.0f} per taxonomy category matched",
+                f"+{RELEVANCE_PER_TERM:.0f} per matched term, counting up to "
+                f"{RELEVANCE_TERMS_COUNTED_PER_CATEGORY} terms per category",
+                *[
+                    f"-{signal['deduction']:.0f} for {signal['label']}"
+                    + ("; suppressed" if signal["action"] == "suppress" else "")
+                    for signal in LOW_VALUE_SIGNALS
+                ],
+                f"Total deductions capped at {MAX_LOW_VALUE_DEDUCTION:.0f}",
+                f"Clamped to 0-{SCORE_MAX:.0f}",
+            ],
+        },
+        {
+            "key": "evidence",
+            "label": "Evidence",
+            "weight": WEIGHTS["evidence"],
+            "summary": (
+                "How directly the record is attested: a primary or structured record "
+                "outranks a secondary mention, and named authors and linked artifacts "
+                "add corroboration."
+            ),
+            "bands": [
+                f"{EVIDENCE_BASE:.0f} baseline for any record that passed ingest",
+                f"+{EVIDENCE_PRIMARY_CREDIT:.0f} from a primary scholarly record "
+                f"({', '.join(EVIDENCE_PRIMARY_SOURCES)})",
+                f"+{EVIDENCE_ARTIFACT_CREDIT:.0f} from a structured artifact registry "
+                f"({', '.join(EVIDENCE_ARTIFACT_SOURCES)})",
+                f"+{EVIDENCE_AUTHORSHIP_CREDIT:.0f} when the source names authors",
+                f"+{EVIDENCE_CROSS_LINK_CREDIT:.0f} when another artifact URL corroborates it",
+                f"Capped at {SCORE_MAX:.0f}",
+            ],
+        },
+        {
+            "key": "recency",
+            "label": "Recency",
+            "weight": WEIGHTS["recency"],
+            "summary": (
+                "How recently the artifact was published or materially updated within "
+                "this scan's configured collection window."
+            ),
+            "bands": [
+                f"{SCORE_MAX:.0f} at publication or update time",
+                f"Decays linearly across the configured {lookback_hours:g}-hour lookback",
+                f"Reaches 0 at {lookback_hours:g} hours",
+            ],
+        },
+        {
+            "key": "adoption",
+            "label": "Adoption",
+            "weight": WEIGHTS["adoption"],
+            "summary": (
+                "The strongest available public uptake counter on a log scale. "
+                "This measures attention, not scientific quality."
+            ),
+            "bands": [
+                f"{metric} reaches 100 at {saturation:g}"
+                for metric, saturation in ADOPTION_METRIC_SATURATION.items()
+            ]
+            + ["Uses the strongest available normalized counter", "Clamped to 0-100"],
+        },
+    ]
 
 
 def priority_formula() -> str:
-    """Render the weighted sum the way the README states it."""
-    return " + ".join(
-        f"{weight:.2f} {component}"
-        for component, weight in ((entry["key"], entry["weight"]) for entry in COMPONENTS)
-    )
+    """Render the weighted sum the way the README and dashboard state it."""
+    return " + ".join(f"{weight:.2f} {component}" for component, weight in WEIGHTS.items())
 
 
-def rubric_reference(*, minimum_score: float | None = None) -> dict[str, Any]:
-    """The rubric as published to the dashboard.
-
-    `minimum_score` is the configured cutoff a record must clear to be reported
-    at all. It is part of what the reader is looking at, so it travels with the
-    rubric rather than being described separately.
-    """
+def rubric_reference(
+    *,
+    minimum_score: float | None = None,
+    lookback_hours: float = DEFAULT_LOOKBACK_HOURS,
+) -> dict[str, Any]:
+    """Return the current rubric as a browser-safe published reference."""
     value: dict[str, Any] = {
+        "scoring_version": SCORING_VERSION,
         "score_max": SCORE_MAX,
         "formula": priority_formula(),
-        "components": [
-            {
-                "key": entry["key"],
-                "label": entry["label"],
-                "weight": entry["weight"],
-                "summary": entry["summary"],
-                "bands": list(entry["bands"]),
-            }
-            for entry in COMPONENTS
+        "components": _components(lookback_hours=lookback_hours),
+        "limits": [
+            "This is triage for a reader deciding what to open next. It is not peer "
+            "review, a quality verdict, or an endorsement.",
+            "Relevance reads only the title and source-published description. Nothing "
+            "this project writes about a record can earn it points.",
+            "Negative signals demote only named artifact patterns. Result indexes, "
+            "submission placeholders, and visualization-only companions are suppressed; "
+            "the selection funnel reports how many were removed.",
+            "Adoption measures attention, not correctness.",
+            "Attention observations are shown separately and are never quality-scored.",
+            "Watchlisted artifacts publish whatever they score and sort first. Their "
+            "rank reflects that request, not a higher score.",
         ],
-        "limits": list(LIMITS),
+        "lookback_hours": float(lookback_hours),
     }
     if minimum_score is not None:
         value["minimum_score"] = float(minimum_score)
     return value
+
+
+def legacy_rubric_reference() -> dict[str, Any]:
+    """Describe v1 records without pretending the current formula produced them."""
+    return {
+        "scoring_version": 1,
+        "score_max": 4.0,
+        "formula": "0.40 relevance + 0.25 evidence + 0.20 recency + 0.15 adoption",
+        "components": [
+            {
+                "key": key,
+                "label": key.title(),
+                "weight": weight,
+                "summary": "Legacy 0-4 component retained for historical audit.",
+                "bands": ["Historical scoring version; superseded by rubric v2."],
+            }
+            for key, weight in {
+                "relevance": 0.40,
+                "evidence": 0.25,
+                "recency": 0.20,
+                "adoption": 0.15,
+            }.items()
+        ],
+        "limits": [
+            "This historical score used the original 0-4 rubric and is not directly "
+            "comparable with current 0-100 scores."
+        ],
+    }

--- a/src/benchmark_radar/snapshots.py
+++ b/src/benchmark_radar/snapshots.py
@@ -9,7 +9,11 @@ from typing import Any
 
 from .attention import fetch_attention_feeds
 from .models import RadarRun
-from .rubric import rubric_reference
+from .rubric import (
+    SCORING_VERSION,
+    legacy_rubric_reference,
+    rubric_reference,
+)
 
 SCHEMA_VERSION = 2
 SUPPORTED_SCHEMA_VERSIONS = {1, SCHEMA_VERSION}
@@ -366,7 +370,17 @@ def dashboard_data(snapshots: list[dict[str, Any]]) -> dict[str, Any]:
     sources: set[str] = set()
     event_kinds: set[str] = set()
     for snapshot in snapshots:
-        evidence_items = snapshot["evidence_items"]
+        # Snapshot schema v2 predates scoring-version metadata. Preserve those
+        # historical 0-4 values explicitly so a current 0-100 label and formula
+        # can never be shown beside arithmetic they did not produce.
+        evidence_items = [
+            {
+                **item,
+                "score_version": int(item.get("score_version") or 1),
+                "score_max": float(item.get("score_max") or 4.0),
+            }
+            for item in snapshot["evidence_items"]
+        ]
         observations = snapshot["attention"]["observations"]
         category_counts = Counter(
             category for item in evidence_items for category in item["categories"]
@@ -423,11 +437,34 @@ def dashboard_data(snapshots: list[dict[str, Any]]) -> dict[str, Any]:
             "kinds": ["evidence", "attention"],
         },
         "days": days,
-        # The rubric travels with the data it explains. A reader asking "why is
-        # this 2.94 out of 4.00?" gets the weights that produced that number,
-        # not a second copy maintained by hand in the browser.
+        # Keep every rubric required by the history. The browser selects by
+        # each record's score_version, so a v1 score is never explained using
+        # v2 arithmetic.
+        "rubrics": {
+            "1": legacy_rubric_reference(),
+            str(SCORING_VERSION): rubric_reference(
+                minimum_score=(
+                    (days[-1].get("selection") or {}).get("minimum_score")
+                    if days
+                    and (days[-1].get("selection") or {}).get("score_version") == SCORING_VERSION
+                    else None
+                ),
+                lookback_hours=(
+                    (days[-1].get("selection") or {}).get("lookback_hours") or 48 if days else 48
+                ),
+            ),
+        },
+        # Backward-compatible alias for the global information button.
         "rubric": rubric_reference(
-            minimum_score=(days[-1].get("selection") or {}).get("minimum_score") if days else None
+            minimum_score=(
+                (days[-1].get("selection") or {}).get("minimum_score")
+                if days
+                and (days[-1].get("selection") or {}).get("score_version") == SCORING_VERSION
+                else None
+            ),
+            lookback_hours=(
+                (days[-1].get("selection") or {}).get("lookback_hours") or 48 if days else 48
+            ),
         ),
     }
 

--- a/src/benchmark_radar/snapshots.py
+++ b/src/benchmark_radar/snapshots.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from .attention import fetch_attention_feeds
+from .corpus import build_corpus, organizations_for_item
 from .models import RadarRun
 from .rubric import (
     SCORING_VERSION,
@@ -299,6 +300,13 @@ def load_snapshots(snapshot_dir: Path) -> list[dict[str, Any]]:
 TREND_BASELINE_DAYS = 7
 
 
+def _collection_context(day: dict[str, Any]) -> tuple[Any, tuple[str, ...]]:
+    return (
+        (day.get("selection") or {}).get("report_limit"),
+        tuple(day.get("coverage_signature") or []),
+    )
+
+
 def _attach_category_trends(days: list[dict[str, Any]]) -> None:
     """Add per-category deltas, baselines and cumulative totals to each day.
 
@@ -325,17 +333,14 @@ def _attach_category_trends(days: list[dict[str, Any]]) -> None:
             for category in record["categories"]:
                 seen.setdefault(category, set()).add(identity)
         cumulative = Counter({category: len(ids) for category, ids in seen.items()})
-        limit = (day.get("selection") or {}).get("report_limit")
+        context = _collection_context(day)
         comparable = [
             entry
             for entry in days[max(0, index - TREND_BASELINE_DAYS) : index]
-            if (entry.get("selection") or {}).get("report_limit") == limit
+            if _collection_context(entry) == context
         ]
         prior_day = days[index - 1] if index else None
-        if (
-            prior_day is not None
-            and (prior_day.get("selection") or {}).get("report_limit") != limit
-        ):
+        if prior_day is not None and _collection_context(prior_day) != context:
             prior_day = None
         previous = prior_day["category_counts"] if prior_day else {}
         trends = {}
@@ -368,6 +373,7 @@ def dashboard_data(snapshots: list[dict[str, Any]]) -> dict[str, Any]:
     days: list[dict[str, Any]] = []
     categories: set[str] = set()
     sources: set[str] = set()
+    organizations: set[str] = set()
     event_kinds: set[str] = set()
     for snapshot in snapshots:
         # Snapshot schema v2 predates scoring-version metadata. Preserve those
@@ -378,6 +384,7 @@ def dashboard_data(snapshots: list[dict[str, Any]]) -> dict[str, Any]:
                 **item,
                 "score_version": int(item.get("score_version") or 1),
                 "score_max": float(item.get("score_max") or 4.0),
+                "organizations": organizations_for_item(item),
             }
             for item in snapshot["evidence_items"]
         ]
@@ -398,8 +405,22 @@ def dashboard_data(snapshots: list[dict[str, Any]]) -> dict[str, Any]:
         )
         sources.update(source_counts)
         sources.update(attention_source_counts)
+        organizations.update(
+            organization
+            for item in evidence_items
+            for organization in item.get("organizations") or []
+        )
         event_kinds.update(event_counts)
         event_kinds.update(attention_event_counts)
+        evidence_health = [
+            entry
+            for entry in snapshot["ingest_health"]
+            if entry.get("kind", "evidence") == "evidence"
+        ]
+        coverage_signature = sorted(
+            f"{entry['source']}:{'ok' if entry['ok'] else 'failed'}" for entry in evidence_health
+        )
+        coverage_gaps = sorted(entry["source"] for entry in evidence_health if not entry["ok"])
         days.append(
             {
                 "date": snapshot["date"],
@@ -421,9 +442,13 @@ def dashboard_data(snapshots: list[dict[str, Any]]) -> dict[str, Any]:
                 "ingest_health": snapshot["ingest_health"],
                 "producer_health": snapshot["producer_health"],
                 "selection": snapshot.get("selection") or {},
+                "coverage_complete": not coverage_gaps,
+                "coverage_gaps": coverage_gaps,
+                "coverage_signature": coverage_signature,
             }
         )
     _attach_category_trends(days)
+    corpus = build_corpus(snapshots)
     return {
         "schema_version": SCHEMA_VERSION,
         "latest_date": days[-1]["date"] if days else None,
@@ -433,10 +458,12 @@ def dashboard_data(snapshots: list[dict[str, Any]]) -> dict[str, Any]:
             "dates": [day["date"] for day in days],
             "categories": sorted(categories),
             "sources": sorted(sources),
+            "organizations": sorted(organizations),
             "event_kinds": sorted(event_kinds),
             "kinds": ["evidence", "attention"],
         },
         "days": days,
+        "corpus": corpus,
         # Keep every rubric required by the history. The browser selects by
         # each record's score_version, so a v1 score is never explained using
         # v2 arithmetic.

--- a/src/benchmark_radar/snapshots.py
+++ b/src/benchmark_radar/snapshots.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from collections import Counter
 from copy import deepcopy
 from datetime import UTC, datetime
@@ -107,6 +108,16 @@ def _validate_evidence_items(items: Any, *, source: str) -> None:
                     source=source,
                     field=f"evidence item {index} {field}",
                 )
+        if item.get("retrieved_at"):
+            _validate_time(
+                item["retrieved_at"],
+                source=source,
+                field=f"evidence item {index} retrieved_at",
+            )
+        if item.get("raw_payload_hash") and not re.fullmatch(
+            r"sha256:[0-9a-f]{64}", str(item["raw_payload_hash"])
+        ):
+            raise SnapshotError(f"{source}: evidence item {index} raw_payload_hash must use sha256")
 
 
 def _validate_health(values: Any, *, source: str, field: str) -> None:

--- a/src/benchmark_radar/sources.py
+++ b/src/benchmark_radar/sources.py
@@ -8,9 +8,52 @@ from datetime import UTC, datetime, timedelta
 from email.utils import parsedate_to_datetime
 from typing import Any
 
-from .describe import github_summary, huggingface_summary
+from .describe import clean_card_text, github_summary, huggingface_summary
 from .http import get_json, get_text
 from .models import RadarItem
+
+
+class ConnectorPayloadError(ValueError):
+    """Raised when a source returns a successful but incompatible payload."""
+
+
+def _payload_dict(payload: Any, source: str) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise ConnectorPayloadError(f"{source} returned a non-object payload")
+    return payload
+
+
+def _payload_rows(payload: Any, key: str, source: str) -> list[dict[str, Any]]:
+    parsed = _payload_dict(payload, source)
+    if key not in parsed:
+        raise ConnectorPayloadError(f"{source} response is missing {key}")
+    value = parsed[key]
+    if not isinstance(value, list) or not all(isinstance(row, dict) for row in value):
+        raise ConnectorPayloadError(f"{source} returned invalid {key}")
+    return value
+
+
+def _request_options(config: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "attempts": int(config.get("attempts", 3)),
+        "timeout": float(config.get("timeout_seconds", 30)),
+    }
+
+
+def _openreview_value(content: dict[str, Any], key: str, default: Any = None) -> Any:
+    value = content.get(key, default)
+    if isinstance(value, dict) and "value" in value:
+        return value["value"]
+    return value
+
+
+def _milliseconds(value: Any) -> datetime | None:
+    if value in (None, ""):
+        return None
+    try:
+        return datetime.fromtimestamp(float(value) / 1000, tz=UTC)
+    except (TypeError, ValueError, OSError):
+        return None
 
 
 def _date(value: str | None) -> datetime:
@@ -90,6 +133,8 @@ def _fetch_arxiv_rss(
                 summary=summary,
                 event_kind="updated" if announce_type == "replace" else "released",
                 authors=[author.strip() for author in creators.split(",") if author.strip()],
+                raw={"xml": ET.tostring(entry, encoding="unicode")},
+                parser_version="arxiv-rss/1",
             )
     return sorted(
         found.values(),
@@ -155,6 +200,8 @@ def fetch_arxiv(config: dict[str, Any], since: datetime, limit: int) -> list[Rad
                         summary=summary,
                         event_kind="updated" if updated > published else "released",
                         authors=authors,
+                        raw={"xml": ET.tostring(entry, encoding="unicode")},
+                        parser_version="arxiv-atom/1",
                     )
         except Exception as error:
             atom_error = error
@@ -190,8 +237,8 @@ def fetch_huggingface(config: dict[str, Any], since: datetime, limit: int) -> li
                     "full": "true",
                 },
             )
-            if not isinstance(rows, list):
-                continue
+            if not isinstance(rows, list) or not all(isinstance(row, dict) for row in rows):
+                raise ConnectorPayloadError("Hugging Face Hub returned a non-array payload")
             for row in rows:
                 changed = _date(row.get("lastModified") or row.get("createdAt"))
                 if changed < since:
@@ -215,6 +262,7 @@ def fetch_huggingface(config: dict[str, Any], since: datetime, limit: int) -> li
                         "likes": float(row.get("likes") or 0),
                     },
                     raw=row,
+                    parser_version="huggingface-hub/1",
                 )
     return list(found.values())
 
@@ -262,7 +310,7 @@ def fetch_github(config: dict[str, Any], since: datetime, limit: int) -> list[Ra
                 },
                 headers=headers,
             )
-            rows = payload.get("items", [])
+            rows = _payload_rows(payload, "items", "GitHub Search")
             for row in rows:
                 changed = _date(row.get("pushed_at") or row.get("updated_at"))
                 if changed < since:
@@ -281,6 +329,7 @@ def fetch_github(config: dict[str, Any], since: datetime, limit: int) -> list[Ra
                         "forks": float(row.get("forks_count") or 0),
                     },
                     raw=row,
+                    parser_version="github-search/1",
                 )
             if len(rows) < min(limit, page_size):
                 exhausted.add(index)
@@ -289,6 +338,282 @@ def fetch_github(config: dict[str, Any], since: datetime, limit: int) -> list[Ra
     # Round-robin can overshoot the per-source cap on its final sweep, since
     # every query contributes before the total is known. Trim to the most
     # recently active repositories so `max_items_per_source` stays honest.
+    return sorted(found.values(), key=lambda item: item.published_at, reverse=True)[:limit]
+
+
+def fetch_openreview(
+    config: dict[str, Any],
+    since: datetime,
+    limit: int,
+) -> list[RadarItem]:
+    """Fetch recent public conference/workshop submissions from API v2."""
+    found: dict[str, RadarItem] = {}
+    venues = [str(value) for value in config.get("venues", []) if str(value).strip()]
+    page_size = min(1000, max(1, int(config.get("page_size", 250))))
+    budget = max(1, int(config.get("max_requests", len(venues) or 1)))
+    requests_made = 0
+    for venue in venues:
+        offset = 0
+        while requests_made < budget and len(found) < limit:
+            payload = get_json(
+                "https://api2.openreview.net/notes",
+                params={
+                    "venueid": venue,
+                    "limit": min(page_size, limit - len(found)),
+                    "offset": offset,
+                    "sort": "mdate:desc",
+                },
+                **_request_options(config),
+            )
+            requests_made += 1
+            rows = _payload_rows(payload, "notes", "OpenReview")
+            if not rows:
+                break
+            oldest: datetime | None = None
+            for row in rows:
+                content = row.get("content")
+                if not isinstance(content, dict):
+                    raise ConnectorPayloadError("OpenReview note content must be an object")
+                note_id = str(row.get("forum") or row.get("id") or "").strip()
+                title = str(_openreview_value(content, "title", "") or "").strip()
+                created = _milliseconds(row.get("cdate") or row.get("pdate"))
+                modified = _milliseconds(row.get("mdate")) or created
+                activity = modified or created
+                if not note_id or not title or not created or not activity:
+                    continue
+                oldest = min(oldest or activity, activity)
+                if activity < since:
+                    continue
+                abstract = str(_openreview_value(content, "abstract", "") or "").strip()
+                authors = _openreview_value(content, "authors", []) or []
+                if isinstance(authors, str):
+                    authors = [authors]
+                if not isinstance(authors, list):
+                    raise ConnectorPayloadError("OpenReview authors must be an array")
+                artifact_urls = []
+                for key in ("code", "dataset", "project", "supplementary_material"):
+                    value = _openreview_value(content, key)
+                    values = value if isinstance(value, list) else [value]
+                    artifact_urls.extend(
+                        str(url)
+                        for url in values
+                        if isinstance(url, str) and url.startswith(("https://", "http://"))
+                    )
+                found[note_id] = RadarItem(
+                    source="OpenReview",
+                    source_id=note_id,
+                    title=title,
+                    url=f"https://openreview.net/forum?id={note_id}",
+                    published_at=created,
+                    updated_at=modified,
+                    summary=abstract,
+                    event_kind="updated" if modified and modified > created else "released",
+                    authors=[str(author) for author in authors if str(author).strip()],
+                    artifact_urls=sorted(set(artifact_urls)),
+                    raw=row,
+                    parser_version="openreview-api-v2/1",
+                )
+            offset += len(rows)
+            if len(rows) < min(page_size, limit - len(found)) or (
+                oldest is not None and oldest < since
+            ):
+                break
+        if requests_made >= budget or len(found) >= limit:
+            break
+    return sorted(
+        found.values(),
+        key=lambda item: (item.updated_at or item.published_at, item.source_id),
+        reverse=True,
+    )[:limit]
+
+
+def fetch_semantic_scholar(
+    config: dict[str, Any],
+    since: datetime,
+    limit: int,
+) -> list[RadarItem]:
+    """Fetch structured scholarly records with exact external identifiers."""
+    api_key = os.getenv("SEMANTIC_SCHOLAR_API_KEY")
+    headers = {"x-api-key": api_key} if api_key else {}
+    found: dict[str, RadarItem] = {}
+    searches = [str(value) for value in config.get("searches", []) if str(value).strip()]
+    budget = max(1, int(config.get("max_requests", len(searches) or 1)))
+    page_size = min(100, max(1, int(config.get("page_size", 100))))
+    requests_made = 0
+    for search in searches:
+        offset = 0
+        while requests_made < budget and len(found) < limit:
+            payload = get_json(
+                "https://api.semanticscholar.org/graph/v1/paper/search",
+                params={
+                    "query": search,
+                    "publicationDateOrYear": f"{since.date().isoformat()}:",
+                    "offset": offset,
+                    "limit": min(page_size, limit - len(found)),
+                    "fields": (
+                        "paperId,externalIds,url,title,abstract,publicationDate,"
+                        "authors,citationCount,influentialCitationCount,openAccessPdf"
+                    ),
+                },
+                headers=headers,
+                **_request_options(config),
+            )
+            requests_made += 1
+            rows = _payload_rows(payload, "data", "Semantic Scholar")
+            if not rows:
+                break
+            for row in rows:
+                paper_id = str(row.get("paperId") or "").strip()
+                title = str(row.get("title") or "").strip()
+                published_text = row.get("publicationDate")
+                if not paper_id or not title or not published_text:
+                    continue
+                published = _date(str(published_text))
+                if published < since:
+                    continue
+                external = row.get("externalIds") or {}
+                if not isinstance(external, dict):
+                    raise ConnectorPayloadError("Semantic Scholar externalIds must be an object")
+                artifact_urls = []
+                if external.get("DOI"):
+                    artifact_urls.append(f"https://doi.org/{external['DOI']}")
+                if external.get("ArXiv"):
+                    artifact_urls.append(f"https://arxiv.org/abs/{external['ArXiv']}")
+                open_access = row.get("openAccessPdf") or {}
+                if not isinstance(open_access, dict):
+                    raise ConnectorPayloadError("Semantic Scholar openAccessPdf must be an object")
+                if str(open_access.get("url") or "").startswith(("https://", "http://")):
+                    artifact_urls.append(str(open_access["url"]))
+                authors = row.get("authors") or []
+                if not isinstance(authors, list):
+                    raise ConnectorPayloadError("Semantic Scholar authors must be an array")
+                found[paper_id] = RadarItem(
+                    source="Semantic Scholar",
+                    source_id=paper_id,
+                    title=title,
+                    url=str(row.get("url") or f"https://www.semanticscholar.org/paper/{paper_id}"),
+                    published_at=published,
+                    updated_at=published,
+                    summary=str(row.get("abstract") or "").strip(),
+                    event_kind="released",
+                    authors=[
+                        str(author.get("name"))
+                        for author in authors
+                        if isinstance(author, dict) and author.get("name")
+                    ],
+                    artifact_urls=sorted(set(artifact_urls)),
+                    metrics={
+                        "citations": float(row.get("citationCount") or 0),
+                        "influential_citations": float(row.get("influentialCitationCount") or 0),
+                    },
+                    raw=row,
+                    parser_version="semantic-scholar-graph/1",
+                )
+            next_offset = _payload_dict(payload, "Semantic Scholar").get("next")
+            if next_offset is None or len(rows) < min(page_size, limit - len(found)):
+                break
+            try:
+                offset = int(next_offset)
+            except (TypeError, ValueError) as error:
+                raise ConnectorPayloadError(
+                    "Semantic Scholar returned an invalid next offset"
+                ) from error
+        if requests_made >= budget or len(found) >= limit:
+            break
+    return sorted(found.values(), key=lambda item: item.published_at, reverse=True)[:limit]
+
+
+def fetch_github_releases(
+    config: dict[str, Any],
+    since: datetime,
+    limit: int,
+) -> list[RadarItem]:
+    """Fetch published releases from a bounded first-party repository allowlist."""
+    token = os.getenv("GITHUB_TOKEN")
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        **({"Authorization": f"Bearer {token}"} if token else {}),
+    }
+    repositories = [
+        str(value).strip()
+        for value in config.get("repositories", [])
+        if re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", str(value).strip())
+    ]
+    page_size = min(100, max(1, int(config.get("page_size", 30))))
+    max_pages = max(1, int(config.get("max_pages_per_repository", 2)))
+    budget = max(1, int(config.get("max_requests", len(repositories) or 1)))
+    requests_made = 0
+    found: dict[str, RadarItem] = {}
+    for repository in repositories:
+        for page in range(1, max_pages + 1):
+            if requests_made >= budget or len(found) >= limit:
+                break
+            payload = get_json(
+                f"https://api.github.com/repos/{repository}/releases",
+                params={"per_page": min(page_size, limit - len(found)), "page": page},
+                headers=headers,
+                **_request_options(config),
+            )
+            requests_made += 1
+            if not isinstance(payload, list) or not all(isinstance(row, dict) for row in payload):
+                raise ConnectorPayloadError("GitHub Releases returned a non-array payload")
+            if not payload:
+                break
+            oldest: datetime | None = None
+            for row in payload:
+                if row.get("draft"):
+                    continue
+                published_text = row.get("published_at") or row.get("created_at")
+                if not published_text:
+                    continue
+                published = _date(str(published_text))
+                oldest = min(oldest or published, published)
+                if published < since:
+                    continue
+                tag = str(row.get("tag_name") or "").strip()
+                url = str(row.get("html_url") or "").strip()
+                if not tag or not url:
+                    continue
+                author = row.get("author") or {}
+                assets = row.get("assets") or []
+                if not isinstance(assets, list) or not all(
+                    isinstance(asset, dict) for asset in assets
+                ):
+                    raise ConnectorPayloadError("GitHub release assets must be an array")
+                found[f"{repository}@{tag}"] = RadarItem(
+                    source="GitHub Release",
+                    source_id=f"{repository}@{tag}",
+                    title=str(row.get("name") or f"{repository} {tag}").strip(),
+                    url=url,
+                    published_at=published,
+                    updated_at=published,
+                    summary=clean_card_text(row.get("body")),
+                    event_kind="prereleased" if row.get("prerelease") else "released",
+                    authors=(
+                        [str(author["login"])]
+                        if isinstance(author, dict) and author.get("login")
+                        else []
+                    ),
+                    artifact_urls=[f"https://github.com/{repository}"],
+                    metrics={
+                        "downloads": float(
+                            sum(
+                                int(asset.get("download_count") or 0)
+                                for asset in assets
+                                if isinstance(asset, dict)
+                            )
+                        )
+                    },
+                    raw=row,
+                    parser_version="github-releases/1",
+                )
+            if len(payload) < min(page_size, limit - len(found)) or (
+                oldest is not None and oldest < since
+            ):
+                break
+        if requests_made >= budget or len(found) >= limit:
+            break
     return sorted(found.values(), key=lambda item: item.published_at, reverse=True)[:limit]
 
 
@@ -328,6 +653,7 @@ def fetch_openalex(config: dict[str, Any], since: datetime, limit: int) -> list[
                 authors=[author for author in authors if author],
                 metrics={"citations": float(row.get("cited_by_count") or 0)},
                 raw=row,
+                parser_version="openalex-works/1",
             )
     return list(found.values())
 
@@ -362,6 +688,7 @@ def fetch_brave(config: dict[str, Any], since: datetime, limit: int) -> list[Rad
                 summary=" ".join([row.get("description") or "", *row.get("extra_snippets", [])]),
                 event_kind="discovered",
                 raw=row,
+                parser_version="brave-web-search/1",
             )
     return list(found.values())
 
@@ -370,6 +697,9 @@ SOURCE_FETCHERS = {
     "arxiv": fetch_arxiv,
     "huggingface": fetch_huggingface,
     "github": fetch_github,
+    "openreview": fetch_openreview,
+    "semantic_scholar": fetch_semantic_scholar,
+    "github_releases": fetch_github_releases,
     "openalex": fetch_openalex,
     "brave": fetch_brave,
 }

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -1,0 +1,86 @@
+import pytest
+
+from benchmark_radar.corpus import (
+    CorpusError,
+    build_corpus,
+    exact_artifact_key,
+    organizations_for_item,
+    validate_corpus,
+)
+
+
+def item(**overrides):
+    value = {
+        "source": "Semantic Scholar",
+        "source_id": "paper-1",
+        "title": "A benchmark",
+        "url": "https://www.semanticscholar.org/paper/paper-1",
+        "published_at": "2026-07-28T12:00:00+00:00",
+        "updated_at": None,
+        "event_kind": "released",
+        "categories": ["benchmark"],
+        "authors": [],
+        "artifact_urls": [],
+        "metrics": {},
+        "total_score": 50,
+    }
+    value.update(overrides)
+    return value
+
+
+def snapshot(*items):
+    return {
+        "date": "2026-07-28",
+        "evidence_items": list(items),
+    }
+
+
+def test_exact_primary_identifier_wins_over_secondary_record_and_repo_links():
+    record = item(
+        artifact_urls=[
+            "https://github.com/org/benchmark",
+            "https://arxiv.org/abs/2607.12345v2",
+        ]
+    )
+
+    assert exact_artifact_key(record) == "artifact:arxiv:2607.12345"
+
+
+def test_equal_titles_do_not_merge_without_an_exact_identifier():
+    first = item(url="https://example.com/releases/one")
+    second = item(source_id="paper-2", url="https://example.net/releases/two")
+
+    assert exact_artifact_key(first) != exact_artifact_key(second)
+
+
+def test_repository_owner_is_a_structured_organization():
+    assert organizations_for_item(item(source="GitHub Release", source_id="OpenAI/evals@v1")) == [
+        "OpenAI"
+    ]
+
+
+def test_cross_source_observations_cluster_under_one_entity():
+    scholarly = item(
+        source="Semantic Scholar",
+        artifact_urls=["https://arxiv.org/abs/2607.12345"],
+    )
+    primary = item(
+        source="arXiv",
+        source_id="2607.12345",
+        url="https://arxiv.org/abs/2607.12345",
+    )
+
+    corpus = build_corpus([snapshot(scholarly, primary)])
+    artifacts = [entity for entity in corpus["entities"] if entity["type"] == "artifact"]
+
+    assert len(artifacts) == 1
+    assert artifacts[0]["observation_count"] == 2
+    assert artifacts[0]["sources"] == ["Semantic Scholar", "arXiv"]
+
+
+def test_validation_rejects_edges_to_unknown_entities():
+    corpus = build_corpus([snapshot(item())])
+    corpus["edges"][0]["target"] = "artifact:missing"
+
+    with pytest.raises(CorpusError, match="unknown entity"):
+        validate_corpus(corpus)

--- a/tests/test_describe.py
+++ b/tests/test_describe.py
@@ -48,7 +48,7 @@ def test_huggingface_uses_real_card_prose():
     )
 
 
-def test_huggingface_falls_back_to_declared_metadata():
+def test_huggingface_does_not_rewrite_declared_metadata_as_prose():
     row = {
         "description": "",
         "cardData": {
@@ -58,12 +58,7 @@ def test_huggingface_falls_back_to_declared_metadata():
         },
         "tags": ["license:mit", "region:us", "benchmark", "medical"],
     }
-    result = huggingface_summary(row, "org/thing")
-    assert "tasks: question-answering" in result
-    assert "size: 1K<n<10K" in result
-    # Machine-generated namespaces and words the pills already show are excluded.
-    assert "license:mit" not in result
-    assert "region:us" not in result
+    assert huggingface_summary(row, "org/thing") == ""
 
 
 def test_huggingface_returns_empty_when_source_published_nothing():

--- a/tests/test_describe.py
+++ b/tests/test_describe.py
@@ -12,10 +12,19 @@ def test_card_text_is_stripped_of_markdown_and_front_matter():
 
 
 def test_card_text_truncates_on_a_sentence_boundary():
-    body = "First sentence is meaningful. " + "padding word " * 60
+    body = "First sentence is meaningful. " + "padding word " * 300
     result = clean_card_text(body)
     assert result.startswith("First sentence is meaningful.")
-    assert len(result) <= 401
+    assert len(result) <= 2_000
+
+
+def test_card_text_preserves_prose_for_inline_expansion():
+    body = " ".join(f"source-word-{index}" for index in range(100))
+
+    result = clean_card_text(body)
+
+    assert len(result) > 400
+    assert "source-word-99" in result
 
 
 def test_empty_card_text_stays_empty():

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,0 +1,98 @@
+import io
+import urllib.error
+
+import pytest
+
+from benchmark_radar.http import RequestError, get_json
+
+
+class Response:
+    def __init__(self, body: bytes):
+        self.body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def read(self):
+        return self.body
+
+
+def test_http_retries_rate_limits_then_succeeds(monkeypatch):
+    attempts = []
+    sleeps = []
+
+    def fake_urlopen(request, **kwargs):
+        attempts.append(request.full_url)
+        if len(attempts) < 3:
+            raise urllib.error.HTTPError(
+                request.full_url,
+                429,
+                "rate limited",
+                {"Retry-After": "0"},
+                io.BytesIO(),
+            )
+        return Response(b'{"ok": true}')
+
+    monkeypatch.setattr("benchmark_radar.http.urllib.request.urlopen", fake_urlopen)
+    monkeypatch.setattr("benchmark_radar.http.time.sleep", sleeps.append)
+
+    assert get_json("https://example.test/data", attempts=3) == {"ok": True}
+    assert len(attempts) == 3
+    assert sleeps == [0.0, 0.0]
+
+
+@pytest.mark.parametrize(
+    ("error", "expected"),
+    [
+        (
+            urllib.error.HTTPError(
+                "https://example.test/data",
+                500,
+                "server error",
+                {},
+                io.BytesIO(),
+            ),
+            "HTTP 500",
+        ),
+        (TimeoutError("timed out"), "TimeoutError"),
+    ],
+)
+def test_http_exhaustion_is_bounded(monkeypatch, error, expected):
+    calls = []
+    monkeypatch.setattr("benchmark_radar.http.time.sleep", lambda seconds: None)
+
+    def fake_urlopen(request, **kwargs):
+        calls.append(request.full_url)
+        raise error
+
+    monkeypatch.setattr("benchmark_radar.http.urllib.request.urlopen", fake_urlopen)
+
+    with pytest.raises(RequestError, match=expected):
+        get_json("https://example.test/data", attempts=2)
+
+    assert len(calls) == 2
+
+
+def test_http_failure_never_exposes_query_credentials(monkeypatch):
+    def fake_urlopen(request, **kwargs):
+        raise urllib.error.HTTPError(
+            request.full_url,
+            401,
+            "unauthorized",
+            {},
+            io.BytesIO(),
+        )
+
+    monkeypatch.setattr("benchmark_radar.http.urllib.request.urlopen", fake_urlopen)
+
+    with pytest.raises(RequestError) as captured:
+        get_json(
+            "https://example.test/data",
+            params={"api_key": "do-not-print", "query": "benchmark"},
+        )
+
+    assert "do-not-print" not in str(captured.value)
+    assert "?" not in str(captured.value)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
@@ -59,7 +59,7 @@ def test_scoring_is_explainable_and_bounded():
     }
     scored = score_item(item(), taxonomy, datetime(2026, 7, 27, 1, tzinfo=UTC))
     assert scored.categories == ["benchmark", "evaluation", "dataset"]
-    assert 0 <= scored.total_score <= 4
+    assert 0 <= scored.total_score <= 100
     assert any("Matched:" in reason for reason in scored.rationale)
 
 
@@ -92,6 +92,92 @@ def test_boilerplate_summary_cannot_earn_relevance():
         datetime(2026, 7, 27, 1, tzinfo=UTC),
     )
     assert "dataset" not in bare.categories
+
+
+def test_low_value_follower_leaderboard_is_explicitly_demoted():
+    taxonomy = {"benchmark": ["leaderboard"], "dataset": ["dataset"]}
+    low_value = score_item(
+        item(
+            source="Hugging Face",
+            source_id="Weyaxi/followers-leaderboard",
+            title="Weyaxi/followers-leaderboard",
+            summary="Follower Leaderboard's History Dataset.",
+        ),
+        taxonomy,
+        datetime(2026, 7, 27, 1, tzinfo=UTC),
+    )
+    real_release = score_item(
+        item(
+            source="Hugging Face",
+            source_id="org/model-eval",
+            title="Model Evaluation Leaderboard",
+            summary="Dataset of verified model evaluation results.",
+        ),
+        taxonomy,
+        datetime(2026, 7, 27, 1, tzinfo=UTC),
+    )
+
+    assert low_value.relevance_score == 0
+    assert real_release.relevance_score == 50
+    assert real_release.total_score > low_value.total_score
+    assert any("Demoted: follower-count leaderboard" in reason for reason in low_value.rationale)
+
+
+def test_recency_uses_the_configured_collection_window():
+    taxonomy = {"benchmark": ["benchmark"]}
+    published = datetime(2026, 7, 27, tzinfo=UTC)
+
+    halfway = score_item(
+        item(published_at=published),
+        taxonomy,
+        published + timedelta(hours=24),
+        lookback_hours=48,
+    )
+    expired = score_item(
+        item(published_at=published),
+        taxonomy,
+        published + timedelta(hours=48),
+        lookback_hours=48,
+    )
+
+    assert halfway.recency_score == 50
+    assert expired.recency_score == 0
+
+
+def test_visualization_companion_is_suppressed_from_pipeline(monkeypatch):
+    companion = item(
+        source="Hugging Face",
+        source_id="org/leaderboard-cases",
+        title="Leaderboard Case Assets",
+        summary=(
+            "This dataset stores compact browser assets and is a visualization "
+            "companion, not an evaluation dataset."
+        ),
+    )
+    monkeypatch.setitem(
+        __import__("benchmark_radar.pipeline", fromlist=["SOURCE_FETCHERS"]).SOURCE_FETCHERS,
+        "huggingface",
+        lambda config, since, limit: [companion],
+    )
+    config = {
+        "radar": {
+            "lookback_hours": 48,
+            "max_items_per_source": 10,
+            "report_limit": 10,
+            "minimum_score": 0,
+        },
+        "taxonomy": {
+            "benchmark": ["leaderboard"],
+            "evaluation": ["evaluation"],
+            "dataset": ["dataset"],
+        },
+        "sources": {"huggingface": {"enabled": True, "required": True}},
+    }
+
+    run = run_pipeline(config, datetime(2026, 7, 27, tzinfo=UTC))
+
+    assert run.items == []
+    assert run.selection["suppressed_low_value"] == 1
 
 
 def test_watchlist_matches_aliases_across_fields():

--- a/tests/test_rubric.py
+++ b/tests/test_rubric.py
@@ -26,7 +26,7 @@ def item(**overrides) -> RadarItem:
 def test_weights_are_a_normalized_mean_over_the_published_scale():
     assert set(rubric.WEIGHTS) == {"relevance", "evidence", "recency", "adoption"}
     assert sum(rubric.WEIGHTS.values()) == 1.0
-    # Priority is presented as "x / 4.00". That only reads as a mean if a record
+    # Priority is presented as "x / 100". That only reads as a mean if a record
     # scoring the maximum on every component reaches exactly the maximum.
     assert sum(rubric.SCORE_MAX * weight for weight in rubric.WEIGHTS.values()) == rubric.SCORE_MAX
 
@@ -36,7 +36,8 @@ def test_published_rubric_describes_every_scored_component():
     keys = [component["key"] for component in reference["components"]]
 
     assert keys == list(rubric.WEIGHTS)
-    assert reference["score_max"] == rubric.SCORE_MAX
+    assert reference["score_max"] == 100
+    assert reference["scoring_version"] == 2
     for component in reference["components"]:
         assert component["weight"] == rubric.WEIGHTS[component["key"]]
         assert component["summary"].strip()
@@ -85,28 +86,30 @@ def test_source_tiers_stay_disjoint():
     assert not overlap, f"sources in two evidence tiers collect both credits: {overlap}"
 
 
-def test_recency_reaches_zero_exactly_where_the_rubric_says_it_does():
+def test_recency_reaches_zero_at_the_configured_lookback():
     published = datetime(2026, 7, 28, 12, 0, tzinfo=UTC)
     at_publication = score_item(item(published_at=published), TAXONOMY, published)
     at_zero = score_item(
         item(published_at=published),
         TAXONOMY,
-        published + timedelta(hours=rubric.RECENCY_ZERO_AT_HOURS),
+        published + timedelta(hours=72),
+        lookback_hours=72,
     )
-    one_step = score_item(
+    halfway = score_item(
         item(published_at=published),
         TAXONOMY,
-        published + timedelta(hours=rubric.RECENCY_HALF_LIFE_HOURS),
+        published + timedelta(hours=36),
+        lookback_hours=72,
     )
 
     assert at_publication.recency_score == rubric.SCORE_MAX
     assert at_zero.recency_score == 0.0
-    assert one_step.recency_score == rubric.SCORE_MAX - 1.0
+    assert halfway.recency_score == 50.0
 
 
 def test_adoption_counts_every_metric_the_rubric_lists():
     now = datetime(2026, 7, 28, 12, 0, tzinfo=UTC)
-    for metric in rubric.ADOPTION_METRIC_WEIGHTS:
+    for metric in rubric.ADOPTION_METRIC_SATURATION:
         scored = score_item(item(metrics={metric: 999}), TAXONOMY, now)
         assert scored.adoption_score > 0, f"{metric} earned no adoption credit"
 
@@ -119,7 +122,7 @@ def test_no_component_can_exceed_the_published_maximum():
             title=f"{every_term} benchmark leaderboard",
             authors=["A"],
             artifact_urls=["https://example.com/a"],
-            metrics={metric: 10**9 for metric in rubric.ADOPTION_METRIC_WEIGHTS},
+            metrics={metric: 10**9 for metric in rubric.ADOPTION_METRIC_SATURATION},
         ),
         TAXONOMY,
         now,

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1,5 +1,6 @@
 from html.parser import HTMLParser
 from pathlib import Path
+from urllib.parse import urlsplit
 
 
 class SiteParser(HTMLParser):
@@ -9,6 +10,7 @@ class SiteParser(HTMLParser):
         self.ids: set[str] = set()
         self.html_lang = ""
         self.viewport = False
+        self.local_refs: list[str] = []
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         values = dict(attrs)
@@ -19,6 +21,9 @@ class SiteParser(HTMLParser):
             self.html_lang = str(values.get("lang", ""))
         if tag == "meta" and values.get("name") == "viewport":
             self.viewport = True
+        reference = values.get("href") or values.get("src")
+        if reference and not urlsplit(reference).scheme and not reference.startswith(("#", "//")):
+            self.local_refs.append(reference)
 
 
 def test_site_has_accessible_landmarks_and_views():
@@ -28,7 +33,7 @@ def test_site_has_accessible_landmarks_and_views():
     assert parser.html_lang == "en"
     assert parser.viewport
     assert {"header", "nav", "main", "footer", "dialog"} <= set(parser.tags)
-    assert {"today-view", "trends-view", "main-content"} <= parser.ids
+    assert {"today-view", "trends-view", "map-view", "main-content"} <= parser.ids
     assert "explorer-view" not in parser.ids
 
 
@@ -153,6 +158,43 @@ def test_hugging_face_expansion_links_to_the_full_card():
 
     assert 'item.source === "Hugging Face"' in script
     assert '"Read full card ↗"' in script
+
+
+def test_trend_map_is_keyboard_accessible_and_coordinates_today_filters():
+    html = Path("site/index.html").read_text(encoding="utf-8")
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    assert 'data-view="map"' in html
+    assert 'id="map-canvas"' in html
+    assert "state.data.corpus" in script
+    assert "HAS_TOPIC" in script
+    assert '"aria-label": `${entity.type}: ${entity.label}`' in script
+    assert 'event.key === "Enter" || event.key === " "' in script
+    assert "mapFilterFor(entity)" in script
+    assert 'id="organization-filter"' in html
+    assert "state.organization" in script
+
+
+def test_trends_gate_comparisons_on_connector_coverage():
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    assert "sameCollectionContext" in script
+    assert "coverage_signature" in script
+    assert "Coverage is incomplete:" in script
+
+
+def test_static_html_references_existing_local_assets():
+    parser = SiteParser()
+    parser.feed(Path("site/index.html").read_text(encoding="utf-8"))
+
+    missing = []
+    for reference in parser.local_refs:
+        path = urlsplit(reference).path
+        target = Path("site") if path in {"", ".", "./"} else Path("site") / path
+        if not target.exists():
+            missing.append(reference)
+
+    assert not missing
 
 
 def test_one_snapshot_trend_explains_history_requirement():

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -28,7 +28,8 @@ def test_site_has_accessible_landmarks_and_views():
     assert parser.html_lang == "en"
     assert parser.viewport
     assert {"header", "nav", "main", "footer", "dialog"} <= set(parser.tags)
-    assert {"today-view", "trends-view", "explorer-view", "main-content"} <= parser.ids
+    assert {"today-view", "trends-view", "main-content"} <= parser.ids
+    assert "explorer-view" not in parser.ids
 
 
 def test_priority_score_is_reachably_explained():
@@ -61,7 +62,8 @@ def test_rubric_is_read_from_published_data_not_restated_in_the_browser():
 def test_attention_signals_are_not_offered_the_evidence_rubric():
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
 
-    assert "if (!isAttention && state.data?.rubric)" in script
+    assert "isAttention ? attentionActivity(item) : scoreBlock(item)" in script
+    assert "openRubric(item)" not in script[script.index("function attentionActivity") :]
 
 
 def test_detail_grid_shows_every_component_that_moves_the_total():
@@ -71,15 +73,19 @@ def test_detail_grid_shows_every_component_that_moves_the_total():
         assert f'["{component}", Number(item.' in script
 
 
-def test_today_view_keeps_one_signal_summary_and_one_source_status():
+def test_today_view_has_one_filterable_observation_list_and_one_source_status():
     html = Path("site/index.html").read_text(encoding="utf-8")
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
 
-    assert html.count("Ranked evidence") == 1
-    assert html.count("Attention signals") == 1
+    assert html.count("Matching observations") == 1
+    assert 'id="today-list"' in html
+    assert 'id="filters"' in html
+    assert 'id="kind-filter"' in html
+    assert "observations.map(observationCard)" in script
     assert "Daily field note" not in html
     assert "What entered the field?" not in html
     assert "today-overview" not in html
+    assert "today-attention-list" not in html
     assert "Sources in results" not in script
     assert "health-summary" not in html
 
@@ -89,6 +95,10 @@ def test_summaries_truncate_at_a_word_boundary():
 
     assert 'const lastSpace = candidate.lastIndexOf(" ");' in script
     assert "candidate.slice(0, lastSpace)" in script
+    # The collapsed row is abbreviated, while the expanded region receives
+    # the retained upstream text rather than the abbreviation.
+    assert "shorten(item.summary)" in script
+    assert 'text: item.summary || "No description published at the source."' in script
 
 
 def test_site_does_not_render_source_content_as_html():
@@ -111,7 +121,7 @@ def test_attention_signals_use_activity_metrics_not_quality_scores():
     assert "evidence_score: 0" not in script
 
 
-def test_explorer_uses_persisted_attention_and_snapshot_dates():
+def test_main_filters_use_persisted_attention_and_snapshot_dates():
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
     html = Path("site/index.html").read_text(encoding="utf-8")
 
@@ -120,6 +130,29 @@ def test_explorer_uses_persisted_attention_and_snapshot_dates():
     assert "day.attention.observations.map" in script
     assert "snapshot_date: day.date" in script
     assert 'id="kind-filter"' in html
+    assert "renderExplorer" not in script
+    assert "explorer-view" not in html
+
+
+def test_records_expand_inline_without_an_exclusive_accordion_or_record_modal():
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+    html = Path("site/index.html").read_text(encoding="utf-8")
+
+    assert '"details"' in script
+    assert '"summary"' in script
+    assert "record-detail" in script
+    assert "detail-dialog" not in html
+    assert "detail-dialog" not in script
+    # A shared details[name] would force one row closed when another opens.
+    assert "attrs: { name:" not in script
+    assert script.count(".showModal()") == 1
+
+
+def test_hugging_face_expansion_links_to_the_full_card():
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    assert 'item.source === "Hugging Face"' in script
+    assert '"Read full card ↗"' in script
 
 
 def test_one_snapshot_trend_explains_history_requirement():

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -50,7 +50,7 @@ def test_rubric_is_read_from_published_data_not_restated_in_the_browser():
 
     # A second hardcoded copy of the weights in the browser is exactly the
     # drift this rubric exists to prevent.
-    assert "state.data?.rubric" in script
+    assert "state.data?.rubrics" in script
     assert "0.40 relevance" not in script
     assert "0.25 evidence" not in script
     for weight in ("0.4 *", "0.25 *", "0.2 *", "0.15 *"):

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -144,13 +144,19 @@ def test_rebuild_is_deterministic(tmp_path):
 def test_dashboard_publishes_the_rubric_that_scored_its_records(tmp_path):
     snapshot_dir = tmp_path / "snapshots"
     run = radar_run(27)
-    run.selection = {"minimum_score": 2.0, "report_limit": 30}
+    run.selection = {
+        "minimum_score": 40.0,
+        "report_limit": 30,
+        "score_version": 2,
+        "score_max": 100,
+        "lookback_hours": 48,
+    }
     write_snapshot(run, snapshot_dir)
 
     data = rebuild_dashboard(snapshot_dir, tmp_path / "radar.json")
 
     published = data["rubric"]
-    assert published["score_max"] == 4.0
+    assert published["score_max"] == 100.0
     assert [component["key"] for component in published["components"]] == [
         "relevance",
         "evidence",
@@ -159,8 +165,25 @@ def test_dashboard_publishes_the_rubric_that_scored_its_records(tmp_path):
     ]
     # The reader is looking at a filtered corpus, so the cutoff that filtered it
     # belongs with the rubric that scored it.
-    assert published["minimum_score"] == 2.0
+    assert published["minimum_score"] == 40.0
     assert published["limits"]
+
+
+def test_dashboard_keeps_legacy_scores_on_their_original_rubric(tmp_path):
+    snapshot_dir = tmp_path / "snapshots"
+    run = radar_run(27)
+    # The fixture models a snapshot written before score_version was persisted.
+    run.items[0].score_version = 1
+    run.items[0].score_max = 4
+    write_snapshot(run, snapshot_dir)
+
+    data = rebuild_dashboard(snapshot_dir, tmp_path / "radar.json")
+    published = data["days"][0]["evidence_items"][0]
+
+    assert published["score_version"] == 1
+    assert published["score_max"] == 4
+    assert data["rubrics"]["1"]["score_max"] == 4
+    assert data["rubrics"]["2"]["score_max"] == 100
 
 
 def test_dashboard_without_snapshots_publishes_no_cutoff(tmp_path):

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -141,6 +141,34 @@ def test_rebuild_is_deterministic(tmp_path):
     assert first["days"][0]["attention"]["active_count"] == 1
 
 
+def test_thirty_snapshots_replay_into_one_deterministic_cumulative_entity(tmp_path):
+    snapshot_dir = tmp_path / "snapshots"
+    for day in range(1, 31):
+        run = radar_run(day)
+        run.items[0].source_id = "2607.0001"
+        run.items[0].url = "https://arxiv.org/abs/2607.0001"
+        write_snapshot(run, snapshot_dir)
+    output = tmp_path / "radar.json"
+
+    first = rebuild_dashboard(snapshot_dir, output)
+    first_bytes = output.read_bytes()
+    second = rebuild_dashboard(snapshot_dir, output)
+    artifacts = [entity for entity in first["corpus"]["entities"] if entity["type"] == "artifact"]
+    benchmark = next(
+        topic for topic in first["corpus"]["aggregates"]["topics"] if topic["topic"] == "benchmark"
+    )
+
+    assert first == second
+    assert first_bytes == output.read_bytes()
+    assert first["snapshot_count"] == 30
+    assert len(artifacts) == 1
+    assert artifacts[0]["observation_count"] == 30
+    assert len(artifacts[0]["seen_days"]) == 30
+    assert benchmark["persistence_days"] == 30
+    assert benchmark["velocity"] == 0
+    assert first["corpus"]["aggregates"]["provenance"]["primary_source_rate"] >= 0.9
+
+
 def test_dashboard_publishes_the_rubric_that_scored_its_records(tmp_path):
     snapshot_dir = tmp_path / "snapshots"
     run = radar_run(27)
@@ -264,6 +292,25 @@ def test_trends_compare_snapshots_sharing_a_report_limit(tmp_path):
     after = data["days"][1]["category_trends"]["benchmark"]
     assert after["delta"] == 0
     assert after["comparable"] is True
+
+
+def test_trends_do_not_compare_when_connector_coverage_changes(tmp_path):
+    snapshot_dir = tmp_path / "snapshots"
+    first = radar_run(26)
+    first.selection = {"report_limit": 300}
+    second = radar_run(27)
+    second.selection = {"report_limit": 300}
+    second.health[1] = SourceHealth(source="brave", ok=True, item_count=1)
+    write_snapshot(first, snapshot_dir)
+    write_snapshot(second, snapshot_dir)
+
+    data = rebuild_dashboard(snapshot_dir, tmp_path / "radar.json")
+
+    before, after = data["days"]
+    assert before["coverage_complete"] is False
+    assert before["coverage_gaps"] == ["brave"]
+    assert after["coverage_complete"] is True
+    assert after["category_trends"]["benchmark"]["comparable"] is False
 
 
 def test_selection_counts_round_trip_through_the_snapshot(tmp_path):

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -103,6 +103,8 @@ def test_snapshot_has_version_and_public_evidence_fields():
     assert snapshot["date"] == "2026-07-27"
     assert snapshot["evidence_items"][0]["event_kind"] == "released"
     assert "raw" not in snapshot["evidence_items"][0]
+    assert snapshot["evidence_items"][0]["parser_version"] == "radar-item/1"
+    assert snapshot["evidence_items"][0]["raw_payload_hash"].startswith("sha256:")
     assert snapshot["attention"]["observations"][0]["quality_scored"] is False
     assert (
         snapshot["attention"]["observations"][0]["supporting_observations"][0]["source"]
@@ -167,6 +169,16 @@ def test_thirty_snapshots_replay_into_one_deterministic_cumulative_entity(tmp_pa
     assert benchmark["persistence_days"] == 30
     assert benchmark["velocity"] == 0
     assert first["corpus"]["aggregates"]["provenance"]["primary_source_rate"] >= 0.9
+    assert all(
+        entity["parser_versions"] and entity["raw_payload_hashes"]
+        for entity in first["corpus"]["entities"]
+    )
+    assert all(
+        observation["retrieved_at"]
+        and observation["parser_version"]
+        and observation["raw_payload_hash"].startswith("sha256:")
+        for observation in first["corpus"]["observations"]
+    )
 
 
 def test_dashboard_publishes_the_rubric_that_scored_its_records(tmp_path):

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,7 +1,17 @@
 from datetime import UTC, datetime
 from urllib.error import HTTPError
 
-from benchmark_radar.sources import fetch_arxiv, fetch_github
+import pytest
+
+from benchmark_radar.http import RequestError
+from benchmark_radar.sources import (
+    ConnectorPayloadError,
+    fetch_arxiv,
+    fetch_github,
+    fetch_github_releases,
+    fetch_openreview,
+    fetch_semantic_scholar,
+)
 
 ARXIV_XML = """\
 <feed xmlns="http://www.w3.org/2005/Atom">
@@ -257,3 +267,218 @@ def test_github_respects_the_per_source_limit_after_round_robin(monkeypatch):
     )
 
     assert len(items) == 150
+
+
+def test_openreview_success_uses_only_upstream_abstract(monkeypatch):
+    timestamp = int(datetime(2026, 7, 27, 12, tzinfo=UTC).timestamp() * 1000)
+    payload = {
+        "notes": [
+            {
+                "id": "note-revision",
+                "forum": "stable-forum",
+                "cdate": timestamp,
+                "mdate": timestamp + 1000,
+                "content": {
+                    "title": {"value": "A Conference Benchmark"},
+                    "abstract": {"value": "The upstream abstract."},
+                    "authors": {"value": ["Ada Radar"]},
+                    "code": {"value": "https://github.com/example/benchmark"},
+                },
+            }
+        ]
+    }
+    monkeypatch.setattr(
+        "benchmark_radar.sources.get_json",
+        lambda url, **kwargs: payload,
+    )
+
+    items = fetch_openreview(
+        {"venues": ["ICLR.cc/2026/Conference"], "max_requests": 1},
+        datetime(2026, 7, 26, tzinfo=UTC),
+        10,
+    )
+
+    assert [item.source_id for item in items] == ["stable-forum"]
+    assert items[0].summary == "The upstream abstract."
+    assert items[0].authors == ["Ada Radar"]
+    assert items[0].parser_version == "openreview-api-v2/1"
+    assert items[0].raw is payload["notes"][0]
+
+
+def test_semantic_scholar_success_preserves_external_ids(monkeypatch):
+    payload = {
+        "data": [
+            {
+                "paperId": "s2-paper",
+                "externalIds": {"DOI": "10.1000/radar", "ArXiv": "2607.12345"},
+                "url": "https://www.semanticscholar.org/paper/s2-paper",
+                "title": "A Structured Benchmark",
+                "abstract": "The upstream scholarly abstract.",
+                "publicationDate": "2026-07-27",
+                "authors": [{"name": "Grace Evidence"}],
+                "citationCount": 2,
+                "influentialCitationCount": 1,
+                "openAccessPdf": {"url": "https://example.test/paper.pdf"},
+            }
+        ],
+        "next": None,
+    }
+    monkeypatch.setattr(
+        "benchmark_radar.sources.get_json",
+        lambda url, **kwargs: payload,
+    )
+
+    items = fetch_semantic_scholar(
+        {"searches": ["benchmark"], "max_requests": 1},
+        datetime(2026, 7, 26, tzinfo=UTC),
+        10,
+    )
+
+    assert [item.source_id for item in items] == ["s2-paper"]
+    assert items[0].summary == "The upstream scholarly abstract."
+    assert "https://doi.org/10.1000/radar" in items[0].artifact_urls
+    assert "https://arxiv.org/abs/2607.12345" in items[0].artifact_urls
+    assert items[0].parser_version == "semantic-scholar-graph/1"
+
+
+def test_github_releases_success_uses_release_notes(monkeypatch):
+    payload = [
+        {
+            "tag_name": "v2.0.0",
+            "name": "Benchmark 2.0",
+            "html_url": "https://github.com/example/benchmark/releases/tag/v2.0.0",
+            "published_at": "2026-07-27T12:00:00Z",
+            "created_at": "2026-07-27T11:00:00Z",
+            "body": "The upstream release notes.",
+            "draft": False,
+            "prerelease": False,
+            "author": {"login": "maintainer"},
+            "assets": [{"download_count": 7}],
+        }
+    ]
+    monkeypatch.setattr(
+        "benchmark_radar.sources.get_json",
+        lambda url, **kwargs: payload,
+    )
+
+    items = fetch_github_releases(
+        {"repositories": ["example/benchmark"], "max_requests": 1},
+        datetime(2026, 7, 26, tzinfo=UTC),
+        10,
+    )
+
+    assert [item.source_id for item in items] == ["example/benchmark@v2.0.0"]
+    assert items[0].summary == "The upstream release notes."
+    assert items[0].metrics["downloads"] == 7
+    assert items[0].parser_version == "github-releases/1"
+
+
+@pytest.mark.parametrize(
+    ("fetcher", "config", "empty_payload"),
+    [
+        (fetch_openreview, {"venues": ["venue"]}, {"notes": []}),
+        (fetch_semantic_scholar, {"searches": ["benchmark"]}, {"data": []}),
+        (fetch_github_releases, {"repositories": ["example/benchmark"]}, []),
+    ],
+)
+def test_new_connectors_accept_empty_upstream_results(monkeypatch, fetcher, config, empty_payload):
+    monkeypatch.setattr(
+        "benchmark_radar.sources.get_json",
+        lambda url, **kwargs: empty_payload,
+    )
+
+    assert fetcher(config, datetime(2026, 7, 26, tzinfo=UTC), 10) == []
+
+
+@pytest.mark.parametrize(
+    ("fetcher", "config", "malformed_payload"),
+    [
+        (fetch_openreview, {"venues": ["venue"]}, {"notes": "wrong"}),
+        (fetch_semantic_scholar, {"searches": ["benchmark"]}, {"data": "wrong"}),
+        (fetch_github_releases, {"repositories": ["example/benchmark"]}, {}),
+    ],
+)
+def test_new_connectors_reject_malformed_payloads(monkeypatch, fetcher, config, malformed_payload):
+    monkeypatch.setattr(
+        "benchmark_radar.sources.get_json",
+        lambda url, **kwargs: malformed_payload,
+    )
+
+    with pytest.raises(ConnectorPayloadError):
+        fetcher(config, datetime(2026, 7, 26, tzinfo=UTC), 10)
+
+
+@pytest.mark.parametrize(
+    ("fetcher", "config"),
+    [
+        (fetch_openreview, {"venues": ["venue"]}),
+        (fetch_semantic_scholar, {"searches": ["benchmark"]}),
+        (fetch_github_releases, {"repositories": ["example/benchmark"]}),
+    ],
+)
+def test_new_connectors_surface_http_failures(monkeypatch, fetcher, config):
+    def fail(url, **kwargs):
+        raise RequestError("HTTP 500 from source after 3 attempts")
+
+    monkeypatch.setattr("benchmark_radar.sources.get_json", fail)
+
+    with pytest.raises(RequestError, match="HTTP 500"):
+        fetcher(config, datetime(2026, 7, 26, tzinfo=UTC), 10)
+
+
+@pytest.mark.parametrize(
+    ("fetcher", "config", "payload"),
+    [
+        (
+            fetch_openreview,
+            {"venues": ["venue"]},
+            {
+                "notes": [
+                    {
+                        "id": "note",
+                        "forum": "forum",
+                        "cdate": 1785153600000,
+                        "mdate": 1785153600000,
+                        "content": {"title": {"value": "No abstract"}},
+                    }
+                ]
+            },
+        ),
+        (
+            fetch_semantic_scholar,
+            {"searches": ["benchmark"]},
+            {
+                "data": [
+                    {
+                        "paperId": "paper",
+                        "title": "No abstract",
+                        "publicationDate": "2026-07-27",
+                        "authors": [],
+                    }
+                ]
+            },
+        ),
+        (
+            fetch_github_releases,
+            {"repositories": ["example/benchmark"]},
+            [
+                {
+                    "tag_name": "v1",
+                    "html_url": "https://github.com/example/benchmark/releases/tag/v1",
+                    "published_at": "2026-07-27T12:00:00Z",
+                    "draft": False,
+                    "assets": [],
+                }
+            ],
+        ),
+    ],
+)
+def test_new_connectors_never_synthesize_missing_summary(monkeypatch, fetcher, config, payload):
+    monkeypatch.setattr(
+        "benchmark_radar.sources.get_json",
+        lambda url, **kwargs: payload,
+    )
+
+    items = fetcher(config, datetime(2026, 7, 26, tzinfo=UTC), 10)
+
+    assert items and items[0].summary == ""


### PR DESCRIPTION
## Summary

- replace the clustered 0–4 priority model with versioned rubric v2 while preserving historical v1 snapshots; demote/suppress narrowly defined low-value artifacts
- merge Explorer filters into Today, use inline multi-record folds, preserve permalink state, and raise upstream prose truncation to 2,000 characters
- build a deterministic cumulative entity/observation/edge corpus, transparent aggregates, coverage-aware trends, and a coordinated keyboard-accessible Trend Map
- add gated OpenReview, Semantic Scholar, and curated GitHub Releases connectors with bounded HTTP behavior, provenance fingerprints, strict payload validation, and an upstream-only summary contract
- split social-source expansion into ktwu01/benchmark-social-signal#2 so attention remains read-only and unranked

## Verification

- `ruff check .`
- `ruff format --check .`
- `pytest -q` — 116 passed
- `benchmark-radar rebuild` — 2 snapshots, 1,140 entities, 216 observations, complete provenance
- `node --check site/assets/app.js`
- cumulative schema JSON parse and static local-link checks
- Chromium smoke: merged filters, two simultaneous inline expansions, rubric interaction, Trend Map selection/permalink coordination, zero page errors
- live connector smoke: GitHub Releases returned records; OpenReview challenge and unauthenticated Semantic Scholar rate limit surfaced as credential-safe optional-source failures

Closes #7
Closes #8
Closes #19
Closes #28
Closes #32