### PR TITLE
Collect OpenAlex without an API key

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -235,6 +235,10 @@ sources:
 
   openalex:
     enabled: true
+    # OpenAlex has no free API key. It asks callers to identify themselves with
+    # a contact address, which routes requests to the faster and more reliable
+    # "polite pool". This is a public repository address, not a credential.
+    mailto: ktwu01@users.noreply.github.com
     searches:
       - large language model benchmark
       - artificial intelligence evaluation dataset

--- a/src/benchmark_radar/sources.py
+++ b/src/benchmark_radar/sources.py
@@ -645,15 +645,24 @@ def fetch_github_releases(
 
 
 def fetch_openalex(config: dict[str, Any], since: datetime, limit: int) -> list[RadarItem]:
-    api_key = os.getenv("OPENALEX_API_KEY")
-    if not api_key:
-        raise RuntimeError("OPENALEX_API_KEY is not configured")
+    # OpenAlex is a fully open API: anonymous requests succeed, and there is no
+    # free key to obtain. Requiring one disabled a working source on every run.
+    # A key is still forwarded when set, because OpenAlex sells premium keys,
+    # but an unset key is the normal case rather than a failure.
+    api_key = os.getenv("OPENALEX_API_KEY") or None
+    # `mailto` is how OpenAlex identifies a caller for its faster, more reliable
+    # "polite pool". It replaces the key as the default courtesy identifier.
+    mailto = str(config.get("mailto") or "").strip() or None
     found: dict[str, RadarItem] = {}
     for search in config.get("searches", []):
         payload = get_json(
             "https://api.openalex.org/works",
             params={
+                # get_json drops None params, so an unset key or mailto is
+                # simply absent instead of being sent as an empty string, which
+                # OpenAlex rejects with HTTP 401.
                 "api_key": api_key,
+                "mailto": mailto,
                 "search": search,
                 "filter": f"from_publication_date:{since.date().isoformat()}",
                 "sort": "publication_date:desc",

--- a/src/benchmark_radar/sources.py
+++ b/src/benchmark_radar/sources.py
@@ -649,7 +649,10 @@ def fetch_openalex(config: dict[str, Any], since: datetime, limit: int) -> list[
     # free key to obtain. Requiring one disabled a working source on every run.
     # A key is still forwarded when set, because OpenAlex sells premium keys,
     # but an unset key is the normal case rather than a failure.
-    api_key = os.getenv("OPENALEX_API_KEY") or None
+    # Stripped, not just falsy-checked: an unset GitHub Actions secret expands
+    # to "" and a pasted one often carries a trailing newline. OpenAlex answers
+    # both with HTTP 401, so an unnormalized value silently disables the source.
+    api_key = os.getenv("OPENALEX_API_KEY", "").strip() or None
     # `mailto` is how OpenAlex identifies a caller for its faster, more reliable
     # "polite pool". It replaces the key as the default courtesy identifier.
     mailto = str(config.get("mailto") or "").strip() or None

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -532,15 +532,66 @@ def test_new_connectors_never_synthesize_missing_summary(monkeypatch, fetcher, c
 def test_openalex_rejects_a_shapeless_payload(monkeypatch):
     # `payload.get("results", [])` made a `{}` reply indistinguishable from a
     # genuine zero-result day, so a broken response reported as healthy.
-    monkeypatch.setenv("OPENALEX_API_KEY", "key")
+    monkeypatch.delenv("OPENALEX_API_KEY", raising=False)
     monkeypatch.setattr("benchmark_radar.sources.get_json", lambda url, params: {})
 
     with pytest.raises(ConnectorPayloadError):
         fetch_openalex({"searches": ["benchmark"]}, datetime(2026, 7, 26, tzinfo=UTC), 10)
 
 
+def test_openalex_collects_without_an_api_key(monkeypatch):
+    # OpenAlex is an open API with no free key. Requiring one raised
+    # "OPENALEX_API_KEY is not configured" on every scheduled run and disabled
+    # a working source, so an unset key must be a normal anonymous request.
+    monkeypatch.delenv("OPENALEX_API_KEY", raising=False)
+    seen: list[dict] = []
+
+    def fake_get_json(url, params):
+        seen.append(params)
+        return {
+            "results": [
+                {
+                    "id": "https://openalex.org/W1",
+                    "display_name": "Keyless benchmark",
+                    "publication_date": "2026-07-27",
+                    "primary_location": {"landing_page_url": "https://example.com/w1"},
+                }
+            ]
+        }
+
+    monkeypatch.setattr("benchmark_radar.sources.get_json", fake_get_json)
+
+    items = fetch_openalex(
+        {"searches": ["benchmark"], "mailto": "radar@example.com"},
+        datetime(2026, 7, 26, tzinfo=UTC),
+        10,
+    )
+
+    assert [item.title for item in items] == ["Keyless benchmark"]
+    # An empty api_key must be dropped, not sent: OpenAlex answers a blank or
+    # wrong key with HTTP 401 rather than ignoring it.
+    assert seen[0]["api_key"] is None
+    assert seen[0]["mailto"] == "radar@example.com"
+
+
+def test_openalex_forwards_a_premium_api_key_when_set(monkeypatch):
+    monkeypatch.setenv("OPENALEX_API_KEY", "premium")
+    seen: list[dict] = []
+
+    def fake_get_json(url, params):
+        seen.append(params)
+        return {"results": []}
+
+    monkeypatch.setattr("benchmark_radar.sources.get_json", fake_get_json)
+
+    fetch_openalex({"searches": ["benchmark"]}, datetime(2026, 7, 26, tzinfo=UTC), 10)
+
+    assert seen[0]["api_key"] == "premium"
+    assert seen[0]["mailto"] is None
+
+
 def test_openalex_skips_undated_works(monkeypatch):
-    monkeypatch.setenv("OPENALEX_API_KEY", "key")
+    monkeypatch.delenv("OPENALEX_API_KEY", raising=False)
     monkeypatch.setattr(
         "benchmark_radar.sources.get_json",
         lambda url, params: {

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -568,14 +568,35 @@ def test_openalex_collects_without_an_api_key(monkeypatch):
     )
 
     assert [item.title for item in items] == ["Keyless benchmark"]
-    # An empty api_key must be dropped, not sent: OpenAlex answers a blank or
+    # An unset api_key must be dropped, not sent: OpenAlex answers a blank or
     # wrong key with HTTP 401 rather than ignoring it.
     assert seen[0]["api_key"] is None
     assert seen[0]["mailto"] == "radar@example.com"
 
 
+@pytest.mark.parametrize("blank", ["", "   ", "\n", " \t\n"])
+def test_openalex_drops_a_blank_or_whitespace_api_key(monkeypatch, blank):
+    # An unset GitHub Actions secret expands to an empty string. Forwarding it
+    # (or a whitespace-only value) sends api_key= and OpenAlex replies 401,
+    # which would disable the source exactly as the missing-key guard did.
+    monkeypatch.setenv("OPENALEX_API_KEY", blank)
+    seen: list[dict] = []
+
+    def fake_get_json(url, params):
+        seen.append(params)
+        return {"results": []}
+
+    monkeypatch.setattr("benchmark_radar.sources.get_json", fake_get_json)
+
+    fetch_openalex({"searches": ["benchmark"]}, datetime(2026, 7, 26, tzinfo=UTC), 10)
+
+    assert seen[0]["api_key"] is None
+
+
 def test_openalex_forwards_a_premium_api_key_when_set(monkeypatch):
-    monkeypatch.setenv("OPENALEX_API_KEY", "premium")
+    # Secrets are routinely pasted with a trailing newline, and OpenAlex
+    # rejects "premium\n" with HTTP 401, so the key is stripped before use.
+    monkeypatch.setenv("OPENALEX_API_KEY", "  premium\n")
     seen: list[dict] = []
 
     def fake_get_json(url, params):


### PR DESCRIPTION
## Summary

- stop requiring `OPENALEX_API_KEY`: OpenAlex is a fully open API with no free key to obtain
- identify the caller with the `mailto` contact address OpenAlex uses to route requests into its faster "polite pool"
- still forward a key when one is set, since OpenAlex sells premium keys
- strip the key so a blank or newline-padded secret is dropped rather than sent

## Why

`fetch_openalex` opened with:

```python
api_key = os.getenv("OPENALEX_API_KEY")
if not api_key:
    raise RuntimeError("OPENALEX_API_KEY is not configured")
```

No free OpenAlex key exists, so this guard could never be satisfied and the connector disabled itself on every scheduled run. The verified production snapshot `data/snapshots/2026-08-01.json` records `openalex` as `ok=false, item_count=0` with exactly that error. The run only stayed green because `openalex` is not marked `required`.

## Validation

Checked against the live API rather than assumed:

| Request | Result |
|---|---|
| no key, no mailto | HTTP 200 |
| no key + `mailto` | HTTP 200, real results |
| `api_key=bogus` | HTTP 401 |
| `api_key=<space>` | HTTP 401 |
| `api_key=bogus\n` | HTTP 401 |

That 401 behavior is why the value is stripped: a wrong or blank key is rejected, not ignored, so forwarding an unset secret would have re-broken the source through a different path.

- live keyless fetch using the committed config returns **68 works**
- same fetch with `OPENALEX_API_KEY="   "` also returns **68 works**
- `pytest` — 182 passed
- `ruff check` / `ruff format --check` clean

## Review

Codex flagged the unstripped key as a P1 (unset Actions secrets expand to `""`, pasted keys carry newlines). Confirmed against the live API and fixed in 52d7713, with parametrized regression coverage for `""`, `"   "`, `"\n"`, `" \t\n"` and a trailing-newline real key.

Gemini review was attempted first per repo policy, but the `gemini` CLI is unauthenticated in this environment (no `oauth_creds.json`), so Codex was used as the reviewer instead.

## Note

This restores a source that returns future-dated works (for example `publication_date: 2050-01-01`). Recency scoring clamps age at `max(0.0, ...)`, so a future date scores a permanent 100. That is pre-existing and independent of this change; filed separately rather than widened into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
