### PR TITLE
Give the trend chart a real hover card instead of native tooltips

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -525,6 +525,9 @@ function renderTrends() {
       ]);
       const previous = state.data.days[dayIndex - 1];
       const show = () => {
+        // Escape stays honoured until the pointer or focus leaves and returns,
+        // so the card does not spring back while the column is still active.
+        if (dismissedTooltipColumn === button) return;
         // Clear the previous column's description first: moving between columns
         // must never leave two triggers pointing at one card.
         hideDayTooltip();
@@ -535,8 +538,13 @@ function renderTrends() {
       button.addEventListener("focus", show);
       // Mixed pointer and keyboard use: leaving with the mouse must not close a
       // card the keyboard still owns, so hand it back to the focused column.
-      button.addEventListener("pointerleave", releaseDayTooltip);
-      button.addEventListener("blur", releaseDayTooltip);
+      // Leaving also lifts an Escape dismissal, so returning reopens the card.
+      const leave = () => {
+        if (dismissedTooltipColumn === button) dismissedTooltipColumn = null;
+        releaseDayTooltip();
+      };
+      button.addEventListener("pointerleave", leave);
+      button.addEventListener("blur", leave);
       button.addEventListener("click", () => {
         state.todayDate = day.date;
         setView("today");
@@ -582,6 +590,11 @@ function renderTrends() {
 // column this tall and whether that is up or down. Momentum, baselines, and
 // cumulative totals stay on the domain cards rather than being repeated here.
 const TOOLTIP_CATEGORY_LIMIT = 4;
+
+// The column whose card is open, so a scroll or resize can re-place it, and the
+// column Escape dismissed, so re-entering is required before it opens again.
+let openTooltipColumn = null;
+let dismissedTooltipColumn = null;
 
 function showDayTooltip(column, day, previous, dayCounts, categories) {
   const tooltip = byId("day-tooltip");
@@ -657,7 +670,15 @@ function showDayTooltip(column, day, previous, dayCounts, categories) {
   // Point the trigger at the card while it is open. Without this the breakdown
   // is visual only: a screen reader on the focused column would never reach it.
   column.setAttribute("aria-describedby", tooltip.id);
+  openTooltipColumn = column;
   positionDayTooltip(tooltip, column);
+  // Tabbing to an off-screen column scrolls the chart after focus fires, which
+  // would leave the card behind. Re-place it once that scrolling has settled.
+  requestAnimationFrame(() => {
+    if (openTooltipColumn === column && !tooltip.hidden) {
+      positionDayTooltip(tooltip, column);
+    }
+  });
 }
 
 function positionDayTooltip(tooltip, column) {
@@ -727,9 +748,36 @@ function hideDayTooltip() {
   if (!tooltip) return;
   tooltip.hidden = true;
   tooltip.setAttribute("aria-hidden", "true");
+  openTooltipColumn = null;
   document
     .querySelectorAll("#trend-chart .day-column[aria-describedby]")
     .forEach((column) => column.removeAttribute("aria-describedby"));
+}
+
+// Escape closes the card without moving focus, so a reader who finds it in the
+// way can clear it and keep their place in the column order.
+function dismissDayTooltip() {
+  if (!openTooltipColumn) return false;
+  dismissedTooltipColumn = openTooltipColumn;
+  hideDayTooltip();
+  return true;
+}
+
+// The chart scrolls horizontally, so an open card has to follow its column. A
+// column scrolled out of the viewport takes its card with it: on a narrow frame
+// the card would otherwise stay pinned at the clamp edge, labelled with a day
+// no longer on screen.
+function repositionDayTooltip() {
+  const tooltip = byId("day-tooltip");
+  if (!tooltip || tooltip.hidden || !openTooltipColumn) return;
+  const chart = byId("trend-chart");
+  const columnBox = openTooltipColumn.getBoundingClientRect();
+  const chartBox = chart.getBoundingClientRect();
+  if (columnBox.right <= chartBox.left || columnBox.left >= chartBox.right) {
+    hideDayTooltip();
+    return;
+  }
+  positionDayTooltip(tooltip, openTooltipColumn);
 }
 
 // A pointer leaving, or focus moving on, closes the card only if no day column
@@ -1518,6 +1566,16 @@ function bindEvents() {
   byId("trend-released-only").addEventListener("change", (event) => {
     state.trendReleasedOnly = event.target.checked;
     renderTrends();
+  });
+  // An open hover card is positioned against the chart, so any scroll or resize
+  // that moves its column has to move it too.
+  byId("trend-chart").addEventListener("scroll", repositionDayTooltip, {
+    passive: true,
+  });
+  window.addEventListener("resize", repositionDayTooltip);
+  document.addEventListener("keydown", (event) => {
+    // Do not swallow Escape unless a card is actually open to close.
+    if (event.key === "Escape" && dismissDayTooltip()) event.preventDefault();
   });
   byId("filters").addEventListener("input", (event) => {
     // The Scan date select has its own dedicated change handler above. A

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -530,10 +530,13 @@ function renderTrends() {
         hideDayTooltip();
         showDayTooltip(button, day, previous, dayCounts, categories);
       };
+      button.showDayTooltip = show;
       button.addEventListener("pointerenter", show);
       button.addEventListener("focus", show);
-      button.addEventListener("pointerleave", hideDayTooltip);
-      button.addEventListener("blur", hideDayTooltip);
+      // Mixed pointer and keyboard use: leaving with the mouse must not close a
+      // card the keyboard still owns, so hand it back to the focused column.
+      button.addEventListener("pointerleave", releaseDayTooltip);
+      button.addEventListener("blur", releaseDayTooltip);
       button.addEventListener("click", () => {
         state.todayDate = day.date;
         setView("today");
@@ -659,6 +662,9 @@ function showDayTooltip(column, day, previous, dayCounts, categories) {
 
 function positionDayTooltip(tooltip, column) {
   const frame = tooltip.parentElement;
+  // Drop any narrowing a previous cramped placement applied, so every hover is
+  // measured at the card's natural width.
+  tooltip.style.maxWidth = "";
   const frameBox = frame.getBoundingClientRect();
   const columnBox = column.getBoundingClientRect();
   const width = tooltip.offsetWidth;
@@ -685,15 +691,30 @@ function positionDayTooltip(tooltip, column) {
   // it, so the hovered bar the reader is inspecting is never covered.
   const gap = 12;
   const rightEdge = columnBox.right - frameBox.left + gap;
+  const leftEdge = columnBox.left - frameBox.left - gap - width;
   const fitsRight = rightEdge + width <= frame.clientWidth - 8;
-  const beside = fitsRight
-    ? rightEdge
-    : columnBox.left - frameBox.left - gap - width;
-  tooltip.style.left = `${clampLeft(beside)}px`;
-  tooltip.style.top = `${Math.max(
-    Math.min(barTop - frameBox.top, frame.clientHeight - height - 8),
-    8,
+  const fitsLeft = leftEdge >= 8;
+  const besideTop = () =>
+    `${Math.max(
+      Math.min(barTop - frameBox.top, frame.clientHeight - tooltip.offsetHeight - 8),
+      8,
+    )}px`;
+  if (fitsRight || fitsLeft) {
+    tooltip.style.left = `${clampLeft(fitsRight ? rightEdge : leftEdge)}px`;
+    tooltip.style.top = besideTop();
+    return;
+  }
+  // Neither side has room at the card's natural width. Narrow it to whichever
+  // side has more space rather than letting it clamp back over the bar; the
+  // card is capped in CSS, so this only ever shrinks it further.
+  const roomRight = frame.clientWidth - 8 - rightEdge;
+  const roomLeft = columnBox.left - frameBox.left - gap - 8;
+  const useRight = roomRight >= roomLeft;
+  tooltip.style.maxWidth = `${Math.max(Math.round(useRight ? roomRight : roomLeft), 120)}px`;
+  tooltip.style.left = `${clampLeft(
+    useRight ? rightEdge : columnBox.left - frameBox.left - gap - tooltip.offsetWidth,
   )}px`;
+  tooltip.style.top = besideTop();
 }
 
 function hideDayTooltip() {
@@ -704,6 +725,25 @@ function hideDayTooltip() {
   document
     .querySelectorAll("#trend-chart .day-column[aria-describedby]")
     .forEach((column) => column.removeAttribute("aria-describedby"));
+}
+
+// A pointer leaving, or focus moving on, closes the card only if no day column
+// still holds focus. Otherwise the keyboard's card is restored. The check is
+// deferred because blur fires before focus settles on the next element.
+function releaseDayTooltip() {
+  hideDayTooltip();
+  requestAnimationFrame(() => {
+    const focused = document.activeElement;
+    if (
+      focused &&
+      focused.classList &&
+      focused.classList.contains("day-column") &&
+      typeof focused.showDayTooltip === "function" &&
+      byId("day-tooltip").hidden
+    ) {
+      focused.showDayTooltip();
+    }
+  });
 }
 
 function metricLabel(value, singular, plural = `${singular}s`) {

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -669,8 +669,13 @@ function positionDayTooltip(tooltip, column) {
   const columnBox = column.getBoundingClientRect();
   const width = tooltip.offsetWidth;
   const height = tooltip.offsetHeight;
+  // Reads the live width, so a placement that narrows the card first still
+  // clamps against its new size rather than the width measured on entry.
   const clampLeft = (value) =>
-    Math.min(Math.max(value, 8), Math.max(frame.clientWidth - width - 8, 8));
+    Math.min(
+      Math.max(value, 8),
+      Math.max(frame.clientWidth - tooltip.offsetWidth - 8, 8),
+    );
   // The bar stack is a fixed-height plotting box, so its own top says nothing
   // about how tall the rendered bars are. Measure the drawn segments instead.
   const drawn = [...column.querySelectorAll(".bar-segment, .attention-volume")]

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -524,7 +524,12 @@ function renderTrends() {
         element("span", { className: "day-label", text: day.date.slice(5) }),
       ]);
       const previous = state.data.days[dayIndex - 1];
-      const show = () => showDayTooltip(button, day, previous, dayCounts, categories);
+      const show = () => {
+        // Clear the previous column's description first: moving between columns
+        // must never leave two triggers pointing at one card.
+        hideDayTooltip();
+        showDayTooltip(button, day, previous, dayCounts, categories);
+      };
       button.addEventListener("pointerenter", show);
       button.addEventListener("focus", show);
       button.addEventListener("pointerleave", hideDayTooltip);
@@ -646,6 +651,9 @@ function showDayTooltip(column, day, previous, dayCounts, categories) {
 
   tooltip.hidden = false;
   tooltip.setAttribute("aria-hidden", "false");
+  // Point the trigger at the card while it is open. Without this the breakdown
+  // is visual only: a screen reader on the focused column would never reach it.
+  column.setAttribute("aria-describedby", tooltip.id);
   positionDayTooltip(tooltip, column);
 }
 
@@ -653,19 +661,39 @@ function positionDayTooltip(tooltip, column) {
   const frame = tooltip.parentElement;
   const frameBox = frame.getBoundingClientRect();
   const columnBox = column.getBoundingClientRect();
-  // The chart scrolls horizontally, so anchor to the frame and clamp inside it
-  // rather than trusting the column to sit within view.
+  const width = tooltip.offsetWidth;
+  const height = tooltip.offsetHeight;
+  const clampLeft = (value) =>
+    Math.min(Math.max(value, 8), Math.max(frame.clientWidth - width - 8, 8));
+  // The bar stack is a fixed-height plotting box, so its own top says nothing
+  // about how tall the rendered bars are. Measure the drawn segments instead.
+  const drawn = [...column.querySelectorAll(".bar-segment, .attention-volume")]
+    .map((bar) => bar.getBoundingClientRect())
+    .filter((box) => box.height > 0);
+  const barTop = drawn.length
+    ? Math.min(...drawn.map((box) => box.top))
+    : columnBox.bottom;
+  const above = barTop - frameBox.top - height - 10;
   const center = columnBox.left - frameBox.left + columnBox.width / 2;
-  tooltip.style.left = `${Math.min(
-    Math.max(center - tooltip.offsetWidth / 2, 8),
-    Math.max(frame.clientWidth - tooltip.offsetWidth - 8, 8),
+  if (above >= 0) {
+    // There is room over the bar, so sit above it and stay centred.
+    tooltip.style.left = `${clampLeft(center - width / 2)}px`;
+    tooltip.style.top = `${above}px`;
+    return;
+  }
+  // A tall bar leaves no headroom. Move beside the column rather than on top of
+  // it, so the hovered bar the reader is inspecting is never covered.
+  const gap = 12;
+  const rightEdge = columnBox.right - frameBox.left + gap;
+  const fitsRight = rightEdge + width <= frame.clientWidth - 8;
+  const beside = fitsRight
+    ? rightEdge
+    : columnBox.left - frameBox.left - gap - width;
+  tooltip.style.left = `${clampLeft(beside)}px`;
+  tooltip.style.top = `${Math.max(
+    Math.min(barTop - frameBox.top, frame.clientHeight - height - 8),
+    8,
   )}px`;
-  // Prefer sitting above the hovered bar, but never escape the frame: a tall
-  // tooltip on a short bar would otherwise float off the top of the panel.
-  const barTop = (column.querySelector(".bar-stack") || column).getBoundingClientRect().top;
-  const preferred = barTop - frameBox.top - tooltip.offsetHeight - 10;
-  const maxTop = Math.max(frame.clientHeight - tooltip.offsetHeight - 8, 0);
-  tooltip.style.top = `${Math.min(Math.max(preferred, 0), maxTop)}px`;
 }
 
 function hideDayTooltip() {
@@ -673,6 +701,9 @@ function hideDayTooltip() {
   if (!tooltip) return;
   tooltip.hidden = true;
   tooltip.setAttribute("aria-hidden", "true");
+  document
+    .querySelectorAll("#trend-chart .day-column[aria-describedby]")
+    .forEach((column) => column.removeAttribute("aria-describedby"));
 }
 
 function metricLabel(value, singular, plural = `${singular}s`) {

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -499,22 +499,16 @@ function renderTrends() {
   );
   replaceChildren(
     byId("trend-chart"),
-    state.data.days.map((day) => {
+    state.data.days.map((day, dayIndex) => {
       const dayCounts = countsFor(day);
       const total = Object.values(dayCounts).reduce((sum, count) => sum + count, 0);
       const segments = categories.map((category, index) => {
-        const segment = element("span", {
-          className: "bar-segment",
-          attrs: { title: `${category.replaceAll("_", " ")}: ${dayCounts[category] || 0}` },
-        });
+        const segment = element("span", { className: "bar-segment" });
         segment.style.height = `${((dayCounts[category] || 0) / maxTotal) * 260}px`;
         segment.style.setProperty("--bar-color", categoryColor(category, index));
         return segment;
       });
-      const attentionBar = element("span", {
-        className: "attention-volume",
-        attrs: { title: `Active attention: ${day.attention.active_count}` },
-      });
+      const attentionBar = element("span", { className: "attention-volume" });
       attentionBar.style.height = `${(day.attention.active_count / maxTotal) * 260}px`;
       const button = element("button", {
         className: "day-column",
@@ -529,6 +523,12 @@ function renderTrends() {
         ]),
         element("span", { className: "day-label", text: day.date.slice(5) }),
       ]);
+      const previous = state.data.days[dayIndex - 1];
+      const show = () => showDayTooltip(button, day, previous, dayCounts, categories);
+      button.addEventListener("pointerenter", show);
+      button.addEventListener("focus", show);
+      button.addEventListener("pointerleave", hideDayTooltip);
+      button.addEventListener("blur", hideDayTooltip);
       button.addEventListener("click", () => {
         state.todayDate = day.date;
         setView("today");
@@ -538,6 +538,7 @@ function renderTrends() {
       return button;
     }),
   );
+  hideDayTooltip();
   byId("snapshot-count").textContent = `${state.data.snapshot_count} snapshots`;
   replaceChildren(
     byId("trend-table"),
@@ -567,6 +568,111 @@ function renderTrends() {
       ]);
     }),
   );
+}
+
+// The chart exists to compare days, so the tooltip answers only what made this
+// column this tall and whether that is up or down. Momentum, baselines, and
+// cumulative totals stay on the domain cards rather than being repeated here.
+const TOOLTIP_CATEGORY_LIMIT = 4;
+
+function showDayTooltip(column, day, previous, dayCounts, categories) {
+  const tooltip = byId("day-tooltip");
+  const total = Object.values(dayCounts).reduce((sum, count) => sum + count, 0);
+  // A different report limit or connector set lifts every count at once, so the
+  // same gate the headline sentence uses decides whether a delta is meaningful.
+  const comparable = previous && sameCollectionContext(day, previous);
+  const previousTotal = comparable
+    ? Object.values(
+        state.trendReleasedOnly
+          ? previous.category_counts_released
+          : previous.category_counts,
+      ).reduce((sum, count) => sum + count, 0)
+    : null;
+  const ranked = categories
+    .map((category, index) => ({
+      category,
+      count: dayCounts[category] || 0,
+      color: categoryColor(category, index),
+    }))
+    .filter((entry) => entry.count > 0)
+    .sort((a, b) => b.count - a.count);
+  const shown = ranked.slice(0, TOOLTIP_CATEGORY_LIMIT);
+  const restCount = ranked
+    .slice(TOOLTIP_CATEGORY_LIMIT)
+    .reduce((sum, entry) => sum + entry.count, 0);
+
+  const rows = shown.map((entry) => {
+    const swatch = element("span", { className: "legend-swatch" });
+    swatch.style.setProperty("--swatch", entry.color);
+    return element("span", { className: "day-tooltip-row" }, [
+      swatch,
+      element("span", {
+        className: "day-tooltip-name",
+        text: entry.category.replaceAll("_", " "),
+      }),
+      element("span", { className: "day-tooltip-value", text: entry.count }),
+    ]);
+  });
+  if (restCount) {
+    rows.push(
+      element("span", { className: "day-tooltip-row day-tooltip-rest" }, [
+        element("span", {
+          className: "day-tooltip-name",
+          text: `+${ranked.length - shown.length} more categories`,
+        }),
+        element("span", { className: "day-tooltip-value", text: restCount }),
+      ]),
+    );
+  }
+
+  replaceChildren(tooltip, [
+    element("span", { className: "day-tooltip-date", text: formatDate(day.date) }),
+    element("span", {
+      className: "day-tooltip-total",
+      text:
+        `${metricLabel(total, "category match", "category matches")}` +
+        (previousTotal === null
+          ? ""
+          : total === previousTotal
+            ? ` · flat vs ${previous.date.slice(5)}`
+            : ` · ${deltaText(total - previousTotal)} vs ${previous.date.slice(5)}`),
+    }),
+    rows.length ? element("span", { className: "day-tooltip-rows" }, rows) : null,
+    element("span", {
+      className: "day-tooltip-attention",
+      text: `Active attention: ${day.attention.active_count}`,
+    }),
+  ]);
+
+  tooltip.hidden = false;
+  tooltip.setAttribute("aria-hidden", "false");
+  positionDayTooltip(tooltip, column);
+}
+
+function positionDayTooltip(tooltip, column) {
+  const frame = tooltip.parentElement;
+  const frameBox = frame.getBoundingClientRect();
+  const columnBox = column.getBoundingClientRect();
+  // The chart scrolls horizontally, so anchor to the frame and clamp inside it
+  // rather than trusting the column to sit within view.
+  const center = columnBox.left - frameBox.left + columnBox.width / 2;
+  tooltip.style.left = `${Math.min(
+    Math.max(center - tooltip.offsetWidth / 2, 8),
+    Math.max(frame.clientWidth - tooltip.offsetWidth - 8, 8),
+  )}px`;
+  // Prefer sitting above the hovered bar, but never escape the frame: a tall
+  // tooltip on a short bar would otherwise float off the top of the panel.
+  const barTop = (column.querySelector(".bar-stack") || column).getBoundingClientRect().top;
+  const preferred = barTop - frameBox.top - tooltip.offsetHeight - 10;
+  const maxTop = Math.max(frame.clientHeight - tooltip.offsetHeight - 8, 0);
+  tooltip.style.top = `${Math.min(Math.max(preferred, 0), maxTop)}px`;
+}
+
+function hideDayTooltip() {
+  const tooltip = byId("day-tooltip");
+  if (!tooltip) return;
+  tooltip.hidden = true;
+  tooltip.setAttribute("aria-hidden", "true");
 }
 
 function metricLabel(value, singular, plural = `${singular}s`) {

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -538,13 +538,11 @@ function renderTrends() {
       button.addEventListener("focus", show);
       // Mixed pointer and keyboard use: leaving with the mouse must not close a
       // card the keyboard still owns, so hand it back to the focused column.
-      // Leaving also lifts an Escape dismissal, so returning reopens the card.
-      const leave = () => {
-        if (dismissedTooltipColumn === button) dismissedTooltipColumn = null;
-        releaseDayTooltip();
-      };
-      button.addEventListener("pointerleave", leave);
-      button.addEventListener("blur", leave);
+      // An Escape dismissal lifts only once the column is neither hovered nor
+      // focused; otherwise taking the mouse off a focused column would undo the
+      // dismissal and reopen the card the reader just closed.
+      button.addEventListener("pointerleave", releaseDayTooltip);
+      button.addEventListener("blur", releaseDayTooltip);
       button.addEventListener("click", () => {
         state.todayDate = day.date;
         setView("today");
@@ -782,10 +780,22 @@ function repositionDayTooltip() {
 
 // A pointer leaving, or focus moving on, closes the card only if no day column
 // still holds focus. Otherwise the keyboard's card is restored. The check is
-// deferred because blur fires before focus settles on the next element.
+// deferred because blur fires before focus settles on the next element, and a
+// pointerleave arrives before :hover has updated.
 function releaseDayTooltip() {
   hideDayTooltip();
   requestAnimationFrame(() => {
+    // An Escape dismissal outlives a pointer moving away: it lifts only once
+    // its column is neither hovered nor focused, so taking the mouse off a
+    // focused column cannot reopen the card the reader just closed.
+    const dismissed = dismissedTooltipColumn;
+    if (
+      dismissed &&
+      document.activeElement !== dismissed &&
+      !dismissed.matches(":hover")
+    ) {
+      dismissedTooltipColumn = null;
+    }
     const focused = document.activeElement;
     if (
       focused &&

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -1044,8 +1044,80 @@ input {
   transition: filter 180ms ease;
 }
 
-.day-column:hover .bar-segment {
+.day-column:hover .bar-segment,
+.day-column:focus-visible .bar-segment {
   filter: saturate(1.35) brightness(0.93);
+}
+
+/* The hovered column stays at full strength while the rest recede, so the eye
+   lands on one day instead of hunting for a highlight. */
+.trend-chart:has(.day-column:hover) .day-column:not(:hover),
+.trend-chart:has(.day-column:focus-visible) .day-column:not(:focus-visible) {
+  opacity: 0.45;
+  transition: opacity 180ms ease;
+}
+
+.trend-chart-frame {
+  position: relative;
+}
+
+.day-tooltip {
+  position: absolute;
+  z-index: 5;
+  display: grid;
+  gap: 0.5rem;
+  width: max-content;
+  max-width: 260px;
+  padding: 0.7rem 0.8rem;
+  border: 1px solid var(--ink);
+  background: var(--panel);
+  box-shadow: var(--shadow);
+  pointer-events: none;
+}
+
+.day-tooltip-date {
+  font-family: var(--display);
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+}
+
+.day-tooltip-total {
+  color: var(--muted);
+  font-family: var(--utility);
+  font-size: 0.68rem;
+}
+
+.day-tooltip-rows {
+  display: grid;
+  gap: 0.3rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--line);
+}
+
+.day-tooltip-row {
+  display: grid;
+  grid-template-columns: 8px 1fr auto;
+  gap: 0.5rem;
+  align-items: center;
+  font-family: var(--utility);
+  font-size: 0.7rem;
+}
+
+.day-tooltip-rest {
+  grid-template-columns: 1fr auto;
+  color: var(--muted);
+}
+
+.day-tooltip-value {
+  font-variant-numeric: tabular-nums;
+}
+
+.day-tooltip-attention {
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--line);
+  color: var(--violet);
+  font-family: var(--utility);
+  font-size: 0.68rem;
 }
 
 .day-label {

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -1008,6 +1008,7 @@ input {
   min-width: 44px;
   border: 0;
   background: transparent;
+  transition: opacity 180ms ease;
 }
 
 .bar-stack {
@@ -1049,12 +1050,17 @@ input {
   filter: saturate(1.35) brightness(0.93);
 }
 
-/* The hovered column stays at full strength while the rest recede, so the eye
-   lands on one day instead of hunting for a highlight. */
-.trend-chart:has(.day-column:hover) .day-column:not(:hover),
-.trend-chart:has(.day-column:focus-visible) .day-column:not(:focus-visible) {
+/* The active column stays at full strength while the rest recede, so the eye
+   lands on one day instead of hunting for a highlight. The card shows a single
+   day, so exactly one column stays lit. A pointer wins when present, which
+   stops a column left focused by the keyboard from keeping a second one lit. */
+.trend-chart:has(.day-column:hover) .day-column:not(:hover) {
   opacity: 0.45;
-  transition: opacity 180ms ease;
+}
+
+.trend-chart:not(:has(.day-column:hover)):has(.day-column:focus-visible)
+  .day-column:not(:focus-visible) {
+  opacity: 0.45;
 }
 
 .trend-chart-frame {

--- a/site/index.html
+++ b/site/index.html
@@ -211,7 +211,10 @@
             </span>
           </label>
           <p class="trend-message" id="trend-message" role="status"></p>
-          <div class="trend-chart" id="trend-chart" role="img" aria-label="Daily category counts"></div>
+          <div class="trend-chart-frame">
+            <div class="trend-chart" id="trend-chart" role="img" aria-label="Daily category counts"></div>
+            <div class="day-tooltip" id="day-tooltip" role="tooltip" aria-hidden="true" hidden></div>
+          </div>
         </div>
 
         <section class="ledger" aria-labelledby="ledger-heading">

--- a/site/index.html
+++ b/site/index.html
@@ -212,7 +212,9 @@
           </label>
           <p class="trend-message" id="trend-message" role="status"></p>
           <div class="trend-chart-frame">
-            <div class="trend-chart" id="trend-chart" role="img" aria-label="Daily category counts"></div>
+            <!-- A group, not an img: role="img" would make the day buttons
+                 presentational and hide their tooltip description. -->
+            <div class="trend-chart" id="trend-chart" role="group" aria-label="Daily category counts"></div>
             <div class="day-tooltip" id="day-tooltip" role="tooltip" aria-hidden="true" hidden></div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

The stacked day columns in the trends chart relied on the `title` attribute, so
inspecting a day meant waiting for a browser tooltip that showed one category at
a time. Hovering a column now opens a hover card, and hovering dims the other
columns so the eye lands on one day.

Addresses the hover half of #60.

## What the card shows, and what it deliberately does not

The chart exists to compare days, so the card answers one question: what made
this column this tall, and was that up or down. It carries the date, the total,
the change against the previous comparable day, and the non-zero categories
ranked and capped at four with the remainder collapsed into a single row.

Momentum, baselines, and cumulative counts stay on the domain cards rather than
being repeated per day. A card holding everything the day knows would just be a
floating second copy of the Today view.

The change against the previous day reuses the same comparability gate as the
headline sentence, so a day scanned with different connector coverage or a
different report limit shows no delta rather than reporting a collection-policy
change as movement.

## Not included

The issue also asks for click-to-expand instead of navigating to the Today view.
That is a product decision about how much of a day belongs inline, so it is left
for a separate change; clicking still opens the Today view as before. #60 should
stay open for it.

One review suggestion was declined: making the card itself hoverable
(`pointer-events: none`). That is the pattern for tooltips holding links or
copyable text, but this card is read-only, so it would add pointer-tracking
across two elements and a close delay for content already readable without
touching it. It is also what guarantees the card never blocks the column
beneath, which the overlap handling relies on.

## Test plan

- `PYTHONPATH=src python3.11 -m pytest -q`: 163 passed.
- Driven in headless Chrome over the DevTools protocol against a real
  `radar.json` (9 snapshots, 5 categories, so the four-category cap and its
  overflow row both exercise):
  - no `title` attributes left in the chart
  - all 9 columns: card aligned to its column, never overlapping that column's
    own drawn bars, never escaping the chart frame
  - tall bars place the card beside the column; short bars place it above
  - at a 315px frame all 9 columns still place with no overlap and no escape
  - real Tab keypresses open the card and advance between columns
  - exactly one column lit in every input mode, including pointer on one column
    while another holds focus
  - Escape closes without moving focus, survives the pointer leaving a focused
    column, and lifts on genuine re-entry
  - a column scrolled out of the chart takes its card with it
  - the releases-only toggle cannot strand a stale card
- Reviewed visually in a browser at full width and at 420px.

## Note on scope

`role="img"` on the chart container was making its day buttons presentational,
which would have hidden the card from screen readers. It is `role="group"` now.
That predates this change, but the card's `aria-describedby` depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
