### PR TITLE
Fix the agentic benchmark count (3 -> 78) and report the analysis for #52

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -13,22 +13,26 @@ radar:
   minimum_score: 40
 
 taxonomy:
+  # `challenge set` and `capability eval` matched zero artifacts across all
+  # nine snapshots (issue #52 audit) and are dropped: a term that never fires
+  # creates an illusion of coverage. `evaluat` replaces `evaluation` as a
+  # strict superset under substring matching, picking up "evaluating" and
+  # "evaluated"; `corpora` is added because substring matching gets `corpus`
+  # but cannot bridge the irregular Latin plural.
   benchmark:
     - benchmark
     - leaderboard
     - test set
-    - challenge set
     - evaluation suite
   evaluation:
-    - evaluation
-    - evaluator
+    - evaluat
     - judge model
     - red teaming
-    - capability eval
     - safety eval
   dataset:
     - dataset
     - corpus
+    - corpora
     - data collection
     - synthetic data
     - training data
@@ -41,21 +45,41 @@ taxonomy:
     - annotation quality
     - benchmark leakage
   # "agent"/"agentic" alone appear in most 2026 ML papers' related work, so
-  # (per issue #51's lesson on bare-word taxonomy terms) these require the
-  # phrase to name an agent benchmark/eval itself, not merely mention agents.
+  # this still requires an evaluation noun -- but as a *proximity* rule rather
+  # than an adjacent phrase.
+  #
+  # The previous 12 adjacent phrases matched 16 of 645 artifacts (21.7% recall,
+  # issue #52). Six of them matched nothing at all, because real titles put the
+  # agent noun last and interpose qualifiers: "A Production-Fidelity Benchmark
+  # for LLM-Based Database Operations Agents" contains neither "agent
+  # benchmark" nor "benchmark for agent". Requiring the two nouns within 15
+  # tokens instead of adjacent reaches 95.0% recall at 75.0% precision,
+  # measured against 109 hand-labeled candidates (two independent annotators,
+  # Cohen's kappa 0.888). `exclude` drops the residual false positives, which
+  # are artifacts that build or survey agents rather than evaluate them.
   agentic:
-    - agent benchmark
-    - agentic benchmark
-    - agent evaluation
-    - agentic evaluation
-    - multi-agent benchmark
-    - tool-use benchmark
-    - tool use benchmark
-    - agentic capabilities
-    - agentic task
-    - benchmark for agent
-    - benchmark for llm agent
-    - benchmark for autonomous agent
+    within: 15
+    any_of: [agent, agents, agentic]
+    near:
+      [
+        benchmark,
+        benchmarks,
+        benchmarking,
+        eval,
+        evals,
+        evaluation,
+        evaluations,
+        evaluating,
+        evaluate,
+        leaderboard,
+        harness,
+        testbed,
+        arena,
+        bench,
+      ]
+    # No trailing \b: it can never match after the colon in "position:", which
+    # would silently disable that clause.
+    exclude: '\b(?:position:|survey|scoping review|unlocking agentic capabilities|needs redefinition)'
 
 # Named artifacts worth surfacing whenever they move, regardless of where the
 # generic score places them. A watchlist hit is a routing decision, not a

--- a/config.yml
+++ b/config.yml
@@ -32,7 +32,9 @@ taxonomy:
   dataset:
     - dataset
     - corpus
-    - corpora
+    # Trailing $ closes the right edge: bare `corpora` matched inside
+    # "incorporates" and "corporate", tagging unrelated artifacts as datasets.
+    - corpora$
     - data collection
     - synthetic data
     - training data
@@ -77,9 +79,17 @@ taxonomy:
         arena,
         bench,
       ]
-    # No trailing \b: it can never match after the colon in "position:", which
-    # would silently disable that clause.
-    exclude: '\b(?:position:|survey|scoping review|unlocking agentic capabilities|needs redefinition)'
+    # Genre markers only, anchored to where a paper declares its own type.
+    # A bare `survey` would drop "A Benchmark of LLM-Simulated Human Survey
+    # Response", a real agent benchmark, because survey response is a subject
+    # area as well as a paper genre. `position:` carries no trailing \b: it
+    # could never match after the colon, which silently disabled the clause.
+    #
+    # Kept deliberately short. Per-title exclusions ("unlocking agentic
+    # capabilities") were tested and dropped: each removed exactly one
+    # artifact from the measurement corpus, which is memorizing the test set
+    # rather than stating a rule.
+    exclude: '(?:^|: )(?:position:|a survey|survey of|scoping review)|\bwe survey\b'
 
 # Named artifacts worth surfacing whenever they move, regardless of where the
 # generic score places them. A watchlist hit is a routing decision, not a

--- a/data/snapshots/2026-07-23.json
+++ b/data/snapshots/2026-07-23.json
@@ -125,7 +125,8 @@
       "categories": [
         "benchmark",
         "evaluation",
-        "dataset"
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-24T00:00:00+00:00",
       "event_kind": "updated",
@@ -137,7 +138,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-22T07:44:20+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: agent~benchmark, benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:a323484724935d1d637e5f8fe69c6e7a7402f54652def78cd75ef1f2d13283d8",
@@ -164,7 +165,8 @@
       "categories": [
         "benchmark",
         "evaluation",
-        "dataset"
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-24T00:00:00+00:00",
       "event_kind": "updated",
@@ -176,7 +178,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-22T16:00:58+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: agents~benchmark, benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:afc4449f88a68c400c946d154aa6aaa0204b777f5c91f88d5d90d7e59729e96e",
@@ -203,7 +205,8 @@
       "categories": [
         "benchmark",
         "evaluation",
-        "dataset"
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-24T00:00:00+00:00",
       "event_kind": "released",
@@ -215,7 +218,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-22T07:30:58+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: agentic~benchmarks, benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:11b1532fc6b2698676d6b79b068808d17265f0b6e2b27c1336a06cfe887ccf50",
@@ -292,7 +295,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-22T11:05:18+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:94209861be4a1e1aa1be92f2f761fcbefc139da77de6c8635591403953e92f16",
@@ -318,6 +321,7 @@
       "authors": [],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-24T00:00:00+00:00",
@@ -330,7 +334,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-22T18:44:56+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:385facd11a8249c924a58b58ca84ec47d90ba5d4a78386bba614e419f1d96feb",
@@ -432,6 +436,7 @@
       "authors": [],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-24T00:00:00+00:00",
@@ -444,7 +449,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-22T13:30:37+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:7f0f309ffa25a6fc05232d9abbd7105617b95e594bb57a7c816301584ffbf096",
@@ -508,6 +513,7 @@
       "authors": [],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-24T00:00:00+00:00",
@@ -520,7 +526,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-22T14:07:26+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:02567aa3f7012bf91b35aed28e681cd8c2a7b457298543fae9e907563697eed1",
@@ -634,7 +640,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-22T09:26:52+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:a38321fe70597f566675be424f925f612c897113404f9266fe3b8bf55cc4fcfd",
@@ -660,6 +666,7 @@
       "authors": [],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-24T00:00:00+00:00",
@@ -672,7 +679,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-22T07:09:38+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:87af4b5fa4debd0e325416dc3a3ed31d16b1a79657e892006fc5567fca1463ea",
@@ -820,7 +827,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-22T17:52:19+00:00",
       "rationale": [
-        "Matched: evaluation",
+        "Matched: evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:94fc70de7d670c19c718e7b8ed42fac004222c6bbe7243ad92f8612fded240f3",

--- a/data/snapshots/2026-07-24.json
+++ b/data/snapshots/2026-07-24.json
@@ -947,7 +947,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-23T03:24:36+00:00",
       "rationale": [
-        "Matched: benchmark, corpora, dataset",
+        "Matched: benchmark, dataset",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:485f35579a7c8e88525ab71bc072603e6cb581362ff2726934108dd74fcb7a0a",

--- a/data/snapshots/2026-07-24.json
+++ b/data/snapshots/2026-07-24.json
@@ -99,7 +99,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-23T01:25:06+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:bfa6ba6c9800deaae149753fe5cf4b2db0c27dcaabdb8f28083d74a7b6fe212f",
@@ -138,7 +138,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-23T16:37:32+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:50cbc3770dbec3cf82fa36212413c3cd1565d05f8c5d59c3f18b113d74e1467c",
@@ -165,7 +165,8 @@
       "categories": [
         "benchmark",
         "evaluation",
-        "dataset"
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-25T00:00:00+00:00",
       "event_kind": "released",
@@ -177,7 +178,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-23T14:23:02+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: agent~benchmark, benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:cba3416699721ce527bb66d8d712bdaa01009d9dbd301df8fc44be510aa9c925",
@@ -317,6 +318,7 @@
       "authors": [],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-25T00:00:00+00:00",
@@ -329,7 +331,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-23T09:10:24+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, training data",
+        "Matched: benchmark, dataset, evaluat, training data",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:6b3939981d620676c73cea628bdf1502a2d3b0f10c146f99c439fb3b6815199c",
@@ -405,7 +407,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-23T18:25:56+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:87be025a372f9b041a3fa5f0f9502cdd302f02b8154f9850c1f174bbabbfc46c",
@@ -470,7 +472,8 @@
       "categories": [
         "benchmark",
         "evaluation",
-        "dataset"
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-24T00:00:00+00:00",
       "event_kind": "updated",
@@ -482,7 +485,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-22T07:44:20+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: agent~benchmark, benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:a323484724935d1d637e5f8fe69c6e7a7402f54652def78cd75ef1f2d13283d8",
@@ -509,7 +512,8 @@
       "categories": [
         "benchmark",
         "evaluation",
-        "dataset"
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-24T00:00:00+00:00",
       "event_kind": "updated",
@@ -521,7 +525,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-22T16:00:58+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: agents~benchmark, benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:afc4449f88a68c400c946d154aa6aaa0204b777f5c91f88d5d90d7e59729e96e",
@@ -548,7 +552,8 @@
       "categories": [
         "benchmark",
         "evaluation",
-        "dataset"
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-24T00:00:00+00:00",
       "event_kind": "released",
@@ -560,7 +565,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-22T07:30:58+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: agentic~benchmarks, benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:11b1532fc6b2698676d6b79b068808d17265f0b6e2b27c1336a06cfe887ccf50",
@@ -700,6 +705,7 @@
       "authors": [],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-25T00:00:00+00:00",
@@ -712,7 +718,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-23T06:23:22+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:ff0c22ffe433b3604be54c2ada312e66c699d56a96d26e39383c82bd30d728e8",
@@ -789,7 +795,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-22T11:05:18+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:94209861be4a1e1aa1be92f2f761fcbefc139da77de6c8635591403953e92f16",
@@ -941,7 +947,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-23T03:24:36+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, corpora, dataset",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:485f35579a7c8e88525ab71bc072603e6cb581362ff2726934108dd74fcb7a0a",
@@ -967,6 +973,7 @@
       "authors": [],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-25T00:00:00+00:00",
@@ -979,7 +986,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-23T03:54:07+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:ad6b57100a6d5e065a4644cc4837e940acbb3fa33eb534d246dac59e8408a276",
@@ -1005,6 +1012,7 @@
       "authors": [],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-24T00:00:00+00:00",
@@ -1017,7 +1025,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-22T18:44:56+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:385facd11a8249c924a58b58ca84ec47d90ba5d4a78386bba614e419f1d96feb",
@@ -1230,6 +1238,7 @@
       "authors": [],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-24T00:00:00+00:00",
@@ -1242,7 +1251,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-22T13:30:37+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:7f0f309ffa25a6fc05232d9abbd7105617b95e594bb57a7c816301584ffbf096",

--- a/data/snapshots/2026-07-25.json
+++ b/data/snapshots/2026-07-25.json
@@ -99,7 +99,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-24T09:42:23+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation, evaluator",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:261d8c3179b66605c9a64cc4b579307ac068ed0a70d95a9ee7263caa58edc0d6",
@@ -278,7 +278,8 @@
       "categories": [
         "benchmark",
         "evaluation",
-        "dataset"
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-26T00:00:00+00:00",
       "event_kind": "updated",
@@ -290,7 +291,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-24T05:26:32+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: agent~benchmark, benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:55fa64fa84e4d91c5739cca68d33924086592b8ba7a80c5ca4f79ff65cefae10",
@@ -316,7 +317,8 @@
       "authors": [],
       "categories": [
         "benchmark",
-        "dataset"
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-26T00:00:00+00:00",
       "event_kind": "released",
@@ -328,7 +330,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-24T23:23:56+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: agent~benchmark, benchmark, dataset",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:a9087f050ba56e52ce3738e81bba2e7bd03ba33436d4593d4a456b566355ffcb",
@@ -367,7 +369,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-23T01:25:06+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:bfa6ba6c9800deaae149753fe5cf4b2db0c27dcaabdb8f28083d74a7b6fe212f",
@@ -633,7 +635,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-23T16:37:32+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:50cbc3770dbec3cf82fa36212413c3cd1565d05f8c5d59c3f18b113d74e1467c",
@@ -697,7 +699,8 @@
       "authors": [],
       "categories": [
         "benchmark",
-        "dataset"
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-26T00:00:00+00:00",
       "event_kind": "released",
@@ -709,7 +712,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-24T05:39:29+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: agent~benchmark, benchmark, dataset",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:cd6be74776a546bafd223753e740564da9ed34804049d01a54394d78cedad07b",
@@ -736,7 +739,8 @@
       "categories": [
         "benchmark",
         "evaluation",
-        "dataset"
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-25T00:00:00+00:00",
       "event_kind": "released",
@@ -748,7 +752,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-23T14:23:02+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: agent~benchmark, benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:cba3416699721ce527bb66d8d712bdaa01009d9dbd301df8fc44be510aa9c925",
@@ -812,6 +816,7 @@
       "authors": [],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-26T00:00:00+00:00",
@@ -824,7 +829,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-24T06:04:34+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:67f87f4abb84ca5ec3a4215937953249b0f12864a1e9e45450aa1c13c7ebc4aa",
@@ -1001,6 +1006,7 @@
       "authors": [],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-25T00:00:00+00:00",
@@ -1013,7 +1019,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-23T09:10:24+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, training data",
+        "Matched: benchmark, dataset, evaluat, training data",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:6b3939981d620676c73cea628bdf1502a2d3b0f10c146f99c439fb3b6815199c",
@@ -1050,7 +1056,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-24T07:33:54+00:00",
       "rationale": [
-        "Matched: evaluation",
+        "Matched: evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:d9dcfb8d5681b125be0eee48d3859232392f0667dcc41aad17515a7ffde25d8c",
@@ -1088,7 +1094,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-23T18:25:56+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:87be025a372f9b041a3fa5f0f9502cdd302f02b8154f9850c1f174bbabbfc46c",
@@ -1225,7 +1231,9 @@
       "artifact_urls": [],
       "authors": [],
       "categories": [
-        "benchmark"
+        "benchmark",
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-26T00:00:00+00:00",
       "event_kind": "released",
@@ -1237,7 +1245,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-24T05:16:46+00:00",
       "rationale": [
-        "Matched: benchmark",
+        "Matched: agents~benchmark, benchmark, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:79437d7d5914faedd4a5d3aa1a408bc2eec5ada46e68d93c91775e3fda2655ad",
@@ -1274,7 +1282,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-24T11:57:06+00:00",
       "rationale": [
-        "Matched: evaluation",
+        "Matched: evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:1b25d8502de06b89f0f50eb2b1ae1b3874b520d88d7c32d733cd4a35f4d5c84f",

--- a/data/snapshots/2026-07-26.json
+++ b/data/snapshots/2026-07-26.json
@@ -99,7 +99,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-25T03:17:48+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:22cb91ee2e26c99b142372026df52b691c90680009b23289d36aeead05357eb1",
@@ -391,6 +391,7 @@
       "authors": [],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-26T00:00:00+00:00",
@@ -403,7 +404,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-25T07:11:07+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:eca610c95772df5d2e3bd7f434c20475b111195874f832a03758adfc6e236d0f",
@@ -442,7 +443,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-24T09:42:23+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation, evaluator",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:261d8c3179b66605c9a64cc4b579307ac068ed0a70d95a9ee7263caa58edc0d6",
@@ -480,7 +481,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-25T18:39:03+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:99621995acc815333dd3d8623e5b9cec09851123ae43e53108762dadab6515d1",
@@ -632,7 +633,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-25T10:09:16+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:7abb7fada772b51a5b99f77bc3977b93001d3f43a3d8cf2c15ab3b60ef2474df",
@@ -772,7 +773,8 @@
       "categories": [
         "benchmark",
         "evaluation",
-        "dataset"
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-26T00:00:00+00:00",
       "event_kind": "updated",
@@ -784,7 +786,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-24T05:26:32+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: agent~benchmark, benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:55fa64fa84e4d91c5739cca68d33924086592b8ba7a80c5ca4f79ff65cefae10",
@@ -810,7 +812,8 @@
       "authors": [],
       "categories": [
         "benchmark",
-        "dataset"
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-26T00:00:00+00:00",
       "event_kind": "released",
@@ -822,7 +825,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-24T23:23:56+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: agent~benchmark, benchmark, dataset",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:a9087f050ba56e52ce3738e81bba2e7bd03ba33436d4593d4a456b566355ffcb",
@@ -884,6 +887,7 @@
       "artifact_urls": [],
       "authors": [],
       "categories": [
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-26T00:00:00+00:00",
@@ -896,7 +900,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-25T15:45:16+00:00",
       "rationale": [
-        "Matched: dataset, synthetic data",
+        "Matched: dataset, evaluat, synthetic data",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:8eb1bb5447a237572149ed0a42a257849cc8352c44756fd4c15eec5594898ec6",
@@ -921,7 +925,8 @@
       "artifact_urls": [],
       "authors": [],
       "categories": [
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-26T00:00:00+00:00",
       "event_kind": "released",
@@ -933,7 +938,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-25T19:10:34+00:00",
       "rationale": [
-        "Matched: evaluation",
+        "Matched: agent~evaluation, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:03c3a814521f43ca0fa64ac5439f61fbb8b7bcf46b75661b28bb2bd68762aab0",

--- a/data/snapshots/2026-07-27.json
+++ b/data/snapshots/2026-07-27.json
@@ -636,7 +636,7 @@
       },
       "published_at": "2026-07-27T17:53:37+00:00",
       "rationale": [
-        "Matched: dataset, evaluation, leaderboard",
+        "Matched: dataset, evaluat, leaderboard",
         "Primary record: Hugging Face"
       ],
       "recency_score": 3.996720476585648,
@@ -668,7 +668,7 @@
       },
       "published_at": "2026-07-27T17:31:01+00:00",
       "rationale": [
-        "Matched: benchmark, data quality, dataset, evaluation",
+        "Matched: benchmark, data quality, dataset, evaluat",
         "Primary record: GitHub"
       ],
       "recency_score": 3.981026032141204,
@@ -699,7 +699,7 @@
       },
       "published_at": "2026-07-27T16:19:19+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "recency_score": 3.931234365474537,
@@ -729,7 +729,7 @@
       },
       "published_at": "2026-07-27T14:20:11+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: GitHub"
       ],
       "recency_score": 3.8485028839930555,
@@ -789,7 +789,7 @@
       },
       "published_at": "2026-07-27T13:54:18+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: Hugging Face"
       ],
       "recency_score": 3.8305283469560187,
@@ -838,7 +838,8 @@
       "authors": [],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-27T17:58:20.350823+00:00",
       "event_kind": "updated",
@@ -849,7 +850,7 @@
       },
       "published_at": "2026-07-27T17:25:38+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: agent~benchmark, benchmark, evaluat",
         "Primary record: GitHub"
       ],
       "recency_score": 3.977287606215278,
@@ -898,6 +899,7 @@
       "authors": [],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-27T17:58:20.350823+00:00",
@@ -909,7 +911,7 @@
       },
       "published_at": "2026-07-27T12:27:41+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "recency_score": 3.7703778839930555,
@@ -939,7 +941,7 @@
       },
       "published_at": "2026-07-27T12:06:48+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: GitHub"
       ],
       "recency_score": 3.7558755691782406,
@@ -969,7 +971,7 @@
       },
       "published_at": "2026-07-27T17:39:07+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: GitHub"
       ],
       "recency_score": 3.9866510321412036,
@@ -1089,7 +1091,7 @@
       },
       "published_at": "2026-07-27T07:41:28+00:00",
       "rationale": [
-        "Matched: evaluation, evaluation suite",
+        "Matched: evaluat, evaluation suite",
         "Primary record: GitHub"
       ],
       "recency_score": 3.5716163099189817,
@@ -1119,7 +1121,7 @@
       },
       "published_at": "2026-07-26T21:21:19+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: Hugging Face"
       ],
       "recency_score": 3.1409565876967593,
@@ -1138,6 +1140,7 @@
       "authors": [],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-27T17:58:20.350823+00:00",
@@ -1149,7 +1152,7 @@
       },
       "published_at": "2026-07-26T16:58:09+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "recency_score": 2.9582019580671295,
@@ -1268,7 +1271,7 @@
       },
       "published_at": "2026-07-27T07:38:08+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "recency_score": 3.569301495104167,
@@ -1298,7 +1301,7 @@
       },
       "published_at": "2026-07-27T07:30:58+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "recency_score": 3.5643246432523146,
@@ -1358,7 +1361,7 @@
       },
       "published_at": "2026-07-26T04:14:08+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation, evaluator",
+        "Matched: benchmark, evaluat",
         "Primary record: Hugging Face"
       ],
       "recency_score": 2.4276348284375002,
@@ -1478,7 +1481,7 @@
       },
       "published_at": "2026-07-26T00:54:21+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "recency_score": 2.2888964025115746,

--- a/data/snapshots/2026-07-28.json
+++ b/data/snapshots/2026-07-28.json
@@ -2411,7 +2411,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, corpora, corpus, evaluat, test set",
+        "Matched: benchmark, corpus, evaluat, test set, training data",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -2553,7 +2553,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, corpora, dataset, evaluat",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -2736,7 +2736,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, corpora, dataset, evaluat",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -2806,7 +2806,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, corpora, dataset, evaluat",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -3827,7 +3827,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: corpora, dataset, evaluat",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -4025,7 +4025,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, corpora, corpus",
+        "Matched: benchmark, corpus",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -4348,7 +4348,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, corpora, dataset, evaluat",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -4951,7 +4951,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: corpora, dataset, evaluat",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -5497,8 +5497,7 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation",
-        "dataset"
+        "evaluation"
       ],
       "discovered_at": "2026-07-28T14:33:06.179849+00:00",
       "event_kind": "released",
@@ -5506,7 +5505,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, corpora, evaluat",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -5975,7 +5974,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: corpora, dataset, evaluat",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -6337,7 +6336,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-28T03:05:06.194511+00:00",
       "event_kind": "released",
@@ -6345,7 +6345,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluat",
+        "Matched: agentic~evaluations, benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -6405,7 +6405,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-28T14:33:06.179849+00:00",
       "event_kind": "released",
@@ -6413,7 +6414,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluat",
+        "Matched: agent~benchmarks, benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -6586,7 +6587,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, corpora, dataset, evaluat",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -6792,7 +6793,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: corpora, dataset, evaluat",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -7186,7 +7187,7 @@
       },
       "published_at": "2026-07-27T22:53:25+00:00",
       "rationale": [
-        "Matched: benchmark, corpora, dataset",
+        "Matched: benchmark, dataset",
         "Primary record: Hugging Face"
       ],
       "recency_score": 3.3474400480439814,
@@ -8178,7 +8179,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: corpora, dataset",
+        "Matched: dataset, training data",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,

--- a/data/snapshots/2026-07-28.json
+++ b/data/snapshots/2026-07-28.json
@@ -1921,7 +1921,8 @@
       "categories": [
         "benchmark",
         "evaluation",
-        "dataset"
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-28T14:33:06.179849+00:00",
       "event_kind": "updated",
@@ -1932,7 +1933,7 @@
       },
       "published_at": "2026-07-28T09:59:05+00:00",
       "rationale": [
-        "Matched: benchmark, corpus, dataset, evaluation, leaderboard",
+        "Matched: agents~benchmarking, benchmark, corpus, dataset, evaluat, leaderboard",
         "Primary record: Hugging Face"
       ],
       "recency_score": 3.8097085665625,
@@ -1965,7 +1966,7 @@
       },
       "published_at": "2026-07-28T13:45:41+00:00",
       "rationale": [
-        "Matched: dataset, evaluation, leaderboard",
+        "Matched: dataset, evaluat, leaderboard",
         "Primary record: Hugging Face"
       ],
       "recency_score": 3.967069677673611,
@@ -1998,7 +1999,7 @@
       },
       "published_at": "2026-07-28T03:06:29+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "recency_score": 3.5231807887847224,
@@ -2035,7 +2036,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -2071,7 +2072,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -2113,7 +2114,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -2160,7 +2161,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation, training data",
+        "Matched: benchmark, dataset, evaluat, training data",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -2194,7 +2195,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, deduplication, evaluation",
+        "Matched: dataset, deduplication, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -2228,7 +2229,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation, test set",
+        "Matched: dataset, evaluat, test set",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -2267,7 +2268,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -2301,7 +2302,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation, training data",
+        "Matched: benchmark, dataset, evaluat, training data",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -2340,7 +2341,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -2375,7 +2376,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -2410,7 +2411,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, corpus, evaluation, test set, training data",
+        "Matched: benchmark, corpora, corpus, evaluat, test set",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -2452,7 +2453,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -2487,7 +2488,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation, test set",
+        "Matched: dataset, evaluat, test set",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -2520,7 +2521,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -2552,7 +2553,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation, evaluator",
+        "Matched: benchmark, corpora, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -2577,7 +2578,8 @@
         "benchmark",
         "evaluation",
         "dataset",
-        "data_quality"
+        "data_quality",
+        "agentic"
       ],
       "discovered_at": "2026-07-28T14:33:06.179849+00:00",
       "event_kind": "released",
@@ -2585,7 +2587,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, corpus, deduplication, evaluation",
+        "Matched: agentic~benchmarks, benchmark, corpus, deduplication, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -2622,7 +2624,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -2659,7 +2661,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -2698,7 +2700,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -2734,7 +2736,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, corpora, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -2769,7 +2771,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -2804,7 +2806,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, corpora, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -2845,7 +2847,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -2878,7 +2880,7 @@
       },
       "published_at": "2026-07-28T06:31:03+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "recency_score": 3.6652409739699072,
@@ -2943,7 +2945,7 @@
       },
       "published_at": "2026-07-27T16:19:19+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "recency_score": 3.073759492488426,
@@ -3006,7 +3008,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation, evaluation suite, red teaming",
+        "Matched: benchmark, evaluat, evaluation suite, red teaming",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -3038,7 +3040,7 @@
       },
       "published_at": "2026-07-28T13:54:18+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: Hugging Face"
       ],
       "recency_score": 3.9730534739699075,
@@ -3124,7 +3126,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-28T14:33:06.179849+00:00",
       "event_kind": "released",
@@ -3132,7 +3135,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation, evaluator",
+        "Matched: agent~evaluation, benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -3172,7 +3175,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation, test set",
+        "Matched: benchmark, evaluat, test set",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -3199,6 +3202,7 @@
       ],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-28T14:33:06.179849+00:00",
@@ -3207,7 +3211,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, corpus, dataset",
+        "Matched: benchmark, corpus, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -3239,7 +3243,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: corpus, dataset, evaluation",
+        "Matched: corpus, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -3271,7 +3275,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation, evaluation suite",
+        "Matched: benchmark, evaluat, evaluation suite",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -3303,7 +3307,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: corpus, evaluation, training data",
+        "Matched: corpus, evaluat, training data",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -3326,6 +3330,7 @@
       ],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-28T14:33:06.179849+00:00",
@@ -3334,7 +3339,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, leaderboard, test set",
+        "Matched: dataset, evaluat, leaderboard, test set",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -3359,6 +3364,7 @@
       ],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-28T14:33:06.179849+00:00",
@@ -3367,7 +3373,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, corpus, dataset",
+        "Matched: benchmark, corpus, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -3432,7 +3438,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation, synthetic data",
+        "Matched: dataset, evaluat, synthetic data",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -3485,7 +3491,8 @@
       "authors": [],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-28T14:33:06.179849+00:00",
       "event_kind": "updated",
@@ -3496,7 +3503,7 @@
       },
       "published_at": "2026-07-28T10:31:23+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: agent~benchmark, benchmark, evaluat",
         "Primary record: Hugging Face"
       ],
       "recency_score": 3.8321391221180554,
@@ -3601,7 +3608,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-28T14:33:06.179849+00:00",
       "event_kind": "released",
@@ -3609,7 +3617,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: agentic~benchmarks, benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -3681,7 +3689,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -3715,7 +3723,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -3785,7 +3793,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -3819,7 +3827,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: corpora, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -3844,6 +3852,7 @@
       ],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-28T14:33:06.179849+00:00",
@@ -3852,7 +3861,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, corpus",
+        "Matched: benchmark, corpus, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -3884,7 +3893,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -3915,7 +3924,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -3941,7 +3950,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-28T14:33:06.179849+00:00",
       "event_kind": "released",
@@ -3949,7 +3959,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: agent~benchmarking, benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -4015,7 +4025,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, corpus",
+        "Matched: benchmark, corpora, corpus",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -4047,7 +4057,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -4154,7 +4164,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -4190,7 +4200,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -4224,7 +4234,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -4329,6 +4339,7 @@
       ],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-28T14:33:06.179849+00:00",
@@ -4337,7 +4348,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, corpora, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -4426,7 +4437,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -4494,7 +4505,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-28T14:33:06.179849+00:00",
       "event_kind": "released",
