### PR TITLE
Keep scheduled radar healthy on empty arXiv days

### DIFF
--- a/.github/workflows/daily-radar.yml
+++ b/.github/workflows/daily-radar.yml
@@ -31,6 +31,30 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
+      - name: Report schedule latency
+        if: github.event_name == 'schedule'
+        env:
+          SCHEDULE_EXPRESSION: ${{ github.event.schedule }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          read -r scheduled_minute scheduled_hour _ <<< "${SCHEDULE_EXPRESSION}"
+          started_at="$(date -u +%s)"
+          scheduled_at="$(date -u --date "$(date -u +%F) ${scheduled_hour}:${scheduled_minute}:00" +%s)"
+          if (( started_at < scheduled_at )); then
+            scheduled_at="$((scheduled_at - 86400))"
+          fi
+          latency_minutes="$(((started_at - scheduled_at) / 60))"
+          {
+            echo "### Schedule timing"
+            echo "- Cron target: \`${SCHEDULE_EXPRESSION}\`"
+            echo "- Scheduled UTC: \`$(date -u --date "@${scheduled_at}" --iso-8601=seconds)\`"
+            echo "- Runner start UTC: \`$(date -u --date "@${started_at}" --iso-8601=seconds)\`"
+            echo "- Trigger latency: **${latency_minutes} minutes**"
+          } >> "${GITHUB_STEP_SUMMARY}"
+          if (( latency_minutes >= 30 )); then
+            echo "::warning title=Delayed scheduled trigger::GitHub started this workflow ${latency_minutes} minutes after its cron target"
+          fi
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false

--- a/README.md
+++ b/README.md
@@ -161,8 +161,11 @@ the snapshot push uses the App token so its `main` push can trigger deployment.
 
 ## Daily publishing
 
-`.github/workflows/daily-radar.yml` runs at 12:15 UTC and can also be started manually.
-It:
+`.github/workflows/daily-radar.yml` targets 06:15 and 12:15 UTC and can also be
+started manually. GitHub scheduled events are best-effort and may start late under
+Actions load, so the two targets provide a same-day retry. Every scheduled run records
+its target, actual runner start, and latency in the job summary, with a warning after
+30 minutes. The workflow:
 
 1. collects and renders with read-only repository permission;
 2. validates and uses the snapshot-writer App to persist one snapshot on `main`;

--- a/config.yml
+++ b/config.yml
@@ -117,6 +117,10 @@ sources:
   arxiv:
     enabled: true
     required: true
+    # Official category RSS feeds publish an empty bulletin on non-announcement
+    # days (notably weekends). A validated empty feed is healthy; HTTP, XML, and
+    # connector failures still fail this required source.
+    allow_empty: true
     # 48h report window + 120h overlap = seven days. arXiv's Atom published
     # timestamp is submission time, while announcements pause on weekends.
     overlap_hours: 120

--- a/src/benchmark_radar/pipeline.py
+++ b/src/benchmark_radar/pipeline.py
@@ -618,7 +618,9 @@ def run_pipeline(
             unavailable_required.append(
                 f"{source} failed" + (f" ({source_health.error})" if source_health.error else "")
             )
-        elif source_health.item_count == 0:
+        elif source_health.item_count == 0 and not config["sources"][source].get(
+            "allow_empty", False
+        ):
             unavailable_required.append(f"{source} returned no records")
     if unavailable_required:
         raise RuntimeError(

--- a/src/benchmark_radar/sources.py
+++ b/src/benchmark_radar/sources.py
@@ -112,23 +112,24 @@ def _fetch_arxiv_rss(
     found: dict[str, RadarItem] = {}
     for category in config.get("rss_categories", ["cs.AI", "cs.CL", "cs.CV"]):
         root = ET.fromstring(get_text(f"https://rss.arxiv.org/rss/{category}"))
-        for entry in root.findall("./channel/item"):
+        channel = root.find("channel") if root.tag == "rss" else None
+        if channel is None:
+            raise ConnectorPayloadError("arXiv RSS returned an incompatible document")
+        for entry in channel.findall("item"):
             title = " ".join((entry.findtext("title") or "").split())
             description = " ".join((entry.findtext("description") or "").split())
+            published_text = entry.findtext("pubDate")
+            url = (entry.findtext("link") or "").replace("http:", "https:")
+            guid = entry.findtext("guid") or url
+            source_id = _arxiv_source_id(guid)
+            if not title or not description or not published_text or not url or not source_id:
+                raise ConnectorPayloadError("arXiv RSS item is missing required fields")
             if keywords and not any(
                 keyword in f"{title} {description}".casefold() for keyword in keywords
             ):
                 continue
-            published_text = entry.findtext("pubDate")
-            if not published_text:
-                continue
             published = parsedate_to_datetime(published_text).astimezone(UTC)
             if published < overlap_since:
-                continue
-            url = (entry.findtext("link") or "").replace("http:", "https:")
-            guid = entry.findtext("guid") or url
-            source_id = _arxiv_source_id(guid)
-            if not source_id or not url:
                 continue
             announce_type = (
                 entry.findtext("arxiv:announce_type", namespaces=namespaces) or ""

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -532,6 +532,36 @@ def test_every_required_source_must_return_records(monkeypatch):
         run_pipeline(config, datetime(2026, 7, 27, tzinfo=UTC))
 
 
+def test_required_source_can_explicitly_allow_empty(monkeypatch):
+    monkeypatch.setitem(
+        __import__("benchmark_radar.pipeline", fromlist=["SOURCE_FETCHERS"]).SOURCE_FETCHERS,
+        "required_fixture",
+        lambda config, since, limit: [],
+    )
+    config = {
+        "radar": {
+            "lookback_hours": 48,
+            "max_items_per_source": 10,
+            "report_limit": 10,
+            "minimum_score": 0,
+        },
+        "taxonomy": {"benchmark": ["benchmark"]},
+        "sources": {
+            "required_fixture": {
+                "enabled": True,
+                "required": True,
+                "allow_empty": True,
+            }
+        },
+    }
+
+    run = run_pipeline(config, datetime(2026, 8, 1, tzinfo=UTC))
+
+    assert run.items == []
+    assert run.health[0].ok is True
+    assert run.health[0].item_count == 0
+
+
 def test_arxiv_discovery_state_suppresses_unchanged_overlap(monkeypatch):
     unchanged = item(
         source_id="2607.12345",

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -124,6 +124,48 @@ def test_arxiv_can_use_official_rss_as_primary(monkeypatch):
     assert [item.source_id for item in items] == ["2607.54321"]
 
 
+def test_arxiv_rejects_incompatible_empty_rss_document(monkeypatch):
+    monkeypatch.setattr(
+        "benchmark_radar.sources.get_text",
+        lambda url, params=None: "<html><body>maintenance</body></html>",
+    )
+
+    with pytest.raises(ConnectorPayloadError, match="arXiv RSS returned an incompatible document"):
+        fetch_arxiv(
+            {
+                "atom_enabled": False,
+                "rss_categories": ["cs.AI"],
+            },
+            datetime(2026, 8, 1, 12, tzinfo=UTC),
+            10,
+        )
+
+
+def test_arxiv_rejects_malformed_present_rss_item(monkeypatch):
+    malformed = """\
+<rss version="2.0">
+  <channel>
+    <item>
+      <title>New benchmark</title>
+      <link>https://arxiv.org/abs/2608.00001</link>
+      <description>A benchmark announcement without a publication date.</description>
+    </item>
+  </channel>
+</rss>
+"""
+    monkeypatch.setattr("benchmark_radar.sources.get_text", lambda url, params=None: malformed)
+
+    with pytest.raises(ConnectorPayloadError, match="arXiv RSS item is missing required fields"):
+        fetch_arxiv(
+            {
+                "atom_enabled": False,
+                "rss_categories": ["cs.AI"],
+            },
+            datetime(2026, 8, 1, 12, tzinfo=UTC),
+            10,
+        )
+
+
 def _github_row(index: int) -> dict:
     return {
         "full_name": f"org/repo{index}",


### PR DESCRIPTION
## Summary

- allow arXiv's validated empty RSS bulletins on non-announcement days while keeping network, XML, envelope, and item-schema failures fatal
- report scheduled-run latency in the GitHub Actions job summary and warn when a runner starts at least 30 minutes late
- document the two daily UTC targets and GitHub's best-effort scheduling behavior

## Root cause

Both August 1 cron events were created, but GitHub queued them well after their target times. Once runners started, collection failed for a separate reason: arXiv legitimately returned empty Saturday RSS bulletins, while the pipeline treated every zero-record response from a required source as a fatal outage.

## Impact

Weekend/non-announcement-day runs can publish normally when arXiv returns a structurally valid empty bulletin. Invalid or malformed arXiv responses still stop publication, and delayed GitHub runner starts are now visible directly in each scheduled run.

## Validation

- `.venv/bin/pytest -q` — 166 passed
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/benchmark-radar rebuild`
- YAML parsing and manual schedule-latency shell checks
- independent Codex review: no actionable defects
