### PR TITLE
Fix Scan date filter and add rubric deep link

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -18,6 +18,7 @@ const state = {
   organization: "",
   event: "",
   entity: "",
+  rubric: "",
 };
 
 function element(tag, options = {}, children = []) {
@@ -84,6 +85,7 @@ function readUrl() {
   state.organization = params.get("organization") || "";
   state.event = params.get("event") || "";
   state.entity = params.get("entity") || "";
+  state.rubric = new URLSearchParams(window.location.hash.slice(1)).get("rubric") || "";
 }
 
 function writeUrl() {
@@ -100,7 +102,16 @@ function writeUrl() {
   if (state.event) params.set("event", state.event);
   if (state.view === "map" && state.entity) params.set("entity", state.entity);
   const query = params.toString();
-  window.history.replaceState(null, "", `${window.location.pathname}${query ? `?${query}` : ""}`);
+  // The rubric dialog is a hashtag, not a query param, so a shared link like
+  // #rubric=2 reads as "jump to this section" rather than another filter.
+  const hashParams = new URLSearchParams();
+  if (state.rubric) hashParams.set("rubric", state.rubric);
+  const hash = hashParams.toString();
+  window.history.replaceState(
+    null,
+    "",
+    `${window.location.pathname}${query ? `?${query}` : ""}${hash ? `#${hash}` : ""}`,
+  );
 }
 
 function setView(view, update = true) {
@@ -618,8 +629,12 @@ function filteredObservations() {
 // When a record is supplied, the rubric is rendered with that record's own
 // component scores beside each weight, so the reader can see the arithmetic
 // that produced the total rather than a generic description of it.
-function openRubric(item = null) {
-  const data = rubricFor(item);
+// versionOverride opens a specific rubric version (e.g. from a #rubric=1
+// deep link) without implying a record's own scores are being shown.
+function openRubric(item = null, versionOverride = null) {
+  const data = versionOverride
+    ? state.data?.rubrics?.[String(versionOverride)] || rubricFor(item)
+    : rubricFor(item);
   const dialog = byId("rubric-dialog");
   if (!data) return;
   const max = Number(data.score_max) || 4;
@@ -634,6 +649,8 @@ function openRubric(item = null) {
   const version = Number(data.scoring_version) || 1;
   const current = Number(state.data?.rubric?.scoring_version) || version;
   const isLegacy = version !== current;
+  state.rubric = String(version);
+  writeUrl();
   const header = [
     element("p", {
       className: "detail-source",
@@ -1196,6 +1213,12 @@ function bindEvents() {
   byId("rubric-dialog").addEventListener("click", (event) => {
     if (event.target === byId("rubric-dialog")) byId("rubric-dialog").close();
   });
+  // Fires for every close path (button, backdrop click, Esc), so #rubric is
+  // cleared from the URL no matter how the reader dismisses the dialog.
+  byId("rubric-dialog").addEventListener("close", () => {
+    state.rubric = "";
+    writeUrl();
+  });
   // Reachable without a record in hand, for a reader who wants the method
   // before they trust any single row.
   byId("rubric-nav").addEventListener("click", () => openRubric());
@@ -1285,6 +1308,9 @@ async function initialize() {
       dateStyle: "medium",
       timeStyle: "short",
     })} UTC`;
+    if (state.rubric && state.data.rubrics?.[state.rubric]) {
+      openRubric(null, state.rubric);
+    }
   } catch (error) {
     document.querySelectorAll(".view").forEach((section) => {
       section.hidden = true;

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -672,7 +672,9 @@ function openRubric(item = null, versionOverride = null) {
           element("p", {
             className: "discovery-note",
             text:
-              `This record was scored by rubric v${version} on a 0 to ${max.toFixed(2)} scale. ` +
+              (item
+                ? `This record was scored by rubric v${version} on a 0 to ${max.toFixed(2)} scale. `
+                : `Rubric v${version} scored records on a 0 to ${max.toFixed(2)} scale. `) +
               `The current rubric is v${current} on a 0 to ` +
               `${(Number(state.data?.rubric?.score_max) || 100).toFixed(2)} scale. Scores from the ` +
               "two versions are not directly comparable, and past records are not rescored.",

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -1168,7 +1168,13 @@ function bindEvents() {
     state.todayDate = event.target.value;
     renderToday();
   });
-  byId("filters").addEventListener("input", () => {
+  byId("filters").addEventListener("input", (event) => {
+    // The Scan date select has its own dedicated change handler above. A
+    // <select> fires "input" before "change", and this bubbled "input"
+    // reaching here would call renderToday() with the still-stale
+    // state.todayDate, which then writes the OLD date back onto the
+    // control and clobbers the user's just-made selection.
+    if (event.target === byId("today-date")) return;
     state.q = byId("search-filter").value;
     state.kind = byId("kind-filter").value;
     state.category = byId("category-filter").value;

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -64,6 +64,17 @@ def test_scan_date_select_is_not_reset_by_the_shared_filters_input_handler():
     assert "return" in handler_body
 
 
+def test_rubric_dialog_is_linkable_by_url_hash():
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    # Issue #41: opening the rubric must be shareable as a hashtag link, and
+    # loading that link must reopen the same rubric version.
+    assert "state.rubric" in script
+    assert 'window.location.hash.slice(1)).get("rubric")' in script
+    assert "hashParams.set(\"rubric\", state.rubric)" in script
+    assert "openRubric(null, state.rubric)" in script
+
+
 def test_rubric_is_read_from_published_data_not_restated_in_the_browser():
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
 

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -51,6 +51,19 @@ def test_priority_score_is_reachably_explained():
     assert "How is this scored?" in script
 
 
+def test_scan_date_select_is_not_reset_by_the_shared_filters_input_handler():
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    # Issue #43: a <select> fires "input" before "change". The shared
+    # #filters input handler must not re-render on the Scan date select's
+    # bubbled "input" event, or it clobbers the pick with the stale date
+    # before the select's own dedicated "change" handler runs.
+    filters_handler = script.split('byId("filters").addEventListener("input"', 1)[1]
+    handler_body = filters_handler.split("});", 1)[0]
+    assert 'event.target === byId("today-date")' in handler_body
+    assert "return" in handler_body
+
+
 def test_rubric_is_read_from_published_data_not_restated_in_the_browser():
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
 

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -71,7 +71,7 @@ def test_rubric_dialog_is_linkable_by_url_hash():
     # loading that link must reopen the same rubric version.
     assert "state.rubric" in script
     assert 'window.location.hash.slice(1)).get("rubric")' in script
-    assert "hashParams.set(\"rubric\", state.rubric)" in script
+    assert 'hashParams.set("rubric", state.rubric)' in script
     assert "openRubric(null, state.rubric)" in script
 
 


### PR DESCRIPTION
## Summary
- Fixes #43 (critical): the "Scan date" filter select was snapping back to the old date immediately after picking a new one. A shared `#filters` form `input` listener fired before the select's own dedicated `change` handler (a `<select>` fires `input` before `change`), re-rendering with stale state and overwriting the user's selection.
- Fixes #41: the "Rubric" dialog now round-trips through the URL as a hashtag (`#rubric=<version>`), matching how every other filter already persists through the query string. Opening it sets the hash, closing it (button, backdrop, or Esc) clears it, and loading a URL with `#rubric=<version>` reopens that rubric.
- Addressed a Codex review finding: a version-only rubric deep link no longer claims "This record was scored by..." when no record is in hand.

## Test plan
- [x] `pytest tests/` — 136 passed
- [x] Headless DOM simulation (jsdom) of a real browser's `input`→`change` event sequence on the Scan date select — confirms the selection now sticks and the observation list/URL update correctly
- [x] Headless DOM simulation of opening/closing the rubric dialog and loading `#rubric=1` directly — confirms hash set/clear and correct rubric version reopened
- [x] `codex review --base main` — clean, no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)