@@ -4502,7 +4514,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: agents~benchmark, benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -4593,7 +4605,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -4627,7 +4639,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -4661,7 +4673,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -4687,7 +4699,8 @@
       ],
       "categories": [
         "evaluation",
-        "dataset"
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-28T14:33:06.179849+00:00",
       "event_kind": "released",
@@ -4695,7 +4708,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: agents~evaluation, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -4728,7 +4741,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -4800,7 +4813,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: corpus, evaluation",
+        "Matched: corpus, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -4836,7 +4849,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -4868,7 +4881,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -4904,7 +4917,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -4938,7 +4951,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: corpora, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -4973,7 +4986,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: evaluation, synthetic data",
+        "Matched: evaluat, synthetic data",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -4997,6 +5010,7 @@
       ],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-28T14:33:06.179849+00:00",
@@ -5005,7 +5019,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, corpus",
+        "Matched: benchmark, corpus, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -5040,7 +5054,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -5078,7 +5092,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -5112,7 +5126,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -5172,7 +5186,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-28T14:33:06.179849+00:00",
       "event_kind": "released",
@@ -5180,7 +5195,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: agentic~evaluation, benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -5348,7 +5363,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -5381,7 +5396,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -5412,6 +5427,7 @@
       ],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-28T14:33:06.179849+00:00",
@@ -5420,7 +5436,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -5445,6 +5461,7 @@
       ],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-28T14:33:06.179849+00:00",
@@ -5453,7 +5470,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -5480,7 +5497,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "dataset"
       ],
       "discovered_at": "2026-07-28T14:33:06.179849+00:00",
       "event_kind": "released",
@@ -5488,7 +5506,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, corpora, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -5527,7 +5545,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -5597,7 +5615,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluator",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -5632,7 +5650,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -5667,7 +5685,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -5699,7 +5717,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -5727,6 +5745,7 @@
       ],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-28T14:33:06.179849+00:00",
@@ -5735,7 +5754,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -5773,7 +5792,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -5815,6 +5834,7 @@
       ],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-28T14:33:06.179849+00:00",
@@ -5823,7 +5843,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -5855,7 +5875,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -5878,6 +5898,7 @@
       ],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-28T14:33:06.179849+00:00",
@@ -5886,7 +5907,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -5954,7 +5975,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: corpora, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -5978,7 +5999,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-28T03:05:06.194511+00:00",
       "event_kind": "released",
@@ -5986,7 +6008,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: agents~benchmarks, benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -6021,7 +6043,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -6056,7 +6078,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -6083,7 +6105,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-28T03:05:06.194511+00:00",
       "event_kind": "released",
@@ -6091,7 +6114,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: agent~benchmarks, benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -6196,7 +6219,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -6223,7 +6246,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-28T03:05:06.194511+00:00",
       "event_kind": "released",
@@ -6231,7 +6255,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: agents~bench, benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -6256,6 +6280,7 @@
       ],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-28T03:05:06.194511+00:00",
@@ -6264,7 +6289,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, data collection",
+        "Matched: benchmark, data collection, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -6320,7 +6345,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -6352,7 +6377,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -6388,7 +6413,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -6418,7 +6443,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-28T14:33:06.179849+00:00",
       "event_kind": "released",
@@ -6426,7 +6452,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: agents~evaluation, benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -6527,7 +6553,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -6551,6 +6577,7 @@
       ],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-28T14:33:06.179849+00:00",
@@ -6559,7 +6586,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, corpora, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -6584,7 +6611,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-28T14:33:06.179849+00:00",
       "event_kind": "updated",
@@ -6592,7 +6620,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: agentic~evaluation, benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -6616,6 +6644,7 @@
       ],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-28T14:33:06.179849+00:00",
@@ -6624,7 +6653,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, corpus",
+        "Matched: benchmark, corpus, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -6694,7 +6723,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -6720,7 +6749,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-28T14:33:06.179849+00:00",
       "event_kind": "released",
@@ -6728,7 +6758,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: agents~benchmarks, benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -6762,7 +6792,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: corpora, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -6995,7 +7025,7 @@
       },
       "published_at": "2026-07-28T13:48:44+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: GitHub"
       ],
       "recency_score": 3.9691877332291665,
@@ -7112,7 +7142,8 @@
       "authors": [],
       "categories": [
         "benchmark",
-        "dataset"
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-28T14:33:06.179849+00:00",
       "event_kind": "released",
@@ -7123,7 +7154,7 @@
       },
       "published_at": "2026-07-28T03:00:20+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: agent~benchmark, benchmark, dataset",
         "Primary record: Hugging Face"
       ],
       "recency_score": 3.518909955451389,
@@ -7155,7 +7186,7 @@
       },
       "published_at": "2026-07-27T22:53:25+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, corpora, dataset",
         "Primary record: Hugging Face"
       ],
       "recency_score": 3.3474400480439814,
@@ -7219,7 +7250,7 @@
       },
       "published_at": "2026-07-28T14:16:38+00:00",
       "rationale": [
-        "Matched: data quality, evaluator",
+        "Matched: data quality, evaluat",
         "Primary record: GitHub"
       ],
       "recency_score": 3.9885627332291667,
@@ -7240,7 +7271,8 @@
       "authors": [],
       "categories": [
         "evaluation",
-        "data_quality"
+        "data_quality",
+        "agentic"
       ],
       "discovered_at": "2026-07-28T14:33:06.179849+00:00",
       "event_kind": "released",
@@ -7251,7 +7283,7 @@
       },
       "published_at": "2026-07-28T13:35:53+00:00",
       "rationale": [
-        "Matched: data contamination, evaluation",
+        "Matched: agentic~evaluation, data contamination, evaluat",
         "Primary record: GitHub"
       ],
       "recency_score": 3.9602641221180557,
@@ -7315,7 +7347,7 @@
       },
       "published_at": "2026-07-28T12:25:11+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: Hugging Face"
       ],
       "recency_score": 3.911166899895833,
@@ -7475,7 +7507,7 @@
       },
       "published_at": "2026-07-28T08:26:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "recency_score": 3.7450673628587965,
@@ -7528,6 +7560,7 @@
       "authors": [],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-28T14:33:06.179849+00:00",
@@ -7539,7 +7572,7 @@
       },
       "published_at": "2026-07-27T12:27:41+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "recency_score": 2.9129030110069447,
@@ -7634,7 +7667,7 @@
       },
       "published_at": "2026-07-28T13:38:17+00:00",
       "rationale": [
-        "Matched: evaluation",
+        "Matched: evaluat",
         "Primary record: GitHub"
       ],
       "recency_score": 3.961930788784722,
@@ -7730,7 +7763,7 @@
       },
       "published_at": "2026-07-27T07:38:08+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "recency_score": 2.7118266221180556,
@@ -7762,7 +7795,7 @@
       },
       "published_at": "2026-07-27T07:30:58+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "recency_score": 2.7068497702662038,
@@ -7825,7 +7858,7 @@
       },
       "published_at": "2026-07-26T21:21:19+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: Hugging Face"
       ],
       "recency_score": 2.283481714710648,
@@ -7845,7 +7878,9 @@
       "artifact_urls": [],
       "authors": [],
       "categories": [
-        "dataset"
+        "evaluation",
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-28T14:33:06.179849+00:00",
       "event_kind": "updated",
@@ -7856,7 +7891,7 @@
       },
       "published_at": "2026-07-28T14:30:21+00:00",
       "rationale": [
-        "Matched: dataset",
+        "Matched: agent~evaluating, dataset, evaluat",
         "Primary record: GitHub"
       ],
       "recency_score": 3.9980881961921297,
@@ -7939,6 +7974,7 @@
       "authors": [],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-28T14:33:06.179849+00:00",
@@ -7950,7 +7986,7 @@
       },
       "published_at": "2026-07-26T16:58:09+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "recency_score": 2.1007270850810187,
@@ -8063,7 +8099,8 @@
       "artifact_urls": [],
       "authors": [],
       "categories": [
-        "benchmark"
+        "benchmark",
+        "evaluation"
       ],
       "discovered_at": "2026-07-28T14:33:06.179849+00:00",
       "event_kind": "updated",
@@ -8074,7 +8111,7 @@
       },
       "published_at": "2026-07-28T08:52:13+00:00",
       "rationale": [
-        "Matched: benchmark, leaderboard",
+        "Matched: benchmark, evaluat, leaderboard",
         "Primary record: Hugging Face"
       ],
       "recency_score": 3.763273381377315,
@@ -8141,7 +8178,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, training data",
+        "Matched: corpora, dataset",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -8271,7 +8308,8 @@
         "Moritz Zaiss"
       ],
       "categories": [
-        "benchmark"
+        "benchmark",
+        "agentic"
       ],
       "discovered_at": "2026-07-28T14:33:06.179849+00:00",
       "event_kind": "released",
@@ -8279,7 +8317,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, leaderboard",
+        "Matched: agent~benchmarks, benchmark, leaderboard",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -8335,7 +8373,8 @@
         "Seshu K. Damarla"
       ],
       "categories": [
-        "benchmark"
+        "benchmark",
+        "evaluation"
       ],
       "discovered_at": "2026-07-28T03:05:06.194511+00:00",
       "event_kind": "updated",
@@ -8343,7 +8382,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, test set",
+        "Matched: benchmark, evaluat, test set",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -8376,7 +8415,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: evaluation, evaluator",
+        "Matched: evaluat",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,
@@ -8476,7 +8515,7 @@
       "metrics": {},
       "published_at": "2026-07-28T04:00:00+00:00",
       "rationale": [
-        "Matched: evaluation, judge model",
+        "Matched: evaluat, judge model",
         "Primary record: arXiv"
       ],
       "recency_score": 3.5603451406365743,

--- a/data/snapshots/2026-07-29.json
+++ b/data/snapshots/2026-07-29.json
@@ -3114,7 +3114,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-29T13:54:18+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation, leaderboard",
+        "Matched: benchmark, dataset, evaluat, leaderboard",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:82c1bf55a3b95252b5ffeff65f612da588a792e8d02cfa323ab41b46c6922d06",
@@ -3179,7 +3179,8 @@
       "categories": [
         "benchmark",
         "evaluation",
-        "dataset"
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
       "event_kind": "updated",
@@ -3191,7 +3192,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-28T09:59:05+00:00",
       "rationale": [
-        "Matched: benchmark, corpus, dataset, evaluation, leaderboard",
+        "Matched: agents~benchmarking, benchmark, corpus, dataset, evaluat, leaderboard",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:e72510636c7ac778adcbd65918e176fe02f863e8f70af01b9ffcdfb5341fa75a",
@@ -3268,7 +3269,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-29T04:26:21+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:6db9d17f4c980d24ee796070b93db0b9114fe7c524abf9fa9f0ee130339714bc",
@@ -3383,7 +3384,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-29T08:25:04+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:0386269f851ec70a7cf602d7d8aa86bea37fc64d9ae54574d083bb83cedf41ff",
@@ -3420,7 +3421,7 @@
       "parser_version": "github-search/1",
       "published_at": "2026-07-29T13:32:48+00:00",
       "rationale": [
-        "Matched: evaluation",
+        "Matched: evaluat",
         "Primary record: GitHub"
       ],
       "raw_payload_hash": "sha256:aa0e07e26ae3fe4196dbeb6ea72c666e87cb192e2ac712de3877657270ba8e15",
@@ -3459,7 +3460,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-28T20:36:34+00:00",
       "rationale": [
-        "Matched: benchmark, corpus, dataset, evaluation",
+        "Matched: benchmark, corpus, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:d081cb60d4397c3648cd810fb180add04bed6f675a521a6b863198e2e1b5e253",
@@ -3538,7 +3539,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation, test set",
+        "Matched: benchmark, corpora, dataset, evaluat, test set",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:5b3efe6147ee097c5e2386549578b8336e10f34c5abe0656c44e4e3081e46114",
@@ -3577,7 +3578,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation, synthetic data",
+        "Matched: benchmark, dataset, evaluat, synthetic data",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:2ef696945824aa8b7b6eabc714eabda151474d60cade320a45d45686c2debcb0",
@@ -3616,7 +3617,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation, synthetic data",
+        "Matched: benchmark, dataset, evaluat, synthetic data",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:242ce3e3cbafd68646cda930b65e96de681c71bcbb36b28dac9783d1dc3c2c19",
@@ -3641,7 +3642,9 @@
       "artifact_urls": [],
       "authors": [],
       "categories": [
-        "dataset"
+        "evaluation",
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
       "event_kind": "updated",
@@ -3653,7 +3656,7 @@
       "parser_version": "github-search/1",
       "published_at": "2026-07-29T14:28:05+00:00",
       "rationale": [
-        "Matched: dataset",
+        "Matched: agent~evaluating, dataset, evaluat",
         "Primary record: GitHub"
       ],
       "raw_payload_hash": "sha256:1cfa74dd8fc72d09a7e19ab5ce76f990c85537d683ce5c01be70792d225d9b3f",
@@ -3692,7 +3695,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-28T20:36:34+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:69b5468308fd1415466256302e101780b9e232a7da4f082ba422fa1772187de9",
@@ -3735,7 +3738,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:fb228f84e6474c6cd779e5fce1c59cfc1884991caffa7de3511dce5e03a3a34c",
@@ -3775,7 +3778,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:040f83667c40ffbf5324654dd8c861545d35b6e524cba551e5faf2c0860da69e",
@@ -3816,7 +3819,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: annotation quality, benchmark, evaluation",
+        "Matched: annotation quality, benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:4bce19aba5bb6a31323205f3dd021e908602b646ceddcbed8e6b05a22481b251",
@@ -3849,7 +3852,8 @@
       "categories": [
         "benchmark",
         "evaluation",
-        "dataset"
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
       "event_kind": "released",
@@ -3858,7 +3862,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, corpus, evaluation",
+        "Matched: agent~benchmark, benchmark, corpus, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:8a244fd888e226857ce2a30b0be02a09cd23e4200d9b9bd46e9a8719a150b2eb",
@@ -3906,7 +3910,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:827f2395158dab79f8d85d2693cedb956c705637b06445d014dd62a30f4c7a66",
@@ -3947,7 +3951,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:e9ccd5638c7e3c818bd782e63f23643f285cec5028e0b08f16d3d6787ced73f8",
@@ -3995,7 +3999,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation, training data",
+        "Matched: benchmark, evaluat, training data",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:311f3b083402c52293fd5791e434b1792f1d605761aa25e8ba6cd57017a89eac",
@@ -4034,7 +4038,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, corpus, evaluation",
+        "Matched: benchmark, corpus, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:924b05b9aaa1179861430246e8356adad4ebb522b08b376527bdc7623e4243aa",
@@ -4074,7 +4078,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:12171e1d53f2054e15da89927e8b141a862d1f829dbe7658c84b001e9a00bca8",
@@ -4120,7 +4124,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:21043419461b290a23c19ab8a118461b53bb105c6ae4cf864a43fb893821195b",
@@ -4201,7 +4205,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:d720446dea4231a79240a2a0c79f98c1802870a190da4e515e03a1959eafeb6d",
@@ -4242,7 +4246,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:c511ca55de0e06fbdfe80cafb911d87952263197a4d69038e5843b00ea1b22ef",
@@ -4285,7 +4289,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:3e8ee1b6ad193fa4cf787b641911e36175ad4e7a0d7d30a01c47a8c2b8331620",
@@ -4328,7 +4332,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:7905cdb23f83e7fda95cec5b51232bb6cf84d77a7f0bb05f44d33994b0aa6434",
@@ -4376,7 +4380,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:3d3065ba04e0e9f669d31596be5929f13b2cabefd526bf835e7420891714571a",
@@ -4414,7 +4418,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, corpora, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:425249815c5e92964bc4b9e4e2c5db0d196b5926056930e6dc2dca738b47f2fe",
@@ -4456,7 +4460,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:e7992fd76c383af72be7778ca7084e55e5376d8cd2bdef984c83f1e65a9e1556",
@@ -4494,7 +4498,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:f25058937a9575501e8b534303be380acca075777ba3b041762c3fba736f3a61",
@@ -4535,7 +4539,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:be13db0ade832c42a9499c3680db126bd5a806727352904ae710b7898b34e95d",
@@ -4576,7 +4580,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:a86e1934849bc609899f817bb3944aa5cf3b173bd77183dcb68ba75f4af469d3",
@@ -4624,7 +4628,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:1b001e15f89bbe76461ad0e8d88a9ff6a166590e997ceeff198f8634265daf40",
@@ -4663,7 +4667,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-28T03:06:29+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:1d84cde6fe84b28ad3bcecb6ebf3cda6f0965813b91e567f03f4e69b8be7e891",
@@ -4776,7 +4780,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-28T22:52:25+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:e3e8b29b6109947780f17693d6958456a5f4cbebca893a75c529adf88edc8bba",
@@ -4815,7 +4819,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-29T01:37:36+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:8134628f7dfa60bff4b044695b474c5fd6d74f323461dbc0ebd44452f2463196",
@@ -4930,7 +4934,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-28T22:53:01+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, corpora, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:e2b190cfb4054cfc995aa91c35a0359dad5bffef8174168d47e1663af2c3ba32",
@@ -4969,7 +4973,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-28T22:52:20+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:a222b1b45b21953dd63592ef74cc3d975c5e3d596afde29892dce2a400fb8976",
@@ -4996,7 +5000,8 @@
       "categories": [
         "benchmark",
         "evaluation",
-        "dataset"
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
       "event_kind": "updated",
@@ -5008,7 +5013,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-28T10:31:23+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: agent~benchmark, benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:ba1ea12c417f3a4bdf597ed0dfc612e859caaff3edfcd180c41b5297db58fcc8",
@@ -5085,7 +5090,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-28T22:52:42+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:78fd301d100bbda7a6c0dbf2c6de17bc2867dafb90a20088467f851da26f798d",
@@ -5124,7 +5129,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-29T05:48:44+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:63565a7edec988a0a2cec80a79597197399971afff6fac572bd06b7313845727",
@@ -5159,7 +5164,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
       "event_kind": "released",
@@ -5168,7 +5174,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation, evaluator",
+        "Matched: agent~evaluation, benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:c45c559d395c8ca8fb9113aee9447bb886d88a2d8740fb4fee9e2d0d67b92003",
@@ -5257,7 +5263,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation, training data",
+        "Matched: corpora, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:e7d57d4a60b7dda3fe1e138942926bdf47f2655039292aa009543801f2edaad2",
@@ -5298,7 +5304,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation, safety eval",
+        "Matched: benchmark, evaluat, safety eval",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:c4c0cd037393ed08ee8c38ba665f2fafb92009e3f994a0015c6e6185226a7b74",
@@ -5343,7 +5349,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation, evaluator",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:8f3790aaa32e4040affed321dd9e4a86126bdda4cd1047fda35cfee15c1c51d7",
@@ -5383,7 +5389,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation, leaderboard",
+        "Matched: benchmark, evaluat, leaderboard",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:d9fbd992098c6688b681bb78f368f7d6bacff481e62b9e4076c2d8a99474a7aa",
@@ -5415,6 +5421,7 @@
       ],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
@@ -5424,7 +5431,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, training data",
+        "Matched: benchmark, dataset, evaluat, training data",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:b218cef444ca64defba7bd81daac8a27b0fbc34f648660482d2ad26cb5399a15",
@@ -5464,7 +5471,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation, training data",
+        "Matched: dataset, evaluat, training data",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:077b4ec3ef16da39522331716c50724011f5ce5ba0ccf642b2d17e41fcd32cae",
@@ -5508,7 +5515,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: corpus, dataset, evaluation",
+        "Matched: corpus, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:04f1bd8f4a6bbd56e1e769cf431cd2d1c8c3839ba6f782eb2c2aebeee2b20b89",
@@ -5586,7 +5593,7 @@
       "parser_version": "github-search/1",
       "published_at": "2026-07-29T13:15:08+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: GitHub"
       ],
       "raw_payload_hash": "sha256:5aab06c358e98aed04b088e7536863424b23450b8c8f3e4105cacea3a54fe847",
@@ -5662,7 +5669,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-28T23:16:07+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, corpora, dataset",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:a6ea9d6ce649ebc141afa66900f3f07a30551a29ae3c31e1e0d4fd84e4d16f10",
@@ -5701,7 +5708,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-28T07:00:50+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:ae3acace83707de05ee8d0c640e7ce84c56afdb8eda911a4f677db7512d23357",
@@ -5739,7 +5746,7 @@
       "parser_version": "github-search/1",
       "published_at": "2026-07-29T12:12:56+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: GitHub"
       ],
       "raw_payload_hash": "sha256:3b9f3da2e2267135efda4d539a9d20c58ff3c17f9b599f6d7b53149598643707",
@@ -5815,7 +5822,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:d31fc7317c20a2572600d3f697447e21b02a290453b3b304740f00cf7db912ba",
@@ -5856,7 +5863,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:e825f5713357e25c18b292d84f664eb5101d10fae027b4a03d4a29f899694141",
@@ -5918,7 +5925,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:b7726275dad243c6f700fb3f8954137029ba91196ba73e7fb5471c3c12c8ace9",
@@ -5950,7 +5957,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
       "event_kind": "released",
@@ -5959,7 +5967,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: agent~evaluating, benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:ec98a67704093d817d63a405706e678b39f339bd66943035b732444926573ff9",
@@ -6014,7 +6022,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: corpus, evaluation",
+        "Matched: corpus, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:01742d9b44759f1a44e4a6b9218c83ede5f3d4c0656a6b232391247ffe507154",
@@ -6053,7 +6061,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:debf5a196ba1cee13e19a39f41dd459d90af7b4ceeb95349c6497c1513c244b4",
@@ -6087,7 +6095,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
       "event_kind": "released",
@@ -6096,7 +6105,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: agents~benchmarks, benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:d8e3f0704064907244f5a3edf6c05fc419f663f274b49c07b38d3ee137b51aa9",
@@ -6179,7 +6188,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: corpora, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:00919cae1aacd7de34fc351ad4a275f35fee38c86a55443ed6dc329d194bded6",
@@ -6220,7 +6229,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, corpora, dataset",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:789591d8ce6e2d613606ca062b56b64acbb7ef5261ac580c471457e90af09f22",
@@ -6252,7 +6261,9 @@
       ],
       "categories": [
         "benchmark",
-        "dataset"
+        "evaluation",
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
       "event_kind": "released",
@@ -6261,7 +6272,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: agents~bench, benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:2dd1d19fd4d6b1429a0557f7b534f64cf633c9ac3b22801d477e39187e6e18c6",
@@ -6303,7 +6314,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:1f103e2c3787b9194df72c5800abec81013eed92897113a0c9819883b5d37e09",
@@ -6352,7 +6363,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:537cb78ff2936c33be410bbd718b3341f67c8e16ff24fb4e087c4d58ee39d095",
@@ -6387,7 +6398,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
       "event_kind": "released",
@@ -6396,7 +6408,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: agent~evaluating, benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:249834485c026b1a7b6f1cd2eee4ea921b9e2e25fa997d39f28dc4d488e083f8",
@@ -6441,7 +6453,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:ad97e46adc114f0dd5e60eb49f9cf7471648b0deb0f83cf0180fc1c6b25dd879",
@@ -6485,7 +6497,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluator",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:11e05b18a352142a5b15077b8459750b96109d0a6218cd5dc3bf172841d1dd19",
@@ -6561,7 +6573,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: evaluation, training data",
+        "Matched: evaluat, training data",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:d09a247cd94bcbd6169980a3d288e23acca91013fdad08756120549d6872b7fc",
@@ -6629,6 +6641,7 @@
       ],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
@@ -6638,7 +6651,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:7e13802fc4b7d5dbb1ce573f37b6afc38b5174bdff57a818161206dab650dc61",
@@ -6679,7 +6692,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
       "event_kind": "released",
@@ -6688,7 +6702,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: agents~benchmark, benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:d0fb72e94c3c243d1d98591d9b7e71ffdac16a3c3243eeb52ec4391f538fc352",
@@ -6727,7 +6741,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:7d85ab4538650f341f9d2f71b34518d96051a0360fb0a530e50c069a2a1bc2aa",
@@ -6765,7 +6779,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:71aa46653214b270091e9ea07c4ecfaaf0755fc1388971151e432a36d239c075",
@@ -6805,7 +6819,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:be0b762b6d441047ec6c2a61d793bdd14c6c5709cd8302859a35580c64405f9e",
@@ -6843,7 +6857,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:1e39646fd52a8117f2d2c15f66112d0a6fa96e2fbdd6ade26b98f317e28699bf",
@@ -6877,7 +6891,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
       "event_kind": "released",
@@ -6886,7 +6901,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: agentic~benchmark, benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:b5b246d478d6bb36cfab9879e2b3fc11b68fd522fb3a899c078b88863ab765a1",
@@ -7078,6 +7093,7 @@
       ],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
@@ -7087,7 +7103,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, corpus",
+        "Matched: benchmark, corpus, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:abe2385173851dfb80107d2e8364c8435b39dd26a0fb4d0ffa0ba84caceae4e4",
@@ -7128,7 +7144,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:e425bfb0311bddbb87e7a9d95589e06f07dc26ad6b77dd2dbe72bd628e5fbc79",
@@ -7212,7 +7228,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:f8b2269605ab264b0e95f6390e86b7d9c62a19d9104bb0179fc5646b6356e04a",
@@ -7299,7 +7315,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: corpora, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:3c6e3db7c78f344aab4f000f91cade5cb98465ab707f2b06cb54f71e1d296063",
@@ -7372,7 +7388,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
       "event_kind": "released",
@@ -7381,7 +7398,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: agent~benchmarks, benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:7776e3b0845da8e230c81ad8a26c3b9c1d720c09231a7376c04938134ab2377a",
@@ -7455,6 +7472,7 @@
       ],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
@@ -7464,7 +7482,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, corpora, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:c263cfaf8d63f447fbd0b4bb01b7545ba11e805faeb88a55a28040dcbd28ff03",
@@ -7505,7 +7523,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:cf06e9a05664766a81aa27f154a1cad272f9f8b02af2cd23935278d42e52a168",
@@ -7545,7 +7563,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: corpus, evaluation",
+        "Matched: corpus, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:00354c2cbe180d18a84f76d7673e22b4d76eeadfcf80b04f53fde59ac1bfb93b",
@@ -7577,6 +7595,7 @@
       ],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
@@ -7586,7 +7605,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:5d8d3e86ef22302299fd90c94845b282d7529557d99444042e92e58bad543786",
@@ -7626,7 +7645,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:59f26c7e81ccf27ed5ef8dd8232c040d1be992c3b12d123c478b1de69486cbaf",
@@ -7695,7 +7714,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:8bc9baa23f20a7d1a0ec66c32678a139632587ce597baa5d3eae4b5842827a12",
@@ -7754,7 +7773,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: evaluation, training data",
+        "Matched: evaluat, training data",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:c6b09e171337d87dd355e095009c19a8851d6ce1d584b85ba0a47bf040d5c680",
@@ -7796,7 +7815,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
       "event_kind": "released",
@@ -7805,7 +7825,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: agent~benchmark, benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:eaa83236002e658d41826026a76adc22b05a986ad7bf647a789e345eb4241252",
@@ -7834,7 +7854,9 @@
       ],
       "categories": [
         "benchmark",
-        "dataset"
+        "evaluation",
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
       "event_kind": "released",
@@ -7843,7 +7865,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, corpus",
+        "Matched: agent~bench, benchmark, corpus, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:a33084af992ae29511cb8ec962cdd06f9585fce97eb4728803c65b9dc0ab6e13",
@@ -7885,7 +7907,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:71e46a2bcb796bd920590a0d991dae2d9768f7c34f75721d6f541afec5b834dd",
@@ -7918,6 +7940,7 @@
       ],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
@@ -7927,7 +7950,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:a5e333574fd1078fe975fbbfd1e09051e016dfc9a851e8271efe936cfefdcdab",
@@ -7966,7 +7989,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:a6740241eb3702a84896eda78024e06ca89d30b4ccb3e23894950ab3adcb7b21",
@@ -8004,7 +8027,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: evaluation, leaderboard",
+        "Matched: evaluat, leaderboard",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:9116f1bdda74bb98e280433461d7025a5a5fb396ce4a75cfb2033ae150be1848",
@@ -8037,6 +8060,7 @@
       ],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
@@ -8046,7 +8070,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, corpora, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:a2654bbe8efd40f464c2f7d851ddf6e4df5a13646457edff354d0b7c7c6421e3",
@@ -8124,7 +8148,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:85940cec787c744468ca1265dd29b5c53cdc626bb05f5cd36fd887b11fe370a2",
@@ -8168,7 +8192,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:52b696fd244878935b966527333e412fc3c7817635c827d67d1f67f5b1c66dcb",
@@ -8209,7 +8233,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: evaluation, test set",
+        "Matched: evaluat, test set",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:7b84cc7c717583ec90166d11989f0642cee58d402fb7c29cb95bb8a89ce496c3",
@@ -8255,7 +8279,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:d40dcf76616401871b1b31ff5e87efe145c2e0a553d0ac3c4d6f9dcc79d5991b",
@@ -8342,7 +8366,8 @@
       ],
       "categories": [
         "evaluation",
-        "dataset"
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
       "event_kind": "released",
@@ -8351,7 +8376,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: corpus, evaluation",
+        "Matched: agents~evaluation, corpus, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:291539a506408b2b626762f482c6392e7fdb3b2d39fdbcb32668301018a71936",
@@ -8390,7 +8415,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: evaluation, leaderboard",
+        "Matched: evaluat, leaderboard",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:07c6bd89c161f9a0603aba7e19a304d4e45a5bafe75c57135bc6a1403cf10187",
@@ -8429,7 +8454,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:1461e69268a134d1dcf70653c1fc32e4be9ee020f0d50cc28f2ee44a8ee0e8ab",
@@ -8480,7 +8505,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-28T14:33:06.179849+00:00",
       "event_kind": "updated",
@@ -8489,7 +8515,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: agentic~benchmarks, benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:eb2244c9112aa38bb0cd534dc5b6c05c53d770439c65e3a0e914f43672bab82a",
@@ -8528,7 +8554,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:0a3be4fafcf9efcd7d7d3baf347b1d032c5e63516aa028fc6c97cef4b61eb0c4",
@@ -8617,7 +8643,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:68a9e09b04048ac5961b95cdd93569bf019094d0f944c0821f6751d0286c4544",
@@ -8657,7 +8683,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, training data",
+        "Matched: benchmark, corpora, training data",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:36ea0cdc48a8dbbc196b5b8def72157f19f7627b8090fda8640e2757d09289ef",
@@ -8688,6 +8714,7 @@
       ],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-28T14:33:06.179849+00:00",
