### PR TITLE
Fix wording, unfold UX, map coverage, arXiv noise, cron cadence, and trend accuracy

### DIFF
--- a/.github/workflows/daily-radar.yml
+++ b/.github/workflows/daily-radar.yml
@@ -2,6 +2,11 @@ name: Daily Benchmark Radar
 
 on:
   schedule:
+    # Issue #44: one early run to catch overnight arXiv/HF activity before the
+    # day starts, one mid-morning run so a failed or late trigger has a same-day
+    # retry instead of waiting 24h. Both land in early hours America/Chicago.
+    # 06:15 UTC = 01:15 America/Chicago during daylight saving time.
+    - cron: "15 6 * * *"
     # 12:15 UTC = 07:15 America/Chicago during daylight saving time.
     - cron: "15 12 * * *"
   workflow_dispatch:

--- a/config.yml
+++ b/config.yml
@@ -76,19 +76,36 @@ sources:
     # Atom parsing remains available for deployments with a stable egress IP.
     atom_enabled: false
     rss_categories: [cs.AI, cs.CL, cs.CV]
+    # "benchmark"/"evaluation"/"dataset" alone match most ML papers, since
+    # almost every paper evaluates on some existing benchmark. cs.AI+cs.CL+cs.CV
+    # publish 700+ papers a day, and the old bare-word list matched roughly two
+    # of every three (issue #51: "111 releases today"). These phrases require
+    # the paper to be introducing a benchmark, dataset, or leaderboard, not
+    # merely using one, which cuts matches to about one in ten.
     rss_keywords:
-      - benchmark
-      - evaluation
-      - evaluator
+      - benchmark for
+      - new benchmark
+      - novel benchmark
+      - benchmark dataset
+      - benchmark suite
       - leaderboard
-      - dataset
-      - test set
+      - evaluation benchmark
+      - evaluation suite
+      - evaluation dataset
+      - we introduce a benchmark
+      - we present a benchmark
+      - we release a benchmark
+      - we introduce a dataset
+      - we present a dataset
+      - we release a dataset
+      - a new dataset for
+      - a novel dataset for
+      - curated dataset
       - data contamination
       - benchmark leakage
-      - data quality
     queries:
-      - 'all:"large language model" AND (all:benchmark OR all:evaluation)'
-      - '(all:benchmark OR all:dataset) AND (cat:cs.AI OR cat:cs.CL OR cat:cs.CV)'
+      - 'ti:"benchmark" AND (all:"we introduce" OR all:"we present" OR all:"we release")'
+      - 'ti:"dataset" AND (all:"we introduce" OR all:"we present" OR all:"we release")'
       - '(all:"data contamination" OR all:"benchmark leakage" OR all:"data quality")'
 
   huggingface:

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -65,6 +65,18 @@ function shorten(value, max = 190) {
   return `${cutoff.replace(/[,:;.!?-]+$/, "")}…`;
 }
 
