### PR TITLE
Resolve artifact aliases across snapshots

### DIFF
--- a/src/benchmark_radar/corpus.py
+++ b/src/benchmark_radar/corpus.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import re
 from collections import Counter, defaultdict
+from collections.abc import Iterable
 from datetime import UTC, datetime
 from typing import Any
 from urllib.parse import parse_qs, urlsplit
@@ -50,51 +51,61 @@ def _arxiv_id(path: str) -> str | None:
     return re.sub(r"v\d+$", "", match.group(1), flags=re.IGNORECASE).lower()
 
 
-def _exact_candidates(item: dict[str, Any]) -> dict[int, str]:
-    """Map priority rank to exact identifier for every one this record carries."""
+def _exact_candidates(item: dict[str, Any]) -> list[tuple[int, str]]:
+    """Return every exact identifier this record carries with its priority."""
     urls = [str(item.get("url") or ""), *map(str, item.get("artifact_urls") or [])]
-    candidates: dict[int, str] = {}
+    candidates: set[tuple[int, str]] = set()
     for url in urls:
         parsed = urlsplit(url)
         host = parsed.netloc.casefold().removeprefix("www.")
         segments = [segment for segment in parsed.path.split("/") if segment]
         if host in {"doi.org", "dx.doi.org"} and segments:
-            candidates[1] = f"artifact:doi:{'/'.join(segments).casefold()}"
+            candidates.add((1, f"artifact:doi:{'/'.join(segments).casefold()}"))
         arxiv = _arxiv_id(parsed.path) if host.endswith("arxiv.org") else None
         if arxiv:
-            candidates[2] = f"artifact:arxiv:{arxiv}"
+            candidates.add((2, f"artifact:arxiv:{arxiv}"))
         if host == "openreview.net":
             forum = (parse_qs(parsed.query).get("id") or [None])[0]
             if forum:
-                candidates[3] = f"artifact:openreview:{str(forum).casefold()}"
+                candidates.add((3, f"artifact:openreview:{str(forum).casefold()}"))
         if host == "github.com" and len(segments) >= 2:
-            candidates[4] = f"artifact:github:{segments[0].casefold()}/{segments[1].casefold()}"
+            candidates.add(
+                (4, f"artifact:github:{segments[0].casefold()}/{segments[1].casefold()}")
+            )
         if host == "huggingface.co" and len(segments) >= 2:
             kind = segments[0].casefold()
             if kind in {"datasets", "spaces", "models"} and len(segments) >= 3:
-                candidates[5] = (
-                    f"artifact:huggingface:{kind}:{segments[1].casefold()}/{segments[2].casefold()}"
+                candidates.add(
+                    (
+                        5,
+                        f"artifact:huggingface:{kind}:"
+                        f"{segments[1].casefold()}/{segments[2].casefold()}",
+                    )
                 )
             elif kind not in {"datasets", "spaces"}:
-                candidates[5] = (
-                    f"artifact:huggingface:models:{segments[0].casefold()}/{segments[1].casefold()}"
+                candidates.add(
+                    (
+                        5,
+                        f"artifact:huggingface:models:"
+                        f"{segments[0].casefold()}/{segments[1].casefold()}",
+                    )
                 )
     if candidates:
-        return candidates
+        return sorted(candidates)
 
     # No recognizable URL identifier, so fall back to the source's own id.
     source = str(item.get("source") or "").casefold()
     source_id = str(item.get("source_id") or "").strip().casefold()
     if source == "arxiv":
         base_id = re.sub(r"v\d+$", "", source_id)
-        return {2: f"artifact:arxiv:{base_id}"}
+        return [(2, f"artifact:arxiv:{base_id}")]
     if source == "openreview":
-        return {3: f"artifact:openreview:{source_id}"}
+        return [(3, f"artifact:openreview:{source_id}")]
     if source in {"github", "github release"}:
-        return {4: f"artifact:github:{source_id.split('@', 1)[0]}"}
+        return [(4, f"artifact:github:{source_id.split('@', 1)[0]}")]
     if source == "hugging face":
-        return {5: f"artifact:huggingface:datasets:{source_id}"}
-    return {9: _stable_id("artifact:url", str(item.get("url") or source_id).casefold())}
+        return [(5, f"artifact:huggingface:datasets:{source_id}")]
+    return [(9, _stable_id("artifact:url", str(item.get("url") or source_id).casefold()))]
 
 
 def exact_artifact_keys(item: dict[str, Any]) -> list[str]:
@@ -106,8 +117,7 @@ def exact_artifact_keys(item: dict[str, Any]) -> list[str]:
     identifier is compared, because the paper resolves to its arXiv id and the
     repository to its owner/repo.
     """
-    candidates = _exact_candidates(item)
-    return [candidates[rank] for rank in sorted(candidates)]
+    return [key for _, key in _exact_candidates(item)]
 
 
 def exact_artifact_key(item: dict[str, Any]) -> str:
@@ -117,8 +127,59 @@ def exact_artifact_key(item: dict[str, Any]) -> str:
     carrying an arXiv, DOI, GitHub, or Hugging Face link joins that primary
     entity. Ambiguous title similarity is deliberately not used.
     """
-    candidates = _exact_candidates(item)
-    return candidates[min(candidates)]
+    return _exact_candidates(item)[0][1]
+
+
+def artifact_alias_map(items: Iterable[dict[str, Any]]) -> dict[str, str]:
+    """Resolve transitively linked exact identifiers to one stable identity.
+
+    A single record can carry several identifiers for the same artifact, such
+    as a DOI and an arXiv URL. Another source may expose only one of them. The
+    shared identifier joins both observations, and transitive links join later
+    observations too. This is the same additive identity rule daily dedup uses,
+    applied across the full snapshot history.
+    """
+    parents: dict[str, str] = {}
+    priorities: dict[str, int] = {}
+
+    def find(key: str) -> str:
+        root = key
+        while parents[root] != root:
+            root = parents[root]
+        while parents[key] != key:
+            parent = parents[key]
+            parents[key] = root
+            key = parent
+        return root
+
+    def union(left: str, right: str) -> None:
+        left_root = find(left)
+        right_root = find(right)
+        if left_root == right_root:
+            return
+        # The parent choice is deterministic; canonical priority is applied
+        # after every connected component has been assembled.
+        first, second = sorted((left_root, right_root))
+        parents[second] = first
+
+    for item in items:
+        candidates = _exact_candidates(item)
+        keys = [key for _, key in candidates]
+        for priority, key in candidates:
+            parents.setdefault(key, key)
+            priorities[key] = min(priority, priorities.get(key, priority))
+        for key in keys[1:]:
+            union(keys[0], key)
+
+    components: dict[str, list[str]] = defaultdict(list)
+    for key in parents:
+        components[find(key)].append(key)
+
+    aliases: dict[str, str] = {}
+    for keys in components.values():
+        canonical = min(keys, key=lambda key: (priorities[key], key))
+        aliases.update({key: canonical for key in keys})
+    return aliases
 
 
 def organizations_for_item(item: dict[str, Any]) -> list[str]:
@@ -184,6 +245,9 @@ def build_corpus(snapshots: list[dict[str, Any]]) -> dict[str, Any]:
     entities: dict[str, dict[str, Any]] = {}
     edges: dict[str, dict[str, Any]] = {}
     observations: list[dict[str, Any]] = []
+    aliases = artifact_alias_map(
+        item for snapshot in snapshots for item in snapshot["evidence_items"]
+    )
 
     def touch(entity: dict[str, Any], *, date: str, source: str = "") -> None:
         entity["first_seen_at"] = min(entity["first_seen_at"] or date, date)
@@ -227,7 +291,7 @@ def build_corpus(snapshots: list[dict[str, Any]]) -> dict[str, Any]:
             retrieved_at = (
                 item.get("retrieved_at") or snapshot.get("generated_at") or f"{date}T00:00:00+00:00"
             )
-            entity_id = exact_artifact_key(item)
+            entity_id = aliases[exact_artifact_key(item)]
             artifact = entities.setdefault(
                 entity_id,
                 _entity(entity_id, "artifact", str(item["title"]), url=str(item["url"])),

--- a/src/benchmark_radar/snapshots.py
+++ b/src/benchmark_radar/snapshots.py
@@ -9,7 +9,12 @@ from pathlib import Path
 from typing import Any
 
 from .attention import fetch_attention_feeds
-from .corpus import build_corpus, exact_artifact_key, organizations_for_item
+from .corpus import (
+    artifact_alias_map,
+    build_corpus,
+    exact_artifact_key,
+    organizations_for_item,
+)
 from .models import RadarRun
 from .rubric import (
     SCORING_VERSION,
@@ -334,16 +339,27 @@ def _attach_category_trends(days: list[dict[str, Any]]) -> None:
     counts would re-count the same repository every day it stayed in range and
     grow steadily while nothing new was found.
 
-    Identity is the exact artifact key, not `source:source_id`. Keying on the
-    latter counted one artifact once per source that reported it, which
-    contradicted the "distinct artifacts" promise above.
+    Identity joins every exact identifier a record carries, not just one
+    preferred key or `source:source_id`. A DOI-plus-arXiv observation and a
+    later arXiv-only observation are two sightings of the same artifact.
     """
     seen: dict[str, set[str]] = {}
     seen_any: set[str] = set()
+    records_seen: list[dict[str, Any]] = []
     for index, day in enumerate(days):
         counts = day["category_counts"]
+        records_seen.extend(day["evidence_items"])
+        aliases = artifact_alias_map(records_seen)
+        # A later observation can bridge identifiers previously thought to be
+        # separate. Reconcile cumulative sets from this day forward without
+        # leaking that later knowledge into already-published historical days.
+        seen_any = {aliases.get(identity, identity) for identity in seen_any}
+        seen = {
+            category: {aliases.get(identity, identity) for identity in identities}
+            for category, identities in seen.items()
+        }
         for record in day["evidence_items"]:
-            identity = exact_artifact_key(record)
+            identity = aliases[exact_artifact_key(record)]
             seen_any.add(identity)
             for category in record["categories"]:
                 seen.setdefault(category, set()).add(identity)

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -4,6 +4,7 @@ from benchmark_radar.corpus import (
     CorpusError,
     build_corpus,
     exact_artifact_key,
+    exact_artifact_keys,
     organizations_for_item,
     validate_corpus,
 )
@@ -46,6 +47,20 @@ def test_exact_primary_identifier_wins_over_secondary_record_and_repo_links():
     assert exact_artifact_key(record) == "artifact:arxiv:2607.12345"
 
 
+def test_every_identifier_of_the_same_kind_is_preserved():
+    record = item(
+        artifact_urls=[
+            "https://github.com/org/benchmark",
+            "https://github.com/org/evaluator",
+        ]
+    )
+
+    assert exact_artifact_keys(record) == [
+        "artifact:github:org/benchmark",
+        "artifact:github:org/evaluator",
+    ]
+
+
 def test_equal_titles_do_not_merge_without_an_exact_identifier():
     first = item(url="https://example.com/releases/one")
     second = item(source_id="paper-2", url="https://example.net/releases/two")
@@ -76,6 +91,34 @@ def test_cross_source_observations_cluster_under_one_entity():
     assert len(artifacts) == 1
     assert artifacts[0]["observation_count"] == 2
     assert artifacts[0]["sources"] == ["Semantic Scholar", "arXiv"]
+
+
+def test_multi_identifier_aliases_cluster_across_snapshots():
+    first = item(
+        artifact_urls=[
+            "https://doi.org/10.1000/radar",
+            "https://arxiv.org/abs/2607.12345",
+        ]
+    )
+    second = item(
+        source="OpenAlex",
+        source_id="W1",
+        url="https://openalex.org/W1",
+        artifact_urls=["https://arxiv.org/abs/2607.12345"],
+    )
+
+    corpus = build_corpus(
+        [
+            {"date": "2026-07-27", "evidence_items": [first]},
+            {"date": "2026-07-28", "evidence_items": [second]},
+        ]
+    )
+    artifacts = [entity for entity in corpus["entities"] if entity["type"] == "artifact"]
+
+    assert len(artifacts) == 1
+    assert artifacts[0]["id"] == "artifact:doi:10.1000/radar"
+    assert artifacts[0]["observation_count"] == 2
+    assert artifacts[0]["sources"] == ["OpenAlex", "Semantic Scholar"]
 
 
 def test_validation_rejects_edges_to_unknown_entities():

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -442,3 +442,62 @@ def test_cumulative_counts_one_artifact_reported_by_two_sources_once(tmp_path):
     # Two sightings, one artifact.
     assert day["category_trends"]["benchmark"]["cumulative"] == 1
     assert day["cumulative_evidence_count"] == 1
+
+
+def test_cumulative_counts_transitively_linked_identifiers_once(tmp_path):
+    first = radar_run(26)
+    first.items[0].source = "Semantic Scholar"
+    first.items[0].source_id = "s2-abc123"
+    first.items[0].url = "https://www.semanticscholar.org/paper/s2-abc123"
+    first.items[0].artifact_urls = [
+        "https://doi.org/10.1000/radar",
+        "https://arxiv.org/abs/2607.0027",
+    ]
+    second = radar_run(27)
+    second.items[0].source = "OpenAlex"
+    second.items[0].source_id = "W1"
+    second.items[0].url = "https://openalex.org/W1"
+    second.items[0].artifact_urls = ["https://arxiv.org/abs/2607.0027"]
+    snapshot_dir = tmp_path / "snapshots"
+    write_snapshot(first, snapshot_dir)
+    write_snapshot(second, snapshot_dir)
+
+    data = rebuild_dashboard(snapshot_dir, tmp_path / "radar.json")
+    day = data["days"][1]
+
+    assert day["category_trends"]["benchmark"]["cumulative"] == 1
+    assert day["cumulative_evidence_count"] == 1
+
+
+def test_later_alias_bridge_does_not_rewrite_earlier_trend(tmp_path):
+    first = radar_run(26)
+    first.items.append(
+        RadarItem(
+            source="OpenAlex",
+            source_id="W1",
+            title="A DOI-only sighting",
+            url="https://openalex.org/W1",
+            published_at=first.generated_at - timedelta(hours=2),
+            summary="A benchmark.",
+            categories=["benchmark"],
+            artifact_urls=["https://doi.org/10.1000/radar"],
+            total_score=50,
+        )
+    )
+    first.items[0].artifact_urls = ["https://arxiv.org/abs/2607.0026"]
+    second = radar_run(27)
+    second.items[0].source = "Semantic Scholar"
+    second.items[0].source_id = "s2-bridge"
+    second.items[0].url = "https://www.semanticscholar.org/paper/s2-bridge"
+    second.items[0].artifact_urls = [
+        "https://doi.org/10.1000/radar",
+        "https://arxiv.org/abs/2607.0026",
+    ]
+    snapshot_dir = tmp_path / "snapshots"
+    write_snapshot(first, snapshot_dir)
+    write_snapshot(second, snapshot_dir)
+
+    data = rebuild_dashboard(snapshot_dir, tmp_path / "radar.json")
+
+    assert data["days"][0]["cumulative_evidence_count"] == 2
+    assert data["days"][1]["cumulative_evidence_count"] == 1


### PR DESCRIPTION
## What changed

- preserve every exact artifact identifier, including multiple identifiers of the same type
- resolve DOI, arXiv, OpenReview, GitHub, and Hugging Face aliases transitively across snapshot history
- apply the same alias model to cumulative trends and corpus entities
- keep historical trend days free from identifiers learned only in the future
- add regressions for multi-ID observations, transitive aliases, and later alias bridges

## Why

Cumulative trends and corpus construction previously selected one preferred identifier per record. The same paper could therefore split into separate entities when one source supplied DOI + arXiv and another supplied only arXiv, even though daily dedup treated those identifiers additively.

## Impact

Cross-source sightings now count as one artifact whenever their exact identifiers form a connected alias set. Rebuilding the two stored snapshots leaves the published cumulative totals unchanged (`30`, `202`) because the affected overlap is not present in current data.

## Validation

- `ruff check src tests`
- `pytest -q` — 134 passed
- dashboard rebuild comparison — published cumulative counts unchanged