### PR TITLE
Add the Model Card Adoption Rank leaderboard (#83)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,9 +5,15 @@ on:
     branches: [main]
     paths:
       - "data/snapshots/**"
+      # The curated Model Card Adoption Rank is a deploy input like the
+      # snapshots are: a maintenance commit that only adds a model card must
+      # rebuild the dashboard, or the published ranking silently stays behind
+      # the registry until some unrelated change happens to trigger Pages.
+      - "data/model_cards.yml"
       - "site/**"
       - "src/benchmark_radar/snapshots.py"
       - "src/benchmark_radar/corpus.py"
+      - "src/benchmark_radar/model_cards.py"
       - ".github/workflows/pages.yml"
   workflow_dispatch:
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,36 @@ the selection funnel reports the count, and every scored deduction remains audit
 
 This is triage, not scientific quality adjudication or endorsement.
 
+## Model Card Adoption Rank
+
+A separate, curated view answering a different question: which benchmarks do frontier
+vendors actually report when they ship a model? It is published at `?view=leaderboard`
+on the dashboard and built from
+[`data/model_cards.yml`](data/model_cards.yml), a hand-maintained list of model cards,
+system cards, and technical reports with the benchmarks each one reports.
+
+The counted unit is the **document, not the result row**. A card reporting AIME at
+pass@1, at consensus@64, and with a Python tool contributes exactly one adoption, the
+same as a card reporting it once, so a long appendix cannot outvote a different vendor.
+Two counts are published side by side and neither is folded into a single score:
+`card_count` is the headline, and `organization_count` breaks ties, because the same
+count from six vendors is a shared standard while from one vendor it is a house style.
+
+This measures vendor attention, not benchmark quality. A saturated or contaminated
+benchmark can rank highly precisely because reporting it is conventional, so every row
+carries its own caveat and that disclaimer is published in `radar.json` rather than only
+stated in the browser. Benchmarks tracked but reported by no card are kept and ranked
+last: "in the registry, adopted by nobody" is itself a finding.
+
+Scores are deliberately out of scope. Vendors differ on prompt, scaffold, tool access,
+reasoning budget, pass@k, and evaluator, so two reported numbers for the same benchmark
+are usually not comparable. A mention survives all of those caveats, which is why it is
+the unit this ranking can honestly publish today.
+
+To extend it, add a benchmark to the `benchmarks:` block and a document to
+`model_cards:`, then run `benchmark-radar rebuild`. A card referencing an unknown
+benchmark id fails the build rather than silently creating a phantom entry.
+
 ## Run locally
 
 ```bash
@@ -96,8 +126,8 @@ graph and aggregates under the
 [versioned public schema](docs/cumulative-corpus.schema.json). No fuzzy match silently
 merges similarly titled artifacts.
 
-The dashboard exposes one filterable Today list, inline multi-record expansion, Trends,
-and a keyboard-accessible Trend Map. Selecting a map node carries its exact topic,
+The dashboard exposes one filterable Today list, inline multi-record expansion, the
+Model Card Adoption Rank leaderboard, Trends, and a keyboard-accessible Trend Map. Selecting a map node carries its exact topic,
 source, organization, or artifact into the Today filters. Trend comparisons require
 both the same report limit and the same connector-coverage signature; incomplete days
 remain visible and are explicitly annotated.

--- a/data/model_cards.yml
+++ b/data/model_cards.yml
@@ -1,0 +1,575 @@
+# Model Card Benchmark Registry (issue #83)
+#
+# A hand-curated list of frontier model cards, technical reports and release
+# posts, and the benchmarks each one reports. This file answers one question:
+# which benchmarks do vendors actually put in front of readers when they ship a
+# model?
+#
+# Deliberately NOT in scope here. Issue #83's first comment sketched a six-table
+# registry (per-configuration scores, reasoning budgets, pass@k, judge models,
+# comparison groups, contamination signals). That schema is right, and it is
+# also unbuildable as a first step: it needs a per-vendor PDF parser before it
+# can produce a single row. This file stores a *mention*, not a score. A mention
+# is the one fact that survives every configuration caveat in that comment -- it
+# does not matter whether GPT-5.6 ran AIME at pass@1 or consensus@64, the card
+# still chose to report AIME. Scores can be added later without invalidating
+# anything recorded here.
+#
+# Maintenance contract:
+#   * `benchmarks` lists the canonical benchmark_id, resolved against
+#     `benchmarks:` below. An id used by a card but absent from that block is a
+#     hard error, so a typo cannot quietly invent a benchmark with one adopter.
+#   * `url` must point at the card, report or release post the mentions were
+#     read from, so any row can be checked against its source.
+#   * `retrieved_at` records when a human last read that document. It is not the
+#     model's release date, and it is not automatically refreshed.
+#
+# Adding a model card: append an entry, list its benchmark ids, run
+# `benchmark-radar rebuild`. Adding a benchmark: add it to `benchmarks:` first.
+
+schema_version: 1
+
+# Canonical benchmark records. `aliases` exist so a future extractor can map
+# vendor spellings ("SWE-bench-Verified", "SWE Bench Verified") onto one id
+# without changing the ids the leaderboard is built from.
+benchmarks:
+  - id: hle
+    name: Humanity's Last Exam
+    aliases: ["HLE", "Humanity's Last Exam"]
+    domain: reasoning
+    url: https://lastexam.ai/
+    caveat: >-
+      Tool access and test-time compute budget move this score more than model
+      capability does, so two reported figures are rarely comparable.
+
+  - id: gpqa_diamond
+    name: GPQA Diamond
+    aliases: ["GPQA", "GPQA-Diamond"]
+    domain: science
+    url: https://arxiv.org/abs/2311.12022
+    caveat: >-
+      198 questions in the Diamond split, so run-to-run variance is wide and a
+      single reported number hides it.
+
+  - id: swe_bench_verified
+    name: SWE-bench Verified
+    aliases: ["SWE-bench Verified", "SWE-bench-Verified", "SWE Bench Verified"]
+    domain: coding_agent
+    url: https://openai.com/index/introducing-swe-bench-verified/
+    caveat: >-
+      Scaffold, tool permissions and time limit are part of the result; vendors
+      run their own harnesses.
+
+  - id: swe_bench_pro
+    name: SWE-bench Pro
+    aliases: ["SWE-bench Pro"]
+    domain: coding_agent
+    url: https://github.com/scaleapi/SWE-bench_Pro-os
+    caveat: Harness and split version must be recorded with any score.
+
+  - id: terminal_bench
+    name: Terminal-Bench
+    aliases: ["Terminal-Bench", "Terminal Bench", "TerminalBench", "Terminal-Bench 2.0"]
+    domain: agent
+    url: https://www.tbench.ai/
+    caveat: >-
+      Environment image, timeout and permitted commands change results
+      independently of the model.
+
+  - id: livecodebench
+    name: LiveCodeBench
+    aliases: ["LiveCodeBench", "LCB"]
+    domain: coding
+    url: https://livecodebench.github.io/
+    caveat: >-
+      Time-sliced problem set. A score without its problem window is not
+      comparable to any other score.
+
+  - id: aime
+    name: AIME
+    aliases: ["AIME", "AIME 2024", "AIME 2025", "AIME 2026"]
+    domain: math
+    url: https://maa.org/maa-invitational-competitions/
+    caveat: >-
+      pass@k, majority vote and Python tool access each shift this by double
+      digits.
+
+  - id: mmmu
+    name: MMMU
+    aliases: ["MMMU", "MMMU-Pro"]
+    domain: multimodal
+    url: https://mmmu-benchmark.github.io/
+    caveat: Image preprocessing and chain-of-thought settings affect results.
+
+  - id: mathvista
+    name: MathVista
+    aliases: ["MathVista"]
+    domain: multimodal
+    url: https://mathvista.github.io/
+    caveat: Mixes OCR quality with visual reasoning.
+
+  - id: video_mme
+    name: Video-MME
+    aliases: ["Video-MME", "VideoMME"]
+    domain: multimodal
+    url: https://video-mme.github.io/
+    caveat: Frame sampling rate dominates long-video results.
+
+  - id: tau_bench
+    name: tau-bench
+    aliases: ["tau-bench", "τ-bench", "tau2-bench", "TAU-bench"]
+    domain: tool_use
+    url: https://github.com/sierra-research/tau-bench
+    caveat: >-
+      Depends on a simulated user and policy; the simulator model is part of
+      the measurement.
+
+  - id: browsecomp
+    name: BrowseComp
+    aliases: ["BrowseComp"]
+    domain: agent
+    url: https://openai.com/index/browsecomp/
+    caveat: >-
+      Live web. The result depends on what the internet contained on the day
+      of the run.
+
+  - id: simpleqa
+    name: SimpleQA
+    aliases: ["SimpleQA", "SimpleQA Verified"]
+    domain: factuality
+    url: https://openai.com/index/introducing-simpleqa/
+    caveat: Knowledge cutoff must be recorded alongside the score.
+
+  - id: longbench
+    name: LongBench
+    aliases: ["LongBench", "LongBench v2"]
+    domain: long_context
+    url: https://github.com/THUDM/LongBench
+    caveat: Nominal context length is not effective context length.
+
+  - id: mrcr
+    name: MRCR
+    aliases: ["MRCR", "OpenAI-MRCR", "MRCR v2"]
+    domain: long_context
+    url: https://huggingface.co/datasets/openai/mrcr
+    caveat: Needle position and generation seed change the result.
+
+  - id: mmlu_pro
+    name: MMLU-Pro
+    aliases: ["MMLU-Pro", "MMLU Pro"]
+    domain: knowledge
+    url: https://github.com/TIGER-AI-Lab/MMLU-Pro
+    caveat: Static closed-set multiple choice; contamination risk rises over time.
+
+  - id: mmlu
+    name: MMLU
+    aliases: ["MMLU"]
+    domain: knowledge
+    url: https://github.com/hendrycks/test
+    caveat: >-
+      Saturated at the frontier and heavily contaminated. Useful as a
+      historical baseline, not as a ranking signal.
+
+  - id: livebench
+    name: LiveBench
+    aliases: ["LiveBench"]
+    domain: general
+    url: https://livebench.ai/
+    caveat: Contents change by release date; each date is a different benchmark.
+
+  - id: arena_hard
+    name: Arena-Hard
+    aliases: ["Arena-Hard", "ArenaHard"]
+    domain: human_preference
+    url: https://github.com/lmarena/arena-hard-auto
+    caveat: LLM-judge dependent, with known style and length bias.
+
+  - id: chatbot_arena
+    name: Chatbot Arena
+    aliases: ["Chatbot Arena", "LMArena", "LMSYS Arena"]
+    domain: human_preference
+    url: https://lmarena.ai/
+    caveat: >-
+      Elo from real user traffic; sampling and prompt distribution are outside
+      any vendor's control.
+
+  - id: bfcl
+    name: BFCL
+    aliases: ["BFCL", "Berkeley Function Calling Leaderboard"]
+    domain: tool_use
+    url: https://gorilla.cs.berkeley.edu/leaderboard.html
+    caveat: Schema complexity and execution checking vary by version.
+
+  - id: humaneval
+    name: HumanEval
+    aliases: ["HumanEval", "HumanEval+"]
+    domain: coding
+    url: https://github.com/openai/human-eval
+    caveat: Saturated. Retained because open-weight cards still report it.
+
+  - id: math_500
+    name: MATH-500
+    aliases: ["MATH-500", "MATH 500", "MATH"]
+    domain: math
+    url: https://github.com/openai/prm800k
+    caveat: Largely saturated at the frontier.
+
+  - id: gsm8k
+    name: GSM8K
+    aliases: ["GSM8K"]
+    domain: math
+    url: https://github.com/openai/grade-school-math
+    caveat: Saturated. A legacy baseline for small open models.
+
+  - id: ifeval
+    name: IFEval
+    aliases: ["IFEval"]
+    domain: instruction_following
+    url: https://github.com/google-research/google-research/tree/master/instruction_following_eval
+    caveat: Verifiable-constraint subset only; does not measure answer quality.
+
+  - id: mbpp
+    name: MBPP
+    aliases: ["MBPP", "MBPP+"]
+    domain: coding
+    url: https://github.com/google-research/google-research/tree/master/mbpp
+    caveat: Saturated; short single-function tasks.
+
+  - id: drop
+    name: DROP
+    aliases: ["DROP"]
+    domain: reasoning
+    url: https://allenai.org/data/drop
+    caveat: Legacy reading-comprehension baseline.
+
+  - id: arc_agi
+    name: ARC-AGI
+    aliases: ["ARC-AGI", "ARC-AGI-1", "ARC-AGI-2"]
+    domain: reasoning
+    url: https://arcprize.org/
+    caveat: >-
+      Compute per task is reported alongside score by the maintainers and
+      should not be dropped.
+
+  - id: aider_polyglot
+    name: Aider Polyglot
+    aliases: ["Aider Polyglot", "Aider"]
+    domain: coding
+    url: https://aider.chat/docs/leaderboards/
+    caveat: Edit-format sensitive; whole-file and diff modes differ substantially.
+
+  - id: mmlu_redux
+    name: MMLU-Redux
+    aliases: ["MMLU-Redux"]
+    domain: knowledge
+    url: https://github.com/aryopg/mmlu-redux
+    caveat: Error-corrected MMLU subset; reported mainly by open-weight cards.
+
+  - id: gpqa
+    name: GPQA (full)
+    aliases: ["GPQA main", "GPQA full"]
+    domain: science
+    url: https://arxiv.org/abs/2311.12022
+    caveat: >-
+      The full split, distinct from the Diamond subset most frontier cards
+      report.
+
+  - id: agieval
+    name: AGIEval
+    aliases: ["AGIEval"]
+    domain: knowledge
+    url: https://github.com/ruixiangcui/AGIEval
+    caveat: Human-exam derived; overlaps heavily with MMLU-style coverage.
+
+# Model cards, technical reports and release posts.
+#
+# `organization` is the publisher of the document. `benchmarks` is the set of
+# canonical ids that document reports a result for. It is a set, not a ranking:
+# a card that reports AIME once and a card that reports it in four
+# configurations both contribute exactly one adoption.
+model_cards:
+  - id: openai_gpt_5_system_card
+    organization: OpenAI
+    model: GPT-5
+    document_type: system_card
+    published: 2025-08-07
+    url: https://openai.com/index/gpt-5-system-card/
+    retrieved_at: 2026-08-02
+    benchmarks:
+      - gpqa_diamond
+      - hle
+      - swe_bench_verified
+      - aime
+      - mmmu
+      - simpleqa
+      - browsecomp
+      - tau_bench
+      - livecodebench
+      - mrcr
+
+  - id: openai_o3_o4_mini_system_card
+    organization: OpenAI
+    model: o3 and o4-mini
+    document_type: system_card
+    published: 2025-04-16
+    url: https://openai.com/index/o3-o4-mini-system-card/
+    retrieved_at: 2026-08-02
+    benchmarks:
+      - gpqa_diamond
+      - aime
+      - swe_bench_verified
+      - mmmu
+      - browsecomp
+      - simpleqa
+      - arc_agi
+      - livecodebench
+
+  - id: openai_gpt_4_1
+    organization: OpenAI
+    model: GPT-4.1
+    document_type: release_post
+    published: 2025-04-14
+    url: https://openai.com/index/gpt-4-1/
+    retrieved_at: 2026-08-02
+    benchmarks:
+      - swe_bench_verified
+      - gpqa_diamond
+      - aime
+      - mmlu
+      - mmmu
+      - video_mme
+      - mrcr
+      - ifeval
+      - aider_polyglot
+
+  - id: anthropic_claude_4_system_card
+    organization: Anthropic
+    model: Claude Opus 4 and Sonnet 4
+    document_type: system_card
+    published: 2025-05-22
+    url: https://www.anthropic.com/claude-4
+    retrieved_at: 2026-08-02
+    benchmarks:
+      - swe_bench_verified
+      - terminal_bench
+      - gpqa_diamond
+      - aime
+      - mmmu
+      - tau_bench
+      - mmlu
+      - mrcr
+
+  - id: anthropic_claude_3_7_sonnet
+    organization: Anthropic
+    model: Claude 3.7 Sonnet
+    document_type: system_card
+    published: 2025-02-24
+    url: https://www.anthropic.com/news/claude-3-7-sonnet
+    retrieved_at: 2026-08-02
+    benchmarks:
+      - swe_bench_verified
+      - tau_bench
+      - gpqa_diamond
+      - aime
+      - mmlu_pro
+      - mmmu
+      - math_500
+      - ifeval
+
+  - id: google_gemini_2_5_report
+    organization: Google DeepMind
+    model: Gemini 2.5 Pro
+    document_type: technical_report
+    published: 2025-06-17
+    url: https://storage.googleapis.com/deepmind-media/gemini/gemini_v2_5_report.pdf
+    retrieved_at: 2026-08-02
+    benchmarks:
+      - hle
+      - gpqa_diamond
+      - aime
+      - livecodebench
+      - swe_bench_verified
+      - mmmu
+      - video_mme
+      - mrcr
+      - simpleqa
+      - arc_agi
+      - mathvista
+
+  - id: google_gemini_1_5_report
+    organization: Google DeepMind
+    model: Gemini 1.5
+    document_type: technical_report
+    published: 2024-03-08
+    url: https://arxiv.org/abs/2403.05530
+    retrieved_at: 2026-08-02
+    benchmarks:
+      - mmlu
+      - gsm8k
+      - math_500
+      - humaneval
+      - mmmu
+      - video_mme
+      - mathvista
+      - drop
+
+  - id: meta_llama_4
+    organization: Meta
+    model: Llama 4
+    document_type: model_card
+    published: 2025-04-05
+    url: https://ai.meta.com/blog/llama-4-multimodal-intelligence/
+    retrieved_at: 2026-08-02
+    benchmarks:
+      - mmlu_pro
+      - gpqa_diamond
+      - livecodebench
+      - mmmu
+      - mathvista
+      - chatbot_arena
+      - mrcr
+
+  - id: meta_llama_3_1
+    organization: Meta
+    model: Llama 3.1 405B
+    document_type: model_card
+    published: 2024-07-23
+    url: https://ai.meta.com/blog/meta-llama-3-1/
+    retrieved_at: 2026-08-02
+    benchmarks:
+      - mmlu
+      - mmlu_pro
+      - gpqa
+      - humaneval
+      - mbpp
+      - gsm8k
+      - math_500
+      - ifeval
+      - arena_hard
+      - agieval
+      - bfcl
+      - drop
+
+  - id: qwen3_technical_report
+    organization: Qwen
+    model: Qwen3
+    document_type: technical_report
+    published: 2025-05-14
+    url: https://arxiv.org/abs/2505.09388
+    retrieved_at: 2026-08-02
+    benchmarks:
+      - mmlu_pro
+      - mmlu_redux
+      - gpqa_diamond
+      - aime
+      - livecodebench
+      - arena_hard
+      - ifeval
+      - bfcl
+      - livebench
+      - humaneval
+
+  - id: qwen2_5_coder_report
+    organization: Qwen
+    model: Qwen2.5-Coder
+    document_type: technical_report
+    published: 2024-09-18
+    url: https://arxiv.org/abs/2409.12186
+    retrieved_at: 2026-08-02
+    benchmarks:
+      - humaneval
+      - mbpp
+      - livecodebench
+      - mmlu
+      - gsm8k
+      - math_500
+
+  - id: deepseek_r1_report
+    organization: DeepSeek
+    model: DeepSeek-R1
+    document_type: technical_report
+    published: 2025-01-22
+    url: https://arxiv.org/abs/2501.12948
+    retrieved_at: 2026-08-02
+    benchmarks:
+      - aime
+      - math_500
+      - gpqa_diamond
+      - livecodebench
+      - mmlu
+      - mmlu_pro
+      - mmlu_redux
+      - simpleqa
+      - ifeval
+      - arena_hard
+      - swe_bench_verified
+      - aider_polyglot
+
+  - id: deepseek_v3_report
+    organization: DeepSeek
+    model: DeepSeek-V3
+    document_type: technical_report
+    published: 2024-12-27
+    url: https://arxiv.org/abs/2412.19437
+    retrieved_at: 2026-08-02
+    benchmarks:
+      - mmlu
+      - mmlu_pro
+      - mmlu_redux
+      - gpqa_diamond
+      - humaneval
+      - mbpp
+      - livecodebench
+      - gsm8k
+      - math_500
+      - aime
+      - ifeval
+      - arena_hard
+      - agieval
+      - drop
+
+  - id: mistral_large_2
+    organization: Mistral
+    model: Mistral Large 2
+    document_type: release_post
+    published: 2024-07-24
+    url: https://mistral.ai/news/mistral-large-2407/
+    retrieved_at: 2026-08-02
+    benchmarks:
+      - mmlu
+      - humaneval
+      - mbpp
+      - gsm8k
+      - math_500
+
+  - id: mistral_medium_3
+    organization: Mistral
+    model: Mistral Medium 3
+    document_type: release_post
+    published: 2025-05-07
+    url: https://mistral.ai/news/mistral-medium-3
+    retrieved_at: 2026-08-02
+    benchmarks:
+      - mmlu_pro
+      - gpqa_diamond
+      - humaneval
+      - livecodebench
+      - math_500
+      - ifeval
+      - aider_polyglot
+
+  - id: xai_grok_4_model_card
+    organization: xAI
+    model: Grok 4
+    document_type: model_card
+    published: 2025-07-09
+    url: https://x.ai/news/grok-4
+    retrieved_at: 2026-08-02
+    benchmarks:
+      - hle
+      - gpqa_diamond
+      - aime
+      - livecodebench
+      - arc_agi
+      - swe_bench_verified
+      - mmmu

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -21,6 +21,12 @@ const state = {
   entity: "",
   rubric: "",
   trendReleasedOnly: false,
+  // Leaderboard filters carry their own prefixed keys so a shared permalink can
+  // hold a Today filter and a Leaderboard filter at once without either view
+  // silently reinterpreting the other's `category` or `organization`.
+  lq: "",
+  ldomain: "",
+  lorg: "",
 };
 
 function element(tag, options = {}, children = []) {
@@ -90,7 +96,7 @@ function readUrl() {
   const params = new URLSearchParams(window.location.search);
   const requestedView = params.get("view");
   // Legacy Explorer permalinks resolve to the filterable Today list.
-  state.view = ["trends", "map"].includes(requestedView) ? requestedView : "today";
+  state.view = ["trends", "map", "leaderboard"].includes(requestedView) ? requestedView : "today";
   state.todayDate = params.get("date") || "";
   state.q = params.get("q") || "";
   state.kind = params.get("kind") || "";
@@ -99,6 +105,9 @@ function readUrl() {
   state.organization = params.get("organization") || "";
   state.event = params.get("event") || "";
   state.entity = params.get("entity") || "";
+  state.lq = params.get("lq") || "";
+  state.ldomain = params.get("ldomain") || "";
+  state.lorg = params.get("lorg") || "";
   state.rubric = new URLSearchParams(window.location.hash.slice(1)).get("rubric") || "";
 }
 
@@ -115,6 +124,9 @@ function writeUrl() {
   if (state.organization) params.set("organization", state.organization);
   if (state.event) params.set("event", state.event);
   if (state.view === "map" && state.entity) params.set("entity", state.entity);
+  if (state.lq) params.set("lq", state.lq);
+  if (state.ldomain) params.set("ldomain", state.ldomain);
+  if (state.lorg) params.set("lorg", state.lorg);
   const query = params.toString();
   // The rubric dialog is a hashtag, not a query param, so a shared link like
   // #rubric=2 reads as "jump to this section" rather than another filter.
@@ -1353,6 +1365,253 @@ function renderMapInsights(corpus) {
   ]);
 }
 
+// --- Model Card Adoption Rank (issue #83) -----------------------------------
+//
+// Counts how many curated model cards report each benchmark. The count is per
+// document, so a card reporting AIME in four configurations contributes the
+// same single adoption as a card reporting it once. That is the whole reason
+// this ranking is publishable while a score table is not: a mention survives
+// every reasoning-budget and pass@k caveat that makes two reported scores
+// incomparable.
+
+function leaderboardEntries() {
+  const board = state.data?.model_card_leaderboard;
+  if (!board) return [];
+  const query = state.lq.trim().toLowerCase();
+  return (board.entries || []).filter((entry) => {
+    if (state.ldomain && entry.domain !== state.ldomain) return false;
+    if (state.lorg && !(entry.organizations || []).includes(state.lorg)) return false;
+    if (!query) return true;
+    const haystack = [entry.name, entry.benchmark_id, ...(entry.aliases || [])]
+      .join(" ")
+      .toLowerCase();
+    return haystack.includes(query);
+  });
+}
+
+function adoptionBar(entry, maxCount) {
+  const width = maxCount ? Math.max(2, Math.round((entry.card_count / maxCount) * 100)) : 0;
+  return element(
+    "div",
+    {
+      className: "adoption-bar",
+      attrs: {
+        role: "img",
+        "aria-label": `${metricLabel(entry.card_count, "model card")} of ${metricLabel(
+          state.data.model_card_leaderboard.model_card_count,
+          "model card",
+        )}`,
+      },
+    },
+    [
+      element("span", {
+        className: "adoption-bar-fill",
+        attrs: { style: `width: ${width}%` },
+      }),
+    ],
+  );
+}
+
+function leaderboardRow(entry) {
+  const board = state.data.model_card_leaderboard;
+  const maxCount = board.entries?.[0]?.card_count || 0;
+  const header = element("summary", { className: "record-summary" }, [
+    element("span", {
+      className: "signal-rank",
+      text: String(entry.rank).padStart(2, "0"),
+    }),
+    element("div", { className: "record-heading" }, [
+      element("div", { className: "signal-meta" }, [
+        element("span", { text: entry.domain.replaceAll("_", " ") }),
+        // A benchmark in the registry that no curated card reports is a real
+        // observation, not an empty row: it says the benchmark is discussed
+        // without yet being adopted in vendor reporting. Say that, rather than
+        // showing a bare "0 organizations of 8".
+        entry.card_count
+          ? element("span", {
+              text: `${metricLabel(entry.organization_count, "organization")} of ${
+                board.organization_count
+              }`,
+            })
+          : element("span", { text: "not yet reported in these cards" }),
+      ]),
+      element("h3", { text: entry.name }),
+      // The caveat is part of the row, not a footnote. A ranking that puts a
+      // saturated benchmark near the top without saying so is misleading in
+      // exactly the direction issue #83 warns about.
+      entry.caveat ? element("p", { className: "signal-tldr", text: entry.caveat }) : null,
+    ]),
+    element("div", { className: "score" }, [
+      element("div", { className: "score-value" }, [
+        element("strong", { text: String(entry.card_count) }),
+        element("span", { text: `/ ${board.model_card_count}` }),
+      ]),
+      adoptionBar(entry, maxCount),
+      element("p", { className: "score-label", text: "Model cards" }),
+    ]),
+  ]);
+
+  const adopters = element(
+    "ul",
+    { className: "adopter-list" },
+    (entry.adopters || []).map((adopter) =>
+      element("li", {}, [
+        // A plain text link, not the .primary-link call-to-action button: a
+        // twelve-row roster of dark blocks reads as twelve competing actions
+        // rather than as one list of sources.
+        element("a", {
+          className: "adopter-link",
+          text: `${adopter.organization} · ${adopter.model}`,
+          attrs: {
+            href: adopter.url,
+            target: "_blank",
+            rel: "noopener noreferrer",
+          },
+        }),
+        element("span", {
+          className: "adopter-meta",
+          text: `${String(adopter.document_type).replaceAll("_", " ")}${
+            adopter.published ? ` · ${formatDate(adopter.published, { dateStyle: "medium" })}` : ""
+          }`,
+        }),
+      ]),
+    ),
+  );
+
+  return element("details", { className: "record-card" }, [
+    header,
+    element("div", { className: "record-detail" }, [
+      element("h3", { text: "Reported by" }),
+      adopters,
+      entry.url
+        ? element("a", {
+            className: "primary-link",
+            text: "Benchmark home ↗",
+            attrs: { href: entry.url, target: "_blank", rel: "noopener noreferrer" },
+          })
+        : null,
+    ]),
+  ]);
+}
+
+function renderLeaderboardFilters(board) {
+  const domains = Object.keys(board.domains || {}).sort();
+  replaceChildren(byId("leaderboard-domain"), [
+    option("", "All domains", !state.ldomain),
+    ...domains.map((domain) =>
+      option(domain, domain.replaceAll("_", " "), domain === state.ldomain),
+    ),
+  ]);
+  const organizations = Object.keys(board.organizations || {}).sort();
+  replaceChildren(byId("leaderboard-organization"), [
+    option("", "All organizations", !state.lorg),
+    ...organizations.map((organization) =>
+      option(organization, organization, organization === state.lorg),
+    ),
+  ]);
+  if (byId("leaderboard-search").value !== state.lq) {
+    byId("leaderboard-search").value = state.lq;
+  }
+}
+
+function renderLeaderboard() {
+  const board = state.data?.model_card_leaderboard;
+  const navButton = document.querySelector('[data-view="leaderboard"]');
+  // A checkout without the curated registry publishes no ranking. Hiding the
+  // nav entry is the honest response: offering a tab that opens an empty page
+  // reads as a broken feature rather than as absent data.
+  if (!board) {
+    if (navButton) navButton.hidden = true;
+    return;
+  }
+  if (navButton) navButton.hidden = false;
+
+  byId("leaderboard-measures").textContent = board.measures || "";
+  renderLeaderboardFilters(board);
+
+  const topEntries = (board.entries || []).filter((entry) => entry.card_count > 0);
+  replaceChildren(byId("leaderboard-insights"), [
+    mapInsightCard(
+      "Registry coverage",
+      [
+        ["Model cards", Number(board.model_card_count || 0).toLocaleString()],
+        ["Organizations", Number(board.organization_count || 0).toLocaleString()],
+        ["Benchmarks tracked", Number(board.benchmark_count || 0).toLocaleString()],
+        ["Reported at least once", Number(topEntries.length).toLocaleString()],
+      ],
+      "No registry entries yet.",
+    ),
+    mapInsightCard(
+      "Cards per organization",
+      Object.entries(board.organizations || {})
+        .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+        .map(([organization, count]) => [organization, metricLabel(count, "card")]),
+      "No organizations in the registry yet.",
+    ),
+    // Counts only benchmarks at least one card reports, which is deliberately
+    // narrower than the domain filter below. A benchmark tracked but reported
+    // by nobody is a real finding about the registry, so it stays visible in
+    // the list while being excluded from "how much of this domain is in use".
+    mapInsightCard(
+      "Domains reported at least once",
+      Object.entries(board.domains || {})
+        .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+        .map(([domain, count]) => [
+          domain.replaceAll("_", " "),
+          metricLabel(count, "benchmark"),
+        ]),
+      "No domains represented yet.",
+    ),
+    mapInsightCard(
+      "Adopted by every organization",
+      topEntries
+        .filter((entry) => entry.organization_count === board.organization_count)
+        .map((entry) => [entry.name, metricLabel(entry.card_count, "card")]),
+      "No benchmark is reported by every organization in the registry.",
+    ),
+  ]);
+
+  const entries = leaderboardEntries();
+  byId("leaderboard-count").textContent = `${metricLabel(
+    entries.length,
+    "benchmark",
+  )} of ${board.entries.length}`;
+  replaceChildren(
+    byId("leaderboard-list"),
+    entries.length
+      ? entries.map(leaderboardRow)
+      : [
+          element("p", {
+            className: "empty-state",
+            text: "No benchmarks match these filters. Clear one or more filters to widen the view.",
+          }),
+        ],
+  );
+
+  const cards = board.model_cards || [];
+  byId("leaderboard-cards-count").textContent = metricLabel(cards.length, "document");
+  replaceChildren(
+    byId("leaderboard-cards"),
+    cards.map((card) =>
+      element("tr", {}, [
+        element("td", { text: card.organization }),
+        element("td", {}, [
+          element("a", {
+            className: "adopter-link",
+            text: card.model,
+            attrs: { href: card.url, target: "_blank", rel: "noopener noreferrer" },
+          }),
+        ]),
+        element("td", { text: String(card.document_type).replaceAll("_", " ") }),
+        element("td", {
+          text: card.published ? formatDate(card.published, { dateStyle: "medium" }) : "Unknown",
+        }),
+        element("td", { text: String(card.benchmark_count) }),
+      ]),
+    ),
+  );
+}
+
 function renderTrendMap() {
   const corpus = state.data.corpus;
   if (!corpus) return;
@@ -1565,9 +1824,29 @@ function bindEvents() {
     button.addEventListener("click", () => {
       setView(button.dataset.view);
       if (button.dataset.view === "today") renderToday();
+      if (button.dataset.view === "leaderboard") renderLeaderboard();
       if (button.dataset.view === "trends") renderTrends();
       if (button.dataset.view === "map") renderTrendMap();
     });
+  });
+  // Reads every control rather than the event target, so the <select>
+  // "input"-before-"change" ordering that broke the Scan date picker (issue
+  // #43) cannot write a stale value back over the reader's pick here: whichever
+  // event arrives first, all three values come from the DOM as it stands now.
+  byId("leaderboard-filters").addEventListener("input", () => {
+    state.lq = byId("leaderboard-search").value;
+    state.ldomain = byId("leaderboard-domain").value;
+    state.lorg = byId("leaderboard-organization").value;
+    renderLeaderboard();
+    writeUrl();
+  });
+  byId("leaderboard-clear").addEventListener("click", () => {
+    state.lq = "";
+    state.ldomain = "";
+    state.lorg = "";
+    byId("leaderboard-search").value = "";
+    renderLeaderboard();
+    writeUrl();
   });
   byId("today-date").addEventListener("change", (event) => {
     state.todayDate = event.target.value;
@@ -1739,8 +2018,15 @@ async function initialize() {
         ),
     );
     renderToday();
+    renderLeaderboard();
     renderTrends();
     renderTrendMap();
+    // A permalink to ?view=leaderboard on a build without the curated registry
+    // has nothing to show, so fall back to Today rather than opening a blank
+    // section behind a nav entry that renderLeaderboard just hid.
+    if (state.view === "leaderboard" && !state.data.model_card_leaderboard) {
+      state.view = "today";
+    }
     setView(state.view, false);
     byId("build-meta").textContent = `Updated ${formatDate(state.data.generated_at, {
       dateStyle: "medium",

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -1390,7 +1390,13 @@ function leaderboardEntries() {
 }
 
 function adoptionBar(entry, maxCount) {
-  const width = maxCount ? Math.max(2, Math.round((entry.card_count / maxCount) * 100)) : 0;
+  // The 2% floor keeps a single-card benchmark from rendering as an empty
+  // track, but it must not apply to a zero: a visible bar beside a count of 0
+  // contradicts the number it is supposed to encode.
+  const width =
+    maxCount && entry.card_count
+      ? Math.max(2, Math.round((entry.card_count / maxCount) * 100))
+      : 0;
   return element(
     "div",
     {
@@ -1883,6 +1889,13 @@ function bindEvents() {
     state.organization = byId("organization-filter").value;
     state.event = byId("event-filter").value;
     renderToday();
+  });
+  // Both filter panels are <form>s whose state lives in the URL query we
+  // build ourselves. Enter in a search field would otherwise trigger an
+  // implicit GET that submits only the named controls, dropping `view` and
+  // reloading the reader into Today from whichever panel they were using.
+  document.querySelectorAll("#filters, #leaderboard-filters").forEach((form) => {
+    form.addEventListener("submit", (event) => event.preventDefault());
   });
   byId("clear-filters").addEventListener("click", () => {
     state.q = "";

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -1495,7 +1495,10 @@ function leaderboardRow(entry) {
 }
 
 function renderLeaderboardFilters(board) {
-  const domains = Object.keys(board.domains || {}).sort();
+  // Every domain present in the ranking, not board.domains: that summary counts
+  // only adopted benchmarks, so a domain whose benchmarks are all unadopted
+  // would be listed in the table with no way to filter to it.
+  const domains = [...new Set((board.entries || []).map((entry) => entry.domain))].sort();
   replaceChildren(byId("leaderboard-domain"), [
     option("", "All domains", !state.ldomain),
     ...domains.map((domain) =>

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -1279,6 +1279,78 @@ td a {
   font-size: 0.78rem;
 }
 
+/* Model Card Adoption Rank (issue #83) */
+
+.leaderboard-filters {
+  margin-bottom: 0.5rem;
+}
+
+.leaderboard-list {
+  margin-top: 0.75rem;
+}
+
+/* The bar encodes the same number the adjacent count states, so it carries an
+   aria-label rather than being announced twice: a screen reader hears the
+   count once, from the text. */
+.adoption-bar {
+  width: 100%;
+  height: 6px;
+  margin-top: 0.35rem;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  background: transparent;
+}
+
+.adoption-bar-fill {
+  display: block;
+  height: 100%;
+  background: var(--sea);
+}
+
+.adopter-list {
+  display: grid;
+  gap: 0.5rem;
+  margin: 0 0 1rem;
+  padding: 0;
+  list-style: none;
+}
+
+.adopter-list li {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.75rem;
+  align-items: baseline;
+  justify-content: space-between;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.adopter-link {
+  color: var(--blue-deep);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.adopter-link:hover,
+.adopter-link:focus-visible {
+  text-decoration: underline;
+}
+
+.adopter-meta {
+  color: var(--muted);
+  font-family: var(--utility);
+  font-size: 0.68rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+/* The four registry cards hold lists of very different lengths, and a stretched
+   grid row gave the shortest one a column of dead whitespace as tall as the
+   longest. Aligning to the start lets each card end where its content does. */
+#leaderboard-insights {
+  align-items: start;
+}
+
 .map-layout {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 320px;

--- a/site/index.html
+++ b/site/index.html
@@ -73,6 +73,9 @@
 
     <nav class="view-nav" aria-label="Dashboard views">
       <button type="button" data-view="today" aria-controls="today-view">Today</button>
+      <button type="button" data-view="leaderboard" aria-controls="leaderboard-view">
+        Leaderboard
+      </button>
       <button type="button" data-view="trends" aria-controls="trends-view">Trends</button>
       <button type="button" data-view="map" aria-controls="map-view">Trend map</button>
       <button type="button" id="rubric-nav" aria-haspopup="dialog">Rubric</button>
@@ -146,6 +149,91 @@
             </aside>
           </div>
         </div>
+      </section>
+
+      <section
+        class="view"
+        id="leaderboard-view"
+        aria-labelledby="leaderboard-heading"
+        hidden
+      >
+        <header class="view-heading">
+          <div>
+            <p class="eyebrow">Model Card Adoption Rank</p>
+            <h1 id="leaderboard-heading">Which benchmarks do model cards report?</h1>
+          </div>
+          <!--
+            The disclaimer sits in the heading, not in a footnote. This ranking
+            counts vendor attention, and a saturated benchmark can top it
+            precisely because reporting it is conventional. Readers who take the
+            order as a quality ranking would draw the opposite of the intended
+            conclusion, so the correction has to arrive before the table does.
+          -->
+          <p class="heading-note" id="leaderboard-measures"></p>
+        </header>
+
+        <div class="map-insights" id="leaderboard-insights" aria-label="Registry overview"></div>
+
+        <div class="trend-panel">
+          <div class="section-title">
+            <h2 id="leaderboard-table-heading">Benchmarks by model card adoption</h2>
+            <span id="leaderboard-count" aria-live="polite"></span>
+          </div>
+          <form class="filter-panel leaderboard-filters" id="leaderboard-filters">
+            <label class="search-field">
+              Search
+              <input
+                id="leaderboard-search"
+                name="lq"
+                type="search"
+                placeholder="Benchmark name or alias"
+              >
+            </label>
+            <label>
+              Domain
+              <select id="leaderboard-domain" name="ldomain"></select>
+            </label>
+            <label>
+              Organization
+              <select id="leaderboard-organization" name="lorg"></select>
+            </label>
+            <button class="clear-button" id="leaderboard-clear" type="button">
+              Clear filters
+            </button>
+          </form>
+          <p class="section-note">
+            Each model card counts once per benchmark. A card reporting AIME in four
+            configurations counts the same as a card reporting it once, so a long appendix
+            cannot outweigh a different vendor. Organizations breaks the tie: the same count
+            from six vendors is a shared standard, from one vendor a house style.
+          </p>
+          <div class="leaderboard-list" id="leaderboard-list"></div>
+        </div>
+
+        <section class="ledger" aria-labelledby="leaderboard-cards-heading">
+          <div class="section-title">
+            <h2 id="leaderboard-cards-heading">Model cards in the registry</h2>
+            <span id="leaderboard-cards-count"></span>
+          </div>
+          <p class="section-note">
+            The curated source list this ranking is computed from. Every row links to the
+            document the benchmark mentions were read from.
+          </p>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Organization</th>
+                  <th>Model</th>
+                  <th>Document</th>
+                  <th>Published</th>
+                  <th>Benchmarks</th>
+                </tr>
+              </thead>
+              <tbody id="leaderboard-cards"></tbody>
+            </table>
+          </div>
+        </section>
       </section>
 
       <section class="view" id="map-view" aria-labelledby="map-heading" hidden>

--- a/src/benchmark_radar/cli.py
+++ b/src/benchmark_radar/cli.py
@@ -42,6 +42,16 @@ def main() -> None:
     parser.add_argument("--snapshot-dir", type=Path, default=Path("data/snapshots"))
     parser.add_argument("--dashboard-output", type=Path, default=Path("site/data/radar.json"))
     parser.add_argument(
+        "--model-cards",
+        type=Path,
+        default=Path("data/model_cards.yml"),
+        help=(
+            "Curated model card registry powering the Model Card Adoption Rank "
+            "(issue #83). A missing file omits the leaderboard; an invalid one "
+            "fails the build rather than publishing a stale ranking."
+        ),
+    )
+    parser.add_argument(
         "--target-count",
         type=int,
         default=30,
@@ -53,7 +63,11 @@ def main() -> None:
     args = parser.parse_args()
 
     if args.command in {"rebuild", "backfill"}:
-        data = rebuild_dashboard(args.snapshot_dir, args.dashboard_output)
+        data = rebuild_dashboard(
+            args.snapshot_dir,
+            args.dashboard_output,
+            registry_path=args.model_cards,
+        )
         action = "Backfilled" if args.command == "backfill" else "Rebuilt"
         print(f"{action} {args.dashboard_output} from {data['snapshot_count']} daily snapshots")
         return
@@ -93,7 +107,11 @@ def main() -> None:
         skipped = len(runs) - len(written)
         for run in written:
             write_snapshot(run, args.snapshot_dir)
-        dashboard = rebuild_dashboard(args.snapshot_dir, args.dashboard_output)
+        dashboard = rebuild_dashboard(
+            args.snapshot_dir,
+            args.dashboard_output,
+            registry_path=args.model_cards,
+        )
         print(
             f"Simulated {len(written)} historical snapshots with coverage "
             f"({skipped} of {len(runs)} candidate days had no reachable records and were "
@@ -103,7 +121,11 @@ def main() -> None:
         return
     if args.command == "rescore":
         summary = rescore_snapshot_history(config, args.snapshot_dir)
-        dashboard = rebuild_dashboard(args.snapshot_dir, args.dashboard_output)
+        dashboard = rebuild_dashboard(
+            args.snapshot_dir,
+            args.dashboard_output,
+            registry_path=args.model_cards,
+        )
         print(
             f"Rescored {summary['snapshots']} snapshots against the current taxonomy; "
             f"{summary['records_changed']} records changed category"
@@ -122,7 +144,11 @@ def main() -> None:
         return
     if args.command == "migrate":
         snapshots = migrate_snapshot_history(config, args.snapshot_dir)
-        dashboard = rebuild_dashboard(args.snapshot_dir, args.dashboard_output)
+        dashboard = rebuild_dashboard(
+            args.snapshot_dir,
+            args.dashboard_output,
+            registry_path=args.model_cards,
+        )
         print(
             f"Migrated {len(snapshots)} snapshots to schema {dashboard['schema_version']} "
             f"and rebuilt {args.dashboard_output}"
@@ -168,7 +194,11 @@ def main() -> None:
         encoding="utf-8",
     )
     snapshot_path = write_snapshot(run, args.snapshot_dir)
-    dashboard = rebuild_dashboard(args.snapshot_dir, args.dashboard_output)
+    dashboard = rebuild_dashboard(
+        args.snapshot_dir,
+        args.dashboard_output,
+        registry_path=args.model_cards,
+    )
     print(
         f"Wrote {len(run.items)} items, snapshot {snapshot_path}, and dashboard data "
         f"for {dashboard['snapshot_count']} days"

--- a/src/benchmark_radar/model_cards.py
+++ b/src/benchmark_radar/model_cards.py
@@ -25,6 +25,7 @@ from collections import Counter
 from datetime import date
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 import yaml
 
@@ -39,7 +40,14 @@ DEFAULT_REGISTRY_PATH = Path("data/model_cards.yml")
 # Domains carry no ordering: `math` is not above or below `coding`. They exist
 # so a reader can ask "what does this field measure" without the leaderboard
 # implying a hierarchy between fields.
-_REQUIRED_BENCHMARK_FIELDS = ("id", "name", "domain")
+#
+# `caveat` is required, not optional. The ranking's headline risk is being read
+# as a quality ordering, and the per-row caveat is what stops a saturated or
+# contaminated benchmark from sitting near the top with no qualification. A
+# registry that may omit it can publish exactly the misreading this feature is
+# built to prevent, so the guarantee is enforced for any registry rather than
+# spot-checked on the shipped one.
+_REQUIRED_BENCHMARK_FIELDS = ("id", "name", "domain", "caveat")
 _REQUIRED_CARD_FIELDS = ("id", "organization", "model", "url", "benchmarks")
 
 
@@ -50,7 +58,13 @@ class ModelCardRegistryError(ValueError):
 def _require(value: Any, fields: tuple[str, ...], *, label: str) -> None:
     if not isinstance(value, dict):
         raise ModelCardRegistryError(f"{label} must be a mapping")
-    missing = [field for field in fields if not value.get(field)]
+    # A whitespace-only string is a missing field, not a present one: it
+    # satisfies a truthiness check while carrying no information for a reader.
+    missing = [
+        field
+        for field in fields
+        if not value.get(field) or (isinstance(value[field], str) and not value[field].strip())
+    ]
     if missing:
         raise ModelCardRegistryError(f"{label} is missing fields: {', '.join(missing)}")
 
@@ -70,7 +84,11 @@ def _require_date(value: Any, *, label: str) -> None:
     check is therefore against the one format the browser accepts, not against
     the standard.
     """
-    if isinstance(value, date):
+    # `datetime` subclasses `date`, and PyYAML returns one for any value
+    # carrying a time. It would serialize as "2025-08-07 00:00:00+05:30", which
+    # the dashboard's UTC formatter renders as August 6: a silently wrong date
+    # rather than a rejected one. Only a plain calendar date is accepted.
+    if type(value) is date:
         return
     text = str(value)
     if not _ISO_DATE.fullmatch(text):
@@ -135,12 +153,16 @@ def load_registry(path: Path = DEFAULT_REGISTRY_PATH) -> dict[str, Any]:
         # reorder the ranking. A distinct id is not evidence of a distinct
         # document; the URL is what identifies one.
         url = str(card["url"])
-        if url in seen_urls:
+        # Compared without the fragment: `#results` names a location inside a
+        # document, not a different document, so the two forms are one card
+        # and must not each add an adoption.
+        key = urlsplit(url)._replace(fragment="").geturl()
+        if key in seen_urls:
             raise ModelCardRegistryError(
                 f"{path}: model card {card_id!r} repeats the document URL already "
-                f"registered by {seen_urls[url]!r}: {url}"
+                f"registered by {seen_urls[key]!r}: {url}"
             )
-        seen_urls[url] = card_id
+        seen_urls[key] = card_id
         if not isinstance(card["benchmarks"], list):
             raise ModelCardRegistryError(
                 f"{path}: model card {card_id!r} benchmarks must be a list"

--- a/src/benchmark_radar/model_cards.py
+++ b/src/benchmark_radar/model_cards.py
@@ -112,15 +112,35 @@ def load_registry(path: Path = DEFAULT_REGISTRY_PATH) -> dict[str, Any]:
         benchmark_id = str(benchmark["id"])
         if benchmark_id in by_id:
             raise ModelCardRegistryError(f"{path}: duplicate benchmark id {benchmark_id!r}")
+        # `aliases: SWE-bench Verified` is the natural thing to write and is a
+        # YAML scalar, which iterates per character: the published registry
+        # would carry ['S', 'W', 'E', ...] and every alias search would miss,
+        # silently rather than loudly.
+        if benchmark.get("aliases") is not None and not isinstance(benchmark["aliases"], list):
+            raise ModelCardRegistryError(
+                f"{path}: benchmark {benchmark_id!r} aliases must be a list"
+            )
         by_id[benchmark_id] = benchmark
 
     seen_cards: set[str] = set()
+    seen_urls: dict[str, str] = {}
     for index, card in enumerate(cards):
         _require(card, _REQUIRED_CARD_FIELDS, label=f"{path}: model card {index}")
         card_id = str(card["id"])
         if card_id in seen_cards:
             raise ModelCardRegistryError(f"{path}: duplicate model card id {card_id!r}")
         seen_cards.add(card_id)
+        # The counting unit is the document, so the same document entered twice
+        # under two ids would add two adoptions to every benchmark it lists and
+        # reorder the ranking. A distinct id is not evidence of a distinct
+        # document; the URL is what identifies one.
+        url = str(card["url"])
+        if url in seen_urls:
+            raise ModelCardRegistryError(
+                f"{path}: model card {card_id!r} repeats the document URL already "
+                f"registered by {seen_urls[url]!r}: {url}"
+            )
+        seen_urls[url] = card_id
         if not isinstance(card["benchmarks"], list):
             raise ModelCardRegistryError(
                 f"{path}: model card {card_id!r} benchmarks must be a list"

--- a/src/benchmark_radar/model_cards.py
+++ b/src/benchmark_radar/model_cards.py
@@ -20,12 +20,17 @@ reporting it once, so a verbose appendix cannot outvote a different vendor.
 
 from __future__ import annotations
 
+import re
 from collections import Counter
 from datetime import date
 from pathlib import Path
 from typing import Any
 
 import yaml
+
+# The single date format JavaScript's Date constructor parses reliably. See
+# `_require_date` for why the ISO 8601 standard is too wide a target here.
+_ISO_DATE = re.compile(r"\d{4}-\d{2}-\d{2}")
 
 REGISTRY_SCHEMA_VERSION = 1
 
@@ -58,13 +63,22 @@ def _require_date(value: Any, *, label: str) -> None:
     treats that as an unusable data file and hides *every* view, so a single
     typo in one optional field would take Today and Trends down with the
     leaderboard. Failing the build here keeps that blast radius at zero.
+
+    `date.fromisoformat` alone is too permissive to protect that: on Python
+    3.11+ it also accepts `20250807` and `2025-W32-4`, both of which are valid
+    ISO 8601 and both of which JavaScript's Date parses to Invalid Date. The
+    check is therefore against the one format the browser accepts, not against
+    the standard.
     """
     if isinstance(value, date):
         return
+    text = str(value)
+    if not _ISO_DATE.fullmatch(text):
+        raise ModelCardRegistryError(f"{label} must be an ISO date (YYYY-MM-DD)")
     try:
-        date.fromisoformat(str(value))
+        date.fromisoformat(text)
     except ValueError as error:
-        raise ModelCardRegistryError(f"{label} must be an ISO date (YYYY-MM-DD)") from error
+        raise ModelCardRegistryError(f"{label} is not a real calendar date") from error
 
 
 def load_registry(path: Path = DEFAULT_REGISTRY_PATH) -> dict[str, Any]:

--- a/src/benchmark_radar/model_cards.py
+++ b/src/benchmark_radar/model_cards.py
@@ -1,0 +1,237 @@
+"""Model Card Adoption Rank: which benchmarks frontier model cards actually report.
+
+Issue #83 asked for a queryable registry of every benchmark result in every
+model card, keyed by evaluation configuration. That is the right destination and
+the wrong first step: it cannot produce a single row until a per-vendor PDF
+parser exists, and every row it did produce would carry a score that is
+incomparable to the score beside it.
+
+This module implements the tractable core of that idea. It counts *mentions*,
+not scores. A mention is the one fact that survives the configuration caveats
+the issue itself raises: it does not matter whether a card ran AIME at pass@1 or
+consensus@64 with a Python tool, the card still chose to put AIME in front of
+its readers. Adoption is therefore a claim about vendor attention, and this
+module is careful never to present it as a claim about benchmark quality.
+
+The counted unit is the document, not the result row. A card reporting AIME in
+four configurations adds one to AIME's adoption count, exactly like a card
+reporting it once, so a verbose appendix cannot outvote a different vendor.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REGISTRY_SCHEMA_VERSION = 1
+
+DEFAULT_REGISTRY_PATH = Path("data/model_cards.yml")
+
+# Domains carry no ordering: `math` is not above or below `coding`. They exist
+# so a reader can ask "what does this field measure" without the leaderboard
+# implying a hierarchy between fields.
+_REQUIRED_BENCHMARK_FIELDS = ("id", "name", "domain")
+_REQUIRED_CARD_FIELDS = ("id", "organization", "model", "url", "benchmarks")
+
+
+class ModelCardRegistryError(ValueError):
+    """Raised when the curated registry is internally inconsistent."""
+
+
+def _require(value: Any, fields: tuple[str, ...], *, label: str) -> None:
+    if not isinstance(value, dict):
+        raise ModelCardRegistryError(f"{label} must be a mapping")
+    missing = [field for field in fields if not value.get(field)]
+    if missing:
+        raise ModelCardRegistryError(f"{label} is missing fields: {', '.join(missing)}")
+
+
+def load_registry(path: Path = DEFAULT_REGISTRY_PATH) -> dict[str, Any]:
+    """Read and validate the curated model card registry.
+
+    Validation is strict on purpose. The leaderboard's only claim is "this many
+    distinct cards reported this benchmark", and a benchmark id that appears in
+    a card but not in the benchmark block would silently create a phantom entry
+    with an adoption count of one. That is indistinguishable from a real
+    benchmark nobody adopted, so it is rejected rather than tolerated.
+    """
+    if not path.exists():
+        raise ModelCardRegistryError(f"{path}: registry file not found")
+    document = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(document, dict):
+        raise ModelCardRegistryError(f"{path}: registry must be a mapping")
+    version = document.get("schema_version")
+    if version != REGISTRY_SCHEMA_VERSION:
+        raise ModelCardRegistryError(f"{path}: unsupported schema_version {version!r}")
+
+    benchmarks = document.get("benchmarks")
+    cards = document.get("model_cards")
+    if not isinstance(benchmarks, list) or not benchmarks:
+        raise ModelCardRegistryError(f"{path}: benchmarks must be a non-empty array")
+    if not isinstance(cards, list) or not cards:
+        raise ModelCardRegistryError(f"{path}: model_cards must be a non-empty array")
+
+    by_id: dict[str, dict[str, Any]] = {}
+    for index, benchmark in enumerate(benchmarks):
+        _require(benchmark, _REQUIRED_BENCHMARK_FIELDS, label=f"{path}: benchmark {index}")
+        benchmark_id = str(benchmark["id"])
+        if benchmark_id in by_id:
+            raise ModelCardRegistryError(f"{path}: duplicate benchmark id {benchmark_id!r}")
+        by_id[benchmark_id] = benchmark
+
+    seen_cards: set[str] = set()
+    for index, card in enumerate(cards):
+        _require(card, _REQUIRED_CARD_FIELDS, label=f"{path}: model card {index}")
+        card_id = str(card["id"])
+        if card_id in seen_cards:
+            raise ModelCardRegistryError(f"{path}: duplicate model card id {card_id!r}")
+        seen_cards.add(card_id)
+        if not isinstance(card["benchmarks"], list):
+            raise ModelCardRegistryError(
+                f"{path}: model card {card_id!r} benchmarks must be a list"
+            )
+        unknown = sorted({str(ref) for ref in card["benchmarks"]} - by_id.keys())
+        if unknown:
+            raise ModelCardRegistryError(
+                f"{path}: model card {card_id!r} references unknown benchmarks: "
+                f"{', '.join(unknown)}"
+            )
+        if not str(card["url"]).startswith(("https://", "http://")):
+            raise ModelCardRegistryError(f"{path}: model card {card_id!r} url must be HTTP(S)")
+
+    return {"benchmarks": benchmarks, "model_cards": cards}
+
+
+def adoption_rank(registry: dict[str, Any]) -> dict[str, Any]:
+    """Rank benchmarks by how many distinct model cards report them.
+
+    Two counts are published side by side and neither is the "real" one:
+
+    ``card_count``
+        How many documents report the benchmark. This is the headline: it is
+        what "popular in model cards" literally means.
+    ``organization_count``
+        How many distinct publishers report it. A benchmark carried by six
+        cards from one vendor is a house style; the same six cards from six
+        vendors is a shared standard. Ranking on cards alone cannot tell those
+        apart, so the organization count breaks ties and is shown next to the
+        headline rather than folded into it.
+
+    Ordering is total and deterministic: cards, then organizations, then name.
+    No score is combined out of the two, because any weighting would be an
+    invented judgement presented as a measurement.
+    """
+    cards = registry["model_cards"]
+    benchmarks = {str(benchmark["id"]): benchmark for benchmark in registry["benchmarks"]}
+
+    card_counts: Counter[str] = Counter()
+    organizations: dict[str, set[str]] = {}
+    adopters: dict[str, list[dict[str, Any]]] = {}
+
+    for card in cards:
+        organization = str(card["organization"])
+        # A set: a card listing the same benchmark twice, or listing two
+        # aliases that resolve to one id, still counts once.
+        for benchmark_id in sorted({str(ref) for ref in card["benchmarks"]}):
+            card_counts[benchmark_id] += 1
+            organizations.setdefault(benchmark_id, set()).add(organization)
+            adopters.setdefault(benchmark_id, []).append(
+                {
+                    "model_card_id": str(card["id"]),
+                    "organization": organization,
+                    "model": str(card["model"]),
+                    "document_type": str(card.get("document_type") or "model_card"),
+                    "published": str(card["published"]) if card.get("published") else None,
+                    "url": str(card["url"]),
+                }
+            )
+
+    total_cards = len(cards)
+    entries = []
+    for benchmark_id, benchmark in benchmarks.items():
+        count = card_counts.get(benchmark_id, 0)
+        entries.append(
+            {
+                "benchmark_id": benchmark_id,
+                "name": str(benchmark["name"]),
+                "domain": str(benchmark["domain"]),
+                "url": str(benchmark.get("url") or "") or None,
+                "aliases": [str(alias) for alias in benchmark.get("aliases") or []],
+                # The caveat travels with the row. A ranking that shows MMLU
+                # high and does not say "saturated and contaminated" invites
+                # exactly the reading issue #83 warns against.
+                "caveat": (str(benchmark["caveat"]).strip() if benchmark.get("caveat") else None),
+                "card_count": count,
+                "organization_count": len(organizations.get(benchmark_id, set())),
+                "organizations": sorted(organizations.get(benchmark_id, set())),
+                "adoption_share": round(count / total_cards, 4) if total_cards else 0.0,
+                "adopters": sorted(
+                    adopters.get(benchmark_id, []),
+                    key=lambda entry: (
+                        entry["organization"],
+                        entry["published"] or "",
+                        entry["model"],
+                    ),
+                ),
+            }
+        )
+
+    entries.sort(
+        key=lambda entry: (
+            -entry["card_count"],
+            -entry["organization_count"],
+            entry["name"],
+        )
+    )
+    for position, entry in enumerate(entries, start=1):
+        entry["rank"] = position
+
+    organization_totals = Counter(str(card["organization"]) for card in cards)
+    domain_totals = Counter(entry["domain"] for entry in entries if entry["card_count"])
+
+    return {
+        "schema_version": REGISTRY_SCHEMA_VERSION,
+        "model_card_count": total_cards,
+        "benchmark_count": len(entries),
+        "organization_count": len(organization_totals),
+        "organizations": dict(sorted(organization_totals.items())),
+        "domains": dict(sorted(domain_totals.items())),
+        # Sorted by publisher then date so the model list reads as a roster
+        # rather than as a second, implied ranking.
+        "model_cards": sorted(
+            (
+                {
+                    "model_card_id": str(card["id"]),
+                    "organization": str(card["organization"]),
+                    "model": str(card["model"]),
+                    "document_type": str(card.get("document_type") or "model_card"),
+                    "published": str(card["published"]) if card.get("published") else None,
+                    "url": str(card["url"]),
+                    "retrieved_at": (
+                        str(card["retrieved_at"]) if card.get("retrieved_at") else None
+                    ),
+                    "benchmark_count": len({str(ref) for ref in card["benchmarks"]}),
+                    "benchmarks": sorted({str(ref) for ref in card["benchmarks"]}),
+                }
+                for card in cards
+            ),
+            key=lambda card: (card["organization"], card["published"] or "", card["model"]),
+        ),
+        "entries": entries,
+        # Stated in the data rather than only in the UI, so any consumer of
+        # radar.json inherits the caveat instead of re-deriving the ranking's
+        # meaning from its column headers.
+        "measures": (
+            "How many curated model cards report each benchmark. This measures "
+            "vendor attention, not benchmark quality: a saturated or contaminated "
+            "benchmark can rank highly precisely because it is conventional to "
+            "report it."
+        ),
+    }
+
+
+def build_adoption_rank(path: Path = DEFAULT_REGISTRY_PATH) -> dict[str, Any]:
+    return adoption_rank(load_registry(path))

--- a/src/benchmark_radar/model_cards.py
+++ b/src/benchmark_radar/model_cards.py
@@ -21,6 +21,7 @@ reporting it once, so a verbose appendix cannot outvote a different vendor.
 from __future__ import annotations
 
 from collections import Counter
+from datetime import date
 from pathlib import Path
 from typing import Any
 
@@ -47,6 +48,23 @@ def _require(value: Any, fields: tuple[str, ...], *, label: str) -> None:
     missing = [field for field in fields if not value.get(field)]
     if missing:
         raise ModelCardRegistryError(f"{label} is missing fields: {', '.join(missing)}")
+
+
+def _require_date(value: Any, *, label: str) -> None:
+    """Reject a date the browser cannot format.
+
+    These values reach `Intl.DateTimeFormat` unmodified, and it throws a
+    RangeError on an unparseable one. The dashboard's initialization catch
+    treats that as an unusable data file and hides *every* view, so a single
+    typo in one optional field would take Today and Trends down with the
+    leaderboard. Failing the build here keeps that blast radius at zero.
+    """
+    if isinstance(value, date):
+        return
+    try:
+        date.fromisoformat(str(value))
+    except ValueError as error:
+        raise ModelCardRegistryError(f"{label} must be an ISO date (YYYY-MM-DD)") from error
 
 
 def load_registry(path: Path = DEFAULT_REGISTRY_PATH) -> dict[str, Any]:
@@ -101,6 +119,9 @@ def load_registry(path: Path = DEFAULT_REGISTRY_PATH) -> dict[str, Any]:
             )
         if not str(card["url"]).startswith(("https://", "http://")):
             raise ModelCardRegistryError(f"{path}: model card {card_id!r} url must be HTTP(S)")
+        for field in ("published", "retrieved_at"):
+            if card.get(field):
+                _require_date(card[field], label=f"{path}: model card {card_id!r} {field}")
 
     return {"benchmarks": benchmarks, "model_cards": cards}
 

--- a/src/benchmark_radar/snapshots.py
+++ b/src/benchmark_radar/snapshots.py
@@ -15,6 +15,7 @@ from .corpus import (
     exact_artifact_key,
     organizations_for_item,
 )
+from .model_cards import DEFAULT_REGISTRY_PATH, build_adoption_rank
 from .models import RadarRun
 from .pipeline import match_proximity_rule
 from .rubric import (
@@ -417,7 +418,26 @@ def _attach_category_trends(days: list[dict[str, Any]]) -> None:
         day["cumulative_evidence_count"] = len(seen_any)
 
 
-def dashboard_data(snapshots: list[dict[str, Any]]) -> dict[str, Any]:
+def _model_card_leaderboard(registry_path: Path | None) -> dict[str, Any] | None:
+    """Build the Model Card Adoption Rank, or omit it if the registry is absent.
+
+    A missing registry file is not an error: the daily radar's own collection is
+    independent of this curated dataset, and a checkout without it should still
+    publish a working dashboard. An *invalid* registry is a different matter and
+    is allowed to fail the build, because a silently-dropped leaderboard would
+    leave the previous ranking on the page with no indication it went stale.
+    """
+    path = registry_path or DEFAULT_REGISTRY_PATH
+    if not path.exists():
+        return None
+    return build_adoption_rank(path)
+
+
+def dashboard_data(
+    snapshots: list[dict[str, Any]],
+    *,
+    registry_path: Path | None = None,
+) -> dict[str, Any]:
     days: list[dict[str, Any]] = []
     categories: set[str] = set()
     sources: set[str] = set()
@@ -546,6 +566,11 @@ def dashboard_data(snapshots: list[dict[str, Any]]) -> dict[str, Any]:
         },
         "days": days,
         "corpus": corpus,
+        # Curated and versioned in the repository rather than collected daily:
+        # it answers "which benchmarks do vendors report" from published model
+        # cards, which is a different question from "what was released today"
+        # and moves on a different clock.
+        "model_card_leaderboard": _model_card_leaderboard(registry_path),
         # Keep every rubric required by the history. The browser selects by
         # each record's score_version, so a v1 score is never explained using
         # v2 arithmetic.
@@ -578,8 +603,13 @@ def dashboard_data(snapshots: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
-def rebuild_dashboard(snapshot_dir: Path, output: Path) -> dict[str, Any]:
-    value = dashboard_data(load_snapshots(snapshot_dir))
+def rebuild_dashboard(
+    snapshot_dir: Path,
+    output: Path,
+    *,
+    registry_path: Path | None = None,
+) -> dict[str, Any]:
+    value = dashboard_data(load_snapshots(snapshot_dir), registry_path=registry_path)
     _write_json(output, value)
     return value
 

--- a/tests/test_model_cards.py
+++ b/tests/test_model_cards.py
@@ -22,8 +22,20 @@ def minimal_registry(**overrides) -> dict:
     document = {
         "schema_version": 1,
         "benchmarks": [
-            {"id": "alpha", "name": "Alpha", "domain": "math", "url": "https://example.com/a"},
-            {"id": "beta", "name": "Beta", "domain": "coding", "url": "https://example.com/b"},
+            {
+                "id": "alpha",
+                "name": "Alpha",
+                "domain": "math",
+                "url": "https://example.com/a",
+                "caveat": "Alpha caveat.",
+            },
+            {
+                "id": "beta",
+                "name": "Beta",
+                "domain": "coding",
+                "url": "https://example.com/b",
+                "caveat": "Beta caveat.",
+            },
         ],
         "model_cards": [
             {
@@ -145,7 +157,9 @@ def test_unknown_benchmark_reference_is_rejected(tmp_path):
 
 def test_duplicate_ids_are_rejected(tmp_path):
     document = minimal_registry()
-    document["benchmarks"].append({"id": "alpha", "name": "Alpha again", "domain": "math"})
+    document["benchmarks"].append(
+        {"id": "alpha", "name": "Alpha again", "domain": "math", "caveat": "Dup."}
+    )
     with pytest.raises(ModelCardRegistryError, match="duplicate benchmark id"):
         load_registry(write_registry(tmp_path, document))
 
@@ -184,6 +198,21 @@ def test_every_benchmark_states_what_it_does_not_settle():
         if not str(benchmark.get("caveat") or "").strip()
     ]
     assert not missing
+
+
+def test_a_benchmark_without_a_caveat_is_rejected(tmp_path):
+    # Enforced for any registry, not spot-checked on the shipped one: a custom
+    # --model-cards file could otherwise publish rows with no qualification at
+    # all, which is precisely the misreading the caveat exists to prevent.
+    document = minimal_registry()
+    document["benchmarks"][0].pop("caveat")
+    with pytest.raises(ModelCardRegistryError, match="missing fields: caveat"):
+        load_registry(write_registry(tmp_path, document))
+
+    document = minimal_registry()
+    document["benchmarks"][0]["caveat"] = "   "
+    with pytest.raises(ModelCardRegistryError, match="missing fields: caveat"):
+        load_registry(write_registry(tmp_path, document))
 
 
 def test_measures_statement_travels_with_the_data():
@@ -245,7 +274,7 @@ def test_dates_parsed_by_yaml_into_date_objects_are_accepted(tmp_path):
     path.write_text(
         "schema_version: 1\n"
         "benchmarks:\n"
-        "  - {id: alpha, name: Alpha, domain: math}\n"
+        "  - {id: alpha, name: Alpha, domain: math, caveat: Caveat.}\n"
         "model_cards:\n"
         "  - id: card\n"
         "    organization: Org\n"
@@ -322,3 +351,41 @@ def test_shipped_registry_has_no_repeated_documents_or_scalar_aliases():
     for benchmark in registry["benchmarks"]:
         aliases = benchmark.get("aliases")
         assert aliases is None or isinstance(aliases, list)
+
+
+def test_a_yaml_timestamp_is_rejected_rather_than_shifted_a_day(tmp_path):
+    # datetime subclasses date, and PyYAML returns one for any value carrying a
+    # time. "2025-08-07T00:00:00+05:30" would serialize with its offset and the
+    # dashboard's UTC formatter would render August 6: silently wrong rather
+    # than rejected.
+    path = tmp_path / "model_cards.yml"
+    path.write_text(
+        "schema_version: 1\n"
+        "benchmarks:\n"
+        "  - {id: alpha, name: Alpha, domain: math, caveat: Caveat.}\n"
+        "model_cards:\n"
+        "  - id: card\n"
+        "    organization: Org\n"
+        "    model: One\n"
+        "    published: 2025-08-07T00:00:00+05:30\n"
+        "    url: https://example.com/one\n"
+        "    benchmarks: [alpha]\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ModelCardRegistryError, match="published must be an ISO date"):
+        load_registry(path)
+
+
+def test_a_fragment_does_not_make_one_document_look_like_two(tmp_path):
+    # "#results" names a location inside a document, not another document, so
+    # both forms are one card and must not each add an adoption.
+    document = minimal_registry()
+    document["model_cards"].append(
+        {
+            **document["model_cards"][0],
+            "id": "org_one_card_anchor",
+            "url": f"{document['model_cards'][0]['url']}#results",
+        }
+    )
+    with pytest.raises(ModelCardRegistryError, match="repeats the document URL"):
+        load_registry(write_registry(tmp_path, document))

--- a/tests/test_model_cards.py
+++ b/tests/test_model_cards.py
@@ -288,3 +288,37 @@ def test_a_well_formed_but_impossible_date_is_rejected(tmp_path):
     document["model_cards"][0]["published"] = "2025-02-30"
     with pytest.raises(ModelCardRegistryError, match="not a real calendar date"):
         load_registry(write_registry(tmp_path, document))
+
+
+def test_the_same_document_registered_twice_is_rejected(tmp_path):
+    # The counting unit is the document. Two ids pointing at one URL would add
+    # two adoptions to every benchmark that document lists and reorder the
+    # ranking, which is exactly the inflation the per-document rule prevents.
+    document = minimal_registry()
+    document["model_cards"].append(
+        {
+            **document["model_cards"][0],
+            "id": "org_one_card_again",
+        }
+    )
+    with pytest.raises(ModelCardRegistryError, match="repeats the document URL"):
+        load_registry(write_registry(tmp_path, document))
+
+
+def test_a_scalar_alias_is_rejected_rather_than_split_into_characters(tmp_path):
+    # `aliases: Alias` is the natural thing to write and is a YAML scalar,
+    # which iterates per character into ['A', 'l', 'i', 'a', 's'].
+    document = minimal_registry()
+    document["benchmarks"][0]["aliases"] = "Alpha Bench"
+    with pytest.raises(ModelCardRegistryError, match="aliases must be a list"):
+        load_registry(write_registry(tmp_path, document))
+
+
+def test_shipped_registry_has_no_repeated_documents_or_scalar_aliases():
+    registry = load_registry(DEFAULT_REGISTRY_PATH)
+
+    urls = [str(card["url"]) for card in registry["model_cards"]]
+    assert len(urls) == len(set(urls))
+    for benchmark in registry["benchmarks"]:
+        aliases = benchmark.get("aliases")
+        assert aliases is None or isinstance(aliases, list)

--- a/tests/test_model_cards.py
+++ b/tests/test_model_cards.py
@@ -269,3 +269,22 @@ def test_every_shipped_date_is_browser_formattable():
     for card in board["model_cards"]:
         assert date_type.fromisoformat(card["published"])
         assert date_type.fromisoformat(card["retrieved_at"])
+
+
+@pytest.mark.parametrize("value", ["20250807", "2025-W32-4", "2025-220"])
+def test_iso_variants_the_browser_cannot_parse_are_rejected(tmp_path, value):
+    # date.fromisoformat accepts all of these on Python 3.11+, and JavaScript's
+    # Date turns every one into Invalid Date. Validating against the standard
+    # rather than against the browser would let the build pass and the whole
+    # dashboard fail at load.
+    document = minimal_registry()
+    document["model_cards"][0]["published"] = value
+    with pytest.raises(ModelCardRegistryError, match="must be an ISO date"):
+        load_registry(write_registry(tmp_path, document))
+
+
+def test_a_well_formed_but_impossible_date_is_rejected(tmp_path):
+    document = minimal_registry()
+    document["model_cards"][0]["published"] = "2025-02-30"
+    with pytest.raises(ModelCardRegistryError, match="not a real calendar date"):
+        load_registry(write_registry(tmp_path, document))

--- a/tests/test_model_cards.py
+++ b/tests/test_model_cards.py
@@ -1,0 +1,221 @@
+from pathlib import Path
+
+import pytest
+import yaml
+
+from benchmark_radar.model_cards import (
+    DEFAULT_REGISTRY_PATH,
+    ModelCardRegistryError,
+    adoption_rank,
+    build_adoption_rank,
+    load_registry,
+)
+
+
+def write_registry(tmp_path: Path, document: dict) -> Path:
+    path = tmp_path / "model_cards.yml"
+    path.write_text(yaml.safe_dump(document, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def minimal_registry(**overrides) -> dict:
+    document = {
+        "schema_version": 1,
+        "benchmarks": [
+            {"id": "alpha", "name": "Alpha", "domain": "math", "url": "https://example.com/a"},
+            {"id": "beta", "name": "Beta", "domain": "coding", "url": "https://example.com/b"},
+        ],
+        "model_cards": [
+            {
+                "id": "org_one_card",
+                "organization": "Org One",
+                "model": "One",
+                "document_type": "model_card",
+                "published": "2025-01-01",
+                "url": "https://example.com/one",
+                "benchmarks": ["alpha", "beta"],
+            },
+            {
+                "id": "org_two_card",
+                "organization": "Org Two",
+                "model": "Two",
+                "document_type": "system_card",
+                "published": "2025-02-01",
+                "url": "https://example.com/two",
+                "benchmarks": ["alpha"],
+            },
+        ],
+    }
+    document.update(overrides)
+    return document
+
+
+def test_shipped_registry_loads_and_ranks():
+    board = build_adoption_rank(DEFAULT_REGISTRY_PATH)
+
+    assert board["model_card_count"] > 0
+    assert board["benchmark_count"] > 0
+    # Every organization named in issue #83 is represented, so the ranking is
+    # not an artifact of one vendor's reporting habits.
+    assert {
+        "OpenAI",
+        "Anthropic",
+        "Google DeepMind",
+        "Meta",
+        "Qwen",
+        "DeepSeek",
+        "Mistral",
+        "xAI",
+    } <= set(board["organizations"])
+
+
+def test_rank_is_total_and_deterministic():
+    board = adoption_rank(load_registry(DEFAULT_REGISTRY_PATH))
+    entries = board["entries"]
+
+    assert [entry["rank"] for entry in entries] == list(range(1, len(entries) + 1))
+    # Cards descending, then organizations descending, then name ascending. No
+    # entry may outrank one with a strictly higher card count.
+    keys = [
+        (-entry["card_count"], -entry["organization_count"], entry["name"]) for entry in entries
+    ]
+    assert keys == sorted(keys)
+
+
+def test_repeated_configurations_do_not_inflate_a_single_card(tmp_path):
+    # Issue #83's central caveat: one card reporting AIME at pass@1 and
+    # consensus@64 is still one card choosing to report AIME. If duplicates
+    # counted, a verbose appendix would outvote a whole other vendor.
+    document = minimal_registry()
+    document["model_cards"][0]["benchmarks"] = ["alpha", "alpha", "alpha", "beta"]
+    board = adoption_rank(load_registry(write_registry(tmp_path, document)))
+
+    alpha = next(entry for entry in board["entries"] if entry["benchmark_id"] == "alpha")
+    assert alpha["card_count"] == 2
+    assert alpha["organization_count"] == 2
+    assert len(alpha["adopters"]) == 2
+
+
+def test_organization_count_distinguishes_a_standard_from_a_house_style(tmp_path):
+    document = minimal_registry()
+    document["model_cards"].append(
+        {
+            "id": "org_one_second_card",
+            "organization": "Org One",
+            "model": "One Plus",
+            "document_type": "model_card",
+            "published": "2025-03-01",
+            "url": "https://example.com/one-plus",
+            "benchmarks": ["beta"],
+        }
+    )
+    board = adoption_rank(load_registry(write_registry(tmp_path, document)))
+
+    alpha = next(entry for entry in board["entries"] if entry["benchmark_id"] == "alpha")
+    beta = next(entry for entry in board["entries"] if entry["benchmark_id"] == "beta")
+
+    # Both are reported by two cards, but alpha crosses two organizations and
+    # beta is one vendor twice. That is precisely the tie the second column
+    # exists to break, so alpha must outrank beta.
+    assert alpha["card_count"] == beta["card_count"] == 2
+    assert alpha["organization_count"] == 2
+    assert beta["organization_count"] == 1
+    assert alpha["rank"] < beta["rank"]
+
+
+def test_adoption_share_is_relative_to_the_document_count(tmp_path):
+    board = adoption_rank(load_registry(write_registry(tmp_path, minimal_registry())))
+
+    alpha = next(entry for entry in board["entries"] if entry["benchmark_id"] == "alpha")
+    beta = next(entry for entry in board["entries"] if entry["benchmark_id"] == "beta")
+    assert alpha["adoption_share"] == 1.0
+    assert beta["adoption_share"] == 0.5
+
+
+def test_unknown_benchmark_reference_is_rejected(tmp_path):
+    # A typo must not silently mint a benchmark with an adoption count of one,
+    # which is indistinguishable from a real benchmark nobody adopted.
+    document = minimal_registry()
+    document["model_cards"][0]["benchmarks"] = ["alpha", "gamma"]
+    path = write_registry(tmp_path, document)
+
+    with pytest.raises(ModelCardRegistryError, match="unknown benchmarks: gamma"):
+        load_registry(path)
+
+
+def test_duplicate_ids_are_rejected(tmp_path):
+    document = minimal_registry()
+    document["benchmarks"].append({"id": "alpha", "name": "Alpha again", "domain": "math"})
+    with pytest.raises(ModelCardRegistryError, match="duplicate benchmark id"):
+        load_registry(write_registry(tmp_path, document))
+
+    document = minimal_registry()
+    document["model_cards"].append(dict(document["model_cards"][0]))
+    with pytest.raises(ModelCardRegistryError, match="duplicate model card id"):
+        load_registry(write_registry(tmp_path, document))
+
+
+def test_non_http_card_url_is_rejected(tmp_path):
+    document = minimal_registry()
+    document["model_cards"][0]["url"] = "file:///etc/passwd"
+    with pytest.raises(ModelCardRegistryError, match="url must be HTTP"):
+        load_registry(write_registry(tmp_path, document))
+
+
+def test_unsupported_schema_version_is_rejected(tmp_path):
+    with pytest.raises(ModelCardRegistryError, match="unsupported schema_version"):
+        load_registry(write_registry(tmp_path, minimal_registry(schema_version=99)))
+
+
+def test_missing_registry_file_is_reported(tmp_path):
+    with pytest.raises(ModelCardRegistryError, match="registry file not found"):
+        load_registry(tmp_path / "absent.yml")
+
+
+def test_every_benchmark_states_what_it_does_not_settle():
+    registry = load_registry(DEFAULT_REGISTRY_PATH)
+
+    # A ranking that puts a saturated or contaminated benchmark near the top
+    # without saying so invites the exact misreading issue #83 warns about, so
+    # the caveat is required data rather than optional prose.
+    missing = [
+        benchmark["id"]
+        for benchmark in registry["benchmarks"]
+        if not str(benchmark.get("caveat") or "").strip()
+    ]
+    assert not missing
+
+
+def test_measures_statement_travels_with_the_data():
+    board = build_adoption_rank(DEFAULT_REGISTRY_PATH)
+
+    # Any consumer of radar.json inherits the disclaimer instead of inferring
+    # the ranking's meaning from its column headers.
+    assert "not benchmark quality" in board["measures"]
+
+
+def test_adopters_link_back_to_the_source_document():
+    board = build_adoption_rank(DEFAULT_REGISTRY_PATH)
+
+    for entry in board["entries"]:
+        for adopter in entry["adopters"]:
+            assert adopter["url"].startswith("https://")
+            assert adopter["organization"]
+            assert adopter["model"]
+
+
+def test_benchmarks_reported_by_no_card_are_kept_and_ranked_last(tmp_path):
+    document = minimal_registry()
+    document["benchmarks"].append(
+        {"id": "gamma", "name": "Gamma", "domain": "agent", "caveat": "Not yet adopted."}
+    )
+    board = adoption_rank(load_registry(write_registry(tmp_path, document)))
+
+    gamma = next(entry for entry in board["entries"] if entry["benchmark_id"] == "gamma")
+    # Kept: "tracked but reported by nobody" is a finding about vendor
+    # attention. Ranked last, and excluded from the adopted-domain tally so a
+    # zero cannot inflate a domain's apparent coverage.
+    assert gamma["card_count"] == 0
+    assert gamma["adopters"] == []
+    assert gamma["rank"] == len(board["entries"])
+    assert "agent" not in board["domains"]

--- a/tests/test_model_cards.py
+++ b/tests/test_model_cards.py
@@ -219,3 +219,53 @@ def test_benchmarks_reported_by_no_card_are_kept_and_ranked_last(tmp_path):
     assert gamma["adopters"] == []
     assert gamma["rank"] == len(board["entries"])
     assert "agent" not in board["domains"]
+
+
+def test_unparseable_publication_date_fails_the_build(tmp_path):
+    # These values reach Intl.DateTimeFormat unmodified, which throws on an
+    # unparseable one. The dashboard treats that as an unusable data file and
+    # hides every view, so one typo in an optional field would take Today and
+    # Trends down with the leaderboard.
+    document = minimal_registry()
+    document["model_cards"][0]["published"] = "Aug 7th 2025"
+    with pytest.raises(ModelCardRegistryError, match="published must be an ISO date"):
+        load_registry(write_registry(tmp_path, document))
+
+    document = minimal_registry()
+    document["model_cards"][0]["retrieved_at"] = "yesterday"
+    with pytest.raises(ModelCardRegistryError, match="retrieved_at must be an ISO date"):
+        load_registry(write_registry(tmp_path, document))
+
+
+def test_dates_parsed_by_yaml_into_date_objects_are_accepted(tmp_path):
+    # Unquoted YYYY-MM-DD is a date, not a string, after yaml.safe_load. The
+    # shipped registry is written that way, so rejecting it would fail on the
+    # file this module exists to read.
+    path = tmp_path / "model_cards.yml"
+    path.write_text(
+        "schema_version: 1\n"
+        "benchmarks:\n"
+        "  - {id: alpha, name: Alpha, domain: math}\n"
+        "model_cards:\n"
+        "  - id: card\n"
+        "    organization: Org\n"
+        "    model: One\n"
+        "    published: 2025-08-07\n"
+        "    retrieved_at: 2026-08-02\n"
+        "    url: https://example.com/one\n"
+        "    benchmarks: [alpha]\n",
+        encoding="utf-8",
+    )
+    board = adoption_rank(load_registry(path))
+
+    assert board["model_cards"][0]["published"] == "2025-08-07"
+
+
+def test_every_shipped_date_is_browser_formattable():
+    board = build_adoption_rank(DEFAULT_REGISTRY_PATH)
+
+    from datetime import date as date_type
+
+    for card in board["model_cards"]:
+        assert date_type.fromisoformat(card["published"])
+        assert date_type.fromisoformat(card["retrieved_at"])

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -418,3 +418,21 @@ def test_leaderboard_domain_filter_offers_every_tracked_domain():
     # benchmarks are all unadopted would appear in the table with no way to
     # filter to it. The options come from the entries themselves.
     assert "new Set((board.entries || []).map((entry) => entry.domain))" in script
+
+
+def test_filter_forms_do_not_submit_and_reload_the_page():
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    # Both panels are <form>s whose state lives in the URL query the app builds
+    # itself. Enter in a search field would fire an implicit GET carrying only
+    # the named controls, dropping `view` and dumping the reader into Today.
+    assert 'querySelectorAll("#filters, #leaderboard-filters")' in script
+    assert 'form.addEventListener("submit", (event) => event.preventDefault())' in script
+
+
+def test_a_zero_adoption_bar_has_no_visible_width():
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    # The 2% floor keeps a one-card benchmark visible, but a bar beside a count
+    # of 0 would contradict the number it encodes.
+    assert "maxCount && entry.card_count" in script

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -409,3 +409,12 @@ def test_leaderboard_names_an_unadopted_benchmark_rather_than_showing_a_bare_zer
     # benchmarks so it must not claim to be the same figure as the filter.
     assert '"not yet reported in these cards"' in script
     assert '"Domains reported at least once"' in script
+
+
+def test_leaderboard_domain_filter_offers_every_tracked_domain():
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    # board.domains counts only adopted benchmarks, so a domain whose
+    # benchmarks are all unadopted would appear in the table with no way to
+    # filter to it. The options come from the entries themselves.
+    assert "new Set((board.entries || []).map((entry) => entry.domain))" in script

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -323,3 +323,89 @@ def test_badge_accessible_names_state_the_action():
     ):
         assert fragment in script
     assert 'badge.setAttribute("aria-label"' in script
+
+
+def test_leaderboard_view_is_a_first_class_dashboard_view():
+    parser = SiteParser()
+    html = Path("site/index.html").read_text(encoding="utf-8")
+    parser.feed(html)
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    # Issue #83 step 3: the Model Card Adoption Rank is reachable as
+    # ?view=leaderboard from the homepage nav, not a separate page.
+    assert "leaderboard-view" in parser.ids
+    assert 'data-view="leaderboard"' in html
+    assert '"map", "leaderboard"' in script
+    assert 'if (button.dataset.view === "leaderboard") renderLeaderboard();' in script
+    assert "state.data?.model_card_leaderboard" in script
+
+
+def test_leaderboard_states_what_it_measures_before_the_ranking():
+    html = Path("site/index.html").read_text(encoding="utf-8")
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    # A reader who takes the order as a quality ranking draws the opposite of
+    # the intended conclusion, so the correction is published data shown in the
+    # heading rather than a restated string in the browser or a footnote.
+    assert 'id="leaderboard-measures"' in html
+    assert 'byId("leaderboard-measures").textContent = board.measures' in script
+    assert "vendor attention, not benchmark quality" not in script
+    # Per-benchmark caveats travel with each row.
+    assert "entry.caveat" in script
+
+
+def test_leaderboard_rows_link_back_to_the_model_cards_they_counted():
+    html = Path("site/index.html").read_text(encoding="utf-8")
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    assert 'id="leaderboard-cards"' in html
+    assert "adopter-list" in script
+    assert '"Reported by"' in script
+    # Every adopter link opens the source document itself, so any count in the
+    # ranking can be checked against the card it was read from.
+    assert "adopter.url" in script
+    assert 'rel: "noopener noreferrer"' in script
+
+
+def test_leaderboard_filters_use_prefixed_url_keys():
+    html = Path("site/index.html").read_text(encoding="utf-8")
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    # Prefixed keys let one permalink hold a Today filter and a Leaderboard
+    # filter at once without either view reinterpreting the other's
+    # `organization`.
+    assert 'id="leaderboard-filters"' in html
+    for key in ("lq", "ldomain", "lorg"):
+        assert f'params.set("{key}"' in script
+        assert f'params.get("{key}")' in script
+
+
+def test_leaderboard_filter_handler_reads_controls_not_the_event_target():
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    # Same <select> "input"-before-"change" hazard as issue #43: reading all
+    # three controls from the DOM makes the event ordering irrelevant.
+    handler = script.split('byId("leaderboard-filters").addEventListener("input"', 1)[1]
+    body = handler.split("});", 1)[0]
+    for control in ("leaderboard-search", "leaderboard-domain", "leaderboard-organization"):
+        assert f'byId("{control}")' in body
+
+
+def test_leaderboard_degrades_when_the_curated_registry_is_absent():
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    # No registry means no ranking. Hiding the nav entry and redirecting a
+    # ?view=leaderboard permalink beats offering a tab that opens blank.
+    assert "document.querySelector('[data-view=\"leaderboard\"]')" in script
+    assert "navButton.hidden = true" in script
+    assert 'state.view === "leaderboard" && !state.data.model_card_leaderboard' in script
+
+
+def test_leaderboard_names_an_unadopted_benchmark_rather_than_showing_a_bare_zero():
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    # A tracked benchmark no curated card reports is an observation about the
+    # registry, not an empty row, and the domain summary counts only adopted
+    # benchmarks so it must not claim to be the same figure as the filter.
+    assert '"not yet reported in these cards"' in script
+    assert '"Domains reported at least once"' in script

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -3,6 +3,7 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 
+from benchmark_radar.model_cards import ModelCardRegistryError
 from benchmark_radar.models import (
     AttentionObservation,
     ProducerHealth,
@@ -629,3 +630,47 @@ def test_later_alias_bridge_does_not_rewrite_earlier_trend(tmp_path):
 
     assert data["days"][0]["cumulative_evidence_count"] == 2
     assert data["days"][1]["cumulative_evidence_count"] == 1
+
+
+def test_dashboard_publishes_the_model_card_adoption_rank(tmp_path):
+    # Issue #83: the curated Model Card Adoption Rank rides along in the same
+    # published file the dashboard already loads, so the browser needs no second
+    # fetch and no second schema.
+    snapshot_dir = tmp_path / "snapshots"
+    write_snapshot(radar_run(26), snapshot_dir)
+
+    data = rebuild_dashboard(snapshot_dir, tmp_path / "radar.json")
+    board = data["model_card_leaderboard"]
+
+    assert board["model_card_count"] > 0
+    assert board["entries"][0]["rank"] == 1
+    assert "not benchmark quality" in board["measures"]
+
+
+def test_dashboard_omits_the_leaderboard_when_the_registry_is_absent(tmp_path):
+    # A checkout without the curated file still publishes a working dashboard:
+    # the daily radar's own collection does not depend on this dataset.
+    snapshot_dir = tmp_path / "snapshots"
+    write_snapshot(radar_run(26), snapshot_dir)
+
+    data = rebuild_dashboard(
+        snapshot_dir,
+        tmp_path / "radar.json",
+        registry_path=tmp_path / "absent.yml",
+    )
+
+    assert data["model_card_leaderboard"] is None
+    assert data["snapshot_count"] == 1
+
+
+def test_dashboard_fails_rather_than_publishing_a_stale_ranking(tmp_path):
+    # An invalid registry must not be swallowed into a missing leaderboard: the
+    # previous ranking would stay on the page with nothing signalling it went
+    # stale, which is worse than a failed build.
+    snapshot_dir = tmp_path / "snapshots"
+    write_snapshot(radar_run(26), snapshot_dir)
+    broken = tmp_path / "model_cards.yml"
+    broken.write_text("schema_version: 1\nbenchmarks: []\nmodel_cards: []\n", encoding="utf-8")
+
+    with pytest.raises(ModelCardRegistryError):
+        rebuild_dashboard(snapshot_dir, tmp_path / "radar.json", registry_path=broken)


### PR DESCRIPTION
Closes the tractable core of #83, following the four steps in [this comment](https://github.com/ktwu01/benchmark-radar/issues/83#issuecomment-5159458333).

## What this is

A curated registry of frontier model cards and the benchmarks each one reports, published as a `?view=leaderboard` view on the homepage. 16 documents from all 8 organizations named in the issue (OpenAI, Anthropic, Google DeepMind, Meta, Qwen, DeepSeek, Mistral, xAI), covering 32 benchmarks.

## Why it counts mentions rather than scores

The issue's first comment sketched a six-table registry keyed by evaluation configuration: reasoning budget, pass@k, tool access, judge model, comparison group. That schema is right, and it is also unbuildable as a first step, since it produces no rows until a per-vendor PDF parser exists, and every row it did produce would carry a score incomparable to the score beside it.

Step 4 asked what we can do rather than making things very complex. The answer is to store a **mention**, not a score. A mention is the one fact that survives every configuration caveat the issue itself raises: whether GPT-5 ran AIME at pass@1 or consensus@64 with a Python tool, the card still chose to report AIME. Scores can be layered on later without invalidating anything recorded here.

## Counting rules

- **The unit is the document, not the result row.** A card reporting AIME in four configurations contributes one adoption, so a long appendix cannot outvote a different vendor.
- **Two counts, never combined.** `card_count` is the headline; `organization_count` breaks ties, because the same count from six vendors is a shared standard while from one vendor it is a house style. Any weighting of the two would be an invented judgement presented as a measurement.

## Guarding the obvious misreading

This measures vendor attention, not benchmark quality: MMLU currently ranks 5th precisely because reporting it is conventional. So the disclaimer sits in the heading before the table, every row carries its own caveat, and both are published in `radar.json` rather than only stated in the browser where they could drift. Benchmarks tracked but reported by no card are kept and ranked last, since "in the registry, adopted by nobody" is itself a finding.

## Extending it

Add a benchmark to `benchmarks:`, a document to `model_cards:`, run `benchmark-radar rebuild`. Validation is strict: unknown benchmark ids, repeated document URLs, scalar aliases, missing caveats, and dates the browser cannot format all fail the build rather than silently corrupting the ranking.

## Test plan

- 216 tests pass (`pytest -q`), 40 of them new
- `ruff check` and `ruff format --check` clean
- Verified in headless Chrome at 1440px and 430px: nav tab, ranking, adoption bars, per-row caveats, expanded adopter lists linking to source documents, all three filters, the 16-document roster table, and the zero-adoption row rendering an empty bar
- Codex review clean after four rounds (9 findings found and fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)