+// Expanding a record whose teaser already ran most of the way through the
+// description used to re-show that same opening text in full, which reads as
+// "this just repeats what I already read" rather than as new information.
+// Continuing from where the teaser was cut keeps the expanded view additive.
+function summaryRemainder(fullText, teaser) {
+  const trimmedFull = (fullText || "").trim();
+  const teaserBody = teaser.replace(/…$/, "").trim();
+  if (!trimmedFull.startsWith(teaserBody)) return trimmedFull;
+  const rest = trimmedFull.slice(teaserBody.length).trim();
+  return rest ? `…${rest}` : "";
+}
+
 function option(value, label, selected = false) {
   return element("option", {
     text: label,
@@ -772,7 +784,7 @@ function openRubric(item = null, versionOverride = null) {
   dialog.showModal();
 }
 
-function expandedRecord(item) {
+function expandedRecord(item, teaser) {
   const isAttention = item.observation_kind === "attention";
   const primaryArtifact = item.primary_artifact_url || item.artifact_urls?.[0];
   const scoreEntries = isAttention
@@ -863,7 +875,11 @@ function expandedRecord(item) {
     }),
     element("p", {
       className: item.summary ? "detail-summary" : "detail-summary signal-nodesc",
-      text: item.summary || "No description published at the source.",
+      text: item.summary
+        ? teaser
+          ? summaryRemainder(item.summary, teaser) || "No further description beyond the preview above."
+          : item.summary
+        : "No description published at the source.",
     }),
     attentionNotice,
     element(
@@ -1260,7 +1276,7 @@ function observationCard(item, index) {
     {
       className: `record-card${isAttention ? " attention-card" : ""}`,
     },
-    [header, expandedRecord(item)],
+    [header, expandedRecord(item, (item.summary || "").trim() ? summary : "")],
   );
 }
 

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -19,6 +19,7 @@ const state = {
   event: "",
   entity: "",
   rubric: "",
+  trendReleasedOnly: false,
 };
 
 function element(tag, options = {}, children = []) {
@@ -324,6 +325,10 @@ function domainCard(category, trend, index) {
     const percent = Math.round(Number(trend.momentum) * 100);
     rows.splice(2, 0, ["vs its average", `${percent > 0 ? "+" : ""}${percent}%`]);
   }
+  const updatedOnly = Math.max(0, (trend.total_count || 0) - (trend.count || 0));
+  if (updatedOnly) {
+    rows.push(["also updated (not counted above)", updatedOnly.toLocaleString()]);
+  }
   return element(
     "article",
     {
@@ -334,7 +339,11 @@ function domainCard(category, trend, index) {
         swatch,
         element("h3", { text: category.replaceAll("_", " ") }),
       ]),
-      element("p", { className: "domain-count", text: String(trend.count ?? 0) }),
+      element("p", {
+        className: "domain-count",
+        text: String(trend.count ?? 0),
+        attrs: { title: "New releases only. Re-announced updates are tracked separately." },
+      }),
       element(
         "dl",
         { className: "domain-stats" },
@@ -383,6 +392,7 @@ function coverageNote(day) {
 
 function renderTrends() {
   const categories = state.data.facets.categories;
+  byId("trend-released-only").checked = state.trendReleasedOnly;
   replaceChildren(
     byId("trend-legend"),
     [
@@ -449,11 +459,13 @@ function renderTrends() {
     }
     trendChart.hidden = false;
   }
+  const countsFor = (day) =>
+    state.trendReleasedOnly ? day.category_counts_released : day.category_counts;
   const maxTotal = Math.max(
     1,
     ...state.data.days.map((day) =>
       Math.max(
-        Object.values(day.category_counts).reduce((sum, count) => sum + count, 0),
+        Object.values(countsFor(day)).reduce((sum, count) => sum + count, 0),
         day.attention.active_count,
       ),
     ),
@@ -461,13 +473,14 @@ function renderTrends() {
   replaceChildren(
     byId("trend-chart"),
     state.data.days.map((day) => {
-      const total = Object.values(day.category_counts).reduce((sum, count) => sum + count, 0);
+      const dayCounts = countsFor(day);
+      const total = Object.values(dayCounts).reduce((sum, count) => sum + count, 0);
       const segments = categories.map((category, index) => {
         const segment = element("span", {
           className: "bar-segment",
-          attrs: { title: `${category.replaceAll("_", " ")}: ${day.category_counts[category] || 0}` },
+          attrs: { title: `${category.replaceAll("_", " ")}: ${dayCounts[category] || 0}` },
         });
-        segment.style.height = `${((day.category_counts[category] || 0) / maxTotal) * 260}px`;
+        segment.style.height = `${((dayCounts[category] || 0) / maxTotal) * 260}px`;
         segment.style.setProperty("--bar-color", categoryColor(category, index));
         return segment;
       });
@@ -1292,6 +1305,10 @@ function bindEvents() {
   byId("today-date").addEventListener("change", (event) => {
     state.todayDate = event.target.value;
     renderToday();
+  });
+  byId("trend-released-only").addEventListener("change", (event) => {
+    state.trendReleasedOnly = event.target.checked;
+    renderTrends();
   });
   byId("filters").addEventListener("input", (event) => {
     // The Scan date select has its own dedicated change handler above. A

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -946,6 +946,16 @@ function selectMapNode(entity, relatedEntities) {
         ]
       : []),
   ];
+  const viewResults = element("button", {
+    className: "primary-link map-view-results",
+    text: "View matching observations →",
+    attrs: { type: "button" },
+  });
+  viewResults.addEventListener("click", () => {
+    setView("today");
+    renderToday();
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  });
   replaceChildren(byId("map-detail"), [
     element("p", { className: "eyebrow", text: "Selected node" }),
     element("h2", { text: entity.label }),
@@ -965,6 +975,7 @@ function selectMapNode(entity, relatedEntities) {
             .join(", ")}${relatedEntities.length > 8 ? "…" : ""}`,
         })
       : null,
+    viewResults,
     entity.url
       ? element("a", {
           className: "primary-link",
@@ -980,26 +991,88 @@ function selectMapNode(entity, relatedEntities) {
   writeUrl();
 }
 
+function rankedCounts(values, limit = 6) {
+  return Object.entries(values || {})
+    .sort((a, b) => Number(b[1] || 0) - Number(a[1] || 0) || a[0].localeCompare(b[0]))
+    .slice(0, limit);
+}
+
+function mapInsightCard(title, entries, emptyText) {
+  return element("article", { className: "map-insight-card" }, [
+    element("h2", { text: title }),
+    entries.length
+      ? element(
+          "ul",
+          {},
+          entries.map(([label, value]) =>
+            element("li", {}, [
+              element("span", { text: label }),
+              element("strong", { text: value }),
+            ]),
+          ),
+        )
+      : element("p", { text: emptyText }),
+  ]);
+}
+
+function renderMapInsights(corpus) {
+  const aggregates = corpus.aggregates || {};
+  const entityTypes = aggregates.entity_types || {};
+  const topicEntries = (aggregates.topics || [])
+    .sort(
+      (a, b) =>
+        Number(b.entity_count || 0) - Number(a.entity_count || 0) ||
+        a.topic.localeCompare(b.topic),
+    )
+    .map((topic) => [
+      topic.topic.replaceAll("_", " "),
+      `${metricLabel(topic.entity_count, "artifact")} · ${metricLabel(
+        topic.source_breadth,
+        "source",
+      )}`,
+    ]);
+  const sourceEntries = rankedCounts(aggregates.sources).map(([source, count]) => [
+    source,
+    metricLabel(count, "observation"),
+  ]);
+  const organizationEntries = rankedCounts(aggregates.organizations).map(
+    ([organization, count]) => [organization, metricLabel(count, "observation")],
+  );
+  const coverageEntries = [
+    ["Artifacts", Number(entityTypes.artifact || 0).toLocaleString()],
+    ["Organizations", Number(entityTypes.organization || 0).toLocaleString()],
+    ["Authors", Number(entityTypes.person || 0).toLocaleString()],
+    ["Discovery sources", Number(entityTypes.source || 0).toLocaleString()],
+    ["Topics", Number(entityTypes.topic || 0).toLocaleString()],
+  ];
+  replaceChildren(byId("map-insights"), [
+    mapInsightCard("Corpus coverage", coverageEntries, "No corpus entities yet."),
+    mapInsightCard("Topic coverage", topicEntries, "No topics assigned yet."),
+    mapInsightCard("Discovery sources", sourceEntries, "No discovery sources yet."),
+    mapInsightCard(
+      "Most represented organizations",
+      organizationEntries,
+      "No organizations identified yet.",
+    ),
+  ]);
+}
+
 function renderTrendMap() {
   const corpus = state.data.corpus;
   if (!corpus) return;
   const entityById = new Map(corpus.entities.map((entity) => [entity.id, entity]));
   const selectedFromUrl = entityById.get(state.entity);
-  let artifacts = corpus.entities
+  const artifacts = corpus.entities
     .filter((entity) => entity.type === "artifact")
     .sort(
       (a, b) =>
         Number(b.latest_score || 0) - Number(a.latest_score || 0) ||
         Number(b.observation_count || 0) - Number(a.observation_count || 0) ||
         a.label.localeCompare(b.label),
-    )
-    .slice(0, 16);
-  if (
-    selectedFromUrl?.type === "artifact" &&
-    !artifacts.some((entity) => entity.id === selectedFromUrl.id)
-  ) {
-    artifacts = [selectedFromUrl, ...artifacts.slice(0, 15)];
-  }
+    );
+  const artifactOrder = new Map(
+    artifacts.map((entity, index) => [entity.id, index]),
+  );
   const artifactIds = new Set(artifacts.map((entity) => entity.id));
   const visibleEdges = corpus.edges.filter(
     (edge) =>
@@ -1026,17 +1099,28 @@ function renderTrendMap() {
       type,
       visibleEntities
         .filter((entity) => entity.type === type)
-        .sort((a, b) => a.label.localeCompare(b.label)),
+        .sort((a, b) =>
+          type === "artifact"
+            ? artifactOrder.get(a.id) - artifactOrder.get(b.id)
+            : a.label.localeCompare(b.label),
+        ),
     ]),
   );
+  const rowSpacing = 36;
   const height = Math.max(
     560,
-    ...typeOrder.map((type) => groups[type].length * 52 + 90),
+    groups.artifact.length * rowSpacing + 120,
   );
   const positions = new Map();
   typeOrder.forEach((type) => {
     groups[type].forEach((entity, index) => {
-      positions.set(entity.id, { x: xByType[type], y: 70 + index * 52 });
+      const y =
+        type === "artifact"
+          ? 70 + index * rowSpacing
+          : groups[type].length === 1
+            ? height / 2
+            : 70 + (index * (height - 140)) / (groups[type].length - 1);
+      positions.set(entity.id, { x: xByType[type], y });
     });
   });
 
@@ -1107,10 +1191,16 @@ function renderTrendMap() {
     });
     svg.append(group);
   });
+  renderMapInsights(corpus);
   replaceChildren(byId("map-canvas"), [svg]);
+  const authorCount = Number(corpus.aggregates?.entity_types?.person || 0);
   byId("map-summary").textContent =
-    `${corpus.entity_count} cumulative entities · ${corpus.observation_count} observations · ` +
-    `${corpus.edge_count} relationships · showing ${artifacts.length} ranked artifacts`;
+    `Showing all ${artifacts.length.toLocaleString()} artifacts · ` +
+    `${groups.organization.length.toLocaleString()} organizations · ` +
+    `${groups.source.length.toLocaleString()} sources · ${groups.topic.length.toLocaleString()} topics` +
+    (authorCount
+      ? ` · ${authorCount.toLocaleString()} author nodes summarized above and omitted from the canvas`
+      : "");
   if (selectedFromUrl) {
     const related = corpus.edges
       .filter(

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -1115,6 +1115,64 @@ td a {
   text-transform: uppercase;
 }
 
+.map-insights {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1rem;
+  margin: 1.5rem 0;
+}
+
+.map-insight-card {
+  min-width: 0;
+  padding: 1rem;
+  border-top: 3px solid var(--blue);
+  background: var(--panel);
+}
+
+.map-insight-card h2 {
+  margin: 0 0 0.75rem;
+  font-family: var(--utility);
+  font-size: 0.72rem;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.map-insight-card ul {
+  display: grid;
+  gap: 0.45rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.map-insight-card li {
+  display: flex;
+  gap: 0.75rem;
+  align-items: baseline;
+  justify-content: space-between;
+  font-size: 0.76rem;
+}
+
+.map-insight-card li span {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--muted);
+}
+
+.map-insight-card li strong {
+  flex: none;
+  font-family: var(--utility);
+  font-size: 0.68rem;
+  font-weight: 600;
+  text-align: right;
+}
+
+.map-insight-card p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+
 .map-layout {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 320px;
@@ -1139,7 +1197,7 @@ td a {
 
 .map-edge {
   stroke: #9baab1;
-  stroke-opacity: 0.38;
+  stroke-opacity: 0.24;
   stroke-width: 1;
 }
 
@@ -1218,6 +1276,11 @@ td a {
 .map-detail .primary-link {
   display: inline-block;
   margin-top: 1rem;
+}
+
+.map-view-results {
+  border: 0;
+  cursor: pointer;
 }
 
 dialog {
@@ -1494,6 +1557,10 @@ footer {
     padding-right: 1rem;
   }
 
+  .map-insights {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .map-layout {
     grid-template-columns: 1fr;
   }
@@ -1521,6 +1588,10 @@ footer {
   }
 
   .detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .map-insights {
     grid-template-columns: 1fr;
   }
 }

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -366,20 +366,50 @@ input {
 
 .record-summary {
   display: grid;
-  grid-template-columns: 54px minmax(0, 1fr) 170px;
-  gap: 1.25rem;
+  grid-template-columns: 26px 38px minmax(0, 1fr) 170px;
+  gap: 1rem;
   align-items: start;
   padding: 1.5rem 0;
   cursor: pointer;
   list-style: none;
 }
 
+.record-summary::before {
+  content: "›";
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border: 1px solid var(--line);
+  border-radius: 50%;
+  color: var(--blue-deep);
+  font-family: var(--utility);
+  font-size: 1rem;
+  line-height: 1;
+  transition:
+    transform 140ms ease,
+    border-color 140ms ease,
+    background 140ms ease;
+}
+
 .record-summary::-webkit-details-marker {
   display: none;
 }
 
+.record-summary:hover::before {
+  border-color: var(--blue);
+}
+
 .record-card[open] {
   background: color-mix(in srgb, var(--panel) 70%, transparent);
+}
+
+.record-card[open] > .record-summary::before {
+  transform: rotate(90deg);
+  border-color: var(--blue);
+  background: var(--blue);
+  color: white;
 }
 
 .record-card[open] .record-summary {
@@ -387,7 +417,7 @@ input {
 }
 
 .record-detail {
-  margin: 0 190px 0 79px;
+  margin: 0 186px 0 96px;
   padding: 1.25rem 0 1.75rem;
 }
 
@@ -1447,19 +1477,20 @@ footer {
   }
 
   .record-summary {
-    grid-template-columns: 36px minmax(0, 1fr);
+    grid-template-columns: 24px 30px minmax(0, 1fr);
+    gap: 0.65rem;
   }
 
   .record-summary .score,
   .record-summary .attention-activity {
-    grid-column: 2;
+    grid-column: 3;
     justify-self: start;
     max-width: 180px;
     text-align: left;
   }
 
   .record-detail {
-    margin: 0 0 0 51px;
+    margin: 0 0 0 75px;
     padding-right: 1rem;
   }
 

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -957,6 +957,26 @@ input {
   background: #756aa8;
 }
 
+.trend-filter {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin: 0.75rem 0 0;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.trend-filter input {
+  cursor: pointer;
+}
+
+.trend-filter .heading-note {
+  margin: 0;
+  font-size: 0.75rem;
+  cursor: default;
+}
+
 .trend-message {
   margin: 1.25rem 0 0;
   padding: 0.9rem 1rem;

--- a/site/index.html
+++ b/site/index.html
@@ -62,7 +62,7 @@
             title="Open a new issue"
           >
             <span aria-hidden="true">◎</span>
-            <span class="repo-badge-label">Report</span>
+            <span class="repo-badge-label">Issues</span>
             <span class="repo-badge-count" data-count>—</span>
           </a>
         </div>

--- a/site/index.html
+++ b/site/index.html
@@ -190,6 +190,13 @@
             <h2>Daily evidence and attention volume</h2>
             <div class="legend" id="trend-legend" aria-label="Category legend"></div>
           </div>
+          <label class="trend-filter">
+            <input type="checkbox" id="trend-released-only" />
+            Releases only
+            <span class="heading-note">
+              Excludes records re-announced as an update to something already surfaced.
+            </span>
+          </label>
           <p class="trend-message" id="trend-message" role="status"></p>
           <div class="trend-chart" id="trend-chart" role="img" aria-label="Daily category counts"></div>
         </div>

--- a/site/index.html
+++ b/site/index.html
@@ -142,10 +142,12 @@
             <h1 id="map-heading">Artifacts and their context</h1>
           </div>
           <p class="heading-note">
-            Exact identifiers connect artifacts to topics, publishers, and discovery sources.
-            Select a node to carry it into the Today filters.
+            The overview summarizes the full corpus. The relationship canvas includes every
+            artifact and connected organization, source, and topic; select a node to carry it
+            into the Today filters.
           </p>
         </header>
+        <div class="map-insights" id="map-insights" aria-label="Corpus overview"></div>
         <p class="map-summary" id="map-summary"></p>
         <div class="map-layout">
           <div

--- a/src/benchmark_radar/snapshots.py
+++ b/src/benchmark_radar/snapshots.py
@@ -342,12 +342,17 @@ def _attach_category_trends(days: list[dict[str, Any]]) -> None:
     Identity joins every exact identifier a record carries, not just one
     preferred key or `source:source_id`. A DOI-plus-arXiv observation and a
     later arXiv-only observation are two sightings of the same artifact.
+
+    Deltas, baselines and momentum are built from `category_counts_released`,
+    not the raw `category_counts`: a version bump reannounced as "updated" is
+    not new activity in the field, so it must not move the 30-day change the
+    way a first "released" sighting does (issue #50).
     """
     seen: dict[str, set[str]] = {}
     seen_any: set[str] = set()
     records_seen: list[dict[str, Any]] = []
     for index, day in enumerate(days):
-        counts = day["category_counts"]
+        counts = day["category_counts_released"]
         records_seen.extend(day["evidence_items"])
         aliases = artifact_alias_map(records_seen)
         # A later observation can bridge identifiers previously thought to be
@@ -373,15 +378,19 @@ def _attach_category_trends(days: list[dict[str, Any]]) -> None:
         prior_day = days[index - 1] if index else None
         if prior_day is not None and _collection_context(prior_day) != context:
             prior_day = None
-        previous = prior_day["category_counts"] if prior_day else {}
+        previous = prior_day["category_counts_released"] if prior_day else {}
         trends = {}
-        for category in sorted({*counts, *previous}):
+        for category in sorted({*counts, *previous, *day["category_counts"]}):
             count = counts.get(category, 0)
-            history = [entry["category_counts"].get(category, 0) for entry in comparable]
+            history = [entry["category_counts_released"].get(category, 0) for entry in comparable]
             baseline = round(sum(history) / len(history), 2) if history else None
             prior = previous.get(category, 0) if prior_day else None
             trends[category] = {
                 "count": count,
+                # The all-events figure this released-only count was drawn
+                # from, so the UI can show how many re-announced updates were
+                # set aside rather than silently dropping them.
+                "total_count": day["category_counts"].get(category, 0),
                 "previous": prior,
                 "delta": None if prior is None else count - prior,
                 "baseline": baseline,
@@ -423,6 +432,16 @@ def dashboard_data(snapshots: list[dict[str, Any]]) -> dict[str, Any]:
         category_counts = Counter(
             category for item in evidence_items for category in item["categories"]
         )
+        # A record re-announced as "updated" (a new version of a paper, a
+        # repository pushing again) is not new activity in the field the way a
+        # first "released" sighting is. Trend deltas built from the mixed count
+        # register a version bump as if it were a fresh benchmark landing.
+        category_counts_released = Counter(
+            category
+            for item in evidence_items
+            if item["event_kind"] == "released"
+            for category in item["categories"]
+        )
         source_counts = Counter(item["source"] for item in evidence_items)
         event_counts = Counter(item["event_kind"] for item in evidence_items)
         attention_source_counts = Counter(item["source"] for item in observations)
@@ -460,6 +479,7 @@ def dashboard_data(snapshots: list[dict[str, Any]]) -> dict[str, Any]:
                 "item_count": len(evidence_items),
                 "evidence_count": len(evidence_items),
                 "category_counts": dict(sorted(category_counts.items())),
+                "category_counts_released": dict(sorted(category_counts_released.items())),
                 "source_counts": dict(sorted(source_counts.items())),
                 "event_kind_counts": dict(sorted(event_counts.items())),
                 "evidence_items": evidence_items,

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -124,10 +124,7 @@ def test_summaries_truncate_at_a_word_boundary():
 
     assert 'const lastSpace = candidate.lastIndexOf(" ");' in script
     assert "candidate.slice(0, lastSpace)" in script
-    # The collapsed row is abbreviated, while the expanded region receives
-    # the retained upstream text rather than the abbreviation.
     assert "shorten(item.summary)" in script
-    assert 'text: item.summary || "No description published at the source."' in script
 
 
 def test_site_does_not_render_source_content_as_html():
@@ -185,6 +182,16 @@ def test_hugging_face_expansion_links_to_the_full_card():
 
     assert 'item.source === "Hugging Face"' in script
     assert '"Read full card ↗"' in script
+
+
+def test_expanded_detail_continues_past_the_teaser_instead_of_repeating_it():
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    assert "function summaryRemainder(fullText, teaser)" in script
+    assert "summaryRemainder(item.summary, teaser)" in script
+    # expandedRecord must receive the same teaser text the summary row shows,
+    # or the remainder cannot know what the reader already read.
+    assert 'expandedRecord(item, (item.summary || "").trim() ? summary : "")' in script
 
 
 def test_trend_map_is_keyboard_accessible_and_coordinates_today_filters():

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -231,6 +231,20 @@ def test_trends_gate_comparisons_on_connector_coverage():
     assert "Coverage is incomplete:" in script
 
 
+def test_trend_chart_can_filter_to_releases_only():
+    html = Path("site/index.html").read_text(encoding="utf-8")
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    assert 'id="trend-released-only"' in html
+    assert 'byId("trend-released-only")' in script
+    assert "state.trendReleasedOnly" in script
+    assert "day.category_counts_released" in script
+    # The domain card shows the release count as the headline, and reports
+    # anything set aside as an update rather than dropping it silently.
+    assert "trend.total_count" in script
+    assert "also updated (not counted above)" in script
+
+
 def test_static_html_references_existing_local_assets():
     parser = SiteParser()
     parser.feed(Path("site/index.html").read_text(encoding="utf-8"))

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -171,8 +171,8 @@ def test_records_expand_inline_without_an_exclusive_accordion_or_record_modal():
     assert '"details"' in script
     assert '"summary"' in script
     assert "record-detail" in script
-    assert '.record-summary::before' in styles
-    assert '.record-card[open] > .record-summary::before' in styles
+    assert ".record-summary::before" in styles
+    assert ".record-card[open] > .record-summary::before" in styles
     assert "detail-dialog" not in html
     assert "detail-dialog" not in script
     # A shared details[name] would force one row closed when another opens.

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -249,7 +249,7 @@ def test_repo_badges_invite_an_action_rather_than_listing_a_roster():
     assert "/stargazers" not in html
     assert "benchmark-radar/forks" not in html
 
-    for label in (">Star<", ">Fork<", ">Report<"):
+    for label in (">Star<", ">Fork<", ">Issues<"):
         assert label in html
 
     # Starring has no GET endpoint, so the star badge opens the repository and

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -198,8 +198,22 @@ def test_trend_map_is_keyboard_accessible_and_coordinates_today_filters():
     assert '"aria-label": `${entity.type}: ${entity.label}`' in script
     assert 'event.key === "Enter" || event.key === " "' in script
     assert "mapFilterFor(entity)" in script
+    assert "View matching observations →" in script
+    assert 'setView("today")' in script
     assert 'id="organization-filter"' in html
     assert "state.organization" in script
+
+
+def test_trend_map_shows_the_complete_corpus_and_summarizes_its_shape():
+    html = Path("site/index.html").read_text(encoding="utf-8")
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    assert 'id="map-insights"' in html
+    assert "renderMapInsights(corpus)" in script
+    assert "Most represented organizations" in script
+    assert "Showing all ${artifacts.length.toLocaleString()} artifacts" in script
+    assert ".slice(0, 16)" not in script
+    assert "author nodes summarized above and omitted from the canvas" in script
 
 
 def test_trends_gate_comparisons_on_connector_coverage():

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -166,10 +166,13 @@ def test_main_filters_use_persisted_attention_and_snapshot_dates():
 def test_records_expand_inline_without_an_exclusive_accordion_or_record_modal():
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
     html = Path("site/index.html").read_text(encoding="utf-8")
+    styles = Path("site/assets/styles.css").read_text(encoding="utf-8")
 
     assert '"details"' in script
     assert '"summary"' in script
     assert "record-detail" in script
+    assert '.record-summary::before' in styles
+    assert '.record-card[open] > .record-summary::before' in styles
     assert "detail-dialog" not in html
     assert "detail-dialog" not in script
     # A shared details[name] would force one row closed when another opens.

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -252,6 +252,33 @@ def test_dashboard_reports_per_category_deltas_and_cumulative(tmp_path):
     assert second["cumulative_evidence_count"] == 2
 
 
+def test_trend_deltas_exclude_records_reannounced_as_updated(tmp_path):
+    # Issue #50: a paper reannounced as an "updated" version is not new
+    # activity in the field, so it must not move the 30-day change the way a
+    # fresh "released" sighting does.
+    snapshot_dir = tmp_path / "snapshots"
+    baseline = radar_run(26)
+    write_snapshot(baseline, snapshot_dir)
+    updated_only = radar_run(27)
+    updated_only.items[0].event_kind = "updated"
+    write_snapshot(updated_only, snapshot_dir)
+
+    data = rebuild_dashboard(snapshot_dir, tmp_path / "radar.json")
+
+    first, second = data["days"]
+    assert first["category_trends"]["benchmark"]["count"] == 1
+    trend = second["category_trends"]["benchmark"]
+    # The all-events total still shows the record; the release-based trend
+    # figures it feeds do not count it as new.
+    assert second["category_counts"]["benchmark"] == 1
+    assert trend["count"] == 0
+    assert trend["delta"] == -1
+    assert trend["total_count"] == 1
+    # Cumulative corpus coverage is unaffected: the artifact is still real and
+    # still in the corpus, whichever event announced it.
+    assert trend["cumulative"] == 2
+
+
 def test_cumulative_counts_artifacts_once_across_overlapping_windows(tmp_path):
     # The scan window overlaps by design, so the same repository appears on
     # adjacent days. Summing daily counts would grow the total while nothing


### PR DESCRIPTION
## Summary

Addresses issues #45, #49, #42, #51, #44, and #50.

- **#45 (wording)**: Renamed the repo badge from "Report" to "Issues" to match what it actually links to.
- **#49 (unfold UX)**: Added a rotating chevron affordance so a folded record visibly signals it can expand. Also fixed the expanded detail to show new content instead of repeating the collapsed teaser's opening text verbatim (the "includes the previous things" complaint).
- **#42 (map improvement)**: The relationship map was capped at 16 ranked artifacts out of 200+, with organizations/sources barely visible. It now renders every artifact and connected entity, plus a corpus-overview panel (coverage, topics, sources, top organizations) so the map reflects the actual corpus size.
- **#51 (arXiv "dedup")**: Investigated — there were no actual duplicate papers; 139 genuinely distinct arXiv papers matched the keyword filter in one day because cs.AI/cs.CL/cs.CV publish 700+ papers/day and generic keywords like "benchmark"/"evaluation"/"dataset" matched ~65% of them. Tightened `rss_keywords`/`queries` to require benchmark/dataset *introduction* phrasing, cutting matches to ~9-12% while keeping genuine releases.
- **#44 (cron cadence)**: Daily radar now runs twice a day (06:15 and 12:15 UTC, both early-morning America/Chicago) instead of once, so a failed or missed trigger gets a same-day retry. Snapshot persistence and issue publishing are already idempotent per UTC date, so this is safe.
- **#50 (trends accuracy)**: Added a "Releases only" toggle on the Trends daily bar chart, and excluded records re-announced as `updated` from the 30-day category delta/baseline/momentum math (a version bump is not new field activity). The raw all-events count is still shown; anything set aside as an update is now surfaced as "also updated" rather than silently dropped.

## Test plan
- [x] `pytest` — 140 passed
- [x] `ruff check` / `ruff format --check` — clean
- [x] Verified served HTML/JSON structurally (element IDs present, `category_counts_released`/`total_count` fields populated after rebuilding the dashboard from snapshots)
- [ ] Could not visually confirm in a real browser — this sandbox is headless with no display. Recommend a quick look at the Today and Trends views after merge.