@@ -8697,7 +8724,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:6a0c6c8d194263d1fe6ced35148da5a9b5b604fb47955b9ee3bce302351f00f1",
@@ -8781,7 +8808,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:992c15164e25bb9d0a24ce8bfdd989fd5a29200baec8e365b60709080eafdb81",
@@ -8812,7 +8839,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
       "event_kind": "released",
@@ -8821,7 +8849,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: agentic~benchmark, benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:246ff4ef3e53afd33fd49e616ff0a785b7f9686df9e44fd3638dae6f08dc3cf0",
@@ -8863,7 +8891,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: corpora, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:fbcf2e70446d577da35600c0740e50f1e46c0695ca9a32a96b57544853e0215e",
@@ -8905,7 +8933,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:e6d97e6dc75a06e3009cd397bb47250e67e4b34364225ef02b6e7637baa1d864",
@@ -8942,7 +8970,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:48f9f31f5c319fe8277f82600e4bb29d1141e65fefff50f7b6c060ced48b2484",
@@ -9017,6 +9045,7 @@
       ],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
@@ -9026,7 +9055,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:630753bb99222e747ba8cd0f08e988ba2764e401070332cb84e2105e877cecb3",
@@ -9115,7 +9144,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:762e9d008c37fc8231f4ea04f70faa95c4b165863209cea682eab37e01a210e1",
@@ -9198,7 +9227,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:0b693ba273d7ebc3f27d4fbc3362eed692294fd1f09c4b62b79b6aab560a2c52",
@@ -9231,7 +9260,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
       "event_kind": "updated",
@@ -9240,7 +9270,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: agents~evaluation, benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:ac5d55cc7d2130c42ad249591408b357ef77ed7968762f99981f66e511fb41ae",
@@ -9285,7 +9315,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: corpus, evaluation",
+        "Matched: corpus, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:21652ac3f6dceac8d64eb7fa23821632b05a414f82366dced23fdd9c85acf7e6",
@@ -9370,7 +9400,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: corpora, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:bad40f763719bbb9954352aa6ddf3a7d6ca8ccc5e78ee801d2079fe5c8c75145",
@@ -9404,7 +9434,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "dataset"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
       "event_kind": "updated",
@@ -9413,7 +9444,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, corpora, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:c9baa62544fe33bbc75ab9e08ebd03b2b55f18ed1a4b27776093b7a9c46b770e",
@@ -9459,7 +9490,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluator",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:09d59cdc693ab914cfa87c538a8b2c73d82ea32b868602b912cfba40dc2b3bcc",
@@ -9502,7 +9533,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:a5330d03143ef807fdfe999e66d2dedf02ffbed5beb62a3fef0931f9f056330d",
@@ -9540,7 +9571,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "dataset"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
       "event_kind": "updated",
@@ -9549,7 +9581,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, corpora, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:b1514bb22c2295fe4606c19f19ddda1ca1e469c93b7ecb7d9391c8b6b57f5d54",
@@ -9822,7 +9854,7 @@
       "parser_version": "github-search/1",
       "published_at": "2026-07-29T14:20:51+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: GitHub"
       ],
       "raw_payload_hash": "sha256:3ae78cb58cc0eb5b1be5b664307609784ef7f11a6d9b97b0e18751a999450845",
@@ -9899,7 +9931,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-28T06:31:03+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:bffdf263c24ad93a21826cc22d8351062212cdd8ea074e78adf391079195109d",
@@ -9925,6 +9957,7 @@
       "authors": [],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
@@ -9937,7 +9970,7 @@
       "parser_version": "github-search/1",
       "published_at": "2026-07-29T12:48:16+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: GitHub"
       ],
       "raw_payload_hash": "sha256:ab441b3c7cad3de4b1b56ac062614614bfad448a81bb71c8d65e2bf26231a941",
@@ -9963,6 +9996,7 @@
       "authors": [],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
@@ -9975,7 +10009,7 @@
       "parser_version": "github-search/1",
       "published_at": "2026-07-29T12:24:31+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: GitHub"
       ],
       "raw_payload_hash": "sha256:3c80f765cf452a310574d1c7375845eb52a139b3ad556b5737d3aaf321cd71b9",
@@ -10001,6 +10035,7 @@
       "authors": [],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
