### PR TITLE
Move Hacker News attention collection into Benchmark Radar

### DIFF
--- a/.github/workflows/daily-radar.yml
+++ b/.github/workflows/daily-radar.yml
@@ -40,7 +40,7 @@ jobs:
           cache: pip
       - name: Install
         run: python -m pip install .
-      - name: Collect and render
+      - name: Collect evidence and public attention
         env:
           GITHUB_TOKEN: ${{ github.token }}
           SEMANTIC_SCHOLAR_API_KEY: ${{ secrets.SEMANTIC_SCHOLAR_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Default sources:
 | Semantic Scholar | Optional `SEMANTIC_SCHOLAR_API_KEY` | Structured scholarly discovery |
 | OpenAlex | `OPENALEX_API_KEY` | Scholarly metadata enrichment |
 | Brave Search | `BRAVE_API_KEY` | Web and lab-blog discovery |
+| Hacker News | No | Public attention only; never quality-scored |
 
 The report remains useful without optional secrets. Missing optional sources are shown
 as warnings in the source-health table instead of being silently ignored.
@@ -164,7 +165,8 @@ the snapshot push uses the App token so its `main` push can trigger deployment.
 `.github/workflows/daily-radar.yml` runs at 12:15 UTC and can also be started manually.
 It:
 
-1. collects and renders with read-only repository permission;
+1. collects evidence plus public Hacker News attention and renders with read-only
+   repository permission;
 2. validates and uses the snapshot-writer App to persist one snapshot on `main`;
 3. creates or updates the date-filtered daily Issue;
 4. lets that App-authenticated push trigger the standalone Pages workflow;
@@ -190,13 +192,20 @@ must exist; they are created during initial repository setup.
 
 ## Public observation feeds
 
-The collector ingests compatible public attention observations from separate, read-only
-repositories before persisting the daily snapshot. Feed producers must follow
+The daily pipeline collects public Hacker News attention directly through its anonymous
+Algolia endpoint before persisting the snapshot. It preserves the original
+`benchmark-social-signal:hacker-news:*` observation IDs so historical records remain
+continuous after the collector migration. A failed collection is reported in source
+health and carries forward the last healthy observations instead of publishing a false
+empty result.
+
+Additional read-only feed producers can follow
 [`docs/public-observation-feed.schema.json`](docs/public-observation-feed.schema.json).
-The collector validates the feed version and HTTP(S) links, records producer health
-separately from radar ingest health, and stamps publication, producer discovery, and
+The radar validates feed versions and HTTP(S) links, records collection/producer health
+separately from evidence ingest health, and stamps publication, producer discovery, and
 first radar observation independently. The dashboard renders source text as plain text
-and labels these records as unranked attention rather than evidence.
+and labels these records as unranked attention rather than evidence. No cookies,
+authenticated sessions, private posts, LinkedIn, or X scraping are used.
 
 ## License
 

--- a/config.yml
+++ b/config.yml
@@ -246,10 +246,23 @@ sources:
       - new agentic AI benchmark leaderboard
 
 attention:
-  feeds:
-    - name: Benchmark Social Signal
-      enabled: true
-      url: "https://raw.githubusercontent.com/ktwu01/benchmark-social-signal/main/feed.json"
+  hacker_news:
+    enabled: true
+    # Keep the v1 producer namespace so observation IDs remain stable after
+    # moving collection out of benchmark-social-signal.
+    producer: benchmark-social-signal
+    lookback_hours: 168
+    items_per_query: 40
+    queries:
+      - AI benchmark
+      - LLM evaluation
+      - machine learning dataset
+      - model leaderboard
+    taxonomy:
+      benchmark: [benchmark, leaderboard, challenge set]
+      evaluation: [evaluation, eval, judge model]
+      dataset: [dataset, corpus, training data, synthetic data]
+      data_quality: [data quality, contamination, deduplication, provenance, leakage]
 
 publish:
   dashboard_url: "https://ktwu01.github.io/benchmark-radar/"

--- a/src/benchmark_radar/attention.py
+++ b/src/benchmark_radar/attention.py
@@ -207,7 +207,16 @@ def fetch_attention_feeds(
     if hacker_news.get("enabled", False):
         name = "Hacker News collector"
         producer = str(hacker_news.get("producer") or LEGACY_HACKER_NEWS_PRODUCER)
-        raw_observations, raw_health = collect_hacker_news(hacker_news, observed_at)
+        prior_source_ids = {
+            str(value.get("source_id"))
+            for value in previous_observations
+            if isinstance(value, dict) and value.get("producer") == producer
+        }
+        raw_observations, raw_health = collect_hacker_news(
+            hacker_news,
+            observed_at,
+            preferred_source_ids=prior_source_ids,
+        )
         if raw_health.get("ok"):
             payload = {
                 "schema_version": 1,

--- a/src/benchmark_radar/attention.py
+++ b/src/benchmark_radar/attention.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from datetime import UTC, datetime
 from typing import Any
 from urllib.parse import urlsplit
 
+from .hacker_news import collect_hacker_news
 from .http import get_json
 from .models import AttentionObservation, ProducerHealth, SourceHealth
+
+LEGACY_HACKER_NEWS_PRODUCER = "benchmark-social-signal"
 
 
 def _date(value: str | None, *, fallback: datetime) -> datetime:
@@ -58,11 +62,135 @@ def _supporting_observations(
     return supporting
 
 
+def _normalize_feed(
+    payload: dict[str, Any],
+    *,
+    name: str,
+    observed_at: datetime,
+    state: dict[str, Any],
+) -> tuple[list[AttentionObservation], SourceHealth, list[ProducerHealth], dict[str, Any]]:
+    if payload.get("schema_version") != 1 or not isinstance(payload.get("observations"), list):
+        raise ValueError("unsupported public observation feed schema")
+    producer = str(payload.get("producer") or name)
+    staged_state = deepcopy(state)
+    staged: dict[str, AttentionObservation] = {}
+    for raw in payload["observations"]:
+        if not isinstance(raw, dict):
+            continue
+        raw_id = str(raw.get("id") or "").strip()
+        source = str(raw.get("source") or producer).strip()
+        source_id = str(raw.get("source_id") or "").strip()
+        title = str(raw.get("title") or "").strip()
+        record_url = _http_url(raw.get("url"))
+        if not raw_id or not source_id or not title or not record_url:
+            continue
+        observation_id = f"{producer}:{raw_id}"
+        previous = staged_state.get(observation_id) or {}
+        first_observed = _date(previous.get("observed_at"), fallback=observed_at)
+        published = _date(raw.get("published_at"), fallback=observed_at)
+        discovered = _date(raw.get("discovered_at"), fallback=observed_at)
+        staged[observation_id] = AttentionObservation(
+            observation_id=observation_id,
+            producer=producer,
+            source=source,
+            source_id=source_id,
+            title=title,
+            url=record_url,
+            published_at=published,
+            discovered_at=discovered,
+            observed_at=first_observed,
+            summary=str(raw.get("summary") or ""),
+            event_kind=str(raw.get("event_kind") or "discussed"),
+            authors=[str(author) for author in raw.get("authors") or []],
+            primary_artifact_url=_http_url(raw.get("primary_artifact_url")),
+            metrics={
+                str(key): float(value)
+                for key, value in (raw.get("metrics") or {}).items()
+                if isinstance(value, int | float) and value >= 0
+            },
+            categories=sorted(
+                {str(category) for category in raw.get("categories") or [] if category}
+            ),
+            rationale=[str(reason) for reason in raw.get("rationale") or []],
+            supporting_observations=_supporting_observations(
+                raw.get("supporting_observations"),
+                default_source=source,
+            ),
+        )
+        staged_state[observation_id] = {
+            "observed_at": first_observed.astimezone(UTC).isoformat(),
+            "last_seen_at": observed_at.astimezone(UTC).isoformat(),
+        }
+    producer_health = []
+    for raw_health in payload.get("health") or []:
+        if not isinstance(raw_health, dict):
+            continue
+        producer_health.append(
+            ProducerHealth(
+                producer=producer,
+                source=str(raw_health.get("source") or producer),
+                ok=bool(raw_health.get("ok")),
+                item_count=int(raw_health.get("item_count") or 0),
+                error=(str(raw_health["error"]) if raw_health.get("error") is not None else None),
+            )
+        )
+    return (
+        list(staged.values()),
+        SourceHealth(source=name, kind="attention", ok=True, item_count=len(staged)),
+        producer_health,
+        staged_state,
+    )
+
+
+def _restore_previous(
+    values: list[dict[str, Any]],
+    *,
+    producer: str,
+) -> list[AttentionObservation]:
+    restored: list[AttentionObservation] = []
+    for raw in values:
+        if not isinstance(raw, dict) or raw.get("producer") != producer:
+            continue
+        try:
+            restored.append(
+                AttentionObservation(
+                    observation_id=str(raw["observation_id"]),
+                    producer=producer,
+                    source=str(raw["source"]),
+                    source_id=str(raw["source_id"]),
+                    title=str(raw["title"]),
+                    url=str(raw["url"]),
+                    published_at=_date(str(raw["published_at"]), fallback=datetime.now(UTC)),
+                    discovered_at=_date(str(raw["discovered_at"]), fallback=datetime.now(UTC)),
+                    observed_at=_date(str(raw["observed_at"]), fallback=datetime.now(UTC)),
+                    summary=str(raw.get("summary") or ""),
+                    event_kind=str(raw.get("event_kind") or "discussed"),
+                    authors=[str(author) for author in raw.get("authors") or []],
+                    primary_artifact_url=_http_url(raw.get("primary_artifact_url")),
+                    metrics={
+                        str(key): float(value)
+                        for key, value in (raw.get("metrics") or {}).items()
+                        if isinstance(value, int | float) and value >= 0
+                    },
+                    categories=[str(value) for value in raw.get("categories") or []],
+                    rationale=[str(value) for value in raw.get("rationale") or []],
+                    supporting_observations=_supporting_observations(
+                        raw.get("supporting_observations"),
+                        default_source=str(raw["source"]),
+                    ),
+                )
+            )
+        except (KeyError, TypeError, ValueError):
+            continue
+    return restored
+
+
 def fetch_attention_feeds(
     config: dict[str, Any],
     *,
     observed_at: datetime,
     previous_state: dict[str, Any] | None = None,
+    previous_observations: list[dict[str, Any]] | None = None,
 ) -> tuple[
     list[AttentionObservation],
     list[SourceHealth],
@@ -72,7 +200,52 @@ def fetch_attention_feeds(
     observations: dict[str, AttentionObservation] = {}
     ingest_health: list[SourceHealth] = []
     producer_health: list[ProducerHealth] = []
-    state = dict(previous_state or {})
+    state = deepcopy(previous_state or {})
+    previous_observations = previous_observations or []
+
+    hacker_news = config.get("hacker_news") or {}
+    if hacker_news.get("enabled", False):
+        name = "Hacker News collector"
+        producer = str(hacker_news.get("producer") or LEGACY_HACKER_NEWS_PRODUCER)
+        raw_observations, raw_health = collect_hacker_news(hacker_news, observed_at)
+        if raw_health.get("ok"):
+            payload = {
+                "schema_version": 1,
+                "producer": producer,
+                "generated_at": observed_at.astimezone(UTC).isoformat(),
+                "observations": raw_observations,
+                "health": [raw_health],
+            }
+            try:
+                parsed, health, reported, state = _normalize_feed(
+                    payload,
+                    name=name,
+                    observed_at=observed_at,
+                    state=state,
+                )
+                observations.update((item.observation_id, item) for item in parsed)
+                ingest_health.append(health)
+                producer_health.extend(reported)
+            except Exception as error:
+                raw_health = {
+                    "source": "Hacker News",
+                    "ok": False,
+                    "item_count": 0,
+                    "error": f"{type(error).__name__}: {error}",
+                }
+        if not raw_health.get("ok"):
+            error = str(raw_health.get("error") or "Hacker News collection failed")
+            ingest_health.append(SourceHealth(source=name, kind="attention", ok=False, error=error))
+            producer_health.append(
+                ProducerHealth(
+                    producer=producer,
+                    source=str(raw_health.get("source") or "Hacker News"),
+                    ok=False,
+                    error=error,
+                )
+            )
+            restored = _restore_previous(previous_observations, producer=producer)
+            observations.update((item.observation_id, item) for item in restored)
 
     for feed_config in config.get("feeds", []):
         if not feed_config.get("enabled", True):
@@ -91,80 +264,17 @@ def fetch_attention_feeds(
             continue
         try:
             payload = get_json(url)
-            if payload.get("schema_version") != 1 or not isinstance(
-                payload.get("observations"), list
-            ):
-                raise ValueError("unsupported public observation feed schema")
-            producer = str(payload.get("producer") or name)
-            accepted = 0
-            for raw in payload["observations"]:
-                if not isinstance(raw, dict):
-                    continue
-                raw_id = str(raw.get("id") or "").strip()
-                source = str(raw.get("source") or producer).strip()
-                source_id = str(raw.get("source_id") or "").strip()
-                title = str(raw.get("title") or "").strip()
-                record_url = _http_url(raw.get("url"))
-                if not raw_id or not source_id or not title or not record_url:
-                    continue
-                observation_id = f"{producer}:{raw_id}"
-                previous = state.get(observation_id) or {}
-                first_observed = _date(previous.get("observed_at"), fallback=observed_at)
-                published = _date(raw.get("published_at"), fallback=observed_at)
-                discovered = _date(raw.get("discovered_at"), fallback=observed_at)
-                observation = AttentionObservation(
-                    observation_id=observation_id,
-                    producer=producer,
-                    source=source,
-                    source_id=source_id,
-                    title=title,
-                    url=record_url,
-                    published_at=published,
-                    discovered_at=discovered,
-                    observed_at=first_observed,
-                    summary=str(raw.get("summary") or ""),
-                    event_kind=str(raw.get("event_kind") or "discussed"),
-                    authors=[str(author) for author in raw.get("authors") or []],
-                    primary_artifact_url=_http_url(raw.get("primary_artifact_url")),
-                    metrics={
-                        str(key): float(value)
-                        for key, value in (raw.get("metrics") or {}).items()
-                        if isinstance(value, int | float) and value >= 0
-                    },
-                    categories=sorted(
-                        {str(category) for category in raw.get("categories") or [] if category}
-                    ),
-                    rationale=[str(reason) for reason in raw.get("rationale") or []],
-                    supporting_observations=_supporting_observations(
-                        raw.get("supporting_observations"),
-                        default_source=source,
-                    ),
-                )
-                observations[observation_id] = observation
-                state[observation_id] = {
-                    "observed_at": first_observed.astimezone(UTC).isoformat(),
-                    "last_seen_at": observed_at.astimezone(UTC).isoformat(),
-                }
-                accepted += 1
-            ingest_health.append(
-                SourceHealth(source=name, kind="attention", ok=True, item_count=accepted)
+            if not isinstance(payload, dict):
+                raise ValueError("public observation feed must be an object")
+            parsed, health, reported, state = _normalize_feed(
+                payload,
+                name=name,
+                observed_at=observed_at,
+                state=state,
             )
-            for raw_health in payload.get("health") or []:
-                if not isinstance(raw_health, dict):
-                    continue
-                producer_health.append(
-                    ProducerHealth(
-                        producer=producer,
-                        source=str(raw_health.get("source") or producer),
-                        ok=bool(raw_health.get("ok")),
-                        item_count=int(raw_health.get("item_count") or 0),
-                        error=(
-                            str(raw_health["error"])
-                            if raw_health.get("error") is not None
-                            else None
-                        ),
-                    )
-                )
+            observations.update((item.observation_id, item) for item in parsed)
+            ingest_health.append(health)
+            producer_health.extend(reported)
         except Exception as error:
             ingest_health.append(
                 SourceHealth(

--- a/src/benchmark_radar/hacker_news.py
+++ b/src/benchmark_radar/hacker_news.py
@@ -27,7 +27,7 @@ def match_categories(title: str, taxonomy: dict[str, list[str]]) -> list[str]:
     return sorted(
         category
         for category, terms in taxonomy.items()
-        if any(str(term).casefold() in haystack for term in terms)
+        if any(re.search(rf"\b{re.escape(str(term).casefold())}", haystack) for term in terms)
     )
 
 
@@ -35,12 +35,18 @@ def normalized_title(title: str) -> str:
     return " ".join(re.findall(r"[a-z0-9]+", title.casefold()))
 
 
-def _attention_total(observation: dict[str, Any]) -> float:
-    metrics = observation["metrics"]
-    return float(metrics.get("points", 0)) + float(metrics.get("comments", 0))
+def cluster_observations(
+    observations: list[dict[str, Any]],
+    *,
+    preferred_source_ids: set[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Cluster repeated titles while keeping the cluster identity immutable.
 
-
-def cluster_observations(observations: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    A previous primary wins when present so IDs created by the standalone
+    collector survive the migration. New clusters use the smallest immutable
+    HN object ID; mutable points and comment counts never select identity.
+    """
+    preferred_source_ids = preferred_source_ids or set()
     groups: dict[tuple[str, str], list[dict[str, Any]]] = {}
     for observation in observations:
         key = (observation["source"], normalized_title(observation["title"]))
@@ -48,14 +54,8 @@ def cluster_observations(observations: list[dict[str, Any]]) -> list[dict[str, A
 
     clustered: list[dict[str, Any]] = []
     for group in groups.values():
-        primary = max(
-            group,
-            key=lambda value: (
-                _attention_total(value),
-                value["published_at"],
-                value["source_id"],
-            ),
-        )
+        preferred = [value for value in group if str(value["source_id"]) in preferred_source_ids]
+        primary = min(preferred or group, key=lambda value: str(value["source_id"]))
         result = {
             **primary,
             "categories": sorted({category for value in group for category in value["categories"]}),
@@ -101,6 +101,8 @@ def collect_hacker_news(
     config: dict[str, Any],
     now: datetime,
     fetcher: Callable[[str, dict[str, Any]], dict[str, Any]] = _fetch_json,
+    *,
+    preferred_source_ids: set[str] | None = None,
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     """Collect public HN stories without treating attention as quality evidence."""
     now = now.astimezone(UTC)
@@ -134,7 +136,7 @@ def collect_hacker_news(
                 if not source_id or not title or not created_at:
                     continue
                 published = parse_time(str(created_at))
-                if published < since:
+                if not since <= published <= now:
                     continue
                 categories = match_categories(title, taxonomy)
                 if not categories:
@@ -191,7 +193,10 @@ def collect_hacker_news(
             "item_count": 0,
             "error": f"{type(error).__name__}: {error}",
         }
-    observations = cluster_observations(list(found.values()))
+    observations = cluster_observations(
+        list(found.values()),
+        preferred_source_ids=preferred_source_ids,
+    )
     return observations, {
         "source": "Hacker News",
         "ok": True,

--- a/src/benchmark_radar/hacker_news.py
+++ b/src/benchmark_radar/hacker_news.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from urllib.parse import urlsplit
+
+from .http import get_json
+
+HN_SEARCH_URL = "https://hn.algolia.com/api/v1/search_by_date"
+
+
+def _fetch_json(url: str, params: dict[str, Any]) -> dict[str, Any]:
+    payload = get_json(url, params=params)
+    if not isinstance(payload, dict):
+        raise ValueError("Hacker News search returned a non-object response")
+    return payload
+
+
+def parse_time(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
+
+
+def match_categories(title: str, taxonomy: dict[str, list[str]]) -> list[str]:
+    haystack = title.casefold()
+    return sorted(
+        category
+        for category, terms in taxonomy.items()
+        if any(str(term).casefold() in haystack for term in terms)
+    )
+
+
+def normalized_title(title: str) -> str:
+    return " ".join(re.findall(r"[a-z0-9]+", title.casefold()))
+
+
+def _attention_total(observation: dict[str, Any]) -> float:
+    metrics = observation["metrics"]
+    return float(metrics.get("points", 0)) + float(metrics.get("comments", 0))
+
+
+def cluster_observations(observations: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    groups: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for observation in observations:
+        key = (observation["source"], normalized_title(observation["title"]))
+        groups.setdefault(key, []).append(observation)
+
+    clustered: list[dict[str, Any]] = []
+    for group in groups.values():
+        primary = max(
+            group,
+            key=lambda value: (
+                _attention_total(value),
+                value["published_at"],
+                value["source_id"],
+            ),
+        )
+        result = {
+            **primary,
+            "categories": sorted({category for value in group for category in value["categories"]}),
+            "metrics": {
+                "points": sum(float(value["metrics"].get("points", 0)) for value in group),
+                "comments": sum(float(value["metrics"].get("comments", 0)) for value in group),
+                "submissions": float(len(group)),
+            },
+            "rationale": sorted({reason for value in group for reason in value["rationale"]}),
+        }
+        supporting = sorted(
+            (value for value in group if value["source_id"] != primary["source_id"]),
+            key=lambda value: (value["published_at"], value["source_id"]),
+            reverse=True,
+        )
+        if supporting:
+            result["rationale"].append(
+                f"Clustered {len(group)} public submissions with the same normalized title"
+            )
+            result["supporting_observations"] = [
+                {
+                    "source_id": value["source_id"],
+                    "url": value["url"],
+                    "published_at": value["published_at"],
+                    "metrics": value["metrics"],
+                    **(
+                        {"primary_artifact_url": value["primary_artifact_url"]}
+                        if value.get("primary_artifact_url")
+                        else {}
+                    ),
+                }
+                for value in supporting
+            ]
+        clustered.append(result)
+    return sorted(
+        clustered,
+        key=lambda value: (value["published_at"], value["source_id"]),
+        reverse=True,
+    )
+
+
+def collect_hacker_news(
+    config: dict[str, Any],
+    now: datetime,
+    fetcher: Callable[[str, dict[str, Any]], dict[str, Any]] = _fetch_json,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Collect public HN stories without treating attention as quality evidence."""
+    now = now.astimezone(UTC)
+    since = now - timedelta(hours=int(config.get("lookback_hours", 72)))
+    limit = max(1, min(int(config.get("items_per_query", 30)), 100))
+    found: dict[str, dict[str, Any]] = {}
+    try:
+        queries = config["queries"]
+        taxonomy = config["taxonomy"]
+        if not isinstance(queries, list) or not isinstance(taxonomy, dict):
+            raise ValueError("Hacker News queries and taxonomy must be configured")
+        for query in queries:
+            payload = fetcher(
+                HN_SEARCH_URL,
+                {
+                    "query": str(query),
+                    "tags": "story",
+                    "numericFilters": f"created_at_i>{int(since.timestamp())}",
+                    "hitsPerPage": limit,
+                },
+            )
+            hits = payload.get("hits")
+            if not isinstance(hits, list):
+                raise ValueError("Hacker News search response is missing a hits array")
+            for hit in hits:
+                if not isinstance(hit, dict):
+                    continue
+                source_id = str(hit.get("objectID") or "")
+                title = str(hit.get("title") or "").strip()
+                created_at = hit.get("created_at")
+                if not source_id or not title or not created_at:
+                    continue
+                published = parse_time(str(created_at))
+                if published < since:
+                    continue
+                categories = match_categories(title, taxonomy)
+                if not categories:
+                    continue
+                discussion_url = f"https://news.ycombinator.com/item?id={source_id}"
+                artifact_url = hit.get("url")
+                artifact_host = (
+                    urlsplit(artifact_url).netloc
+                    if isinstance(artifact_url, str)
+                    and artifact_url.startswith(("https://", "http://"))
+                    else ""
+                )
+                rationale = [
+                    f"Public Hacker News story matched query: {query}",
+                    "Attention signal only; not scientific-quality evidence",
+                ]
+                observation = found.get(source_id)
+                if observation:
+                    observation["categories"] = sorted(
+                        set(observation["categories"]) | set(categories)
+                    )
+                    observation["rationale"] = sorted(
+                        set(observation["rationale"]) | set(rationale)
+                    )
+                    continue
+                observation = {
+                    "id": f"hacker-news:{source_id}",
+                    "source": "Hacker News",
+                    "source_id": source_id,
+                    "title": title,
+                    "url": discussion_url,
+                    "published_at": published.isoformat(),
+                    "discovered_at": now.isoformat(),
+                    "summary": (
+                        f"Public Hacker News discussion linking to {artifact_host}."
+                        if artifact_host
+                        else "Public discussion submitted to Hacker News."
+                    ),
+                    "event_kind": "discussed",
+                    "categories": categories,
+                    "metrics": {
+                        "points": float(hit.get("points") or 0),
+                        "comments": float(hit.get("num_comments") or 0),
+                    },
+                    "rationale": rationale,
+                }
+                if artifact_host:
+                    observation["primary_artifact_url"] = artifact_url
+                found[source_id] = observation
+    except Exception as error:
+        return [], {
+            "source": "Hacker News",
+            "ok": False,
+            "item_count": 0,
+            "error": f"{type(error).__name__}: {error}",
+        }
+    observations = cluster_observations(list(found.values()))
+    return observations, {
+        "source": "Hacker News",
+        "ok": True,
+        "item_count": len(observations),
+        "error": None,
+    }

--- a/src/benchmark_radar/pipeline.py
+++ b/src/benchmark_radar/pipeline.py
@@ -637,6 +637,8 @@ def run_pipeline(
         observed_at=now,
         previous_state=((previous_snapshot or {}).get("discovery_state") or {}).get("attention")
         or {},
+        previous_observations=((previous_snapshot or {}).get("attention") or {}).get("observations")
+        or [],
     )
     return RadarRun(
         generated_at=now,

--- a/tests/fixtures/hn.json
+++ b/tests/fixtures/hn.json
@@ -1,0 +1,31 @@
+{
+  "hits": [
+    {
+      "created_at": "2026-07-27T10:00:00Z",
+      "title": "Show HN: A transparent LLM evaluation benchmark",
+      "url": "https://example.org/benchmark",
+      "author": "researcher",
+      "points": 42,
+      "num_comments": 12,
+      "objectID": "12345"
+    },
+    {
+      "created_at": "2026-07-27T09:00:00Z",
+      "title": "Show HN: A transparent LLM evaluation benchmark",
+      "url": "https://mirror.example.org/benchmark",
+      "author": "second-reader",
+      "points": 1,
+      "num_comments": 0,
+      "objectID": "12346"
+    },
+    {
+      "created_at": "2026-07-27T08:00:00Z",
+      "title": "A general programming discussion",
+      "url": "https://example.org/unrelated",
+      "author": "reader",
+      "points": 3,
+      "num_comments": 1,
+      "objectID": "99999"
+    }
+  ]
+}

--- a/tests/test_attention.py
+++ b/tests/test_attention.py
@@ -30,7 +30,7 @@ def test_integrated_collector_preserves_legacy_observation_ids(monkeypatch):
     observed = datetime(2026, 7, 27, 12, tzinfo=UTC)
     monkeypatch.setattr(
         "benchmark_radar.attention.collect_hacker_news",
-        lambda config, now: (
+        lambda config, now, **kwargs: (
             [local_observation(now)],
             {"source": "Hacker News", "ok": True, "item_count": 1, "error": None},
         ),
@@ -52,7 +52,7 @@ def test_failed_integrated_collection_carries_forward_last_healthy_observations(
     observed = datetime(2026, 7, 27, 12, tzinfo=UTC)
     monkeypatch.setattr(
         "benchmark_radar.attention.collect_hacker_news",
-        lambda config, now: (
+        lambda config, now, **kwargs: (
             [local_observation(now)],
             {"source": "Hacker News", "ok": True, "item_count": 1, "error": None},
         ),
@@ -61,7 +61,7 @@ def test_failed_integrated_collection_carries_forward_last_healthy_observations(
     previous = [first[0].to_dict()]
     monkeypatch.setattr(
         "benchmark_radar.attention.collect_hacker_news",
-        lambda config, now: (
+        lambda config, now, **kwargs: (
             [],
             {
                 "source": "Hacker News",

--- a/tests/test_attention.py
+++ b/tests/test_attention.py
@@ -2,6 +2,89 @@ from datetime import UTC, datetime
 
 from benchmark_radar.attention import fetch_attention_feeds
 
+LOCAL_CONFIG = {
+    "hacker_news": {
+        "enabled": True,
+        "producer": "benchmark-social-signal",
+    }
+}
+
+
+def local_observation(now):
+    return {
+        "id": "hacker-news:1",
+        "source": "Hacker News",
+        "source_id": "1",
+        "title": "Benchmark discussion",
+        "url": "https://news.ycombinator.com/item?id=1",
+        "published_at": "2026-07-26T12:00:00+00:00",
+        "discovered_at": now.isoformat(),
+        "event_kind": "discussed",
+        "categories": ["benchmark"],
+        "metrics": {"points": 2},
+        "rationale": ["Attention signal only"],
+    }
+
+
+def test_integrated_collector_preserves_legacy_observation_ids(monkeypatch):
+    observed = datetime(2026, 7, 27, 12, tzinfo=UTC)
+    monkeypatch.setattr(
+        "benchmark_radar.attention.collect_hacker_news",
+        lambda config, now: (
+            [local_observation(now)],
+            {"source": "Hacker News", "ok": True, "item_count": 1, "error": None},
+        ),
+    )
+
+    observations, ingest, producer, _ = fetch_attention_feeds(
+        LOCAL_CONFIG,
+        observed_at=observed,
+    )
+
+    assert observations[0].observation_id == "benchmark-social-signal:hacker-news:1"
+    assert observations[0].quality_scored is False
+    assert ingest[0].source == "Hacker News collector"
+    assert ingest[0].ok is True
+    assert producer[0].producer == "benchmark-social-signal"
+
+
+def test_failed_integrated_collection_carries_forward_last_healthy_observations(monkeypatch):
+    observed = datetime(2026, 7, 27, 12, tzinfo=UTC)
+    monkeypatch.setattr(
+        "benchmark_radar.attention.collect_hacker_news",
+        lambda config, now: (
+            [local_observation(now)],
+            {"source": "Hacker News", "ok": True, "item_count": 1, "error": None},
+        ),
+    )
+    first, _, _, state = fetch_attention_feeds(LOCAL_CONFIG, observed_at=observed)
+    previous = [first[0].to_dict()]
+    monkeypatch.setattr(
+        "benchmark_radar.attention.collect_hacker_news",
+        lambda config, now: (
+            [],
+            {
+                "source": "Hacker News",
+                "ok": False,
+                "item_count": 0,
+                "error": "TimeoutError: fixture timeout",
+            },
+        ),
+    )
+
+    restored, ingest, producer, next_state = fetch_attention_feeds(
+        LOCAL_CONFIG,
+        observed_at=observed.replace(day=28),
+        previous_state=state,
+        previous_observations=previous,
+    )
+
+    assert [item.to_dict() for item in restored] == previous
+    assert ingest[0].ok is False
+    assert "TimeoutError" in ingest[0].error
+    assert producer[0].ok is False
+    assert next_state == state
+
 
 def test_feed_is_normalized_without_quality_scores(monkeypatch):
     payload = {

--- a/tests/test_hacker_news.py
+++ b/tests/test_hacker_news.py
@@ -2,7 +2,12 @@ import json
 from datetime import UTC, datetime
 from pathlib import Path
 
-from benchmark_radar.hacker_news import collect_hacker_news, normalized_title
+from benchmark_radar.hacker_news import (
+    cluster_observations,
+    collect_hacker_news,
+    match_categories,
+    normalized_title,
+)
 
 
 def config():
@@ -65,6 +70,38 @@ def test_title_normalization_is_exact_but_punctuation_insensitive():
     )
 
 
+def test_category_terms_are_anchored_at_word_starts():
+    taxonomy = {"evaluation": ["eval"], "dataset": ["dataset"]}
+
+    assert match_categories("A retrieval dataset", taxonomy) == ["dataset"]
+    assert match_categories("An evaluation dataset", taxonomy) == ["dataset", "evaluation"]
+
+
+def test_cluster_identity_does_not_change_with_engagement():
+    def observation(source_id, points):
+        return {
+            "id": f"hacker-news:{source_id}",
+            "source": "Hacker News",
+            "source_id": source_id,
+            "title": "The same benchmark",
+            "url": f"https://news.ycombinator.com/item?id={source_id}",
+            "published_at": f"2026-07-27T0{source_id}:00:00+00:00",
+            "categories": ["benchmark"],
+            "metrics": {"points": points, "comments": 0},
+            "rationale": [],
+        }
+
+    first = cluster_observations([observation("1", 10), observation("2", 5)])[0]
+    later = cluster_observations([observation("1", 10), observation("2", 15)])[0]
+    preserved = cluster_observations(
+        [observation("1", 10), observation("2", 15)],
+        preferred_source_ids={"2"},
+    )[0]
+
+    assert first["id"] == later["id"] == "hacker-news:1"
+    assert preserved["id"] == "hacker-news:2"
+
+
 def test_empty_result_is_healthy():
     observations, health = collect_hacker_news(
         config(),
@@ -102,3 +139,22 @@ def test_malformed_search_response_is_a_visible_failure():
     assert observations == []
     assert health["ok"] is False
     assert "hits array" in health["error"]
+
+
+def test_stories_newer_than_collection_time_are_excluded():
+    observations, health = collect_hacker_news(
+        config(),
+        datetime(2026, 7, 27, 12, tzinfo=UTC),
+        fetcher=lambda _url, _params: {
+            "hits": [
+                {
+                    "objectID": "future",
+                    "title": "A future AI benchmark",
+                    "created_at": "2026-07-28T12:00:00Z",
+                }
+            ]
+        },
+    )
+
+    assert observations == []
+    assert health["ok"] is True

--- a/tests/test_hacker_news.py
+++ b/tests/test_hacker_news.py
@@ -1,0 +1,104 @@
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+from benchmark_radar.hacker_news import collect_hacker_news, normalized_title
+
+
+def config():
+    return {
+        "lookback_hours": 168,
+        "items_per_query": 40,
+        "queries": ["AI benchmark", "LLM evaluation"],
+        "taxonomy": {
+            "benchmark": ["benchmark", "leaderboard", "challenge set"],
+            "evaluation": ["evaluation", "eval", "judge model"],
+            "dataset": ["dataset", "corpus"],
+        },
+    }
+
+
+def fixture_fetcher(_url, _params):
+    return json.loads(Path("tests/fixtures/hn.json").read_text(encoding="utf-8"))
+
+
+def test_public_collector_emits_clustered_attention_observation():
+    observations, health = collect_hacker_news(
+        config(),
+        datetime(2026, 7, 27, 12, tzinfo=UTC),
+        fetcher=fixture_fetcher,
+    )
+
+    assert health == {
+        "source": "Hacker News",
+        "ok": True,
+        "item_count": 1,
+        "error": None,
+    }
+    assert len(observations) == 1
+    observation = observations[0]
+    assert observation["id"] == "hacker-news:12345"
+    assert observation["url"] == "https://news.ycombinator.com/item?id=12345"
+    assert observation["primary_artifact_url"] == "https://example.org/benchmark"
+    assert observation["categories"] == ["benchmark", "evaluation"]
+    assert observation["metrics"] == {
+        "comments": 12.0,
+        "points": 43.0,
+        "submissions": 2.0,
+    }
+    assert observation["supporting_observations"] == [
+        {
+            "source_id": "12346",
+            "url": "https://news.ycombinator.com/item?id=12346",
+            "published_at": "2026-07-27T09:00:00+00:00",
+            "metrics": {"points": 1.0, "comments": 0.0},
+            "primary_artifact_url": "https://mirror.example.org/benchmark",
+        }
+    ]
+    assert any("not scientific-quality evidence" in value for value in observation["rationale"])
+    assert any("Clustered 2 public submissions" in value for value in observation["rationale"])
+
+
+def test_title_normalization_is_exact_but_punctuation_insensitive():
+    assert normalized_title("DeepSWE – Best Benchmark?") == normalized_title(
+        "DeepSWE: Best Benchmark!"
+    )
+
+
+def test_empty_result_is_healthy():
+    observations, health = collect_hacker_news(
+        config(),
+        datetime(2026, 7, 27, 12, tzinfo=UTC),
+        fetcher=lambda _url, _params: {"hits": []},
+    )
+
+    assert observations == []
+    assert health["ok"] is True
+    assert health["item_count"] == 0
+
+
+def test_failure_does_not_look_like_empty_success():
+    def fail(_url, _params):
+        raise TimeoutError("fixture timeout")
+
+    observations, health = collect_hacker_news(
+        config(),
+        datetime(2026, 7, 27, 12, tzinfo=UTC),
+        fetcher=fail,
+    )
+
+    assert observations == []
+    assert health["ok"] is False
+    assert "TimeoutError" in health["error"]
+
+
+def test_malformed_search_response_is_a_visible_failure():
+    observations, health = collect_hacker_news(
+        config(),
+        datetime(2026, 7, 27, 12, tzinfo=UTC),
+        fetcher=lambda _url, _params: {},
+    )
+
+    assert observations == []
+    assert health["ok"] is False
+    assert "hits array" in health["error"]


### PR DESCRIPTION
## Summary

- port the public Hacker News collector, configuration, fixtures, and tests into `benchmark-radar`
- collect attention during the normal radar run and remove the runtime dependency on `benchmark-social-signal/feed.json`
- preserve the legacy `benchmark-social-signal:hacker-news:*` ID namespace, first-observed timestamps, clustering, metrics, and `quality_scored: false` boundary
- keep the last validated observations when collection fails while reporting both collection and producer health as failed
- make cluster IDs invariant to changing points/comments and exclude future-dated results from historical collection

## Why

The radar owned the ingest and dashboard but depended on a separate scheduled repository for a small public-only collector. That duplicated scheduling, configuration, tests, schema ownership, and persistence while adding a cross-repository runtime failure mode.

## Impact

Hacker News attention is now collected through the anonymous Algolia endpoint as part of the daily radar job. It remains unranked and does not contribute to scientific-quality scores. Existing observation IDs remain continuous across the migration.

## Validation

- `.venv/bin/pytest -q` — 173 passed
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/benchmark-radar rebuild`
- live anonymous Hacker News collection — healthy, 17 observations
- high-effort Codex review; three P2 findings fixed and regression-tested; repeat review clean

## Rollout

Tracks #74. Keep the issue open and do not archive `benchmark-social-signal` until this PR and #75 are merged and a scheduled production run verifies Hacker News observations in the persisted snapshot and dashboard.