### PR TITLE
Default the Corpus totals panel open so it isn't missed

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -136,7 +136,7 @@
               </details>
             </aside>
             <aside class="health-panel corpus-totals-panel" aria-labelledby="corpus-totals-heading">
-              <details id="corpus-totals-details">
+              <details id="corpus-totals-details" open>
                 <summary>
                   <span class="health-panel-title" id="corpus-totals-heading">Corpus totals</span>
                   <span class="health-panel-status" id="corpus-totals-status"></span>

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -306,6 +306,10 @@ def test_today_view_shows_total_corpus_counts_by_category():
     assert 'id="corpus-totals-status"' in html
     assert "state.data.corpus?.aggregates?.topics" in script
     assert "state.data.corpus?.aggregates?.entity_types?.artifact" in script
+    # A collapsed <details> next to a long, often multi-screen record list was
+    # reported unreadable ("I cannot see it") -- default it open so the totals
+    # are visible without a click, on both wide and stacked-mobile layouts.
+    assert '<details id="corpus-totals-details" open>' in html
 
 
 def test_badge_accessible_names_state_the_action():


### PR DESCRIPTION
## Summary

- Issue #52's dashboard fix added a "Corpus totals" panel (total distinct artifacts + per-category breakdown), but it was reported as invisible ("I cannot see it").
- Root cause: the panel is a collapsed `<details>` inside a sidebar that is the *second* column of a two-column CSS grid (`.content-grid { grid-template-columns: minmax(0,1fr) 320px; }`). Below the tablet breakpoint, that grid collapses to a single column, so the sidebar (Sources + Corpus totals) renders *after* the entire main "Matching observations" list in document order — often several screens of scrolling before it's ever reached.
- Fix: default the panel open (`<details id="corpus-totals-details" open>`) so its contents render without an extra click, reducing (though not eliminating) how easy it is to miss on a stacked layout.

## Test plan

- [x] `pytest tests/test_site.py -q` — new assertion locks in the `open` attribute
- [x] `ruff check` / `ruff format --check` — clean
- [ ] Visual confirmation on the deployed dashboard once merged (could not open a real browser window in this sandboxed session — served locally on port 8811 and verified structurally only)

Related to #52.