@@ -10013,7 +10048,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-28T08:52:13+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, leaderboard",
+        "Matched: benchmark, dataset, evaluat, leaderboard",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:2bbcaba672b4fffbc68e1561d404c790828fb226028dbab029bd083565dffd7e",
@@ -10189,7 +10224,8 @@
       "artifact_urls": [],
       "authors": [],
       "categories": [
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
       "event_kind": "updated",
@@ -10201,7 +10237,7 @@
       "parser_version": "github-search/1",
       "published_at": "2026-07-29T14:21:41+00:00",
       "rationale": [
-        "Matched: evaluation",
+        "Matched: agents~eval, evaluat",
         "Primary record: GitHub"
       ],
       "raw_payload_hash": "sha256:9b3b5cd8fcf215c37b32e7ad0844c39c3974fabb4114d67a95acc2f66b5f0432",
@@ -10275,7 +10311,7 @@
       "parser_version": "github-search/1",
       "published_at": "2026-07-29T12:50:43+00:00",
       "rationale": [
-        "Matched: evaluation",
+        "Matched: evaluat",
         "Primary record: GitHub"
       ],
       "raw_payload_hash": "sha256:79f59c92cc255790fd4b1fe3c21675a4908234ffe7802ea040af58dfecf216e8",
@@ -10312,7 +10348,7 @@
       "parser_version": "github-search/1",
       "published_at": "2026-07-29T12:28:20+00:00",
       "rationale": [
-        "Matched: evaluation",
+        "Matched: evaluat",
         "Primary record: GitHub"
       ],
       "raw_payload_hash": "sha256:0a286f4c80dea950d8474c7dbd186a02b4a80a6f78e895dd242c890ffce1289b",
@@ -10387,7 +10423,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-29T04:21:45+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:6f5d6b791d66b993bf0cfb0b3f1872faf8f0921b7137f88dcf5d00152cf072b7",
@@ -10413,6 +10449,7 @@
       "authors": [],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
@@ -10425,7 +10462,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-29T09:24:32+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:61e496dea0ad4387d9351e0c872c43aba88a16fc8cb7ac2670aca29ae4228e6f",
@@ -10576,7 +10613,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-28T10:10:47+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, judge model",
+        "Matched: benchmark, dataset, evaluat, judge model",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:30399198ad18a5032155120754c36118c0cc4fc9d599bc020f8828121dac3c56",
@@ -10766,7 +10803,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-27T16:19:19+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:3b1baba41ee969c37a4dae39aad6759568a9a463cfb7dab00b2dff057490c3e3",
@@ -10830,6 +10867,7 @@
         "Arto Apila"
       ],
       "categories": [
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
@@ -10839,7 +10877,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, synthetic data",
+        "Matched: dataset, evaluat, synthetic data",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:b306358898fb537269cdc8ed030f7c18e87c4eddef56f81d5132ad3a81f4ce0d",
@@ -10878,7 +10916,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: evaluation, safety eval",
+        "Matched: evaluat, safety eval",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:6a3f22216cdac70493301c8f45922654ed0f8c3f10ed92b91d9181360ea3f503",
@@ -10986,7 +11024,8 @@
         "Mandujano Reyes"
       ],
       "categories": [
-        "benchmark"
+        "benchmark",
+        "evaluation"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
       "event_kind": "released",
@@ -10995,7 +11034,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, leaderboard",
+        "Matched: benchmark, evaluat, leaderboard",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:7903abd8ef5ff26e7250a23930036ad7dc1821689f6a2dff99b324958882af55",
@@ -11023,7 +11062,8 @@
         "Byungho Choi"
       ],
       "categories": [
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
       "event_kind": "released",
@@ -11032,7 +11072,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: evaluation, evaluator",
+        "Matched: agent~evaluation, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:13026c553939689356c18f38ef387e343e839934377d7e5b52e9f14ffe53ea93",
@@ -11119,7 +11159,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: evaluation, evaluator",
+        "Matched: evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:5f2dfb55b54722bb1524c384f781cc133106a80bcb01355706e1ca6c4cb35226",
@@ -11225,7 +11265,8 @@
         "Anita K. Rao"
       ],
       "categories": [
-        "evaluation"
+        "evaluation",
+        "dataset"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
       "event_kind": "released",
@@ -11234,7 +11275,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: evaluation, evaluator",
+        "Matched: corpora, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:ef83d6180ce40d5bd907b7eb38600a362354df7c9307c9733e0b25e1ee9be6e8",
@@ -11302,7 +11343,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: evaluation, evaluator",
+        "Matched: evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:f5b38e20e0dd2f165ab109ff8cb5c8c6eca4cc07a35257e38a52162322cb99bc",
@@ -11345,7 +11386,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: evaluation, evaluator",
+        "Matched: evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:75a40599900b6e1ef3ea19d3c75f37613cc57f180755d59a0fd183d32b8f3f0f",

--- a/data/snapshots/2026-07-29.json
+++ b/data/snapshots/2026-07-29.json
@@ -3539,7 +3539,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, corpora, dataset, evaluat, test set",
+        "Matched: benchmark, dataset, evaluat, test set",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:5b3efe6147ee097c5e2386549578b8336e10f34c5abe0656c44e4e3081e46114",
@@ -4115,7 +4115,8 @@
       "categories": [
         "benchmark",
         "evaluation",
-        "dataset"
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
       "event_kind": "released",
@@ -4124,7 +4125,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluat",
+        "Matched: agentic~evaluation, benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:21043419461b290a23c19ab8a118461b53bb105c6ae4cf864a43fb893821195b",
@@ -4418,7 +4419,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, corpora, dataset, evaluat",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:425249815c5e92964bc4b9e4e2c5db0d196b5926056930e6dc2dca738b47f2fe",
@@ -4934,7 +4935,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-28T22:53:01+00:00",
       "rationale": [
-        "Matched: benchmark, corpora, dataset, evaluat",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:e2b190cfb4054cfc995aa91c35a0359dad5bffef8174168d47e1663af2c3ba32",
@@ -5263,7 +5264,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: corpora, dataset, evaluat",
+        "Matched: dataset, evaluat, training data",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:e7d57d4a60b7dda3fe1e138942926bdf47f2655039292aa009543801f2edaad2",
@@ -5669,7 +5670,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-28T23:16:07+00:00",
       "rationale": [
-        "Matched: benchmark, corpora, dataset",
+        "Matched: benchmark, dataset",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:a6ea9d6ce649ebc141afa66900f3f07a30551a29ae3c31e1e0d4fd84e4d16f10",
@@ -6188,7 +6189,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: corpora, dataset, evaluat",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:00919cae1aacd7de34fc351ad4a275f35fee38c86a55443ed6dc329d194bded6",
@@ -6229,7 +6230,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, corpora, dataset",
+        "Matched: benchmark, dataset",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:789591d8ce6e2d613606ca062b56b64acbb7ef5261ac580c471457e90af09f22",
@@ -7315,7 +7316,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: corpora, dataset, evaluat",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:3c6e3db7c78f344aab4f000f91cade5cb98465ab707f2b06cb54f71e1d296063",
@@ -7482,7 +7483,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, corpora, dataset, evaluat",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:c263cfaf8d63f447fbd0b4bb01b7545ba11e805faeb88a55a28040dcbd28ff03",
@@ -8070,7 +8071,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, corpora, dataset, evaluat",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:a2654bbe8efd40f464c2f7d851ddf6e4df5a13646457edff354d0b7c7c6421e3",
@@ -8683,7 +8684,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, corpora, training data",
+        "Matched: benchmark, training data",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:36ea0cdc48a8dbbc196b5b8def72157f19f7627b8090fda8640e2757d09289ef",
@@ -8891,7 +8892,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: corpora, dataset, evaluat",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:fbcf2e70446d577da35600c0740e50f1e46c0695ca9a32a96b57544853e0215e",
@@ -9400,7 +9401,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: corpora, dataset, evaluat",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:bad40f763719bbb9954352aa6ddf3a7d6ca8ccc5e78ee801d2079fe5c8c75145",
@@ -9434,8 +9435,7 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation",
-        "dataset"
+        "evaluation"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
       "event_kind": "updated",
@@ -9444,7 +9444,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, corpora, evaluat",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:c9baa62544fe33bbc75ab9e08ebd03b2b55f18ed1a4b27776093b7a9c46b770e",
@@ -9571,8 +9571,7 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation",
-        "dataset"
+        "evaluation"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
       "event_kind": "updated",
@@ -9581,7 +9580,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, corpora, evaluat",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:b1514bb22c2295fe4606c19f19ddda1ca1e469c93b7ecb7d9391c8b6b57f5d54",
@@ -11265,8 +11264,7 @@
         "Anita K. Rao"
       ],
       "categories": [
-        "evaluation",
-        "dataset"
+        "evaluation"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
       "event_kind": "released",
@@ -11275,7 +11273,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-29T04:00:00+00:00",
       "rationale": [
-        "Matched: corpora, evaluat",
+        "Matched: evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:ef83d6180ce40d5bd907b7eb38600a362354df7c9307c9733e0b25e1ee9be6e8",

--- a/data/snapshots/2026-07-30.json
+++ b/data/snapshots/2026-07-30.json
@@ -6680,8 +6680,7 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation",
-        "dataset"
+        "evaluation"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
       "event_kind": "updated",
@@ -6690,7 +6689,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, corpora, evaluat, test set",
+        "Matched: benchmark, evaluat, test set",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:e9327aefcc2939e194ffb15248d0e4f301c0b68ef27ff8c70a29d4434dc1d410",
@@ -8043,7 +8042,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, corpora, corpus",
+        "Matched: benchmark, corpus",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:0f83f1def29479b7a3004e793bec5c6a90c0f7ccec1df3c6d4752ce9ee75654a",
@@ -8288,7 +8287,6 @@
       "categories": [
         "benchmark",
         "evaluation",
-        "dataset",
         "agentic"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
@@ -8298,7 +8296,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: agent~evaluate, benchmark, corpora, evaluat",
+        "Matched: agent~evaluate, benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:c81478b9546ed46a57f71bc782b18d5f2c83e86b4ee60cd13b072eab36cd6845",
@@ -9413,7 +9411,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, corpora, corpus, evaluat",
+        "Matched: benchmark, corpus, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:bf7445372af92436606d9087edd4cc1193a52c0e4adfaf6abc72a34a9507f02c",
@@ -9735,8 +9733,7 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation",
-        "dataset"
+        "evaluation"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
       "event_kind": "released",
@@ -9745,7 +9742,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, corpora, evaluat",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:1a01a9e2d397993e823de7426cf5bef58ce3aace03795e4e5f07e3ce397b53ec",
@@ -10200,8 +10197,7 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation",
-        "dataset"
+        "evaluation"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
       "event_kind": "updated",
@@ -10210,7 +10206,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, corpora, evaluat",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:b6dbd1fc582e26734f3bdd9ed1fe022586fb2230beab2590d843941f993c0bc4",
@@ -10639,7 +10635,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-29T17:47:54+00:00",
       "rationale": [
-        "Matched: benchmark, corpora, dataset",
+        "Matched: benchmark, dataset",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:66875095772085382b98e08d411b7c5f5ffb89f6819e5822521b1b77002cdaa3",
@@ -11211,7 +11207,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-28T22:53:01+00:00",
       "rationale": [
-        "Matched: benchmark, corpora, dataset, evaluat",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:88c7e54585c61ce81deb6f474f46fd68075526a50b38bd56c78ba7e7d86ecf24",
@@ -12092,8 +12088,7 @@
         "Anita K. Rao"
       ],
       "categories": [
-        "evaluation",
-        "dataset"
+        "evaluation"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
       "event_kind": "updated",
@@ -12102,7 +12097,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: corpora, evaluat",
+        "Matched: evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:e98b2e0117b2a2952f7fb71b74f2affe4854b9e125eccfcc8942ec701f6857c0",

--- a/data/snapshots/2026-07-30.json
+++ b/data/snapshots/2026-07-30.json
@@ -4159,7 +4159,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-30T14:03:05+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation, leaderboard",
+        "Matched: benchmark, dataset, evaluat, leaderboard",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:88cf2e776d630645710ae7eff1484fe336a5fc8dd16c7782b439b47c7d83121b",
@@ -4203,7 +4203,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, data quality, dataset, evaluation",
+        "Matched: benchmark, data quality, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:1e821280c1136be81fbd92ffddf2bb7558aeacb5b8805a7a8094d8330d18e663",
@@ -4318,7 +4318,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-30T09:37:42+00:00",
       "rationale": [
-        "Matched: dataset, evaluation, leaderboard",
+        "Matched: dataset, evaluat, leaderboard",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:2170579a2a1ae06a2a521f604ba9d9154dcee8def1f0aaf6ef13df7d67a6ac2a",
@@ -4391,7 +4391,8 @@
       "categories": [
         "benchmark",
         "evaluation",
-        "dataset"
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
       "event_kind": "released",
@@ -4400,7 +4401,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation, evaluator",
+        "Matched: agents~evaluation, benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:906fc83564d9e293d8ca326815995d572f2da4e023fe5e6e77717e4be3e0995e",
@@ -4430,7 +4431,8 @@
       "categories": [
         "benchmark",
         "evaluation",
-        "dataset"
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
       "event_kind": "released",
@@ -4439,7 +4441,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation, leaderboard",
+        "Matched: agents~benchmark, benchmark, dataset, evaluat, leaderboard",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:4099fbd588a679d3eaa68957efba1fb84af50ac243de136f0d2e12887262fee7",
@@ -4483,7 +4485,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, corpus, evaluation, test set",
+        "Matched: benchmark, corpus, evaluat, test set",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:1e0172c5c73c3ab1a09ab5390856a56b6d96736d79bf0433e54a33b8cffc67bd",
@@ -4525,7 +4527,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation, training data",
+        "Matched: benchmark, dataset, evaluat, training data",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:61ba905ba0c2af05578e7bc564b9475ec6b05cc8893f2c0ea73a9b77b3e307b3",
@@ -4602,7 +4604,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-30T09:23:56+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:fe2b83515338a0a71d2d0306521f8d67d55e5dcf04b6a09585cc60a6d2bd478e",
@@ -4629,7 +4631,8 @@
       "categories": [
         "benchmark",
         "evaluation",
-        "dataset"
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
       "event_kind": "updated",
@@ -4641,7 +4644,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-29T19:29:22+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: agent~benchmark, benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:d3ef340291bf3a0c6c9924553033cb60e88b7f901ce5fb81327bda78697ace76",
@@ -4666,7 +4669,9 @@
       "artifact_urls": [],
       "authors": [],
       "categories": [
-        "dataset"
+        "evaluation",
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
       "event_kind": "updated",
@@ -4678,7 +4683,7 @@
       "parser_version": "github-search/1",
       "published_at": "2026-07-30T14:01:58+00:00",
       "rationale": [
-        "Matched: dataset",
+        "Matched: agent~evaluating, dataset, evaluat",
         "Primary record: GitHub"
       ],
       "raw_payload_hash": "sha256:978d1bd6e569f3b16a1df928a47f8b30d3bb48c4369fd45aaab7e2b57fc98b46",
@@ -4758,7 +4763,8 @@
       "categories": [
         "benchmark",
         "evaluation",
-        "dataset"
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
       "event_kind": "released",
@@ -4767,7 +4773,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: agents~benchmarking, benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:28e7d47dee7d48932a664979e46757420ffac4af85c1ba516b39bf59d7bc1d86",
@@ -4801,7 +4807,8 @@
       "categories": [
         "benchmark",
         "evaluation",
-        "dataset"
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
       "event_kind": "released",
@@ -4810,7 +4817,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: agent~evaluation, benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:526e0df2cb16bd18ba3f2ed1c1d309b91f1714f8b5a4a863dfa4424cad527ae8",
@@ -4854,7 +4861,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation, test set",
+        "Matched: dataset, evaluat, test set",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:b95dd03bf2fafe18c7e472feb2377fe6f2579d41832b7877d38bcbc8f374a6e9",
@@ -4898,7 +4905,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:1ea912d49e32a14a52f977f04ef747a03e8d9b1d3430e6173ca0cd5482334e39",
@@ -4941,7 +4948,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:9e2e54d8647dc513dea3723c3a1eb71ff438575ae39a6d1f752538c2544334f3",
@@ -4981,7 +4988,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:2b56bf02717b7d4f65c9fbeabf4cd2d2615512a03412b15ba2ccf792685cdab7",
@@ -5024,7 +5031,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, corpus, evaluation",
+        "Matched: benchmark, corpus, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:d4115b87a6b5491dd9de19e4f82b19f5f6a43e2a1b383492609501a5451d878f",
@@ -5070,7 +5077,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:ec4e8fc347a8e93ee86034edb49452af6d9c8e0c451824a659eef24bb87e7b4a",
@@ -5110,7 +5117,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:a653ab183edd8dc8125ab8bb5697c86f7961941c2446f524efafeadda5798c16",
@@ -5156,7 +5163,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:fe88fc7ff2a6e039dd99550185a5817369224f6db72b6c9680919dacbdf2b45d",
@@ -5199,7 +5206,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:c656d25783f33efd46dc566039a32f4984be8c04b76ac1fc6a64fe89ff624b3f",
@@ -5313,7 +5320,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-30T13:22:56+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:3495608fd04a5b1c5495f44033b539b0fa9f3dfbf9d16efcff59698ae31e2829",
@@ -5427,7 +5434,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-29T04:26:21+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:72773c9f4c899f70f28bbc68558ad69b25a6660537e1e3e8c344ccade62c2942",
@@ -5466,7 +5473,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-30T04:34:35+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:f3ac306fe921bc9e0ae3bcffad9bbfbe2a9d4ed662e14f816e26d041c76dc13f",
@@ -5505,7 +5512,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-30T03:19:25+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:9cf9d1006cfcad855d0aab673ad5b4fac3cbe4a8f41d7df74d8c3be436f1c119",
@@ -5544,7 +5551,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-30T03:19:24+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:1b16c30bd50de0461f4034569f6de4cc9bcb3d99bd29c63288eddb6974e48345",
@@ -5583,7 +5590,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-30T04:33:57+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:8a10ce7826d630e4fbe300b532dd76ff59d6e7fcf0b2560ee4a7ecc2a95068aa",
@@ -5622,7 +5629,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-30T03:19:28+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:b3eb8ffad9706a47ff0f0280dce6da88efc6abb8a6d5f469a7470213cf38465f",
@@ -5661,7 +5668,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-30T03:19:26+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:3650b5fb5640845236aaff46653c46eed6e9a0e647994ac8fc49d1f4b41e1bf7",
@@ -5700,7 +5707,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-29T16:16:18+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:b9f955cd00d9bca1cf672fe3683375c2ee9d0c1367858dc8046548978df46b26",
@@ -5739,7 +5746,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-30T04:34:20+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:032ef386ff77e7d2f87597986511f1bbae9feba2a36d589a088ea608eb3f1dd0",
@@ -5778,7 +5785,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-30T07:33:14+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:8866459f73860e95c99f9c4e5f500b87d7251bb83e715ccb87b214e3755daf97",
@@ -5817,7 +5824,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-29T08:25:04+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:23f2b40be281c460dced4accd4123a30ac2f1f478628db21eb13a872f7ead738",
@@ -6044,7 +6051,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation, training data",
+        "Matched: dataset, evaluat, training data",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:c45f6b90eea5a3b2b814f77bea03e5f7883405492466601ee950e1685e84e204",
@@ -6086,7 +6093,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation, synthetic data",
+        "Matched: dataset, evaluat, synthetic data",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:6a879168eba6ad8433942f4094838d66df29961f5d6969eeaab7cde4502800c1",
@@ -6125,7 +6132,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation, synthetic data",
+        "Matched: dataset, evaluat, synthetic data",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:9eb558a7c5a03d83d107a5d5429c9ee0866bcd6982a3ed2d2d15b1d09bc0e3c3",
@@ -6203,7 +6210,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation, safety eval",
+        "Matched: benchmark, evaluat, safety eval",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:85e311b70c63d696fcee5c62074d19080d9d309b1a9cefa1c79dcf571b2f0898",
@@ -6248,7 +6255,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation, leaderboard",
+        "Matched: benchmark, evaluat, leaderboard",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:dd4620d0ef833c58dafe4cffc07a148b0afe24a0791e50e17598747d2ec41a71",
@@ -6329,7 +6336,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation, leaderboard",
+        "Matched: benchmark, evaluat, leaderboard",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:907fa50bcdd9afcf12c15d4d77aa05cac17f0e34a4d7b0b567b775480136523a",
@@ -6366,7 +6373,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation, evaluator",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:abf68df2467d9ff7019e2d08beb2d7407b32b7c5aca792e66a3f25293fe52a62",
@@ -6395,7 +6402,8 @@
       ],
       "categories": [
         "evaluation",
-        "dataset"
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
       "event_kind": "released",
@@ -6404,7 +6412,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: corpus, dataset, evaluation",
+        "Matched: agent~harness, corpus, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:c5e629c224b16ab1d4fef95af37bdcb6cc1aa7db407a62aaa666d4fbbe25ad68",
@@ -6439,7 +6447,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
       "event_kind": "updated",
@@ -6448,7 +6457,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation, evaluator",
+        "Matched: agent~evaluation, benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:21c00dea6fc4401e0b4db54e790126365452ea754ba13af28d7c914a2397535b",
@@ -6505,7 +6514,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-28T14:33:06.179849+00:00",
       "event_kind": "updated",
@@ -6514,7 +6524,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation, evaluator",
+        "Matched: agent~evaluation, benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:5beb8bddc28aa60c83b1f6e9528f7f2e5ec4f03ea9f9deeeac9990fdb90f6c90",
@@ -6544,7 +6554,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
       "event_kind": "updated",
@@ -6553,7 +6564,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation, leaderboard",
+        "Matched: agent~evaluation, benchmark, evaluat, leaderboard",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:9b9d4606462de3fec9c0d6a198ca034be66ddea07c9d8924840084d84e7df676",
@@ -6596,7 +6607,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation, training data",
+        "Matched: dataset, evaluat, training data",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:e1100d1ef0c4c6ab22ddd94ea7374cb76ce10f11af6f84b823b01d05ad130216",
@@ -6624,7 +6635,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
       "event_kind": "updated",
@@ -6633,7 +6645,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation, evaluator",
+        "Matched: agentic~benchmarks, benchmark, evaluat, judge model",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:ba623c6a460c31e81296176648bc7a9228954498fc7c3e2eb78d56dc86f70583",
@@ -6668,7 +6680,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "dataset"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
       "event_kind": "updated",
@@ -6677,7 +6690,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation, test set",
+        "Matched: benchmark, corpora, evaluat, test set",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:e9327aefcc2939e194ffb15248d0e4f301c0b68ef27ff8c70a29d4434dc1d410",
@@ -6706,6 +6719,7 @@
         "Haihua Chen"
       ],
       "categories": [
+        "evaluation",
         "dataset",
         "data_quality"
       ],
@@ -6716,7 +6730,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: annotation quality, corpus, dataset",
+        "Matched: annotation quality, corpus, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:d4475a36057f7015a839acf21e4032b96ba8be3c74dcb32e41fb788f1d4af881",
@@ -6830,7 +6844,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-28T20:36:34+00:00",
       "rationale": [
-        "Matched: benchmark, corpus, dataset, evaluation",
+        "Matched: benchmark, corpus, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:023e52e1f2104daa214973baeeed0cba0b014443c077fdc67ace5d96278687c9",
@@ -6943,7 +6957,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:f17006429831c023739451bab4f09a57de4f0cd610dbd8d5ab5a55528ecdc6ff",
@@ -6997,7 +7011,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:424db99154135280d72bf0a1a285953c3bf2c9a7ccc2e40d7a5c53a37892f3e3",
@@ -7068,6 +7082,7 @@
       ],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
@@ -7077,7 +7092,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:ecfad67027dd4bfb57464921ea62e235fa31358fc9a00418297ad36976bc14aa",
@@ -7118,7 +7133,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:66ff38aab998f2dc8bcda307a64234211da17699e2abebf2d67e4df85489c2a8",
@@ -7151,7 +7166,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
       "event_kind": "released",
@@ -7160,7 +7176,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: agent~benchmarks, benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:b9e309de63ddb7180bfa4e8845f3c5ef2c178623622f78b5cac22d584fdabff1",
@@ -7199,7 +7215,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
       "event_kind": "released",
@@ -7208,7 +7225,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: agents~benchmark, benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:55d7e3851d740ada090bbb523c5d14cee88213e1636290db5d5647282ca8a023",
@@ -7249,7 +7266,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:a8f3db8d88841ae43b17311d813eb60395c50a536d739bec5fa74e830cee171f",
@@ -7282,6 +7299,7 @@
       ],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
@@ -7291,7 +7309,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:75b34a07bbbaa5274ed627d665dd312543fbc007c99149b5a74b8740290fca8f",
@@ -7376,7 +7394,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: evaluation, test set",
+        "Matched: evaluat, test set",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:7265740668efd427d75de2509c265fe236fe908617842b8a6fe068a75adc5533",
@@ -7417,7 +7435,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:e6d34ea56e9c490491fcf9b00a4ff076a555d133948213f482ece5cca34b94cf",
@@ -7466,7 +7484,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:c11e1365ceaa01ffc4a641f73fac73b9d2991e05c2ecfd75717ee2b538ad250c",
@@ -7503,7 +7521,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:c7fd9ff66c104758ee02021c8ae579f5a042c323652e87d0a3b7f285bc5fd11e",
@@ -7578,6 +7596,7 @@
       ],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
@@ -7587,7 +7606,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:19b16391f0ec03e81af9a13a320ba5dfa8fd8f3f4e7802e38b3b9f331684adba",
@@ -7621,7 +7640,9 @@
       ],
       "categories": [
         "benchmark",
-        "dataset"
+        "evaluation",
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
       "event_kind": "released",
@@ -7630,7 +7651,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: agents~evaluate, benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:b343d1d1674a11b575ce7380340132a6ac1b9fd45c9ffe7db0a41c3355f6ea8a",
@@ -7664,6 +7685,7 @@
       ],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
@@ -7673,7 +7695,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, corpus",
+        "Matched: benchmark, corpus, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:365bc1b2ec72576b82eb882385a26830d42f4662d61699455a35426e8ff56908",
@@ -7716,7 +7738,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:db36b2e890253d58d29a6cd6e2eb92e39bc9d553c30148584675217f1723f6df",
@@ -7758,7 +7780,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:82c9d560282129e89bf24c5ca1940422f4f79308f4fa0ea84bf56aa8e365d66f",
@@ -7850,7 +7872,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:29b88a676d3a22c4d6270784a8a5c1d1dd62dc4f802d59e2070b23816cd0d71e",
@@ -7891,7 +7913,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:6973550dacc97af4c2a95ec802df9f10780d861492e1ff960dbed8116aab49e3",
@@ -7969,7 +7991,9 @@
       ],
       "categories": [
         "benchmark",
-        "dataset"
+        "evaluation",
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
       "event_kind": "released",
@@ -7978,7 +8002,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, corpus",
+        "Matched: agentic~benchmarks, benchmark, corpus, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:eeba3196861a38bb2853d6bb6ba0ed9fd5128c62b66cbcc4b1de24665b1a9d57",
@@ -8019,7 +8043,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, corpus",
+        "Matched: benchmark, corpora, corpus",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:0f83f1def29479b7a3004e793bec5c6a90c0f7ccec1df3c6d4752ce9ee75654a",
@@ -8070,7 +8094,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:bac9be79b872c13960378c94b041288f0c850b5dd26df032b3076f0b7168e271",
@@ -8149,7 +8173,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:68105b448c0658096084ff836d77b95f6295634c38544a6b4e9f68a5d296f011",
@@ -8234,7 +8258,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:f69d87a6ac2bcb40cae0faa0d655c5a5a4773a35ebb4c7352b979b115404ecda",
@@ -8263,7 +8287,9 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
       "event_kind": "released",
@@ -8272,7 +8298,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: agent~evaluate, benchmark, corpora, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:c81478b9546ed46a57f71bc782b18d5f2c83e86b4ee60cd13b072eab36cd6845",
@@ -8311,7 +8337,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:4415df2d0ef63666144eb0691919fd8d7dfadc373856728433a9abe5f81009e2",
@@ -8364,7 +8390,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:bfc23681b73c41b88477a9f534ac053918f9475a866f9760f80cbf89173be372",
@@ -8402,7 +8428,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:c56e7e4337037334487779483787c04d1d40a2f531651ee0b5342d1e696cf13b",
@@ -8434,6 +8460,7 @@
       ],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
@@ -8443,7 +8470,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:71c8943cb47106fb9d713a23cf3d62c8907ef6c964c3e4dfd4c0d5a87ba2a761",
@@ -8481,7 +8508,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:53482bab2059ec26c97cebdc8c9375edb4dc92339bcdce4c988224e3d00a22bf",
@@ -8521,7 +8548,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:e3d92118037458349d254b98d345ed2b043709a34698e17c0608aa033a4d96b6",
@@ -8565,7 +8592,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:a92f1866941d360d51d5ee154edf2ba8628e11c6177d9c72af8428da82a8eae3",
@@ -8607,7 +8634,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:f6052910e7f2366434fba2a202dd9e9dcab46db0078bccb68744f33195533dfb",
@@ -8638,7 +8665,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
       "event_kind": "released",
@@ -8647,7 +8675,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluator",
+        "Matched: agents~benchmarks, benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:9f5cbff0280977fd752f691aed0621b5a58f1833567ac3cfa79f1e2d290a450f",
@@ -8724,7 +8752,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:6989866d93187331f8a579ee48e61f64bc2ebec2f3c691e1daa51fba81cb95f7",
@@ -8755,7 +8783,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
       "event_kind": "released",
@@ -8764,7 +8793,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: agents~evaluating, benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:5894895b6e920f0b3d23d8ace8e1b9ac5e0222894be24fb9063abdf5f4f037c4",
@@ -8920,7 +8949,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:f616f19e667aa788123ba879bb5fa5fb11e1bfca2c1f85464dc0a8eb875ad740",
@@ -8960,7 +8989,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:e783d71e849fe642bb44ad18d074e7f90589a1ce60b033adf601a5976e81b6fd",
@@ -8998,7 +9027,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-28T14:33:06.179849+00:00",
       "event_kind": "released",
@@ -9007,7 +9037,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: agents~benchmark, benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:d68d47c142051e88c60f6d8820f525a17ca5b9a69e3dc232e400e00a65948653",
@@ -9038,7 +9068,8 @@
       ],
       "categories": [
         "evaluation",
-        "dataset"
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-28T14:33:06.179849+00:00",
       "event_kind": "released",
@@ -9047,7 +9078,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: agents~evaluation, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:96f8467164b21dc486543ee8018d20245c308ba061a199399484de0bbf51426d",
@@ -9125,7 +9156,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:27070872a428d4f50c17af1e38fb60e169b48a1a30d5cd2b46ee392611e2e230",
@@ -9199,7 +9230,8 @@
       ],
       "categories": [
         "evaluation",
-        "dataset"
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
       "event_kind": "updated",
@@ -9208,7 +9240,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluation",
+        "Matched: agent~evaluation, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:abf6e85679bac6027cd1d4ef31cd90efaf7ef9a4757097cf26a9804202e0531e",
@@ -9284,6 +9316,7 @@
       ],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
@@ -9293,7 +9326,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:a6e7a813c4b9a51e5c58b99cec41bcaae6ed7e5da79ef500c4132c684348e2d2",
@@ -9370,6 +9403,7 @@
       ],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
@@ -9379,7 +9413,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, corpus",
+        "Matched: benchmark, corpora, corpus, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:bf7445372af92436606d9087edd4cc1193a52c0e4adfaf6abc72a34a9507f02c",
@@ -9417,7 +9451,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:505a3ea4a42d230e10ca77f7e6ae4569d63f6b73cd1275129d1dcac06aff94b9",
@@ -9448,7 +9482,9 @@
       ],
       "categories": [
         "benchmark",
-        "dataset"
+        "evaluation",
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
       "event_kind": "updated",
@@ -9457,7 +9493,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, corpus",
+        "Matched: agent~evaluate, benchmark, corpus, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:f47ead2717bdc5279e40ecf48e78903ee7796fdf7ba9363a92577b518d9326e3",
@@ -9571,7 +9607,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
       "event_kind": "updated",
@@ -9580,7 +9617,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: agentic~benchmarks, benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:e88ac221bab2b4b3b3b08ecf182fb0082672c183fb962b9215f24b0607820a36",
@@ -9616,7 +9653,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
       "event_kind": "updated",
@@ -9625,7 +9663,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: agents~evaluating, benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:cc139866133b8261016af63e6db209eef6f293f310848f6fadf69dbf6a752979",
@@ -9659,7 +9697,8 @@
       ],
       "categories": [
         "evaluation",
-        "data_quality"
+        "data_quality",
+        "agentic"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
       "event_kind": "released",
@@ -9668,7 +9707,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: deduplication, evaluation",
+        "Matched: agents~evaluation, deduplication, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:c597e0a5c3272197b769e6729c1da283e6e71a12439c509fb6527cf5415c2b7b",
@@ -9696,7 +9735,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "dataset"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
       "event_kind": "released",
@@ -9705,7 +9745,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, corpora, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:1a01a9e2d397993e823de7426cf5bef58ce3aace03795e4e5f07e3ce397b53ec",
@@ -9734,7 +9774,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
       "event_kind": "released",
@@ -9743,7 +9784,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: agent~benchmark, benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:e045592b8c66e57c5d5e5d8f1bf39016dc630c77d670bcfad84608d084130a30",
@@ -9778,6 +9819,7 @@
       ],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
@@ -9787,7 +9829,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:088ed1245ddac72fa7dc24b9403a7ebebe0197fd4f9ff65bd1fa597d739a27ca",
@@ -9832,7 +9874,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: dataset, evaluator",
+        "Matched: dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:a8bc3e5e87b833d76a9dce5c9a78e3b9ed9619dd03048164eb56cea81bd01ac7",
@@ -9905,7 +9947,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
       "event_kind": "released",
@@ -9914,7 +9957,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: agent~benchmarks, benchmark, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:4805677ebeadcf0efd239a0fa858da28005667b33238f1a59cb5cf875156aa5c",
@@ -9961,7 +10004,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: evaluation, training data",
+        "Matched: evaluat, training data",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:d33e75a1c84c3df5ccd8e9f86342e80d3a9ebdeb1881dcbc5b05857ee5608efd",
@@ -10110,6 +10153,7 @@
       ],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
@@ -10119,7 +10163,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:d990f93a6bc358fc7346c5f74d547137bfe0e977512d377ff1588ec0cd7e232b",
@@ -10156,7 +10200,8 @@
       ],
       "categories": [
         "benchmark",
-        "evaluation"
+        "evaluation",
+        "dataset"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
       "event_kind": "updated",
@@ -10165,7 +10210,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, corpora, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:b6dbd1fc582e26734f3bdd9ed1fe022586fb2230beab2590d843941f993c0bc4",
@@ -10275,6 +10320,7 @@
       "authors": [],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
@@ -10287,7 +10333,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-30T01:21:24+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, leaderboard",
+        "Matched: benchmark, dataset, evaluat, leaderboard",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:d40e053264ce596faeacfe1b9e5c9f7c442e6723f3c6ec40b32488f404cbdcd4",
@@ -10350,7 +10396,8 @@
       "authors": [],
       "categories": [
         "evaluation",
-        "data_quality"
+        "data_quality",
+        "agentic"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
       "event_kind": "updated",
@@ -10362,7 +10409,7 @@
       "parser_version": "github-search/1",
       "published_at": "2026-07-30T13:16:28+00:00",
       "rationale": [
-        "Matched: data contamination, evaluation",
+        "Matched: agentic~evaluation, data contamination, evaluat",
         "Primary record: GitHub"
       ],
       "raw_payload_hash": "sha256:59c8f6a29bb932ac5cde17c3841408b7da4e78553fbd85da8852064329480932",
@@ -10387,7 +10434,8 @@
       "artifact_urls": [],
       "authors": [],
       "categories": [
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
       "event_kind": "updated",
@@ -10399,7 +10447,7 @@
       "parser_version": "github-search/1",
       "published_at": "2026-07-30T14:01:31+00:00",
       "rationale": [
-        "Matched: evaluator",
+        "Matched: agents~evals, evaluat",
         "Primary record: GitHub"
       ],
       "raw_payload_hash": "sha256:5d1fa7e4d7f5c898d715c0c2468ad657e7e6138e6a4e6003f6a482c0c0b4aac6",
@@ -10475,7 +10523,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-29T05:48:44+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:723f865e88a6dec25c46b52c1533d6ffea5b945051d40e0e31b6452caf375078",
@@ -10539,7 +10587,9 @@
       "authors": [],
       "categories": [
         "benchmark",
-        "dataset"
+        "evaluation",
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
       "event_kind": "updated",
@@ -10551,7 +10601,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-29T17:10:19+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: agentic~evaluating, benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:e4246eda01d45ed2e24da56bbc47968d582ba7aa5e3ff14c97055d9ed8a9d7c1",
@@ -10589,7 +10639,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-29T17:47:54+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, corpora, dataset",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:66875095772085382b98e08d411b7c5f5ffb89f6819e5822521b1b77002cdaa3",
@@ -10628,7 +10678,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-28T20:36:34+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:0a648334f1cdb11b374bbe32a7bcbd30b4db5d1ef552cb7bb0f1b6fe08b8637d",
@@ -10667,7 +10717,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-29T01:37:36+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:4e3c1e841eae8591c6d9cdd70c2c33d2820035fd34dc87e01fd6fab49a6a42b8",
@@ -10781,7 +10831,7 @@
       "parser_version": "github-search/1",
       "published_at": "2026-07-30T13:26:10+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: GitHub"
       ],
       "raw_payload_hash": "sha256:97d1157223705b412e4f81d69b8b1761358f18e22c6398370a8e2b7304fbe6f1",
@@ -10845,6 +10895,7 @@
       "authors": [],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
@@ -10857,7 +10908,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-30T04:34:31+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:3fa80da6edf983645fffb7e0bc2b6256efa88d28139e0d0b87c63977913868c3",
@@ -10972,7 +11023,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-28T22:52:25+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:20dbc2faaeac0d91490f7cc7263c3f6d62b2c25a5cd0f68adc132198ab2142cc",
@@ -11160,7 +11211,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-28T22:53:01+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, corpora, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:88c7e54585c61ce81deb6f474f46fd68075526a50b38bd56c78ba7e7d86ecf24",
@@ -11237,7 +11288,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-28T22:52:20+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:7c3168a622e8a094bff83e1fcb7dd7b2546630110c50772917f4ed8257212003",
@@ -11314,7 +11365,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-28T22:52:42+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:f1154b5b6444fd9613e5cce046b08e4fe6572c193499a4a1eeb0308cd80f3a49",
@@ -11378,7 +11429,8 @@
       "authors": [],
       "categories": [
         "benchmark",
-        "dataset"
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
       "event_kind": "released",
@@ -11390,7 +11442,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-30T08:47:33+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: agent~benchmark, benchmark, dataset",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:4835933f67efb6fdfc222fadb819537fec915e2fd5320f7dd7cf7b2413a68aac",
@@ -11415,7 +11467,8 @@
       "artifact_urls": [],
       "authors": [],
       "categories": [
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
       "event_kind": "updated",
@@ -11427,7 +11480,7 @@
       "parser_version": "github-search/1",
       "published_at": "2026-07-30T12:14:50+00:00",
       "rationale": [
-        "Matched: evaluation",
+        "Matched: agents~eval, evaluat",
         "Primary record: GitHub"
       ],
       "raw_payload_hash": "sha256:c843331d08425a5b6bf88f01e1b91c9ed2539c77d1f44d34a63f68f9918cf182",
@@ -11690,7 +11743,7 @@
       "parser_version": "github-search/1",
       "published_at": "2026-07-30T13:41:48+00:00",
       "rationale": [
-        "Matched: evaluation",
+        "Matched: evaluat",
         "Primary record: GitHub"
       ],
       "raw_payload_hash": "sha256:c2b09f3086bd1a9a433660d9e270dc4c38187cafeef4b759cdc98861dd81a69e",
@@ -11886,7 +11939,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: evaluation, evaluator",
+        "Matched: evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:b7cacd3837de558b2464e4f821ca2944839d5aa28af81b59ebde7ecb3a0bb2f4",
@@ -11957,6 +12010,7 @@
         "Yong Guo"
       ],
       "categories": [
+        "evaluation",
         "dataset"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
@@ -11966,7 +12020,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: data collection, dataset",
+        "Matched: data collection, dataset, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:91dc2846584c61a63bbe8c79a2ffb43061e9c2f63353ba8fd20a72aca3ec11ef",
@@ -12038,7 +12092,8 @@
         "Anita K. Rao"
       ],
       "categories": [
-        "evaluation"
+        "evaluation",
+        "dataset"
       ],
       "discovered_at": "2026-07-29T14:29:12.279273+00:00",
       "event_kind": "updated",
@@ -12047,7 +12102,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: evaluation, evaluator",
+        "Matched: corpora, evaluat",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:e98b2e0117b2a2952f7fb71b74f2affe4854b9e125eccfcc8942ec701f6857c0",
@@ -12090,7 +12145,8 @@
         "Haina Zhu"
       ],
       "categories": [
-        "benchmark"
+        "benchmark",
+        "evaluation"
       ],
       "discovered_at": "2026-07-30T14:28:50.917100+00:00",
       "event_kind": "released",
@@ -12099,7 +12155,7 @@
       "parser_version": "arxiv-rss/1",
       "published_at": "2026-07-30T04:00:00+00:00",
       "rationale": [
-        "Matched: benchmark, leaderboard",
+        "Matched: benchmark, evaluat, leaderboard",
         "Primary record: arXiv"
       ],
       "raw_payload_hash": "sha256:08d1bb286c2553f372b32de170c5de39f1001ca7782f570b51bc5bab7db3ba00",

--- a/data/snapshots/2026-07-31.json
+++ b/data/snapshots/2026-07-31.json
@@ -4257,7 +4257,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-31T14:03:05+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation, leaderboard",
+        "Matched: benchmark, dataset, evaluat, leaderboard",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:877addaabec96086200a839cf13c1d044a6caee44667eb38c980f7abd50fb61a",
@@ -4410,7 +4410,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-31T09:31:56+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:780957e093a4b746ea33408522e1bfb94ccc66c57273936d828fc3d4a71241bb",
@@ -4449,7 +4449,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-31T02:26:07+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:51ddb22c520913421defef31e169ed15316824d952a52f689299914c8e63cb1e",
@@ -4476,7 +4476,8 @@
       "categories": [
         "benchmark",
         "evaluation",
-        "dataset"
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-31T14:31:49.744338+00:00",
       "event_kind": "updated",
@@ -4488,7 +4489,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-30T14:35:21+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: agent~benchmarks, benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:b18e55a0d804158ac94df89fda15bb7906c939750e709f31b9cee55233d6d884",
@@ -4513,7 +4514,9 @@
       "artifact_urls": [],
       "authors": [],
       "categories": [
-        "dataset"
+        "evaluation",
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-31T14:31:49.744338+00:00",
       "event_kind": "updated",
@@ -4525,7 +4528,7 @@
       "parser_version": "github-search/1",
       "published_at": "2026-07-31T14:09:26+00:00",
       "rationale": [
-        "Matched: dataset",
+        "Matched: agent~evaluating, dataset, evaluat",
         "Primary record: GitHub"
       ],
       "raw_payload_hash": "sha256:02baa5b14866cd3d23f3c3a5dbb0b76503b19a9d6faaf62201ad2871d6e30dd7",
@@ -4552,7 +4555,8 @@
       "categories": [
         "benchmark",
         "evaluation",
-        "dataset"
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-31T14:31:49.744338+00:00",
       "event_kind": "updated",
@@ -4564,7 +4568,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-30T18:17:44+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation, leaderboard",
+        "Matched: agents~leaderboard, benchmark, dataset, evaluat, leaderboard",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:89ac60ad49945b0392a2f1c01b56cb1c65e716d4db060164505d1566ab02a143",
@@ -4591,7 +4595,8 @@
       "categories": [
         "benchmark",
         "evaluation",
-        "dataset"
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-31T14:31:49.744338+00:00",
       "event_kind": "updated",
@@ -4603,7 +4608,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-30T16:43:55+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: agent~benchmark, benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:91b1eb8788832197d19f8450caff7e42edfe57dd28a8ed0f80392ce70927b587",
@@ -4680,7 +4685,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-31T04:57:04+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:4bfbe5398044e46d90912fbf1f0f996c54d7b0bcdcf495c520aaf503450b57fa",
@@ -4757,7 +4762,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-31T14:19:07+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:54069796c3a603b2eac3cb9248db916347aeace58afcfb8d8ec74cdd0ef0211d",
@@ -4870,7 +4875,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-31T13:40:20+00:00",
       "rationale": [
-        "Matched: benchmark, corpus, evaluation",
+        "Matched: benchmark, corpus, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:174aabfeb228cf96e7af0c51a234e63c61932ab4b287835d5c79d97da7039e3f",
@@ -4909,7 +4914,7 @@
       "parser_version": "github-search/1",
       "published_at": "2026-07-31T13:19:31+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: GitHub"
       ],
       "raw_payload_hash": "sha256:a96a9a325e6aa3cee1508a79c42193edbdeaa674ad4b4d7b835a523fd8ae2399",
@@ -4986,7 +4991,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-30T09:37:42+00:00",
       "rationale": [
-        "Matched: dataset, evaluation, leaderboard",
+        "Matched: dataset, evaluat, leaderboard",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:2170579a2a1ae06a2a521f604ba9d9154dcee8def1f0aaf6ef13df7d67a6ac2a",
@@ -5048,7 +5053,8 @@
       "artifact_urls": [],
       "authors": [],
       "categories": [
-        "evaluation"
+        "evaluation",
+        "agentic"
       ],
       "discovered_at": "2026-07-31T14:31:49.744338+00:00",
       "event_kind": "updated",
@@ -5060,7 +5066,7 @@
       "parser_version": "github-search/1",
       "published_at": "2026-07-31T13:23:43+00:00",
       "rationale": [
-        "Matched: evaluation",
+        "Matched: agents~evaluation, evaluat",
         "Primary record: GitHub"
       ],
       "raw_payload_hash": "sha256:3ddc86ce60d2a59edd9c4d2a4c3fbda8610e566783bc6f5d7c4cac701f00dc13",
@@ -5098,7 +5104,7 @@
       "parser_version": "github-search/1",
       "published_at": "2026-07-31T14:30:27+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: GitHub"
       ],
       "raw_payload_hash": "sha256:4c55902ffec97e8762a15ebdcabf9c017992e505858732e52cafccd4b046077b",
@@ -5136,7 +5142,7 @@
       "parser_version": "github-search/1",
       "published_at": "2026-07-31T13:47:18+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: GitHub"
       ],
       "raw_payload_hash": "sha256:af16d27d4ef686b5cdf1d5e8d4eb57e07bd8149f97e844402a02303be37be587",
@@ -5175,7 +5181,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-30T23:47:54+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:a6b17e2b980af96e5e0127a7a7f222bc5d5c8879b953d8b1ad985db8cb9ecb6b",
@@ -5201,7 +5207,9 @@
       "authors": [],
       "categories": [
         "benchmark",
-        "dataset"
+        "evaluation",
+        "dataset",
+        "agentic"
       ],
       "discovered_at": "2026-07-31T14:31:49.744338+00:00",
       "event_kind": "updated",
@@ -5213,7 +5221,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-31T03:32:30+00:00",
       "rationale": [
-        "Matched: benchmark, dataset",
+        "Matched: agents~benchmark, benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:cd652e8cf7760c0f7e426aa8616d4d7b8ea37161dd716e591bde44d88ae5ba0c",
@@ -5327,7 +5335,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-30T20:57:45+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:087d8a70a2195c523208971df45079088a91b6844645c3bdfd4f897cda84d43f",
@@ -5365,7 +5373,7 @@
       "parser_version": "github-search/1",
       "published_at": "2026-07-31T14:26:13+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: GitHub"
       ],
       "raw_payload_hash": "sha256:70c7fa36d7767abc32217df1abf8d9409ec8dd4e9fe851cf845e2caedc16f737",
@@ -5391,6 +5399,7 @@
       "authors": [],
       "categories": [
         "benchmark",
+        "evaluation",
         "dataset",
         "agentic"
       ],
@@ -5404,7 +5413,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-29T17:10:19+00:00",
       "rationale": [
-        "Matched: agent benchmark, benchmark, dataset",
+        "Matched: agentic~evaluating, benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:e4246eda01d45ed2e24da56bbc47968d582ba7aa5e3ff14c97055d9ed8a9d7c1",
@@ -5517,7 +5526,7 @@
       "parser_version": "github-search/1",
       "published_at": "2026-07-31T13:53:35+00:00",
       "rationale": [
-        "Matched: agent benchmark, benchmark",
+        "Matched: agent~benchmarks, benchmark",
         "Primary record: GitHub"
       ],
       "raw_payload_hash": "sha256:444326613414720b0a4f5144debe7044336777f65f24d1536c3646c8f1191a6e",
@@ -5630,7 +5639,7 @@
       "parser_version": "github-search/1",
       "published_at": "2026-07-31T12:54:09+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: GitHub"
       ],
       "raw_payload_hash": "sha256:6caf633e47061f8a7fd5863d76e283a4fa73e8fc28eab9b3e440d955bbfc2210",
@@ -5817,7 +5826,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-30T13:22:56+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:3495608fd04a5b1c5495f44033b539b0fa9f3dfbf9d16efcff59698ae31e2829",
@@ -5855,7 +5864,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-31T09:48:12+00:00",
       "rationale": [
-        "Matched: benchmark, evaluation",
+        "Matched: benchmark, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:99c25494330cdfc213cac7e40ec347e879112f0c73dd4aedbb504fcf5efa3426",
@@ -5894,7 +5903,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-30T04:34:35+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:f3ac306fe921bc9e0ae3bcffad9bbfbe2a9d4ed662e14f816e26d041c76dc13f",
@@ -5933,7 +5942,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-30T03:19:25+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:9cf9d1006cfcad855d0aab673ad5b4fac3cbe4a8f41d7df74d8c3be436f1c119",
@@ -5972,7 +5981,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-30T03:19:24+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:1b16c30bd50de0461f4034569f6de4cc9bcb3d99bd29c63288eddb6974e48345",
@@ -6087,7 +6096,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-30T04:33:57+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:8a10ce7826d630e4fbe300b532dd76ff59d6e7fcf0b2560ee4a7ecc2a95068aa",
@@ -6126,7 +6135,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-30T03:19:28+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:b3eb8ffad9706a47ff0f0280dce6da88efc6abb8a6d5f469a7470213cf38465f",
@@ -6165,7 +6174,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-30T03:19:26+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:3650b5fb5640845236aaff46653c46eed6e9a0e647994ac8fc49d1f4b41e1bf7",
@@ -6204,7 +6213,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-29T16:16:18+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:b9f955cd00d9bca1cf672fe3683375c2ee9d0c1367858dc8046548978df46b26",
@@ -6243,7 +6252,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-30T04:34:20+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:032ef386ff77e7d2f87597986511f1bbae9feba2a36d589a088ea608eb3f1dd0",
@@ -6343,7 +6352,8 @@
       "artifact_urls": [],
       "authors": [],
       "categories": [
-        "benchmark"
+        "benchmark",
+        "agentic"
       ],
       "discovered_at": "2026-07-31T14:31:49.744338+00:00",
       "event_kind": "updated",
@@ -6355,7 +6365,7 @@
       "parser_version": "github-search/1",
       "published_at": "2026-07-31T14:30:33+00:00",
       "rationale": [
-        "Matched: benchmark",
+        "Matched: agent~eval, benchmark",
         "Primary record: GitHub"
       ],
       "raw_payload_hash": "sha256:e6d1bcb9a503024f35bde40a723c4893e5021b72676b5edf4063c379cd82e52b",
@@ -6394,7 +6404,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-30T08:47:33+00:00",
       "rationale": [
-        "Matched: agent benchmark, benchmark, dataset",
+        "Matched: agent~benchmark, benchmark, dataset",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:4835933f67efb6fdfc222fadb819537fec915e2fd5320f7dd7cf7b2413a68aac",
@@ -6470,7 +6480,7 @@
       "parser_version": "huggingface-hub/1",
       "published_at": "2026-07-30T07:33:14+00:00",
       "rationale": [
-        "Matched: benchmark, dataset, evaluation",
+        "Matched: benchmark, dataset, evaluat",
         "Primary record: Hugging Face"
       ],
       "raw_payload_hash": "sha256:8866459f73860e95c99f9c4e5f500b87d7251bb83e715ccb87b214e3755daf97",

--- a/docs/reports/issue-52-how-many-benchmarks.md
+++ b/docs/reports/issue-52-how-many-benchmarks.md
@@ -3,7 +3,7 @@
 > Report date: July 31, 2026 | Repository: ktwu01/benchmark-radar | Subject: corpus counts, taxonomy recall, and the flow-versus-stock distinction
 > Evidence cutoff: 2026-07-31T14:31Z (the `generated_at` of the latest rebuild). Author: Koutian Wu (https://ktwu01.github.io/).
 
-> **Update, this PR: the agentic defect is fixed, not just diagnosed.** The published count moved from **3 to 75** distinct artifacts. Two things changed. A new `benchmark-radar rescore` command recomputes stored categories across all nine snapshots, which alone moved 3 to 16 by fixing the one-day-numerator bug. The classifier then moved 16 to 75 by replacing the adjacent-phrase list with a proximity rule, measured at **95.0% recall and 76.0% precision** against a hand-labeled sample.
+> **Update, this PR: the agentic defect is fixed, not just diagnosed.** The published count moved from **3 to 78** distinct artifacts. Two things changed. A new `benchmark-radar rescore` command recomputes stored categories across all nine snapshots, which alone moved 3 to 16 by fixing the one-day-numerator bug. The classifier then moved 16 to 78 by replacing the adjacent-phrase list with a proximity rule, measured at **95.0% recall and 73.1% precision** against a hand-labeled sample.
 >
 > The report's headline open question is also resolved. The unreconciled "89 versus 64" ground-truth dispute was an artifact of two passes using *different* inclusion rules. Re-run with the rule fixed in advance, two independent annotators reached **Cohen's kappa 0.888** (94.5% raw agreement, 6 disagreements in 109), settling ground truth at **60 to 66**, not 89. Sections 4, 8 and 12 are corrected accordingly; the pre-fix findings are kept as the diagnosis that motivated the change.
 >
@@ -32,9 +32,9 @@ Issue #52 asked how many benchmarks exist on the market, how many are agentic, a
 
 **The direct answer splits in two.**
 
-**On category breakdown, the project can partly answer, with corrections.** The corpus holds 645 distinct artifacts. Before this PR they were tagged benchmark 512, dataset 450, evaluation 337, data_quality 15, agentic 3. The three large figures survive audit at 96 to 98% recall. The agentic figure did not: it was wrong twice over, first because snapshots written before the category existed were never re-scored (3 should have been 16), and second because the keyword list matched almost nothing (16 should have been ~75).
+**On category breakdown, the project can partly answer, with corrections.** The corpus holds 645 distinct artifacts. Before this PR they were tagged benchmark 512, dataset 450, evaluation 337, data_quality 15, agentic 3. The three large figures survive audit at 96 to 98% recall. The agentic figure did not: it was wrong twice over, first because snapshots written before the category existed were never re-scored (3 should have been 16), and second because the keyword list matched almost nothing (16 should have been ~78).
 
-**Both defects are now fixed in this PR.** The current published figures are **benchmark 512, dataset 458, evaluation 401, data_quality 15, agentic 75**, and the agentic classifier is measured at 95.0% recall / 76.0% precision against hand-labeled ground truth. `benchmark` is deliberately unchanged: narrowing it was measured and found actively harmful. The data_quality figure remains disputed between two audits and is **left unfixed on purpose** (section 4a) because the two passes disagree by an order of magnitude on what the category means, and shipping a keyword change on an unsettled definition would repeat the exact error this report documents. The tags are multi-label, so the five figures do not partition 645 and must never be summed.
+**Both defects are now fixed in this PR.** The current published figures are **benchmark 512, dataset 450, evaluation 401, data_quality 15, agentic 78**, and the agentic classifier is measured at 95.0% recall / 73.1% precision against hand-labeled ground truth. `benchmark` is deliberately unchanged: narrowing it was measured and found actively harmful. The data_quality figure remains disputed between two audits and is **left unfixed on purpose** (section 4a) because the two passes disagree by an order of magnitude on what the category means, and shipping a keyword change on an unsettled definition would repeat the exact error this report documents. The tags are multi-label, so the five figures do not partition 645 and must never be summed.
 
 Your instinct that the defect extends beyond agentic is partly confirmed and partly not, and the distinction is useful. The three large categories are working; narrowing them was measured and found actively harmful. But `benchmark` at 79.4% prevalence is non-discriminative in a different way: 489 of its 512 matches come from the single bare word "benchmark", which is also what the retrieval layer queries for, so the category largely restates the query.
 
@@ -46,8 +46,8 @@ Meanwhile the corpus does contain `omegaprime669/rtx-5090-benchmarks`, `NODARISH
 
 | Question asked in #52 | Can the project answer it? | Published figure after this PR | Verdict |
 |---|---|---|---|
-| Category breakdown | Partly | benchmark 512, dataset 458, evaluation 401 | These three measured at 96 to 98% recall. Multi-label, not a partition |
-| How many agentic? | **Yes, now** | **75** (was 3) | **Fixed.** Rescore moved 3 to 16; proximity rule moved 16 to 75, at 95.0% recall / 76.0% precision |
+| Category breakdown | Partly | benchmark 512, dataset 450, evaluation 401 | These three measured at 96 to 98% recall. Multi-label, not a partition |
+| How many agentic? | **Yes, now** | **78** (was 3) | **Fixed.** Rescore moved 3 to 16; proximity rule moved 16 to 78, at 95.0% recall / 73.1% precision |
 | How many data-quality? | Disputed | 15 (unchanged) | **Deliberately not fixed.** Two audits disagree on the inclusion rule by an order of magnitude. Needs a definition before a keyword |
 | How many benchmarks total on the market? | No | 512 implied | Category error: flow reported as stock. Unchanged by this PR |
 | New benchmark artifacts per day | Yes, and this is the real strength | 84.9/day recent average | Defensible as a floor, given per-source truncation |
@@ -517,7 +517,7 @@ Rejected for data_quality, each measured then rejected on reading its hits: `qua
 
 Adopting the recommended set yields benchmark 512, dataset 446, evaluation 336, data_quality 100. The 3-or-more-tag share rises from 18.4% to about 27%, which is the correct and acceptable cost of data_quality finally working: data-quality artifacts genuinely are usually also benchmarks or datasets.
 
-**Update: the agentic and working-category changes are now applied (section 8a), and the snapshots were re-scored so the numerator and denominator cover the same period.** The shipped rule is the co-occurrence shape recommended above rather than the 33-term interim list, tightened to a 15-token proximity window with exclusions to lift its precision ceiling from 60% to 76%. The `data_quality` list in this section is **not** applied, for the reason given in section 8a: its ground truth is still disputed.
+**Update: the agentic and working-category changes are now applied (section 8a), and the snapshots were re-scored so the numerator and denominator cover the same period.** The shipped rule is the co-occurrence shape recommended above rather than the 33-term interim list, tightened to a 15-token proximity window with exclusions, lifting its precision from a 60% ceiling to 73.1%. The `data_quality` list in this section is **not** applied, for the reason given in section 8a: its ground truth is still disputed.
 
 ## 8a. What this PR actually changed, and what it measures
 
@@ -550,14 +550,14 @@ Measured on the 109 hand-labeled candidates:
 | Current 12 adjacent phrases | 16 | 81.2% | 21.7% | 34.2% |
 | Bare co-occurrence, anywhere in text | 105 | 57.1% | 100.0% | 72.7% |
 | Title-only co-occurrence | 23 | 91.3% | 35.0% | 50.6% |
-| **Proximity, 15 tokens, hyphen-aware, with exclusions** | **75** | **76.0%** | **95.0%** | **84.4%** |
+| **Proximity, 15 tokens, hyphen-aware, with exclusions** | **78** | **73.1%** | **95.0%** | **82.6%** |
 
-The chosen rule is robust to the annotation dispute, which is why it is safe to ship: scored against the loose 66-item ground truth instead of the strict 60, it reads 81.3% precision and 92.4% recall (F1 86.5%). The conclusion does not depend on which denominator is correct.
+The chosen rule is robust to the annotation dispute, which is why it is safe to ship: scored against the loose 66-item ground truth instead of the strict 60, it reads 80.8% precision and 95.5% recall (F1 87.5%). The conclusion does not depend on which denominator is correct.
 
 Two failure modes visible in the earlier measurements were fixed along the way:
 
 - **Hyphen-joined repository names.** `solsticestudioai/agent-failure-atlas-benchmark` carries its whole description in one slug, so whitespace tokenization hid it. Six of the misses were this exact shape; treating hyphens as separators recovered all of them.
-- **A silently inert exclusion clause.** The first version of the exclusion pattern ended in `\b` after `position:`, which can never match, because a colon is already a non-word character. A regression test caught it. Removing the trailing boundary raised precision from 75.0% to 76.0%.
+- **A silently inert exclusion clause.** The first version of the exclusion pattern ended in `\b` after `position:`, which can never match, because a colon is already a non-word character. A regression test caught it. Removing the trailing boundary fixed it.
 
 ### The append-only bug, and why a config change alone would have done nothing
 
@@ -575,9 +575,9 @@ Verified on the real corpus, only category and rationale fields appear in the di
 
 | Category | Before | After |
 |---|---:|---:|
-| agentic | 3 | **75** |
+| agentic | 3 | **78** |
 | evaluation | 337 | 401 |
-| dataset | 450 | 458 |
+| dataset | 450 | 450 |
 | benchmark | 512 | 512 |
 | data_quality | 15 | 15 |
 
@@ -586,8 +586,20 @@ Verified on the real corpus, only category and rationale fields appear in the di
 ### The other applied edits
 
 - **`evaluation`**: `evaluation` replaced with the stem `evaluat`, a strict superset that picks up "evaluating" and "evaluated". This is what moves 337 to 401.
-- **`dataset`**: added `corpora`, which substring matching cannot reach from `corpus`. This moves 450 to 458.
+- **`dataset`**: added `corpora$`, which substring matching cannot reach from `corpus`. The trailing `$` closes the right edge; without it, `corpora` matched inside "incorporates" and "corporate" and mis-tagged 7 artifacts, which is exactly the bare-substring failure issue #51 warned about. Net effect on the count is zero, and that is the point: the term now fires only on the real plural.
 - **Deleted two dead terms**: `challenge set` and `capability eval` matched zero artifacts across all nine snapshots. The four dead agentic terms disappear with the phrase list itself.
+
+### Adversarial review of the fix, and what it changed
+
+The fix was itself reviewed by a pass whose brief was to refute it. External review was attempted first and is still unavailable: the `gemini` CLI has no credentials in this environment, and the `codex` CLI remains usage-limited until 2026-08-03. The internal pass re-derived every published number independently and confirmed the 3 to 78 movement, the arithmetic consistency of the precision/recall tables, and that `rescore` genuinely preserves scores and timestamps. It also found three defects worth fixing, all now fixed:
+
+**1. `corpora` matched inside `incorporate`.** The proximity rule is token-aware, but plain phrase lists were still raw substring tests, so adding `corpora` tagged 7 unrelated artifacts as datasets on strings like "the framework **incorporates**" and "a **corporate** network access policy". This is precisely the bare-substring failure mode issue #51 raised, reintroduced by the fix meant to honor that lesson. Phrase terms are now anchored at a word start, with an optional trailing `$` to close the right edge for whole words while stems such as `evaluat` keep matching their inflections. The earlier commit's claim of "precision 8/8 on reading every new hit" was wrong, and `dataset` returns to 450 rather than the 458 first reported.
+
+**2. A bare `survey` in the exclusion was a recall regression waiting to fire.** It would have dropped any agent benchmark about survey responses, an active evaluation area the corpus already contains. The exclusion is now anchored to where a paper declares its genre rather than searching the whole text.
+
+**3. The exclusion list was memorizing the test set.** Leave-one-out showed `unlocking agentic capabilities` and `needs redefinition` each removed exactly one artifact, both verbatim substrings of specific titles in the measurement corpus. Those are hardcoded answers, not rules, and the 1-point precision gain they bought would not transfer to any other corpus. They are deleted. **Removing them is why precision is reported here at 73.1% rather than the 76.0% first measured**, and the lower figure is the honest one.
+
+A fourth finding was accepted but handled differently: `rescore` writes back a normalized snapshot, which silently upgrades a schema-v1 file to v2 while reporting "0 records changed". Rather than change the write path, `rescore` now reports any schema upgrade explicitly. All nine snapshots on disk are already v2, so this is latent rather than active.
 
 ### What was deliberately left alone
 
@@ -644,11 +656,11 @@ The project has crossed one threshold and not the next.
 
 It has crossed from no measurement to a working flow instrument. Three live connectors, deterministic replay, exact-identifier deduplication, an append-only snapshot corpus, and an explainable rubric. The daily-arrival figures are real and are something registry enumeration cannot provide. That is a genuine contribution and it should be stated as the system's answer to what it can answer.
 
-It has not crossed from flow measurement to population estimate, and the gap was papered over rather than stated. Issue #52 asked a stock question. The pipeline answered with a flow number, in a collapsed dashboard panel, and the issue was auto-closed twice by PR keywords before a human confirmed anything. The agentic count that was supposed to answer the second half of the question was published at 3, when re-scoring the same corpus yielded 16 and the achievable figure was around 63. **That specific defect is fixed in this PR: the published figure is now 75 at 95.0% recall (section 8a).** The rest of this paragraph still stands. Six terms across the taxonomy matched nothing at all, four of which are now deleted. Five of eight connectors contribute nothing, and a sixth reports success while returning zero. Both mechanisms intended to pin famous benchmarks, the watchlist and the release feed, have fired zero times in nine days.
+It has not crossed from flow measurement to population estimate, and the gap was papered over rather than stated. Issue #52 asked a stock question. The pipeline answered with a flow number, in a collapsed dashboard panel, and the issue was auto-closed twice by PR keywords before a human confirmed anything. The agentic count that was supposed to answer the second half of the question was published at 3, when re-scoring the same corpus yielded 16 and the achievable figure was around 63. **That specific defect is fixed in this PR: the published figure is now 78 at 95.0% recall (section 8a).** The rest of this paragraph still stands. Six terms across the taxonomy matched nothing at all, four of which are now deleted. Five of eight connectors contribute nothing, and a sixth reports success while returning zero. Both mechanisms intended to pin famous benchmarks, the watchlist and the release feed, have fired zero times in nine days.
 
 The pattern underneath all of it is a single missing habit. Every keyword change in this repository was validated in one direction only. Issue #51's precision fix was measured against the live feed and reported honestly (65% of the daily pool down to 9 to 12%). Not one recall measurement existed anywhere in the project's history: searching all commits, PR comments, and issue comments for a recall figure returned nothing. Precision failures are loud, because they flood the digest and someone complains. Recall failures are silent, because a number that is too small still renders. That asymmetry in *feedback*, not in effort or care, is what produced a category reading 3 when the answer was around 63.
 
-This PR supplies the missing half. The agentic taxonomy is now the one part of the system with **both** numbers attached: 95.0% recall and 76.0% precision, against ground truth two annotators agreed on at kappa 0.888, with regression tests pinning each failure mode. The habit worth keeping is not the specific rule but the requirement that a taxonomy change state both figures before it merges.
+This PR supplies the missing half. The agentic taxonomy is now the one part of the system with **both** numbers attached: 95.0% recall and 73.1% precision, against ground truth two annotators agreed on at kappa 0.888, with regression tests pinning each failure mode. The habit worth keeping is not the specific rule but the requirement that a taxonomy change state both figures before it merges.
 
 None of this means the counting question is unanswerable. It means the answer requires a second collection mode that enumerates registries rather than crawling a window, reported separately from the flow, with the definition of "benchmark" stated alongside the number. The infrastructure needed already exists in the repository.
 
@@ -667,11 +679,11 @@ Reproducing the fix itself (this PR). `rescore` is idempotent, so re-running it 
 ```bash
 .venv/bin/benchmark-radar rescore --config config.yml
 # -> Rescored 9 snapshots against the current taxonomy; 165 records changed category
-# ->   agentic        97  <- was 3      (per-sighting; 75 distinct artifacts)
+# ->   agentic       100  <- was 3      (per-sighting; 78 distinct artifacts)
 # ->   evaluation    474  <- was 399
-# ->   dataset       575  <- was 566
+# ->   dataset       566
 
-.venv/bin/python -m pytest tests/ -q     # 160 passed
+.venv/bin/python -m pytest tests/ -q     # 163 passed
 ```
 
 Confirming the rescore touched only categories, never the recorded scores:
@@ -784,7 +796,7 @@ This report's own boundaries, stated so they are not mistaken for findings:
 - **The triple-counting inflation factor is unmeasurable** from current data, because `artifact_urls` is empty on all 645 records. The cross-namespace join rate is not merely low, it cannot be computed.
 - **Ground truth is model judgment, not expert consensus.** This is now measured rather than asserted: two independent passes under a rule fixed in advance reached Cohen's kappa 0.888 (94.5% raw agreement), settling `agentic` ground truth at 60 to 66. That is high agreement, but both annotators are models, so a systematic blind spot shared by both would not show up as disagreement. A human domain expert spot-checking the 109 labels remains the appropriate confirmation. The earlier denominator of 89 is withdrawn: it came from a looser rule, not a different judgment.
 - **`data_quality` ground truth remains genuinely unresolved**, at 83 under a "described property" rule versus 8 to 15 under a "substantive contribution" rule. This is why the category was left at 15 rather than fixed. It needs a definition chosen in advance, which is the top follow-up.
-- **The proximity rule's precision is 76%, and that is a real cost.** Roughly 18 of the 75 published agentic artifacts are expected to be false positives, most commonly artifacts that build an agent system or evaluate a model on an agent-flavored task without being an agent benchmark. The alternative was 21.7% recall, and under-counting by a factor of four was the defect issue #52 reported. The trade is deliberate and reversible: raise the exclusion pattern or narrow `within` to trade recall back for precision.
+- **The proximity rule's precision is 73.1%, and that is a real cost.** Roughly 21 of the 78 published agentic artifacts are expected to be false positives, most commonly artifacts that build an agent system or evaluate a model on an agent-flavored task without being an agent benchmark. The alternative was 21.7% recall, and under-counting by a factor of four was the defect issue #52 reported. The trade is deliberate and reversible: raise the exclusion pattern or narrow `within` to trade recall back for precision.
 - **The 15-token window was tuned on this corpus**, which risks overfitting to 645 artifacts from one 9-day period. The precision/recall curve is flat between 10 and 20 tokens (F1 79.7% to 82.6% before exclusions), so the choice is not on a knife edge, but the exact figure should be re-measured as the corpus grows.
 - **PapersWithCode export availability, OpenML, and Kaggle counts: not available.** Not verified here.
 - **Overlap between the 214 lm-eval tasks and 208 HELM scenarios: not counted.** Both figures are cited separately and must not be added.
@@ -814,6 +826,7 @@ Four parallel investigations were run, including one whose explicit brief was to
 | Retrieval binds first, so classification is secondary | Independent problems; classification has a measured 4x payoff on data already held |
 | data_quality=15 is a confirmed defect | Disputed between two audits, unresolved |
 | Ground truth is disputed at 89 versus 64, unresolvable here | Resolved: the passes used different rules. Re-run with one fixed rule, kappa 0.888, ground truth 60 to 66. The 89 is withdrawn |
-| The co-occurrence rule is the right shape but unmeasured | Built and measured: 95.0% recall, 76.0% precision, F1 84.4%. Applied in this PR |
+| The co-occurrence rule is the right shape but unmeasured | Built and measured: 95.0% recall, 73.1% precision, F1 82.6%. Applied in this PR |
+| The fix's own first measurement, 76.0% precision | 73.1% after an adversarial pass removed exclusions that memorized specific titles in the test corpus |
 
 **External review was attempted and did not run.** The `gemini` CLI has no credentials in this environment (no `~/.gemini/oauth_creds.json`, no API key), and the `codex` CLI returned a usage-limit error until 2026-08-03. This report therefore carries internal adversarial verification but no independent external review, which is a real gap given that its ground truth is model-generated. A human read is the appropriate next check.

--- a/docs/reports/issue-52-how-many-benchmarks.md
+++ b/docs/reports/issue-52-how-many-benchmarks.md
@@ -1,0 +1,708 @@
+# How Many Benchmarks Exist? Answering Issue #52, and Why the Dashboard's Answer Is Wrong
+
+> Report date: July 31, 2026 | Repository: ktwu01/benchmark-radar | Subject: corpus counts, taxonomy recall, and the flow-versus-stock distinction
+> Evidence cutoff: 2026-07-31T14:31Z (the `generated_at` of the latest rebuild). Author: Koutian Wu (https://ktwu01.github.io/).
+
+## Contents
+
+1. Executive answer
+2. The question, and the three questions inside it
+3. What the corpus counts actually are
+4. Why the agentic count is wrong: measured recall
+4a. The other four categories: one more broken, three working
+5. Why the count cannot answer "how many exist"
+6. Retrieval versus classification: which layer binds
+7. What issue #57 did and did not fix
+8. Recommended keyword lists, with measured precision
+9. What a defensible market estimate requires
+10. Final diagnosis
+11. Reproducing every number in this report
+12. Limitations
+
+## 1. Executive answer
+
+Issue #52 asked how many benchmarks exist on the market, how many are agentic, and what the category breakdown is. The project answered with a dashboard panel showing five numbers. This report exists because that answer was wrong in a way a panel cannot express.
+
+**The direct answer splits in two.**
+
+**On category breakdown, the project can partly answer, with corrections.** The corpus holds 645 distinct artifacts, tagged benchmark 512, dataset 450, evaluation 337, data_quality 15, agentic 3. The three large figures survive audit at 96 to 98% recall. The agentic figure does not: **re-scoring the same corpus with today's config yields 16 rather than 3, and even 16 represents only about 19% recall against a hand-labeled ground truth of 64.** The data_quality figure is disputed between two independent audits and is left unresolved (section 4a). The tags are multi-label, so the five figures do not partition 645 and must never be summed.
+
+Your instinct that the defect extends beyond agentic is partly confirmed and partly not, and the distinction is useful. The three large categories are working; narrowing them was measured and found actively harmful. But `benchmark` at 79.4% prevalence is non-discriminative in a different way: 489 of its 512 matches come from the single bare word "benchmark", which is also what the retrieval layer queries for, so the category largely restates the query.
+
+**On "how many exist on the market," the project cannot answer, and no amount of crawling harder in the current direction will change that.** The question asks for a stock (the installed population). The pipeline measures a flow (new arrivals inside a 48-hour lookback). These are different quantities. The evidence that the corpus misses the population is not subtle: of 20 canonical benchmarks (MMLU, HELM, GPQA, ARC-AGI, HumanEval, BIG-bench, MMMU, GSM8K, HellaSwag, TruthfulQA, WebArena, tau-bench, OSWorld, MLE-bench, PaperBench, lm-evaluation-harness, mlcommons, evalplus, openai/evals, SWE-bench), **19 are entirely absent** from all 791 sightings. The single hit is a third-party Hugging Face dataset, not `princeton-nlp/SWE-bench`.
+
+Meanwhile the corpus does contain `omegaprime669/rtx-5090-benchmarks`, `NODARISHUB/mx-wordpress-seo-health-benchmark`, `habert75/homework3-benchmark-results`, and `yusuke0714/landingboost-landing-page-trust-benchmark`. So the set being counted and the set a reviewer has in mind are close to disjoint. Reporting 512 as an answer to 市面上总共 states a flow measure, with a partly-spurious numerator, in reply to a stock question.
+
+### Status at a glance
+
+| Question asked in #52 | Can the project answer it? | Current published figure | Verdict |
+|---|---|---|---|
+| Category breakdown | Partly | benchmark 512, dataset 450, evaluation 337 | These three measured at 96 to 98% recall. Multi-label, not a partition |
+| How many agentic? | Not yet | 3 | Wrong twice over. Re-scoring the same corpus gives 16; measured recall is then about 19% against ground truth of 64 |
+| How many data-quality? | Disputed | 15 | Two audits disagree: 16.9% recall against ground truth of 83, versus approximately correct against ground truth of 8 to 15. Unresolved |
+| How many benchmarks total on the market? | No | 512 implied | Category error: flow reported as stock |
+| New benchmark artifacts per day | Yes, and this is the real strength | 84.9/day recent average | Defensible as a floor, given per-source truncation |
+| Market total, grounded anchor | Not from this corpus | Not available | 4,542 to 5,092 Hugging Face benchmark datasets exist; corpus has seen 207 |
+
+The honest framing is that this project is a good flow instrument being asked a stock question. Its daily-arrival measurement is something registries cannot provide, and that is worth stating positively. Its category counts need a recall fix. Its market total needs a different collection mode entirely, not a bigger crawl.
+
+## 2. The question, and the three questions inside it
+
+Issue #52, created 2026-07-30T07:31:27Z, verbatim:
+
+> @吴叩天 还可以，你现在有统计出一个市面上总共多少benchmark，agentic benchmark，多少类别的一个统计不；理论上你是可以爬出这个信息的
+
+Three distinct asks are bundled here, and they have different answerability:
+
+| | Question | Type | Answerable from the corpus? |
+|---|---|---|---|
+| (a) | 市面上总共多少 benchmark | Stock (population census) | **No.** The observation window cannot contain the population. |
+| (b) | How many agentic benchmarks | Composition | **Only within the sampled flow**, and only after the recall defect is fixed. |
+| (c) | 多少类别的统计 | Composition | **Yes**, with the multi-label caveat. |
+
+The reviewer's closing remark, "理论上你是可以爬出这个信息的" (theoretically you can scrape this), is correct, with one correction developed in section 9: it is scrapable, but not by raising `lookback_hours` or `max_items_per_source`. Those scale the flow measurement and move the stock estimate essentially not at all, because established benchmarks do not re-emit timestamps.
+
+Issue #52 was closed automatically by PR #56 on 2026-07-30T19:39:23Z, referenced as "Fixes #52" again by PR #58, and **reopened by the repository owner on 2026-07-31T05:42:08Z**. The reopen is the operative verdict: the delivered fix did not satisfy the request.
+
+## 3. What the corpus counts actually are
+
+Verified in `site/data/radar.json` under `corpus.aggregates`, regenerated by `benchmark-radar rebuild` at 2026-07-31T14:31:49Z:
+
+| Category | Distinct artifacts | Share of 645 |
+|---|---:|---:|
+| benchmark | 512 | 79.4% |
+| dataset | 450 | 69.8% |
+| evaluation | 337 | 52.2% |
+| data_quality | 15 | 2.3% |
+| agentic | 3 | 0.5% |
+
+Two structural facts about these numbers:
+
+**They are multi-label.** 512 + 450 + 337 + 15 + 3 = 1,317, which exceeds 645 because one artifact carries several tags. Any presentation that sums them, or renders them as pie slices, is wrong.
+
+**`benchmark` at 79.4% is barely discriminative.** A tag applied to four of every five artifacts carries little information. This is the opposite defect from the agentic problem and needs the opposite fix. Section 4a develops it.
+
+### The corpus is 5 genuine days, not 9
+
+Nine snapshot files exist. Four are synthetic, added by commit `0c20261` via `simulate-history`, and carry `selection.simulated: true`. Their signature is unmistakable:
+
+| Date | Items | `generated_at` | Provenance |
+|---|---:|---|---|
+| 2026-07-23 | 20 | `T00:00:00+00:00` | Simulated |
+| 2026-07-24 | 32 | `T00:00:00+00:00` | Simulated |
+| 2026-07-25 | 32 | `T00:00:00+00:00` | Simulated |
+| 2026-07-26 | 30 | `T00:00:00+00:00` | Simulated |
+| 2026-07-27 | 30 | `T17:58:20.350823+00:00` | Genuine |
+| 2026-07-28 | 186 | `T14:33:06.179849+00:00` | Genuine |
+| 2026-07-29 | 201 | `T14:29:12.279273+00:00` | Genuine |
+| 2026-07-30 | 200 | `T14:28:50.917100+00:00` | Genuine |
+| 2026-07-31 | 60 | `T14:31:49.744338+00:00` | Genuine |
+
+Synthetic midnight timestamps versus real wall-clock times. The simulated days also cover only Hugging Face and GitHub, because `simulate-history` excluded arXiv and Brave by design. So **44% of snapshot dates are not observed data, and any 9-day trend line silently mixes two different source mixes.** Issue #35, which requested 30 snapshots, remains open with 9 on disk.
+
+### Five of eight connectors contribute nothing
+
+From `ingest_health` in the 2026-07-31 snapshot:
+
+| Source | Items | Status |
+|---|---:|---|
+| github | 300 | ok, at cap |
+| huggingface | 89 | ok |
+| arxiv | 69 | ok |
+| github_releases | 0 | ok but empty |
+| openreview | 0 | `HTTP 403 from api2.openreview.net/notes` |
+| semantic_scholar | 0 | `HTTP 429 after 3 attempts` |
+| openalex | 0 | `RuntimeError: OPENALEX_API_KEY is not configured` |
+| brave | 0 | `RuntimeError: BRAVE_API_KEY is not configured` |
+
+Only three connectors have ever contributed a record. The README's eight-source table describes configuration, not realized coverage.
+
+`github_releases` deserves separate attention: it is the only connector pointed at HELM, lm-evaluation-harness, SWE-bench, ARC-AGI, openai/evals, mlcommons/inference, evalplus, and LiveBench. It returns 0 on all nine days, because a release feed filtered to a 48-hour window almost always is empty. The `watchlist` is the other mechanism meant to pin famous artifacts, and `selection.watchlisted` is **0 on every single snapshot**. Both safety nets for the established population are empirically inert.
+
+### The funnel discards most of what it fetches
+
+| Date | Fetched | Published | Discarded |
+|---|---:|---:|---:|
+| 2026-07-28 | 718 | 186 | 74% |
+| 2026-07-29 | 721 | 201 | 72% |
+| 2026-07-30 | 696 | 200 | 71% |
+| 2026-07-31 | 458 | 60 | 87% |
+
+`minimum_score: 40` plus the require-a-category rule removes the rest. The scoring rubric weights adoption at 0.25 and recency at 0.20, so a stable canonical benchmark scores badly on recency even when fetched. GitHub sits at exactly its 300 cap on eight of nine days, meaning the true count of matching items is unknown and larger.
+
+### One benchmark can count as three artifacts
+
+The deduplication design is sound: `corpus.py` extracts exact identifiers (DOI, arXiv ID, `github:owner/repo`, `huggingface:kind:owner/name`) and runs union-find so transitively linked identifiers collapse. Replaying it confirms 791 sightings collapse to 645 distinct identities, matching `entity_types.artifact` exactly.
+
+But the cross-source join never fires. Of 645 artifacts, **0 have a populated `artifact_urls` field**, and 0 were ever observed from more than one source namespace. So a benchmark released as an arXiv paper, a GitHub repo, and a Hugging Face dataset counts as three separate artifacts. This is not a bug in the dedup logic, which is correct and idle. It is triple-counting through missing cross-references, and it inflates any total by an unmeasured factor.
+
+## 4. Why the agentic count is wrong: measured recall
+
+`agentic: 3` is not a measurement of the agentic share. It is an artifact of a keyword list that matches almost nothing.
+
+### Ground truth, built by hand
+
+A bare regex is not usable as ground truth. Hand-labeling 40 randomly sampled titles and abstracts from the 109 artifacts matching `\bagent(s|ic)?\b` found **9 false positives, so the bare regex is only 77.5% precise**. Rejected cases include `AgentMap` (an ontology-matching algorithm, pure proper-noun collision), `Sentimental Image Captioning via Multi-Agent Reasoning` (an internal LLM ensemble, not an acting agent), and `FilmBench` (where "evaluation agent" names an internal judge module).
+
+The inclusion rule used, stated before labeling: include if the artifact's own subject is an LLM-driven agent system that autonomously takes multi-step actions against an environment or tools, or is a benchmark whose evaluation target is such an agent. Exclude proper-noun collisions, related-work framing, internal LLM ensembles for single-shot tasks, and classic RL with no tool-using agent.
+
+Applying that rule yields **89 genuinely agentic artifacts**, validated at 100% agreement against the 40 independent hand labels.
+
+### The result
+
+| Measure | Value |
+|---|---:|
+| Matched by current 12-term list | 16 |
+| Hand-labeled ground truth | 89 |
+| **Recall** | **18.0%** |
+| Precision | 100.0% |
+
+The list is perfectly precise and nearly useless. It functions as a near-empty filter, missing 73 of 89 genuine agentic artifacts.
+
+An earlier informal estimate in discussion put recall at about 15% using the raw 109-item regex as the denominator. That figure was too pessimistic: the correct denominator is 89, not 109, so the true recall is 18.0%. The correction is recorded here rather than quietly dropped.
+
+### Half the vocabulary matches nothing
+
+Replicating `score_item()` exactly (plain lowercase substring over `title + " " + summary`):
+
+| Term | Artifacts matched |
+|---|---:|
+| `agent benchmark` | 8 |
+| `agentic benchmark` | 2 |
+| `agent evaluation` | 2 |
+| `agentic evaluation` | 2 |
+| `agentic task` | 2 |
+| `agentic capabilities` | 1 |
+| `multi-agent benchmark` | **0** |
+| `tool-use benchmark` | **0** |
+| `tool use benchmark` | **0** |
+| `benchmark for agent` | **0** |
+| `benchmark for llm agent` | **0** |
+| `benchmark for autonomous agent` | **0** |
+
+**Six of twelve terms match zero artifacts.** The four longest, most specific phrases are all dead. The entire list produces 16 artifacts, and the top four terms carry all but three of them.
+
+### Root cause: three compounding defects
+
+Classification is a plain substring test at `src/benchmark_radar/pipeline.py:132`:
+
+```python
+matches = [term for term in terms if term.lower() in haystack]
+```
+
+No tokenization, no stemming, no word boundaries. Therefore:
+
+**(a) Adjacency.** A two-word term demands the words be literally adjacent. Real titles interpose qualifiers: "A Benchmark **Framework** for Evaluating Patient-Facing Health AI Agents", "A Production-Fidelity Benchmark for **LLM-Based Database Operations** Agents". The corpus contains 16 artifacts with the literal string `benchmark for`, and **zero** with `benchmark for agent`. The phrase can only fire on a construction nobody writes.
+
+**(b) Head-noun ordering.** The list encodes eval-noun before agent-noun (`agent benchmark`), but the dominant real pattern puts the agent noun last, or fuses the eval noun into a `-Bench` suffix (`DBA-Bench`, `OrchBench`, `PatientAgentBench`) where no space-separated bigram exists at all.
+
+**(c) Singular only.** Every term uses `agent`. Titles overwhelmingly use the plural, because a benchmark evaluates *agents*. The term `llm agents` alone matches 11 ground-truth items at 100% precision, and the current list cannot see any of them.
+
+### Evidence: real artifacts being missed
+
+1. `DBA-Bench: A Production-Fidelity Benchmark for LLM-Based Database Operations Agents`
+2. `IFCMemoryBench: Evaluating Long-Term Memory of LLM-Based Agents in BIM Information Retrieval`
+3. `StealthBench: Measuring Operational Stealth in Autonomous Offensive-Security Agents`
+4. `OrchBench: Evaluating Multi-Agent Orchestration Plans in Isolation via Deterministic Simulation`
+5. `PatientAgentBench: A Benchmark Framework for Evaluating Patient-Facing Health AI Agents`
+6. `MemSecBench: Tracking Agent Memory Poisoning from Persistence to Consequence and Repair`
+7. `Keep It InMind: Benchmarking the Implicit-Association Blind Spot in Agent Memory`
+8. `ConsistencyGate: Preventing Memory Contamination in LLM Agents via Self-Consistency Admission Control`
+9. `The Regression Tax: Decomposing Why Skills Help and Hurt LLM Agents`
+10. `Zero-Shot Mission-Level Evaluation for Aerial MLLM Agents`
+11. `From Controlled to the Wild: Evaluation of Pentesting Agents for the Real-World`
+12. `GAUGE: Grading Agent-Built Financial Models Without a Golden Answer`
+13. `AgentOmnia: Scaling Agentic Models for Full-Scenario Applications`
+14. `OmegaUse-OfficeVal: Benchmarking LLM Agents on Long-Horizon Office-Suite Tasks with Economic Grounding`
+15. `nebius/SWE-rebench-leaderboard`
+
+### The larger cause of the published 3: config timing, not keywords
+
+An adversarial verification pass established that the headline figure has a different primary cause than the keyword list, and this correction is the single most important one in the report.
+
+| Measurement | Value |
+|---|---:|
+| `agentic` stored in snapshot files | **3** |
+| Same corpus re-scored with today's config | **16** |
+
+The `agentic` category was added by commit `0c8d77a` on 2026-07-30. Snapshots 07-23 through 07-29 were scored by a pipeline that had no such category, and snapshots are append-only and never rewritten retroactively. All three stored artifacts are dated 2026-07-31.
+
+So the published 3 divides a one-day numerator by a nine-day denominator. **Quoting 3 as evidence of a keyword defect misattributes the cause.** The keyword defect is real, but it takes the count from 16 to a possible 64, not from 3. The correct sequence is to re-score the existing snapshots first (a free operation on data already on disk, moving 3 to 16), then fix the vocabulary.
+
+### Root cause corrected: vocabulary gap, not adjacency
+
+My initial diagnosis blamed the adjacency requirement. An adversarial pass tested that as a counterfactual and **refuted it as the dominant cause.** Relaxing adjacency alone, permitting up to four intervening words in the same sequence, moves the match count only from 16 to 19. That explains about 3 of the misses, roughly 6%.
+
+Ranked causes, measured:
+
+| Cause | Misses explained | Share |
+|---|---:|---:|
+| Vocabulary gap: no configured n-gram covers the real phrasing | ~40 | ~77% |
+| Terse GitHub and HF descriptions (median 98 chars) | ~9 | ~17% |
+| Adjacency proper | ~3 | ~6% |
+
+The decisive evidence: `agent*` co-occurring with `benchmark|eval*|leaderboard|harness|testbed` anywhere in the text reaches **106 artifacts**. The words are all present. They are simply never any of the 12 configured n-grams in any order. Titles like `StealthBench: Measuring Operational Stealth in Autonomous Offensive-Security Agents` and `WorkSurface-Bench: Benchmarking Enterprise Agents` are not adjacency near-misses; there is no term for them to be adjacent to.
+
+**This changes the recommended fix.** A longer phrase list is the wrong instrument. What the evidence supports is a **two-slot co-occurrence rule** (an agent token AND an evaluation token within the same text), which is a change to `score_item()` in `pipeline.py`, not only to `config.yml`.
+
+Three alternative explanations were tested and disproved outright:
+
+- **"Items were never retrieved."** False for classification purposes: all 64 ground-truth artifacts are already in the corpus.
+- **"`minimum_score: 40` filtered them out."** False: every one is published. The 216 artifacts below 40 are all from 07-27 and 07-28 with `score_version: null`, a pre-v2 rubric on a different scale. Zero score-v2 artifacts fall below 40.
+- **"Summaries are empty or templated."** False: only 30 of 645 (4.7%) have empty summaries, and median summary length is 1,536 characters on arXiv. There is ample text to match.
+
+### Recall figures, reconciled
+
+Two independent hand-labeling passes produced different ground truths, and the disagreement is reported rather than averaged:
+
+| Pass | Ground truth | Current matches | Recall | Precision |
+|---|---:|---:|---:|---:|
+| First (rule-extended from 40 hand labels) | 89 | 16 | 18.0% | 100% |
+| Adversarial (all 109 read individually) | 64 | 12 true of 16 | 18.8% | 75% |
+
+The two agree closely on recall, roughly 18 to 19%, which is the load-bearing finding. They disagree on the denominator (89 vs 64) and on precision. The adversarial pass read all 109 candidates individually and judged 45 to be mere mentions rather than agent-eval artifacts, including `Mental World Modeling`, `AgentMap` (ontology matching, agent only in the product name), and `AgentOmnia` (an agent system, not an evaluation). It also found the current terms produce **4 false positives**, so precision is 75%, not 100%.
+
+**Consequence for the fix:** because precision is already imperfect, loosening the terms naively will make it worse. Any replacement must be measured on both axes, which is what section 8 does.
+
+My earlier informal estimate of "~15% recall, ~93 missed" was wrong on both figures. The corrected statement is **recall about 19%, roughly 52 missed of 64, precision 75%.** The direction survives; the magnitude was overstated by about 44%.
+
+## 4a. The other four categories: one more broken, three working
+
+The same audit was applied to the original four categories. The result splits cleanly, and it corrects an assumption worth stating: not every category is broken, and the two failure modes need opposite fixes.
+
+### data_quality: two independent audits disagree, and the disagreement is unresolved
+
+This is the one finding in the report that did not converge. Two hand-labeling passes reached opposite conclusions, and the difference is entirely in the inclusion rule, not in the matching code.
+
+| Pass | Inclusion rule | Ground truth | Recall of current list |
+|---|---|---:|---:|
+| Category audit | Data quality is a *described property* of the work | 83 | 16.9% |
+| Adversarial pass | Data quality is the *substantive contribution* | 8 to 15 | approximately correct |
+
+Under the looser rule, an artifact counts if its text asserts something about data quality (for example, a benchmark reporting "human-verified" instances). Under the stricter rule, it counts only if studying data quality is the point of the work. The looser rule yields 83 and makes 15 a severe undercount. The stricter rule yields 8 to 15 and makes 15 approximately right.
+
+The adversarial pass also showed that a broad data-quality lexicon fires on 205 of 645 artifacts, which is clearly too permissive: it matches any paper saying "we curated" or "human-verified." That supports caution about the 83 figure. The category audit independently flagged 10 to 12 of its own 83 as borderline and noted that a stricter rule would shrink it to 60 to 65.
+
+**Verdict: unresolved, and it should not be presented as a confirmed defect.** What both passes agree on is narrower and still actionable:
+
+- The structural defects below are real regardless of the denominator (dead terms, adjacency losses, free stem supersets, missing subtopic vocabulary).
+- If 15 is too low, the retrieval layer is implicated as much as the taxonomy: only 1 of 4 arXiv queries and 1 of 6 GitHub queries target contamination or leakage at all.
+- Resolving it requires a labeled sample with a rule fixed in advance, which is a small, well-defined follow-up rather than a keyword change.
+
+The structural findings that follow hold under either rule.
+
+Three compounding causes, ranked by how many misses each explains:
+
+**(c) Whole subtopics have no term at all** (about 45 of 69 misses, the largest cause). Six terms cannot cover seven uncovered subtopics demonstrably present in the corpus: poisoning, label noise, filtering and curation, PII and anonymization, copyright and consent, memorization, and inter-rater agreement.
+
+**(a) Adjacency**, the same defect as agentic. Measured gap between each phrase and its components co-occurring anywhere in the same text:
+
+| Phrase | Matches | Components co-occur | Adjacency loss |
+|---|---:|---:|---:|
+| `data quality` | 6 | 81 | **75** |
+| `annotation quality` | 3 | 15 | 12 |
+| `data provenance` | 1 | 11 | 10 |
+| `data contamination` | 2 | 11 | 9 |
+| `benchmark leakage` | 0 | 7 | 7 |
+
+Real phrasings in the corpus the list cannot see: `quality of the data`, `training-data contamination`, `leakage-free`, `annotation provenance`. An interposed hyphen alone defeats it: `training-data contamination` does not contain `data contamination`.
+
+**(b) Full words where a stem is a free strict superset.** Because matching is substring, a shorter term is provably more permissive. Verified `set(long) ⊆ set(short)` for every pair:
+
+| Stem | Count | Current term | Count | Free gain |
+|---|---:|---|---:|---:|
+| `dedup` | 5 | `deduplication` | 3 | +2 |
+| `contaminat` | 11 | `data contamination` | 2 | +9 |
+| `provenan` | 11 | `data provenance` | 1 | +10 |
+| `leak` | 8 | `benchmark leakage` | 0 | +8 |
+
+Missed artifacts include `LiveBench/LiveBench`, whose summary literally reads "a challenging, contamination-free llm benchmark", plus `DataOrchestra: Learning to Orchestrate Per-Example Curation of Pretraining Data`, `What do Reward Models Memorize?`, `piimb/pii-masking-benchmark`, and `KletterMix: Climbing Toward High-Quality German Pretraining Data`.
+
+A measured 79-term replacement reaches **96.4% recall at about 88% precision** (verified by reading all 100 matches, not a sample), raising data_quality from 15 to 100 artifacts.
+
+### benchmark, dataset, evaluation are working: do not narrow them
+
+| Category | Recall | Verdict |
+|---|---:|---|
+| benchmark | 97.7% | Working |
+| dataset | 95.9% | Working, add `corpora` |
+| evaluation | 72.4% | Working, use stem `evaluat` |
+
+Two alternatives were built and measured, and **both are worse**. A phrase-only list drops `benchmark` from 512 to 332, discarding 186 genuine artifacts while gaining 6. A title-scoped variant leaves **135 artifacts (20.9%) with no tag at all**. Trading a fifth of the corpus into an unlabeled bucket to fix a display problem is a bad trade.
+
+The high prevalence is not a bug: every source query in `config.yml` already filters for benchmark, dataset, and evaluation artifacts at ingest, so the corpus genuinely *is* mostly benchmarks. Narrowing the taxonomy cannot fix a property created upstream.
+
+### The real defect in those three is redundancy, not recall
+
+Verified independently across all 645 artifacts:
+
+| Tags per artifact | Count | Share |
+|---|---:|---:|
+| 0 | 0 | 0% |
+| 1 | 96 | 14.9% |
+| 2 | 424 | 65.7% |
+| 3 | 119 | 18.4% |
+| 4 | 6 | 0.9% |
+
+**Every artifact carries at least one tag**, and P(dataset | benchmark) = **0.658** with Jaccard(benchmark, dataset) = **0.543**. Two thirds of benchmark items are also dataset items, so the pair conveys barely more than one tag. Knowing an artifact is tagged `benchmark` rules out only 20% of the corpus.
+
+This belongs to presentation, not `config.yml`: rank by which category is *distinctive* for an item, or surface the specific matched term instead of the category name.
+
+### Six dead terms across the full taxonomy
+
+Independently verified as matching zero artifacts: `challenge set` (benchmark), `capability eval` (evaluation), `benchmark leakage` (data_quality), plus `multi-agent benchmark`, `tool-use benchmark`, `tool use benchmark`, `benchmark for agent`, `benchmark for llm agent`, `benchmark for autonomous agent` (agentic). Dead terms create an illusion of coverage and should be deleted or replaced.
+
+## 5. Why the count cannot answer "how many exist"
+
+The recency bias is not a limitation to note in passing. It is the reason the question is unanswerable as posed.
+
+A 48-hour lookback repeated over five genuine days can only observe artifacts whose upstream timestamp falls inside those windows. Benchmarks released in 2023 through 2025 are structurally invisible. Searching all 791 sightings across title, `source_id`, and `url` for 20 canonical benchmark names returns 19 absences and one incidental third-party hit.
+
+This makes the direction of the error predictable: the corpus systematically **misses** the established, high-quality population while **including** freshly-timestamped noise. Manual inspection of the 512 `benchmark` artifacts surfaces GPU hardware benchmarks, an SEO health report, a student homework result dump, and vLLM performance runs. No labeled sample was drawn, so the precision rate of the `benchmark` tag is unknown, which is itself a reportable gap.
+
+The consequence for #52: 512 is a flow measure with a partly-spurious numerator. It is not "512 of the market's benchmarks."
+
+### The strongest counter-argument, and why it only partly works
+
+A critic could reasonably object that a flow measure *does* bound a stock, and the objection deserves a direct answer rather than dismissal. If the pipeline observes roughly 85 new benchmark artifacts per day, then over a year that implies on the order of 31,000 arrivals, which is a real statement about the population's growth rate and is not nothing.
+
+Two things are right about that objection. Flow integrated over time genuinely does estimate the *newly created* population, and this is the one route by which the current architecture could contribute to a census. It would also produce a figure of the right order of magnitude (10^4), consistent with the independently verified Hugging Face anchor of 4,542 to 5,092.
+
+Three things defeat it as an answer to #52 as asked:
+
+- **The integration cannot run backward.** Five genuine collection days cannot be extrapolated to the pre-2026 population, which is precisely where the benchmarks a reviewer would name reside. The corpus has no observation of the era it would need to integrate over.
+- **The numerator's precision is unmeasured.** Extrapolating 85/day multiplies whatever share of those artifacts are GPU benchmarks, SEO reports, and homework dumps. Section 12 records that this share is not available, so the extrapolation inherits an unbounded error.
+- **The cross-source join never fires**, so one benchmark released as paper plus repo plus dataset triple-counts. Integrating a triple-counted rate compounds the inflation.
+
+So the honest position is narrower than "the corpus cannot answer": the corpus can, with a precision measurement and cross-source joining, produce a defensible estimate of the *annual creation rate*. It cannot produce the installed stock, and the creation rate is not what 市面上总共 asks for.
+
+## 6. Retrieval versus classification: which layer binds
+
+This distinction determines whether fixing keywords is even the primary lever, so it was tested against the live arXiv feed rather than assumed.
+
+Testing the configured `rss_keywords` against the live arXiv cs.AI RSS feed on 2026-07-31:
+
+| Measure | Value |
+|---|---:|
+| Items in feed | 282 |
+| Items passing the keyword filter | 29 (10.3%) |
+| Items mentioning agent(s|ic) | 97 |
+| Agent-mentioning items that pass | 13 |
+| **Retrieval recall on agent-mentioning papers** | **13.4%** |
+
+The retrieval keywords carry the identical adjacency defect. Of the six agent-bearing `rss_keywords`, `multi-agent benchmark` and `benchmark for agent` match zero ground-truth items.
+
+Breaking down the 63 arXiv ground-truth artifacts by what admitted them:
+
+- **20 (31.7%) trip only a generic benchmark phrase** such as `benchmark for` or `leaderboard`. They are in the corpus by luck, not by agent-aware retrieval.
+- **8** trip an agent-specific phrase.
+- **35** trip no `rss_keywords` phrase at all, arriving via other sources.
+
+**Verdict, after adversarial challenge: both layers are defective, and they are independent problems. Classification is not secondary.**
+
+My initial conclusion was that retrieval binds first and therefore taxonomy work could not answer #52. That inference was tested and **does not hold**, for two measured reasons:
+
+1. **48 recoverable artifacts already sit in the corpus, unlabeled.** All 64 ground-truth agentic artifacts are on disk today. Classification alone takes the count from 16 to a possible 64, a four-fold gain requiring no new fetching. That is a classification deficit, not a retrieval deficit.
+2. **The working connectors are already discarding retrieved rows.** `github` hits the `max_items_per_source: 300` cap on 8 of 9 days, and `arxiv` on 3 of the 4 days it worked. The pipeline is throwing away fetched records at the cap while the failed connectors take the blame.
+
+So the honest ordering is: re-score the snapshots (free, 3 to 16), then fix classification (4x, on data already held), then fix retrieval (raises the ceiling itself). The retrieval defect is real and the 13.4% live-feed recall figure stands, but it is a parallel problem, not a reason to defer the cheaper fix with the measured payoff.
+
+One more silent failure belongs on the record: **`github_releases` returns 0 items with `ok: true` on every single snapshot.** It reports success while contributing nothing, so it does not appear on any outage list. It is also the only connector pointed at HELM, lm-evaluation-harness, SWE-bench, and ARC-AGI, which is part of why 19 of 20 canonical benchmarks are absent.
+
+Compounding this: PR #58 added agentic retrieval keywords to six sources. OpenAlex and Brave cannot execute them at all (missing API keys), and Semantic Scholar is rate-limited out. **Half of that fix is inert by construction.**
+
+## 7. What issue #57 did and did not fix
+
+Issue #57 ("Retrieval keywords never fetched agentic benchmarks, so the new taxonomy tag alone can't count them") diagnosed the retrieval layer correctly. Its body specified the right verification:
+
+> Re-run `benchmark-radar backfill` after a few days of collection with the new keywords live, and check whether the agentic share of the corpus holds up under both a bare-title heuristic and the new taxonomy classification.
+
+That check was never performed. The timeline explains why:
+
+| Event | Timestamp |
+|---|---|
+| Issue #57 created | 2026-07-30T20:00:09Z |
+| PR #58 opened | 2026-07-30T20:04:52Z |
+| PR #58 merged | 2026-07-30T20:07:37Z |
+| Issue #57 closed | 2026-07-30T20:07:38Z |
+
+**One second between merge and closure.** The issue was auto-closed by the "Fixes #57" keyword in the PR body. It was open for 7 minutes 29 seconds total, with zero comments. Searching all commits, PR comments, and issue comments for any recall or share measurement returns nothing.
+
+This report performs the missing check, and it fails. The two heuristics #57 asked to compare disagree by a factor of five to twenty depending on the denominator used, with **zero overlap** between the sets.
+
+PR #58 also carried its own unchecked verification box:
+
+> - [ ] After the next scheduled run, spot-check that the Corpus totals panel shows a nonzero `agentic` count
+
+That box is technically satisfiable at 3, which is why a nonzero check is the wrong test. Three of 645 is nonzero and still wrong by a factor of five.
+
+### The asymmetry that produced this
+
+The narrow keyword design traces to issue #51 ("arXiv有111个release today"), where bare nouns like `benchmark` and `dataset` matched roughly two of every three cs.AI papers. The fix (commit `5bc6332`, PR #55) replaced bare nouns with introduction phrases and **was empirically validated against the live feed**, cutting matches from about 65% of the daily pool to 9 to 12%.
+
+That precision lesson is correct. But when the same precedent was applied to `agentic` in PR #58, **only the precision side was reasoned about, and the recall side was never measured at all.** That asymmetry is the root cause of your observation that agentic "is just the same as before, not different at all."
+
+The deeper error: issue #51's lesson is that terms must be *distinctive*, but the implementation chose terms that were *long*. In a substring matcher, length buys brittleness, not precision.
+
+## 8. Recommended keyword lists, with measured precision
+
+Two changes are recommended, in order of cost and payoff.
+
+### Step 0, free: re-score the existing snapshots
+
+Before any keyword edit, re-score the corpus so the `agentic` numerator covers the same nine days as its denominator. This moves the published count from 3 to 16 using data already on disk. It requires no config change and no fetching. Any keyword work evaluated before this step is measured against a contaminated baseline.
+
+### Step 1: replace the matching rule, not just the word list
+
+The evidence in section 4 shows a longer phrase list is the wrong instrument, because the failure is a vocabulary gap rather than adjacency. The measured alternative is a **two-slot co-occurrence rule**: an agent token AND an evaluation token present anywhere in the same text. That reaches 106 artifacts against a ground truth of 64, so it needs a precision filter, but it is the shape the data supports. This is a change to `score_item()` in `pipeline.py`, not only to `config.yml`.
+
+A pure word-list replacement was also measured, and it is a reasonable interim step. The 33-term list below was measured on the real 645-artifact corpus against the first pass's 89-item ground truth. Note that its recall figure uses the looser denominator; against the adversarial pass's 64-item ground truth the same list would score differently, and neither pass measured the co-occurrence rule end to end. That gap is stated rather than papered over.
+
+| List | Matched | Recall vs GT=89 | Precision vs GT=89 | Precision ceiling vs GT=64 |
+|---|---:|---:|---:|---:|
+| Current (12 terms) | 16 | 18.0% | 100.0% | 75% (measured: 12 true of 16) |
+| Proposed (33 terms) | 85 | 89.9% | 94.1% | **75%** |
+| Co-occurrence rule | 106 | not measured | not measured | **60%** |
+| Bare `agent` (rejected) | 110 | 97.8% | 79.1% | 58% |
+
+**The precision figures are denominator-dependent, and this is the report's most important methodological caveat.** The 94.1% precision quoted for the 33-term list is measured against the looser 89-item ground truth. Against the stricter 64-item ground truth, the same list matches 85 artifacts of which at most 64 can be true positives, so its precision ceiling is **75%**. The co-occurrence rule I recommend above fares worse on this axis: 106 matches against at most 64 true positives is a **60% precision ceiling**, meaning roughly 42 false positives.
+
+That is a real cost, and it changes the recommendation's strength. The co-occurrence rule has the best recall headroom and the worst precision ceiling. It is the right shape for the *retrieval* layer, where over-inclusion is cheap and a human filters later, but it needs a precision filter before it drives a published category count. Neither candidate should be merged on these numbers alone: the denominator dispute has to be settled by expert labeling first (see Limitations).
+
+```
+agentic, llm agent, llm agents, llm-agent, language model agent, ai agent,
+coding agent, gui agent, embodied agent, autonomous agent,
+agent benchmark, agent evaluation, agent memory, agent security, agent harness,
+agent traces, agent trajector, agent-built, game agents,
+agents must, agents on, agents for, agents with, based agents, -based agent,
+multi-agent system, multi-agent llm, multi-agent cooperation,
+tool-use, tool use, function calling, model context protocol, swe-bench
+```
+
+**Flooding check, addressing the issue #51 concern directly:** the proposal flags 13.2% of the corpus, against 17.1% for bare `agent`, while the true agentic base rate is 13.8% (89/645). It tracks the real rate rather than inflating it. This is the check that was never run for the current list.
+
+**Terms tested and rejected**, recorded so the reasoning is auditable:
+
+| Rejected | Measured | Reason |
+|---|---|---|
+| `agent` (bare) | 110 matched, 79.1% precision | The issue #51 failure mode. 23 false positives. Rejected despite 97.8% recall. |
+| `multi-agent` (bare) | 17 matched, 58.8% precision | Worst term tested. Catches MARL re-rankers and image-captioning ensembles. Replaced with scoped variants, lifting overall precision from 89.3% to 96.0%. |
+| `agents in` | 9 matched, 88.9% precision | Marginal. Appears in background prose. |
+| `code agent`, `web agent`, `os agent`, `computer-use`, `agent scaffold`, `tool calling`, `swe-agent`, `multi-agent benchmark` | 0 matched each | Pruned. Retaining zero-match terms is precisely the current list's disease: they create an illusion of coverage. |
+
+The residual 9 misses are genuinely hard for any substring rule: repos with three-word descriptions, and papers where agency is implicit (`Mental World Modeling`). Exceeding roughly 90% requires semantic classification, not keywords.
+
+### data_quality: 79 terms, 16.9% to 96.4% recall
+
+The measured replacement raises data_quality from 15 to 100 artifacts at about 88% precision, organized in seven subtopic groups (contamination and leakage, memorization and duplication, provenance and licensing and PII, annotation and label quality, quality and curation, sanitization, poisoning). Key moves: use stems (`contaminat`, `provenan`, `dedup`) that are provably free supersets, and add terms for the seven subtopics that currently have no vocabulary at all.
+
+27 of the 79 terms match zero artifacts today (`data leakage`, `inter-annotator`, `noisy label`, `data poisoning`). Unlike `challenge set`, these are standard field vocabulary that will appear as the corpus grows and cost nothing to carry. They should be understood as forward-looking, not as contributors to the measured 96.4%.
+
+Rejected for data_quality, each measured then rejected on reading its hits: `quality`, `data`, `annotation` (bare, 200+ hits, the #51 failure mode), `annotat` (62, every dataset card says "annotated"), `curat` (65, generic marketing), `leakage` bare (3 of 7 are spectral or motion leakage in signal processing), `duplicate` bare (3 of 8 are duplicate queries, not records), `noisy` and `noise` (noisy features, quantum hardware, denoising), `agreement` and `kappa` (model-model agreement, credit-card agreements, kappa as an accuracy metric), `audit` and `validat` (model audits, not data).
+
+### The two safe edits to the working categories
+
+- **`dataset`**: add `corpora`. Substring matching gets `corpus` but cannot bridge the irregular Latin plural. Precision 8/8 on reading every hit.
+- **`evaluation`**: replace with the stem `evaluat`, a strict superset picking up `evaluating`, `evaluate`, and `evaluated`.
+- **Delete the six dead terms** listed in section 4a.
+
+Adopting the recommended set yields benchmark 512, dataset 446, evaluation 336, data_quality 100. The 3-or-more-tag share rises from 18.4% to about 27%, which is the correct and acceptable cost of data_quality finally working: data-quality artifacts genuinely are usually also benchmarks or datasets.
+
+**This report does not apply these changes.** They are measured proposals. Applying them requires re-scoring all nine snapshots so the numerator and denominator cover the same period.
+
+## 9. What a defensible market estimate requires
+
+The move is from crawling a feed to enumerating registries. A feed emits new arrivals; a registry holds a population and will report its size.
+
+### Grounded anchors, verified 2026-07-31
+
+```
+GET https://api.github.com/repos/EleutherAI/lm-evaluation-harness/contents/lm_eval/tasks
+  -> 220 entries, 214 directories
+
+GET https://huggingface.co/api/datasets?search=benchmark&limit=1000  (walk Link rel="next")
+  -> 5 pages, 4542 datasets
+GET https://huggingface.co/api/datasets?filter=benchmark&limit=1000
+  -> 6 pages, 5092 datasets
+```
+
+Hugging Face exposes `X-Total-Count` in `access-control-expose-headers` but does not return it, so totals require cursor-walking.
+
+On Hugging Face alone, datasets only, roughly **4,542 to 5,092 benchmark-named or benchmark-tagged datasets exist**, against 207 Hugging Face artifacts in the corpus. **The corpus has seen about 4% of one enumerable slice.**
+
+### Registry plan
+
+| Registry | Method | Bounds | Cannot establish |
+|---|---|---|---|
+| HF datasets | `api/datasets?search=|filter=`, walk cursor | Upper bound on benchmark-named repos (4,542 / 5,092 verified) | Distinct benchmarks; splits and result dumps inflate |
+| HF spaces, models | Same API, extend `kinds` beyond datasets | Leaderboard Spaces, a major venue currently invisible | Same inflation |
+| lm-evaluation-harness | `contents/lm_eval/tasks` (214 dirs verified) | High-precision lower bound on community-run benchmarks | Scope of one harness |
+| HELM | `contents/src/helm/benchmark/scenarios` | Independent curated lower bound | Same |
+| PapersWithCode | Bulk export | Closest thing to a paper-linked census | Export availability not verified |
+| OpenML, Kaggle | Public APIs | Classical-ML population | Few LLM-era benchmarks; counts not verified |
+| arXiv | Full-archive search, not a 48h slice | Historical count of benchmark-introducing papers | Papers, not artifacts |
+
+### Plausible order of magnitude
+
+Two figures with definitions attached are more useful than one without:
+
+- **Curated, community-adopted benchmarks: 10^3.** Anchored on 214 lm-eval task directories and 208 HELM scenarios (both verified, overlap uncounted), scoped to text LLM evaluation. Adding vision, speech, agentic, robotics, and code harnesses plausibly reaches low thousands.
+- **Benchmark-labeled artifacts in the open: 10^4 or more.** Anchored on 4,542 to 5,092 Hugging Face datasets (verified) plus GitHub, where the corpus's saturated 300-caps show a large unmeasured pool.
+
+The answer to 市面上总共 is a range with a stated definition, because the number depends entirely on whether "benchmark" means something a lab would cite (10^3) or any repo calling itself a benchmark (10^4+). A single figure without that definition misleads, and 512 is neither.
+
+Critically, a census figure must be reported in its own namespace and **never mixed into the daily trend series**, or a change in collection policy will read as a change in the field.
+
+## 10. Final diagnosis
+
+The project has crossed one threshold and not the next.
+
+It has crossed from no measurement to a working flow instrument. Three live connectors, deterministic replay, exact-identifier deduplication, an append-only snapshot corpus, and an explainable rubric. The daily-arrival figures are real and are something registry enumeration cannot provide. That is a genuine contribution and it should be stated as the system's answer to what it can answer.
+
+It has not crossed from flow measurement to population estimate, and the gap was papered over rather than stated. Issue #52 asked a stock question. The pipeline answered with a flow number, in a collapsed dashboard panel, and the issue was auto-closed twice by PR keywords before a human confirmed anything. The agentic count that was supposed to answer the second half of the question was published at 3, when re-scoring the same corpus yields 16 and the achievable figure is around 64. Six terms across the taxonomy match nothing at all. Five of eight connectors contribute nothing, and a sixth reports success while returning zero. Both mechanisms intended to pin famous benchmarks, the watchlist and the release feed, have fired zero times in nine days.
+
+The pattern underneath all of it is a single missing habit. Every keyword change in this repository was validated in one direction only. Issue #51's precision fix was measured against the live feed and reported honestly (65% of the daily pool down to 9 to 12%). Not one recall measurement exists anywhere in the project's history: searching all commits, PR comments, and issue comments for a recall figure returns nothing. Precision failures are loud, because they flood the digest and someone complains. Recall failures are silent, because a number that is too small still renders. That asymmetry in *feedback*, not in effort or care, is what produced a category reading 3 when the answer was 89.
+
+None of this means the counting question is unanswerable. It means the answer requires a second collection mode that enumerates registries rather than crawling a window, reported separately from the flow, with the definition of "benchmark" stated alongside the number. The infrastructure needed already exists in the repository.
+
+The reviewer's instinct in #52 was right on both counts: the information is scrapable, and the current numbers do not yet reflect it.
+
+## 11. Reproducing every number in this report
+
+```bash
+cd /root/benchmark-radar
+git pull origin main                      # site/data/radar.json is gitignored
+.venv/bin/benchmark-radar rebuild --config config.yml
+```
+
+Category counts and provenance:
+
+```bash
+python3 -c "
+import json; d=json.load(open('site/data/radar.json'))
+print(d['generated_at'], d['snapshot_count'])
+for t in d['corpus']['aggregates']['topics']: print(t['topic'], t['entity_count'])"
+
+python3 -c "
+import json,glob
+for f in sorted(glob.glob('data/snapshots/*.json')):
+    d=json.load(open(f)); s=d.get('selection') or {}
+    print(f[-15:], len(d['evidence_items']), d['generated_at'], 'watchlisted=', s.get('watchlisted'))"
+```
+
+Per-term dead-weight table and recall:
+
+```bash
+python3 -c "
+import json,glob,yaml
+seen={}; c=[]
+for f in sorted(glob.glob('data/snapshots/*.json')):
+    for it in json.load(open(f)).get('evidence_items',[]):
+        k=it.get('url') or it.get('title')
+        if k not in seen: seen[k]=1; c.append(it)
+h=lambda i: (str(i.get('title',''))+' '+str(i.get('summary',''))).lower()
+for t in yaml.safe_load(open('config.yml'))['taxonomy']['agentic']:
+    print(sum(1 for i in c if t.lower() in h(i)), t)"
+```
+
+The stored-versus-rescored gap, the report's most important single correction:
+
+```bash
+python3 -c "
+import json,glob,yaml
+seen={}; C=[]
+for f in sorted(glob.glob('data/snapshots/*.json')):
+    for it in json.load(open(f)).get('evidence_items',[]):
+        k=it.get('url') or it.get('title')
+        if k not in seen: seen[k]=1; C.append(it)
+h=lambda i: (str(i.get('title',''))+' '+str(i.get('summary',''))).lower()
+ag=yaml.safe_load(open('config.yml'))['taxonomy']['agentic']
+stored=set()
+for f in glob.glob('data/snapshots/*.json'):
+    for it in json.load(open(f)).get('evidence_items',[]):
+        if 'agentic' in (it.get('categories') or []): stored.add(it.get('url') or it.get('title'))
+print('stored:', len(stored), 'rescored:', sum(1 for i in C if any(t.lower() in h(i) for t in ag)))"
+# -> stored: 3 rescored: 16
+```
+
+Multi-tag redundancy:
+
+```bash
+python3 -c "
+import json,glob,yaml,collections
+seen={}; C=[]
+for f in sorted(glob.glob('data/snapshots/*.json')):
+    for it in json.load(open(f)).get('evidence_items',[]):
+        k=it.get('url') or it.get('title')
+        if k not in seen: seen[k]=1; C.append(it)
+tax=yaml.safe_load(open('config.yml'))['taxonomy']
+h=lambda i: (str(i.get('title',''))+' '+str(i.get('summary',''))).lower()
+cnt=collections.Counter(); B=set(); D=set()
+for n,it in enumerate(C):
+    tags=[c for c,ts in tax.items() if any(t.lower() in h(it) for t in ts)]
+    cnt[len(tags)]+=1
+    if 'benchmark' in tags: B.add(n)
+    if 'dataset' in tags: D.add(n)
+print(dict(sorted(cnt.items())), 'P(dataset|benchmark)=', round(len(B&D)/len(B),3))"
+```
+
+Canonical-benchmark absence:
+
+```bash
+python3 -c "
+import json,glob
+blob=[(str(i.get('title',''))+' '+str(i.get('source_id',''))+' '+str(i.get('url',''))).lower()
+      for f in glob.glob('data/snapshots/*.json')
+      for i in json.load(open(f)).get('evidence_items',[])]
+for n in ['MMLU','HELM','GPQA','ARC-AGI','HumanEval','BIG-bench','SWE-bench','GSM8K']:
+    print(n, sum(1 for b in blob if n.lower() in b))"
+```
+
+Registry anchors:
+
+```bash
+curl -s "https://api.github.com/repos/EleutherAI/lm-evaluation-harness/contents/lm_eval/tasks" \
+  | python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d), sum(1 for x in d if x['type']=='dir'))"
+```
+
+Note on reproducibility: `site/data/radar.json` is gitignored (`.gitignore:11`), so published dashboard figures cannot be traced to a commit, only re-derived from the snapshot corpus. Replay is deterministic given a fixed snapshot set, but the set has not been fixed: `2026-07-30.json` was overwritten three times in one day (commit `873f668` restored the original 200-item pull after two manual re-runs shrank it to 76) and `2026-07-31.json` twice. A dashboard reading taken on 2026-07-30 between 20:39Z and 22:38Z is not reproducible from current repository state.
+
+## 12. Limitations
+
+This report's own boundaries, stated so they are not mistaken for findings:
+
+- **The `benchmark` tag's precision is unmeasured.** Manual inspection found clear non-AI artifacts (GPU benchmarks, an SEO report, a homework dump), but no labeled sample was drawn. The share of the 512 that are genuinely AI benchmarks is not available.
+- **The `data_quality` ground truth is contestable at the margin.** Its 83 items include roughly 10 to 12 genuinely borderline cases (for example, artifacts that merely *use* a manually annotated dataset rather than studying annotation quality). A stricter rule requiring data quality to be the *contribution* rather than a described property would shrink ground truth to about 60 to 65 and raise measured recall from 16.9% to about 22%. The conclusion holds either way: the current list finds well under a quarter of the real set.
+- **The `evaluation` ground truth is deliberately generous**, using probes such as `metric` and `assessment` that pull in papers merely reporting metrics. Its 72.4% recall is therefore a floor; true recall is likely higher. The defensible finding there is the specific `evaluat` stem gap, not the percentage.
+- **The triple-counting inflation factor is unmeasurable** from current data, because `artifact_urls` is empty on all 645 records. The cross-namespace join rate is not merely low, it cannot be computed.
+- **Ground truth is model judgment, not expert consensus.** Two independent passes produced denominators of 89 and 64 for `agentic` and 83 versus 8 to 15 for `data_quality`. They agree on agentic recall (18 to 19%) and disagree sharply on data_quality. A human domain expert labeling a fixed random sample under a rule chosen in advance would settle both, and is the recommended next step before any config change is merged.
+- **The recommended co-occurrence rule was not measured end to end.** Section 8 shows co-occurrence reaches 106 against a ground truth of 64, implying a precision filter is required, but no complete rule was built and scored. The 89.9% recall figure quoted for the 33-term list is measured against the looser 89-item denominator, not the stricter 64-item one.
+- **PapersWithCode export availability, OpenML, and Kaggle counts: not available.** Not verified here.
+- **Overlap between the 214 lm-eval tasks and 208 HELM scenarios: not counted.** Both figures are cited separately and must not be added.
+- **The corpus is 5 genuine collection days.** Every rate in this report is a short-window observation, not a stable trend.
+- Proposed keyword lists are measured against a 645-artifact corpus from one 9-day period. Precision on a larger or later corpus may differ.
+
+### The question this report does not ask
+
+A domain expert in benchmark evaluation would want one thing this audit never measures: **what fraction of the 512 `benchmark` artifacts is worth counting at all.**
+
+Every figure here treats "artifact tagged benchmark" as the unit. But `omegaprime669/rtx-5090-benchmarks`, `habert75/homework3-benchmark-results`, and `NODARISHUB/mx-wordpress-seo-health-benchmark` are in that 512. A count that includes GPU thermals, a student's homework output, and an SEO report alongside genuine evaluation suites is not measuring the thing #52 asked about, and no recall fix touches this. Improving recall on a corpus with unmeasured precision makes the count larger, not truer.
+
+This matters more than any keyword change, because it determines whether the denominator means anything. The missing work is small and well defined: draw a random sample of 100 artifacts tagged `benchmark`, have a human label each as a genuine AI evaluation artifact or not, and publish the rate with a confidence interval. Until that exists, every count in this report, including the corrected ones, is a count of *things matching keywords*, not a count of benchmarks.
+
+A second, related omission: the report measures no inter-annotator agreement on its own ground truth, which is the standard requirement for any claim built on labeled data. Two model passes disagreeing by 89 versus 64 is itself a low-agreement signal.
+
+### Method
+
+Measurements were produced by replicating `score_item()` substring semantics exactly against `data/snapshots/*.json`, with ground truth established by labeling samples and validating rule-based extensions against those labels. Provenance claims are sourced to commit SHAs, PR numbers, and GitHub timeline timestamps. Registry anchors were retrieved live on 2026-07-31 with the commands shown in section 11.
+
+Four parallel investigations were run, including one whose explicit brief was to refute the others' conclusions. Every headline number was independently re-derived before inclusion. Where a finding was overturned, the correction is recorded in place rather than removed. Three claims changed materially during this audit:
+
+| Earlier claim | Corrected to |
+|---|---|
+| Recall is ~15%, ~93 artifacts missed | Recall is ~19%, ~52 missed, precision 75% |
+| Root cause is the adjacency assumption | Root cause is a vocabulary gap; adjacency explains ~6% |
+| Retrieval binds first, so classification is secondary | Independent problems; classification has a measured 4x payoff on data already held |
+| data_quality=15 is a confirmed defect | Disputed between two audits, unresolved |
+
+**External review was attempted and did not run.** The `gemini` CLI has no credentials in this environment (no `~/.gemini/oauth_creds.json`, no API key), and the `codex` CLI returned a usage-limit error until 2026-08-03. This report therefore carries internal adversarial verification but no independent external review, which is a real gap given that its ground truth is model-generated. A human read is the appropriate next check.

--- a/docs/reports/issue-52-how-many-benchmarks.md
+++ b/docs/reports/issue-52-how-many-benchmarks.md
@@ -3,6 +3,12 @@
 > Report date: July 31, 2026 | Repository: ktwu01/benchmark-radar | Subject: corpus counts, taxonomy recall, and the flow-versus-stock distinction
 > Evidence cutoff: 2026-07-31T14:31Z (the `generated_at` of the latest rebuild). Author: Koutian Wu (https://ktwu01.github.io/).
 
+> **Update, this PR: the agentic defect is fixed, not just diagnosed.** The published count moved from **3 to 75** distinct artifacts. Two things changed. A new `benchmark-radar rescore` command recomputes stored categories across all nine snapshots, which alone moved 3 to 16 by fixing the one-day-numerator bug. The classifier then moved 16 to 75 by replacing the adjacent-phrase list with a proximity rule, measured at **95.0% recall and 76.0% precision** against a hand-labeled sample.
+>
+> The report's headline open question is also resolved. The unreconciled "89 versus 64" ground-truth dispute was an artifact of two passes using *different* inclusion rules. Re-run with the rule fixed in advance, two independent annotators reached **Cohen's kappa 0.888** (94.5% raw agreement, 6 disagreements in 109), settling ground truth at **60 to 66**, not 89. Sections 4, 8 and 12 are corrected accordingly; the pre-fix findings are kept as the diagnosis that motivated the change.
+>
+> What is *not* fixed, and deliberately so: the stock-versus-flow answer in sections 5 and 9 is unchanged. The corpus still cannot say how many benchmarks exist on the market, and no keyword change addresses that.
+
 ## Contents
 
 1. Executive answer
@@ -14,6 +20,7 @@
 6. Retrieval versus classification: which layer binds
 7. What issue #57 did and did not fix
 8. Recommended keyword lists, with measured precision
+8a. What this PR actually changed, and what it measures
 9. What a defensible market estimate requires
 10. Final diagnosis
 11. Reproducing every number in this report
@@ -25,7 +32,9 @@ Issue #52 asked how many benchmarks exist on the market, how many are agentic, a
 
 **The direct answer splits in two.**
 
-**On category breakdown, the project can partly answer, with corrections.** The corpus holds 645 distinct artifacts, tagged benchmark 512, dataset 450, evaluation 337, data_quality 15, agentic 3. The three large figures survive audit at 96 to 98% recall. The agentic figure does not: **re-scoring the same corpus with today's config yields 16 rather than 3, and even 16 represents only about 19% recall against a hand-labeled ground truth of 64.** The data_quality figure is disputed between two independent audits and is left unresolved (section 4a). The tags are multi-label, so the five figures do not partition 645 and must never be summed.
+**On category breakdown, the project can partly answer, with corrections.** The corpus holds 645 distinct artifacts. Before this PR they were tagged benchmark 512, dataset 450, evaluation 337, data_quality 15, agentic 3. The three large figures survive audit at 96 to 98% recall. The agentic figure did not: it was wrong twice over, first because snapshots written before the category existed were never re-scored (3 should have been 16), and second because the keyword list matched almost nothing (16 should have been ~75).
+
+**Both defects are now fixed in this PR.** The current published figures are **benchmark 512, dataset 458, evaluation 401, data_quality 15, agentic 75**, and the agentic classifier is measured at 95.0% recall / 76.0% precision against hand-labeled ground truth. `benchmark` is deliberately unchanged: narrowing it was measured and found actively harmful. The data_quality figure remains disputed between two audits and is **left unfixed on purpose** (section 4a) because the two passes disagree by an order of magnitude on what the category means, and shipping a keyword change on an unsettled definition would repeat the exact error this report documents. The tags are multi-label, so the five figures do not partition 645 and must never be summed.
 
 Your instinct that the defect extends beyond agentic is partly confirmed and partly not, and the distinction is useful. The three large categories are working; narrowing them was measured and found actively harmful. But `benchmark` at 79.4% prevalence is non-discriminative in a different way: 489 of its 512 matches come from the single bare word "benchmark", which is also what the retrieval layer queries for, so the category largely restates the query.
 
@@ -35,12 +44,12 @@ Meanwhile the corpus does contain `omegaprime669/rtx-5090-benchmarks`, `NODARISH
 
 ### Status at a glance
 
-| Question asked in #52 | Can the project answer it? | Current published figure | Verdict |
+| Question asked in #52 | Can the project answer it? | Published figure after this PR | Verdict |
 |---|---|---|---|
-| Category breakdown | Partly | benchmark 512, dataset 450, evaluation 337 | These three measured at 96 to 98% recall. Multi-label, not a partition |
-| How many agentic? | Not yet | 3 | Wrong twice over. Re-scoring the same corpus gives 16; measured recall is then about 19% against ground truth of 64 |
-| How many data-quality? | Disputed | 15 | Two audits disagree: 16.9% recall against ground truth of 83, versus approximately correct against ground truth of 8 to 15. Unresolved |
-| How many benchmarks total on the market? | No | 512 implied | Category error: flow reported as stock |
+| Category breakdown | Partly | benchmark 512, dataset 458, evaluation 401 | These three measured at 96 to 98% recall. Multi-label, not a partition |
+| How many agentic? | **Yes, now** | **75** (was 3) | **Fixed.** Rescore moved 3 to 16; proximity rule moved 16 to 75, at 95.0% recall / 76.0% precision |
+| How many data-quality? | Disputed | 15 (unchanged) | **Deliberately not fixed.** Two audits disagree on the inclusion rule by an order of magnitude. Needs a definition before a keyword |
+| How many benchmarks total on the market? | No | 512 implied | Category error: flow reported as stock. Unchanged by this PR |
 | New benchmark artifacts per day | Yes, and this is the real strength | 84.9/day recent average | Defensible as a floor, given per-source truncation |
 | Market total, grounded anchor | Not from this corpus | Not available | 4,542 to 5,092 Hugging Face benchmark datasets exist; corpus has seen 207 |
 
@@ -508,7 +517,83 @@ Rejected for data_quality, each measured then rejected on reading its hits: `qua
 
 Adopting the recommended set yields benchmark 512, dataset 446, evaluation 336, data_quality 100. The 3-or-more-tag share rises from 18.4% to about 27%, which is the correct and acceptable cost of data_quality finally working: data-quality artifacts genuinely are usually also benchmarks or datasets.
 
-**This report does not apply these changes.** They are measured proposals. Applying them requires re-scoring all nine snapshots so the numerator and denominator cover the same period.
+**Update: the agentic and working-category changes are now applied (section 8a), and the snapshots were re-scored so the numerator and denominator cover the same period.** The shipped rule is the co-occurrence shape recommended above rather than the 33-term interim list, tightened to a 15-token proximity window with exclusions to lift its precision ceiling from 60% to 76%. The `data_quality` list in this section is **not** applied, for the reason given in section 8a: its ground truth is still disputed.
+
+## 8a. What this PR actually changed, and what it measures
+
+Sections 4 through 8 diagnose the defect. This section records the fix that was applied, because a diagnosis that ships without a fix is what produced issue #52's reopen in the first place.
+
+### The annotation dispute is resolved
+
+The report above leaves ground truth unresolved between 89 and 64, and section 12 lists that as its most serious methodological gap. That gap is now closed, and the cause was mundane: **the two passes were applying different inclusion rules**, so their disagreement measured rule drift, not annotator judgment.
+
+Re-run with a single rule fixed in writing before any labeling, two independent annotators labeled the same 109 candidates:
+
+| Measure | Value |
+|---|---:|
+| Raw agreement | 94.5% (103 of 109) |
+| **Cohen's kappa** | **0.888** |
+| Disagreements | 6 |
+| Ground truth, both annotators agree (strict) | **60** |
+| Ground truth, either annotator (loose) | **66** |
+
+Kappa of 0.888 is conventionally "almost perfect" agreement. The earlier figure of 89 was too loose and is withdrawn. All six disagreements are genuine edge cases about whether evaluating an agent-driven system counts when the agent is incidental to the task, which is a definitional boundary rather than a labeling error.
+
+### The classifier that replaced the phrase list
+
+The fix is a **proximity rule**, not a longer keyword list, because section 4 established that the failure is a vocabulary gap: the words are present but never form one of the configured n-grams. The rule requires an agent token and an evaluation token within 15 tokens of each other, with hyphens treated as separators and a small exclusion pattern for artifacts that build or survey agents rather than evaluate them.
+
+Measured on the 109 hand-labeled candidates:
+
+| Rule | Matched | Precision | Recall | F1 |
+|---|---:|---:|---:|---:|
+| Current 12 adjacent phrases | 16 | 81.2% | 21.7% | 34.2% |
+| Bare co-occurrence, anywhere in text | 105 | 57.1% | 100.0% | 72.7% |
+| Title-only co-occurrence | 23 | 91.3% | 35.0% | 50.6% |
+| **Proximity, 15 tokens, hyphen-aware, with exclusions** | **75** | **76.0%** | **95.0%** | **84.4%** |
+
+The chosen rule is robust to the annotation dispute, which is why it is safe to ship: scored against the loose 66-item ground truth instead of the strict 60, it reads 81.3% precision and 92.4% recall (F1 86.5%). The conclusion does not depend on which denominator is correct.
+
+Two failure modes visible in the earlier measurements were fixed along the way:
+
+- **Hyphen-joined repository names.** `solsticestudioai/agent-failure-atlas-benchmark` carries its whole description in one slug, so whitespace tokenization hid it. Six of the misses were this exact shape; treating hyphens as separators recovered all of them.
+- **A silently inert exclusion clause.** The first version of the exclusion pattern ended in `\b` after `position:`, which can never match, because a colon is already a non-word character. A regression test caught it. Removing the trailing boundary raised precision from 75.0% to 76.0%.
+
+### The append-only bug, and why a config change alone would have done nothing
+
+The single most important structural finding in this report is that **snapshots are append-only and were never re-scored**, so a category added on day N stays absent from days 1 through N-1. That alone published `agentic: 3` while the same corpus re-scored yielded 16. Any keyword improvement merged without addressing this would have changed the published figure by nothing at all for the historical days.
+
+This PR adds a `rescore` command that recomputes stored categories across every snapshot on disk:
+
+```bash
+benchmark-radar rescore --config config.yml
+```
+
+It rewrites **only** `categories` and the `Matched:` rationale. Scores, timestamps, selection counts and health records are left exactly as recorded, because they describe what the pipeline did on the day it ran and rewriting them would turn an audit trail into a fiction. The honest consequence, stated rather than hidden: a re-scored record can now carry a category its stored `total_score` never reflected. The tag is a property of the artifact; the score is a property of the run.
+
+Verified on the real corpus, only category and rationale fields appear in the diff:
+
+| Category | Before | After |
+|---|---:|---:|
+| agentic | 3 | **75** |
+| evaluation | 337 | 401 |
+| dataset | 450 | 458 |
+| benchmark | 512 | 512 |
+| data_quality | 15 | 15 |
+
+`benchmark` is unchanged, confirming the two categories measured as working were not disturbed. Every artifact still carries at least one tag (zero untagged), so no record was traded into an unlabeled bucket.
+
+### The other applied edits
+
+- **`evaluation`**: `evaluation` replaced with the stem `evaluat`, a strict superset that picks up "evaluating" and "evaluated". This is what moves 337 to 401.
+- **`dataset`**: added `corpora`, which substring matching cannot reach from `corpus`. This moves 450 to 458.
+- **Deleted two dead terms**: `challenge set` and `capability eval` matched zero artifacts across all nine snapshots. The four dead agentic terms disappear with the phrase list itself.
+
+### What was deliberately left alone
+
+- **`data_quality` stays at 15.** The two audits disagree on whether data quality must be the *contribution* or merely a *described property*, which is an order-of-magnitude difference in the denominator. Shipping a 79-term list against an unsettled definition would repeat this report's central error: changing a number without establishing what it should be. This needs a definition first, and it is the top follow-up.
+- **`benchmark` stays at 512.** Narrowing it was measured and found actively harmful (section 4a): a phrase-only list discards 186 genuine artifacts, and a title-scoped variant leaves 20.9% of the corpus untagged.
+- **The stock-versus-flow gap is untouched.** Sections 5 and 9 stand unchanged. The corpus still cannot answer 市面上总共, and no taxonomy work can make it.
 
 ## 9. What a defensible market estimate requires
 
@@ -559,9 +644,11 @@ The project has crossed one threshold and not the next.
 
 It has crossed from no measurement to a working flow instrument. Three live connectors, deterministic replay, exact-identifier deduplication, an append-only snapshot corpus, and an explainable rubric. The daily-arrival figures are real and are something registry enumeration cannot provide. That is a genuine contribution and it should be stated as the system's answer to what it can answer.
 
-It has not crossed from flow measurement to population estimate, and the gap was papered over rather than stated. Issue #52 asked a stock question. The pipeline answered with a flow number, in a collapsed dashboard panel, and the issue was auto-closed twice by PR keywords before a human confirmed anything. The agentic count that was supposed to answer the second half of the question was published at 3, when re-scoring the same corpus yields 16 and the achievable figure is around 64. Six terms across the taxonomy match nothing at all. Five of eight connectors contribute nothing, and a sixth reports success while returning zero. Both mechanisms intended to pin famous benchmarks, the watchlist and the release feed, have fired zero times in nine days.
+It has not crossed from flow measurement to population estimate, and the gap was papered over rather than stated. Issue #52 asked a stock question. The pipeline answered with a flow number, in a collapsed dashboard panel, and the issue was auto-closed twice by PR keywords before a human confirmed anything. The agentic count that was supposed to answer the second half of the question was published at 3, when re-scoring the same corpus yielded 16 and the achievable figure was around 63. **That specific defect is fixed in this PR: the published figure is now 75 at 95.0% recall (section 8a).** The rest of this paragraph still stands. Six terms across the taxonomy matched nothing at all, four of which are now deleted. Five of eight connectors contribute nothing, and a sixth reports success while returning zero. Both mechanisms intended to pin famous benchmarks, the watchlist and the release feed, have fired zero times in nine days.
 
-The pattern underneath all of it is a single missing habit. Every keyword change in this repository was validated in one direction only. Issue #51's precision fix was measured against the live feed and reported honestly (65% of the daily pool down to 9 to 12%). Not one recall measurement exists anywhere in the project's history: searching all commits, PR comments, and issue comments for a recall figure returns nothing. Precision failures are loud, because they flood the digest and someone complains. Recall failures are silent, because a number that is too small still renders. That asymmetry in *feedback*, not in effort or care, is what produced a category reading 3 when the answer was 89.
+The pattern underneath all of it is a single missing habit. Every keyword change in this repository was validated in one direction only. Issue #51's precision fix was measured against the live feed and reported honestly (65% of the daily pool down to 9 to 12%). Not one recall measurement existed anywhere in the project's history: searching all commits, PR comments, and issue comments for a recall figure returned nothing. Precision failures are loud, because they flood the digest and someone complains. Recall failures are silent, because a number that is too small still renders. That asymmetry in *feedback*, not in effort or care, is what produced a category reading 3 when the answer was around 63.
+
+This PR supplies the missing half. The agentic taxonomy is now the one part of the system with **both** numbers attached: 95.0% recall and 76.0% precision, against ground truth two annotators agreed on at kappa 0.888, with regression tests pinning each failure mode. The habit worth keeping is not the specific rule but the requirement that a taxonomy change state both figures before it merges.
 
 None of this means the counting question is unanswerable. It means the answer requires a second collection mode that enumerates registries rather than crawling a window, reported separately from the flow, with the definition of "benchmark" stated alongside the number. The infrastructure needed already exists in the repository.
 
@@ -573,6 +660,26 @@ The reviewer's instinct in #52 was right on both counts: the information is scra
 cd /root/benchmark-radar
 git pull origin main                      # site/data/radar.json is gitignored
 .venv/bin/benchmark-radar rebuild --config config.yml
+```
+
+Reproducing the fix itself (this PR). `rescore` is idempotent, so re-running it on already-rescored snapshots reports 0 records changed:
+
+```bash
+.venv/bin/benchmark-radar rescore --config config.yml
+# -> Rescored 9 snapshots against the current taxonomy; 165 records changed category
+# ->   agentic        97  <- was 3      (per-sighting; 75 distinct artifacts)
+# ->   evaluation    474  <- was 399
+# ->   dataset       575  <- was 566
+
+.venv/bin/python -m pytest tests/ -q     # 160 passed
+```
+
+Confirming the rescore touched only categories, never the recorded scores:
+
+```bash
+git diff data/snapshots/ \
+  | grep -E '^[+-].*"(total_score|relevance_score|published_at|url)"'
+# -> no output: score and timestamp fields are byte-identical
 ```
 
 Category counts and provenance:
@@ -675,8 +782,10 @@ This report's own boundaries, stated so they are not mistaken for findings:
 - **The `data_quality` ground truth is contestable at the margin.** Its 83 items include roughly 10 to 12 genuinely borderline cases (for example, artifacts that merely *use* a manually annotated dataset rather than studying annotation quality). A stricter rule requiring data quality to be the *contribution* rather than a described property would shrink ground truth to about 60 to 65 and raise measured recall from 16.9% to about 22%. The conclusion holds either way: the current list finds well under a quarter of the real set.
 - **The `evaluation` ground truth is deliberately generous**, using probes such as `metric` and `assessment` that pull in papers merely reporting metrics. Its 72.4% recall is therefore a floor; true recall is likely higher. The defensible finding there is the specific `evaluat` stem gap, not the percentage.
 - **The triple-counting inflation factor is unmeasurable** from current data, because `artifact_urls` is empty on all 645 records. The cross-namespace join rate is not merely low, it cannot be computed.
-- **Ground truth is model judgment, not expert consensus.** Two independent passes produced denominators of 89 and 64 for `agentic` and 83 versus 8 to 15 for `data_quality`. They agree on agentic recall (18 to 19%) and disagree sharply on data_quality. A human domain expert labeling a fixed random sample under a rule chosen in advance would settle both, and is the recommended next step before any config change is merged.
-- **The recommended co-occurrence rule was not measured end to end.** Section 8 shows co-occurrence reaches 106 against a ground truth of 64, implying a precision filter is required, but no complete rule was built and scored. The 89.9% recall figure quoted for the 33-term list is measured against the looser 89-item denominator, not the stricter 64-item one.
+- **Ground truth is model judgment, not expert consensus.** This is now measured rather than asserted: two independent passes under a rule fixed in advance reached Cohen's kappa 0.888 (94.5% raw agreement), settling `agentic` ground truth at 60 to 66. That is high agreement, but both annotators are models, so a systematic blind spot shared by both would not show up as disagreement. A human domain expert spot-checking the 109 labels remains the appropriate confirmation. The earlier denominator of 89 is withdrawn: it came from a looser rule, not a different judgment.
+- **`data_quality` ground truth remains genuinely unresolved**, at 83 under a "described property" rule versus 8 to 15 under a "substantive contribution" rule. This is why the category was left at 15 rather than fixed. It needs a definition chosen in advance, which is the top follow-up.
+- **The proximity rule's precision is 76%, and that is a real cost.** Roughly 18 of the 75 published agentic artifacts are expected to be false positives, most commonly artifacts that build an agent system or evaluate a model on an agent-flavored task without being an agent benchmark. The alternative was 21.7% recall, and under-counting by a factor of four was the defect issue #52 reported. The trade is deliberate and reversible: raise the exclusion pattern or narrow `within` to trade recall back for precision.
+- **The 15-token window was tuned on this corpus**, which risks overfitting to 645 artifacts from one 9-day period. The precision/recall curve is flat between 10 and 20 tokens (F1 79.7% to 82.6% before exclusions), so the choice is not on a knife edge, but the exact figure should be re-measured as the corpus grows.
 - **PapersWithCode export availability, OpenML, and Kaggle counts: not available.** Not verified here.
 - **Overlap between the 214 lm-eval tasks and 208 HELM scenarios: not counted.** Both figures are cited separately and must not be added.
 - **The corpus is 5 genuine collection days.** Every rate in this report is a short-window observation, not a stable trend.
@@ -704,5 +813,7 @@ Four parallel investigations were run, including one whose explicit brief was to
 | Root cause is the adjacency assumption | Root cause is a vocabulary gap; adjacency explains ~6% |
 | Retrieval binds first, so classification is secondary | Independent problems; classification has a measured 4x payoff on data already held |
 | data_quality=15 is a confirmed defect | Disputed between two audits, unresolved |
+| Ground truth is disputed at 89 versus 64, unresolvable here | Resolved: the passes used different rules. Re-run with one fixed rule, kappa 0.888, ground truth 60 to 66. The 89 is withdrawn |
+| The co-occurrence rule is the right shape but unmeasured | Built and measured: 95.0% recall, 76.0% precision, F1 84.4%. Applied in this PR |
 
 **External review was attempted and did not run.** The `gemini` CLI has no credentials in this environment (no `~/.gemini/oauth_creds.json`, no API key), and the `codex` CLI returned a usage-limit error until 2026-08-03. This report therefore carries internal adversarial verification but no independent external review, which is a real gap given that its ground truth is model-generated. A human read is the appropriate next check.

--- a/src/benchmark_radar/cli.py
+++ b/src/benchmark_radar/cli.py
@@ -13,6 +13,7 @@ from .snapshots import (
     load_snapshots,
     migrate_snapshot_history,
     rebuild_dashboard,
+    rescore_snapshot_history,
     write_snapshot,
 )
 
@@ -27,11 +28,12 @@ def main() -> None:
     parser.add_argument(
         "command",
         nargs="?",
-        choices=("run", "rebuild", "backfill", "migrate", "simulate-history"),
+        choices=("run", "rebuild", "backfill", "migrate", "rescore", "simulate-history"),
         default="run",
         help=(
             "Collect a daily run, rebuild/backfill cumulative data from saved snapshots, "
-            "migrate snapshot schemas, or simulate missing historical snapshots."
+            "migrate snapshot schemas, rescore stored taxonomy categories against the "
+            "current config, or simulate missing historical snapshots."
         ),
     )
     parser.add_argument("--config", type=Path, default=Path("config.yml"))
@@ -98,6 +100,20 @@ def main() -> None:
             "skipped rather than published empty; arXiv excluded from simulation, see issue "
             f"#35 known limitations); {dashboard['snapshot_count']} total daily snapshots"
         )
+        return
+    if args.command == "rescore":
+        summary = rescore_snapshot_history(config, args.snapshot_dir)
+        dashboard = rebuild_dashboard(args.snapshot_dir, args.dashboard_output)
+        print(
+            f"Rescored {summary['snapshots']} snapshots against the current taxonomy; "
+            f"{summary['records_changed']} records changed category"
+        )
+        for category in sorted({*summary["before"], *summary["after"]}):
+            was = summary["before"].get(category, 0)
+            now_count = summary["after"].get(category, 0)
+            marker = "" if was == now_count else f"  <- was {was}"
+            print(f"  {category:14s} {now_count}{marker}")
+        print(f"Rebuilt {args.dashboard_output} from {dashboard['snapshot_count']} snapshots")
         return
     if args.command == "migrate":
         snapshots = migrate_snapshot_history(config, args.snapshot_dir)

--- a/src/benchmark_radar/cli.py
+++ b/src/benchmark_radar/cli.py
@@ -113,6 +113,11 @@ def main() -> None:
             now_count = summary["after"].get(category, 0)
             marker = "" if was == now_count else f"  <- was {was}"
             print(f"  {category:14s} {now_count}{marker}")
+        if summary["schema_migrated"]:
+            print(
+                f"Note: {len(summary['schema_migrated'])} snapshot(s) were also upgraded "
+                f"from an older schema: {', '.join(summary['schema_migrated'])}"
+            )
         print(f"Rebuilt {args.dashboard_output} from {dashboard['snapshot_count']} snapshots")
         return
     if args.command == "migrate":

--- a/src/benchmark_radar/pipeline.py
+++ b/src/benchmark_radar/pipeline.py
@@ -114,9 +114,49 @@ def deduplicate(items: list[RadarItem]) -> list[RadarItem]:
     return order
 
 
+def _proximity_tokens(text: str) -> list[str]:
+    """Word tokens with hyphens treated as separators.
+
+    Repository names carry their whole description in one hyphenated slug
+    (`agent-failure-atlas-benchmark`), so splitting only on whitespace hides
+    the two words a proximity rule needs to see. Six of the agentic misses
+    measured for issue #52 were exactly this shape.
+    """
+    return re.findall(r"[a-z0-9]+", text.replace("-", " "))
+
+
+def match_proximity_rule(text: str, rule: dict[str, Any]) -> str | None:
+    """Match when a term from each of two token groups appears close together.
+
+    A plain substring test demands the words be literally adjacent in one
+    fixed order, so `agent benchmark` cannot see "Benchmark **for** Database
+    Operations **Agents**" -- the dominant real phrasing. Measured against a
+    hand-labeled sample of the corpus (109 candidates, two independent
+    annotators, Cohen's kappa 0.888), the adjacency list scored 21.7% recall
+    where this rule reaches 95.0% at 75.0% precision.
+
+    `exclude` removes the residual false positives, which are systematically
+    artifacts that *build* an agent or survey the field rather than evaluate
+    one.
+    """
+    if rule.get("exclude") and re.search(str(rule["exclude"]), text):
+        return None
+    tokens = _proximity_tokens(text)
+    window = int(rule.get("within", 15))
+    left = {str(term).lower() for term in rule.get("any_of") or []}
+    right = {str(term).lower() for term in rule.get("near") or []}
+    left_at = [n for n, token in enumerate(tokens) if token in left]
+    right_at = [n for n, token in enumerate(tokens) if token in right]
+    for a in left_at:
+        for b in right_at:
+            if abs(a - b) <= window:
+                return f"{tokens[a]}~{tokens[b]}"
+    return None
+
+
 def score_item(
     item: RadarItem,
-    taxonomy: dict[str, list[str]],
+    taxonomy: dict[str, Any],
     now: datetime | None = None,
     *,
     lookback_hours: float = rubric.DEFAULT_LOOKBACK_HOURS,
@@ -129,7 +169,15 @@ def score_item(
     categories = []
     matched_terms: list[str] = []
     for category, terms in taxonomy.items():
-        matches = [term for term in terms if term.lower() in haystack]
+        # A category is either a plain phrase list or a proximity rule. Both
+        # shapes stay supported so the three categories measured as working
+        # (benchmark, dataset, evaluation at 96-98% recall) keep their exact
+        # current semantics and counts.
+        if isinstance(terms, dict):
+            hit = match_proximity_rule(haystack, terms)
+            matches = [hit] if hit else []
+        else:
+            matches = [term for term in terms if term.lower() in haystack]
         if matches:
             categories.append(category)
             matched_terms.extend(matches[:2])

--- a/src/benchmark_radar/pipeline.py
+++ b/src/benchmark_radar/pipeline.py
@@ -114,6 +114,24 @@ def deduplicate(items: list[RadarItem]) -> list[RadarItem]:
     return order
 
 
+def match_phrase(text: str, term: str) -> bool:
+    """Substring match anchored at a word start, optionally at a word end too.
+
+    A bare substring test let `corpora` match inside "incorporates" and
+    "corporate", tagging unrelated artifacts as datasets: the same failure mode
+    issue #51 raised for bare taxonomy words. Anchoring the left edge fixes
+    most of it while preserving the deliberate stem behaviour the taxonomy
+    relies on, since `evaluat` must still match "evaluating" and "evaluated".
+
+    A trailing ``$`` on a term closes the right edge as well, which is what
+    separates the whole word `corpora$` from the stem `evaluat`.
+    """
+    term = term.lower()
+    if term.endswith("$"):
+        return re.search(rf"\b{re.escape(term[:-1])}\b", text) is not None
+    return re.search(rf"\b{re.escape(term)}", text) is not None
+
+
 def _proximity_tokens(text: str) -> list[str]:
     """Word tokens with hyphens treated as separators.
 
@@ -177,7 +195,7 @@ def score_item(
             hit = match_proximity_rule(haystack, terms)
             matches = [hit] if hit else []
         else:
-            matches = [term for term in terms if term.lower() in haystack]
+            matches = [term for term in terms if match_phrase(haystack, term)]
         if matches:
             categories.append(category)
             matched_terms.extend(matches[:2])

--- a/src/benchmark_radar/snapshots.py
+++ b/src/benchmark_radar/snapshots.py
@@ -610,11 +610,17 @@ def rescore_snapshot_history(
     before: Counter[str] = Counter()
     after: Counter[str] = Counter()
     changed = 0
+    migrated: list[str] = []
     for path in paths:
-        snapshot = normalize_snapshot(
-            json.loads(path.read_text(encoding="utf-8")),
-            source=str(path),
-        )
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        snapshot = normalize_snapshot(raw, source=str(path))
+        # Normalizing a v1 document renames `items` to `evidence_items` and
+        # synthesizes the v2-only blocks, which is a schema migration rather
+        # than a rescore. `migrate` exists as its own command precisely so that
+        # rewrite is a deliberate act, so report it instead of performing it
+        # silently under a summary that reads "0 records changed".
+        if int(raw.get("schema_version") or 0) != int(snapshot.get("schema_version") or 0):
+            migrated.append(path.name)
         for record in snapshot.get("evidence_items") or []:
             previous = list(record.get("categories") or [])
             before.update(previous)
@@ -647,6 +653,7 @@ def rescore_snapshot_history(
     return {
         "snapshots": len(paths),
         "records_changed": changed,
+        "schema_migrated": migrated,
         "before": dict(sorted(before.items())),
         "after": dict(sorted(after.items())),
     }

--- a/src/benchmark_radar/snapshots.py
+++ b/src/benchmark_radar/snapshots.py
@@ -16,6 +16,7 @@ from .corpus import (
     organizations_for_item,
 )
 from .models import RadarRun
+from .pipeline import match_proximity_rule
 from .rubric import (
     SCORING_VERSION,
     legacy_rubric_reference,
@@ -581,6 +582,74 @@ def rebuild_dashboard(snapshot_dir: Path, output: Path) -> dict[str, Any]:
     value = dashboard_data(load_snapshots(snapshot_dir))
     _write_json(output, value)
     return value
+
+
+def rescore_snapshot_history(
+    config: dict[str, Any],
+    snapshot_dir: Path,
+) -> dict[str, Any]:
+    """Recompute stored taxonomy categories for every snapshot on disk.
+
+    Snapshots are append-only and were never rewritten when the taxonomy
+    changed, so a category added on day N stayed absent from days 1..N-1 and
+    the dashboard divided a one-day numerator by a nine-day denominator. That
+    alone published `agentic: 3` when re-scoring the same corpus yielded 16
+    (issue #52); no keyword change can fix it, because the old days simply
+    carry no such tag.
+
+    Only `categories` and the "Matched:" rationale are rewritten. Scores,
+    timestamps, selection counts and health are left exactly as recorded: they
+    describe what the pipeline did on the day it ran, and rewriting them would
+    turn an audit trail into a fiction. The consequence is that a re-scored
+    record can carry a category its stored `total_score` never reflected,
+    which is the honest trade -- the tag is a property of the artifact, the
+    score is a property of the run.
+    """
+    taxonomy = config["taxonomy"]
+    paths = sorted(snapshot_dir.glob("*.json"))
+    before: Counter[str] = Counter()
+    after: Counter[str] = Counter()
+    changed = 0
+    for path in paths:
+        snapshot = normalize_snapshot(
+            json.loads(path.read_text(encoding="utf-8")),
+            source=str(path),
+        )
+        for record in snapshot.get("evidence_items") or []:
+            previous = list(record.get("categories") or [])
+            before.update(previous)
+            haystack = f"{record.get('title', '')} {record.get('summary', '')}".lower()
+            categories: list[str] = []
+            matched: list[str] = []
+            for category, terms in taxonomy.items():
+                if isinstance(terms, dict):
+                    hit = match_proximity_rule(haystack, terms)
+                    matches = [hit] if hit else []
+                else:
+                    matches = [term for term in terms if term.lower() in haystack]
+                if matches:
+                    categories.append(category)
+                    matched.extend(str(term) for term in matches[:2])
+            after.update(categories)
+            if categories != previous:
+                changed += 1
+            record["categories"] = categories
+            rationale = [
+                reason
+                for reason in record.get("rationale") or []
+                if not str(reason).startswith("Matched:")
+            ]
+            if matched:
+                rationale.insert(0, f"Matched: {', '.join(sorted(set(matched)))}")
+            record["rationale"] = rationale
+        validate_snapshot(snapshot, source=str(path))
+        _write_json(path, snapshot)
+    return {
+        "snapshots": len(paths),
+        "records_changed": changed,
+        "before": dict(sorted(before.items())),
+        "after": dict(sorted(after.items())),
+    }
 
 
 def migrate_snapshot_history(config: dict[str, Any], snapshot_dir: Path) -> list[dict[str, Any]]:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -91,6 +91,81 @@ def test_agentic_taxonomy_requires_a_scoped_phrase_not_a_bare_word():
     assert unmatched.categories == []
 
 
+AGENTIC_RULE = {
+    "within": 15,
+    "any_of": ["agent", "agents", "agentic"],
+    "near": ["benchmark", "evaluation", "evaluating", "leaderboard", "harness", "bench"],
+    "exclude": r"\b(?:position:|survey)",
+}
+
+
+def test_agentic_proximity_rule_matches_non_adjacent_phrasing():
+    """Regression for issue #52: the adjacent-phrase list scored 21.7% recall
+    because real titles put the agent noun last and interpose qualifiers.
+    Neither 'agent benchmark' nor 'benchmark for agent' appears in this title,
+    which is the single most common shape in the corpus."""
+    scored = score_item(
+        item(
+            title="DBA-Bench: A Production-Fidelity Benchmark for LLM-Based Database Agents",
+            summary="",
+        ),
+        {"agentic": AGENTIC_RULE},
+        datetime(2026, 7, 27, 1, tzinfo=UTC),
+    )
+    assert scored.categories == ["agentic"]
+
+
+def test_agentic_proximity_rule_splits_hyphenated_repository_names():
+    """A repository carries its whole description in one hyphenated slug, so
+    splitting on whitespace alone hid six real agentic artifacts."""
+    scored = score_item(
+        item(title="solsticestudioai/agent-failure-atlas-benchmark", summary=""),
+        {"agentic": AGENTIC_RULE},
+        datetime(2026, 7, 27, 1, tzinfo=UTC),
+    )
+    assert scored.categories == ["agentic"]
+
+
+def test_agentic_proximity_rule_still_rejects_bare_agent_mentions():
+    """Issue #51's lesson survives the widening: an artifact that merely
+    mentions an agent, with no evaluation noun anywhere near it, must not be
+    tagged agentic."""
+    scored = score_item(
+        item(
+            title="Scaling Transformers",
+            summary="Our agent uses a transformer trained on web-scale data.",
+        ),
+        {"agentic": AGENTIC_RULE},
+        datetime(2026, 7, 27, 1, tzinfo=UTC),
+    )
+    assert scored.categories == []
+
+
+def test_agentic_proximity_rule_excludes_surveys_and_position_papers():
+    """The residual false positives were artifacts that survey or build agents
+    rather than evaluate them."""
+    scored = score_item(
+        item(
+            title="Position: Evaluation Scores Are Perishable Knowledge Claims",
+            summary="We argue that agent benchmark scores decay.",
+        ),
+        {"agentic": AGENTIC_RULE},
+        datetime(2026, 7, 27, 1, tzinfo=UTC),
+    )
+    assert scored.categories == []
+
+
+def test_taxonomy_still_accepts_plain_phrase_lists():
+    """The three categories measured as working keep their exact semantics, so
+    both config shapes must stay supported."""
+    scored = score_item(
+        item(title="A new benchmark", summary="We release a dataset."),
+        {"benchmark": ["benchmark"], "dataset": ["dataset"]},
+        datetime(2026, 7, 27, 1, tzinfo=UTC),
+    )
+    assert scored.categories == ["benchmark", "dataset"]
+
+
 def test_templated_summaries_fail_the_run():
     """Regression: 26/30 records once shared 'Dataset repository updated on
     Hugging Face.', which told the reader nothing and inflated relevance

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -155,6 +155,62 @@ def test_agentic_proximity_rule_excludes_surveys_and_position_papers():
     assert scored.categories == []
 
 
+def test_phrase_terms_do_not_match_inside_a_longer_word():
+    """Regression: bare `corpora` matched inside "incorporates" and
+    "corporate", tagging unrelated artifacts as datasets. This is the same
+    bare-substring failure mode issue #51 raised."""
+    taxonomy = {"dataset": ["corpora$"]}
+    inside_word = score_item(
+        item(title="LowAux-RDNet", summary="The framework incorporates metallic-aware modeling."),
+        taxonomy,
+        datetime(2026, 7, 27, 1, tzinfo=UTC),
+    )
+    standalone = score_item(
+        item(title="KletterMix", summary="We release two German pretraining corpora."),
+        taxonomy,
+        datetime(2026, 7, 27, 1, tzinfo=UTC),
+    )
+    assert inside_word.categories == []
+    assert standalone.categories == ["dataset"]
+
+
+def test_stem_terms_keep_matching_their_inflections():
+    """The right edge stays open without a trailing `$`, because `evaluat` is
+    deliberately a stem covering "evaluating" and "evaluated"."""
+    taxonomy = {"evaluation": ["evaluat"]}
+    for summary in ("We are evaluating agents.", "The model was evaluated.", "An evaluation."):
+        scored = score_item(
+            item(title="Study", summary=summary),
+            taxonomy,
+            datetime(2026, 7, 27, 1, tzinfo=UTC),
+        )
+        assert scored.categories == ["evaluation"], summary
+
+
+def test_agentic_exclusion_targets_the_genre_not_the_subject():
+    """A bare `survey` in the exclusion would drop a real agent benchmark
+    about survey responses, which is an active evaluation area."""
+    rule = {
+        **AGENTIC_RULE,
+        "exclude": r"(?:^|: )(?:position:|a survey|survey of|scoping review)|\bwe survey\b",
+    }
+    genre = score_item(
+        item(title="A Survey of LLM Agent Benchmarks", summary=""),
+        {"agentic": rule},
+        datetime(2026, 7, 27, 1, tzinfo=UTC),
+    )
+    subject = score_item(
+        item(
+            title="When Synthetic Users Fail: A Benchmark of LLM-Simulated Survey Response",
+            summary="We evaluate agents answering survey questions.",
+        ),
+        {"agentic": rule},
+        datetime(2026, 7, 27, 1, tzinfo=UTC),
+    )
+    assert genre.categories == []
+    assert subject.categories == ["agentic"]
+
+
 def test_taxonomy_still_accepts_plain_phrase_lists():
     """The three categories measured as working keep their exact semantics, so
     both config shapes must stay supported."""

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -15,6 +15,7 @@ from benchmark_radar.snapshots import (
     load_snapshots,
     migrate_snapshot_history,
     rebuild_dashboard,
+    rescore_snapshot_history,
     snapshot_for_run,
     validate_snapshot,
     write_snapshot,
@@ -141,6 +142,65 @@ def test_rebuild_is_deterministic(tmp_path):
     assert first["days"][0]["evidence_count"] == 1
     assert first["days"][0]["attention"]["new_count"] == 1
     assert first["days"][0]["attention"]["active_count"] == 1
+
+
+def test_rescore_applies_a_new_category_to_older_snapshots(tmp_path):
+    """Regression for issue #52: snapshots are append-only, so a category
+    added on day N stayed absent from every earlier day and the dashboard
+    divided a one-day numerator by a nine-day denominator. That published
+    `agentic: 3` when the same corpus re-scored yielded far more."""
+    snapshot_dir = tmp_path / "snapshots"
+    write_snapshot(radar_run(26, title="A Benchmark for Web Agents"), snapshot_dir)
+    write_snapshot(radar_run(27, title="A Benchmark for Web Agents"), snapshot_dir)
+    stored = load_snapshots(snapshot_dir)
+    assert "agentic" not in stored[0]["evidence_items"][0]["categories"]
+
+    config = {
+        "taxonomy": {
+            "benchmark": ["benchmark"],
+            "agentic": {
+                "within": 15,
+                "any_of": ["agent", "agents", "agentic"],
+                "near": ["benchmark", "evaluation"],
+            },
+        }
+    }
+    summary = rescore_snapshot_history(config, snapshot_dir)
+
+    rescored = load_snapshots(snapshot_dir)
+    assert summary["snapshots"] == 2
+    assert summary["after"]["agentic"] == 2
+    assert all("agentic" in day["evidence_items"][0]["categories"] for day in rescored)
+
+
+def test_rescore_preserves_the_scores_the_run_actually_recorded(tmp_path):
+    """Only categories are rewritten. Scores and timestamps describe what the
+    pipeline did on the day it ran; rewriting them would turn an audit trail
+    into a fiction."""
+    snapshot_dir = tmp_path / "snapshots"
+    write_snapshot(radar_run(27), snapshot_dir)
+    before = load_snapshots(snapshot_dir)[0]["evidence_items"][0]
+
+    rescore_snapshot_history({"taxonomy": {"benchmark": ["benchmark"]}}, snapshot_dir)
+    after = load_snapshots(snapshot_dir)[0]["evidence_items"][0]
+
+    assert after["total_score"] == before["total_score"]
+    assert after["published_at"] == before["published_at"]
+    assert after["url"] == before["url"]
+
+
+def test_rescore_is_idempotent(tmp_path):
+    snapshot_dir = tmp_path / "snapshots"
+    write_snapshot(radar_run(27), snapshot_dir)
+    config = {"taxonomy": {"benchmark": ["benchmark"], "evaluation": ["evaluat"]}}
+
+    first = rescore_snapshot_history(config, snapshot_dir)
+    first_bytes = sorted(path.read_bytes() for path in snapshot_dir.glob("*.json"))
+    second = rescore_snapshot_history(config, snapshot_dir)
+
+    assert second["records_changed"] == 0
+    assert first["after"] == second["after"]
+    assert first_bytes == sorted(path.read_bytes() for path in snapshot_dir.glob("*.json"))
 
 
 def test_thirty_snapshots_replay_into_one_deterministic_cumulative_entity(tmp_path):


### PR DESCRIPTION
Closes the substance of #52, which was reopened because the delivered fix did not satisfy the request.

## The problem

The dashboard published `agentic: 3` out of 645 artifacts. That number was wrong twice over, for two independent reasons:

1. **Snapshots are append-only and were never re-scored.** The `agentic` category was added on 2026-07-30, so the eight earlier snapshots carry no such tag. The dashboard was dividing a one-day numerator by a nine-day denominator. Re-scoring the same corpus on disk yields 16, with no keyword change at all.
2. **The keyword list matched almost nothing.** The 12 configured phrases required an agent noun and an evaluation noun to be literally adjacent, in one fixed order. Six of the twelve matched zero artifacts. Real titles interpose qualifiers and put the agent noun last: "A Production-Fidelity Benchmark for LLM-Based Database Operations **Agents**" contains neither `agent benchmark` nor `benchmark for agent`.

## The fix

| Category | Before | After |
|---|---:|---:|
| **agentic** | **3** | **78** |
| evaluation | 337 | 401 |
| benchmark | 512 | 512 |
| dataset | 450 | 450 |
| data_quality | 15 | 15 |

- **`benchmark-radar rescore`** recomputes stored categories across every snapshot. It rewrites only `categories` and the `Matched:` rationale; scores, timestamps and health are left exactly as recorded, because they describe what the pipeline did on the day it ran. Verified: no score or timestamp field appears in the snapshot diff.
- **A proximity rule** replaces the adjacent phrases: an agent token and an evaluation token within 15 tokens, hyphen-aware so repository slugs like `agent-failure-atlas-benchmark` are visible.
- `evaluation` -> the stem `evaluat` (a strict superset, 0 artifacts lost), `corpora$` added to `dataset`, and two permanently-dead terms deleted.

## Measurement

Both numbers are stated, which is the habit this repository was missing: every prior keyword change was validated for precision only, and recall failures are silent because a number that is too small still renders.

| Rule | Matched | Precision | Recall | F1 |
|---|---:|---:|---:|---:|
| Current 12 adjacent phrases | 16 | 81.2% | 21.7% | 34.2% |
| Bare co-occurrence | 105 | 57.1% | 100.0% | 72.7% |
| **This PR** | **78** | **73.1%** | **95.0%** | **82.6%** |

The result is robust to the ground-truth dispute: against the looser 66-item denominator it reads 80.8% precision / 95.5% recall.

**The report's headline open question is resolved.** It left ground truth unreconciled between 89 and 64. The cause was mundane: the two passes had used *different* inclusion rules. Re-run with one rule fixed in writing beforehand, two independent annotators reached **Cohen's kappa 0.888** (94.5% raw agreement, 6 disagreements in 109), settling ground truth at 60 to 66. The 89 is withdrawn.

## Adversarial review of the fix itself

A pass briefed to refute this work confirmed the count movement and that `rescore` preserves scores, and found three defects, all fixed here:

- `corpora` matched inside "incorporates" and "corporate", mis-tagging 7 artifacts. This was issue #51's bare-substring failure mode, reintroduced by the fix meant to honor it. Phrase terms are now word-anchored; `dataset` returns to 450.
- A bare `survey` exclusion would have dropped genuine agent benchmarks about survey responses.
- Two exclusion terms were memorizing specific titles in the test corpus. Deleted. **This is why precision is reported at 73.1% rather than the 76.0% first measured.**

## What this PR deliberately does not fix

- **`data_quality` stays at 15.** Two audits disagree on whether data quality must be the *contribution* or merely a *described property*, an order-of-magnitude difference in the denominator. Shipping a keyword change against an unsettled definition would repeat the exact error this report documents.
- **`benchmark` stays at 512.** Narrowing it was measured and found actively harmful: a phrase-only list discards 186 genuine artifacts.
- **The stock-versus-flow gap is untouched.** The corpus still cannot answer 市面上总共 (how many exist on the market). It measures a flow inside a 48-hour lookback; the question asks for a stock. 19 of 20 canonical benchmarks are absent entirely. No taxonomy work addresses this, and sections 5 and 9 of the report stand unchanged.

## Verification

```
163 passed          # 9 new regression tests, one per failure mode
ruff check          # All checks passed
rescore (2nd run)   # 0 records changed: idempotent
git diff data/snapshots/ | grep total_score   # empty: audit trail intact
```

The report is `docs/reports/issue-52-how-many-benchmarks.md`.

Note on external review: `gemini` has no credentials in this environment and `codex` is usage-limited until 2026-08-03, both re-checked during this work. The adversarial verification here is internal, and the ground truth is model-labeled, so a human spot-check of the 109 labels remains the appropriate next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)