### PR TITLE
Add agentic taxonomy category and matching retrieval keywords

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -40,6 +40,22 @@ taxonomy:
     - data provenance
     - annotation quality
     - benchmark leakage
+  # "agent"/"agentic" alone appear in most 2026 ML papers' related work, so
+  # (per issue #51's lesson on bare-word taxonomy terms) these require the
+  # phrase to name an agent benchmark/eval itself, not merely mention agents.
+  agentic:
+    - agent benchmark
+    - agentic benchmark
+    - agent evaluation
+    - agentic evaluation
+    - multi-agent benchmark
+    - tool-use benchmark
+    - tool use benchmark
+    - agentic capabilities
+    - agentic task
+    - benchmark for agent
+    - benchmark for llm agent
+    - benchmark for autonomous agent
 
 # Named artifacts worth surfacing whenever they move, regardless of where the
 # generic score places them. A watchlist hit is a routing decision, not a
@@ -103,10 +119,17 @@ sources:
       - curated dataset
       - data contamination
       - benchmark leakage
+      - agent benchmark
+      - agentic benchmark
+      - agent evaluation
+      - agentic evaluation
+      - multi-agent benchmark
+      - benchmark for agent
     queries:
       - 'ti:"benchmark" AND (all:"we introduce" OR all:"we present" OR all:"we release")'
       - 'ti:"dataset" AND (all:"we introduce" OR all:"we present" OR all:"we release")'
       - '(all:"data contamination" OR all:"benchmark leakage" OR all:"data quality")'
+      - '(all:"agent benchmark" OR all:"agentic benchmark" OR all:"agent evaluation")'
 
   huggingface:
     enabled: true
@@ -118,6 +141,7 @@ sources:
       - leaderboard
       - preference
       - synthetic-data
+      - agent benchmark
 
   github:
     enabled: true
@@ -127,6 +151,8 @@ sources:
       - '"AI evaluation" in:name,description,readme'
       - '"benchmark dataset" in:name,description,readme'
       - '"data contamination" in:name,description,readme'
+      - '"agent benchmark" in:name,description,readme'
+      - '"agentic benchmark" in:name,description,readme'
 
   openreview:
     enabled: true
@@ -146,6 +172,7 @@ sources:
       - large language model benchmark
       - artificial intelligence evaluation dataset
       - data contamination benchmark
+      - agentic benchmark evaluation
     page_size: 100
     max_requests: 3
     attempts: 3
@@ -174,6 +201,7 @@ sources:
       - large language model benchmark
       - artificial intelligence evaluation dataset
       - benchmark contamination data quality
+      - agentic benchmark evaluation
 
   brave:
     enabled: true
@@ -181,6 +209,7 @@ sources:
       - new AI benchmark evaluation dataset
       - new LLM benchmark leaderboard
       - AI dataset release data quality
+      - new agentic AI benchmark leaderboard
 
 attention:
   feeds:

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -3,6 +3,7 @@ const CATEGORY_COLORS = {
   evaluation: "#dc633f",
   dataset: "#4c948b",
   data_quality: "#c99327",
+  agentic: "#756aa8",
 };
 const FALLBACK_COLORS = ["#756aa8", "#397f9a", "#a4576d", "#70833d"];
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -65,6 +65,32 @@ def test_scoring_is_explainable_and_bounded():
     assert any("Matched:" in reason for reason in scored.rationale)
 
 
+def test_agentic_taxonomy_requires_a_scoped_phrase_not_a_bare_word():
+    """Regression for issue #52/#57: a bare 'agent' term would match almost
+    every 2026 ML paper's related work, the same failure issue #51 hit with
+    bare 'benchmark'/'evaluation'. The taxonomy phrase must name an agent
+    benchmark/eval itself."""
+    taxonomy = {"agentic": ["agent benchmark", "agentic evaluation"]}
+    matched = score_item(
+        item(
+            title="AgentBench-Pro",
+            summary="We introduce a new agent benchmark for tool-use reasoning.",
+        ),
+        taxonomy,
+        datetime(2026, 7, 27, 1, tzinfo=UTC),
+    )
+    unmatched = score_item(
+        item(
+            title="Scaling Transformers",
+            summary="Our agent uses a transformer trained on web-scale data.",
+        ),
+        taxonomy,
+        datetime(2026, 7, 27, 1, tzinfo=UTC),
+    )
+    assert matched.categories == ["agentic"]
+    assert unmatched.categories == []
+
+
 def test_templated_summaries_fail_the_run():
     """Regression: 26/30 records once shared 'Dataset repository updated on
     Hugging Face.', which told the reader nothing and inflated relevance


### PR DESCRIPTION
## Summary

- Adds an `agentic` taxonomy category (scored the same way as `benchmark`/`evaluation`/`dataset`/`data_quality`) so the dashboard's existing "Corpus totals" panel (added for #52) can report an agentic-benchmark count, not just the four original categories.
- Adds matching agentic retrieval keywords/queries to every source (arXiv, Hugging Face, GitHub, Semantic Scholar, OpenAlex, Brave). Without this, the taxonomy tag alone can't count agentic benchmarks: it only classifies items a source connector already fetched, and none of the retrieval-side keyword lists ever mentioned "agent"/"agentic" (filed and fixed as its own issue, #57, since it's a distinct and important gap).
- All new terms are scoped phrases ("agent benchmark", "agentic evaluation", etc.), not bare "agent"/"agentic" — per issue #51's lesson, a bare word would match almost every 2026 ML paper's related-work section and blow out relevance scores.

## Why the dashboard will show 0 agentic items today

Snapshots in `data/snapshots/` are the versioned, canonical, append-only corpus (see README) and are never rewritten retroactively. The 616 artifacts already in the corpus were scored under the old taxonomy (no `agentic` key existed), so `benchmark-radar backfill` correctly reproduces 0 for `agentic` right now — that's expected, not a bug. The count will start populating once the next scheduled collection run fetches and scores new items with this config live.

## Test plan

- [x] `pytest tests/ -q` — 152 passed
- [x] `ruff check` / `ruff format --check` — clean
- [x] New regression test (`test_agentic_taxonomy_requires_a_scoped_phrase_not_a_bare_word`) locks in scoped-phrase matching vs. bare-word false positives
- [ ] After the next scheduled run, spot-check that the Corpus totals panel shows a nonzero `agentic` count

Fixes #52 (agentic count is now trackable, not just the four original categories). Fixes #57.
