### PR TITLE
Harden scholarly source reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Default sources:
 
 The report remains useful without optional secrets. Missing optional sources are shown
 as warnings in the source-health table instead of being silently ignored.
+In GitHub Actions, an optional source that fails for three consecutive runs also emits a
+workflow warning; `radar.optional_source_failure_warning_runs` controls that threshold.
 
 ## How ranking works
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,11 @@ OPENALEX_API_KEY
 BRAVE_API_KEY
 ```
 
+OpenAlex replaced its old `mailto` polite pool with free API keys in February 2026.
+Create the key at <https://openalex.org/settings/api>. Semantic Scholar keys also start
+with a one-request-per-second limit, so its connector is paced by
+`sources.semantic_scholar.request_delay_seconds`.
+
 Daily snapshot persistence also requires a private GitHub App with **Contents: read and
 write** access to this repository. Add the App to the `main-protect` ruleset's bypass
 list with **Always allow**, then configure:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Default sources:
 | GitHub | No in Actions | Code and artifact discovery |
 | GitHub Releases | No in Actions | Curated first-party release discovery |
 | Semantic Scholar | Optional `SEMANTIC_SCHOLAR_API_KEY` | Structured scholarly discovery |
-| OpenAlex | `OPENALEX_API_KEY` | Scholarly metadata enrichment |
+| OpenAlex | Free `OPENALEX_API_KEY` | Scholarly metadata enrichment |
 | Brave Search | `BRAVE_API_KEY` | Web and lab-blog discovery |
 | Hacker News | No | Public attention only; never quality-scored |
 

--- a/config.yml
+++ b/config.yml
@@ -213,6 +213,8 @@ sources:
       - agentic benchmark evaluation
     page_size: 100
     max_requests: 3
+    # A free individual API key starts at one request per second.
+    request_delay_seconds: 1.1
     attempts: 3
     timeout_seconds: 30
 

--- a/config.yml
+++ b/config.yml
@@ -235,6 +235,9 @@ sources:
     page_size: 30
     max_pages_per_repository: 1
     max_requests: 8
+    # Invalid future-dated rows may consume a page slot. Replacement requests
+    # use a separate cap so they cannot steal the first request from later repos.
+    future_replacement_requests: 2
     attempts: 3
     timeout_seconds: 30
 

--- a/config.yml
+++ b/config.yml
@@ -1,5 +1,8 @@
 radar:
   lookback_hours: 48
+  # Optional connectors remain non-fatal, but repeated failures must not hide
+  # indefinitely inside green scheduled runs.
+  optional_source_failure_warning_runs: 3
   # Sources routinely return several hundred rows a day. The previous 60/30
   # pair discarded most of them before anyone could see them, so the dashboard
   # claimed "228 found" while publishing 8 GitHub records.

--- a/src/benchmark_radar/cli.py
+++ b/src/benchmark_radar/cli.py
@@ -33,13 +33,20 @@ def _emit_persistent_source_warnings(run, config: dict) -> None:
         if source_config.get("enabled", True) and source_config.get("required", False)
     }
     streaks = run.discovery_state.get("source_failure_streaks") or {}
-    for health in [*run.health, *run.attention_ingest_health, *run.producer_health]:
+
+    def emit(health, *, required_source: bool = False) -> None:
         streak = int(streaks.get(health.source, 0) or 0)
-        if not health.ok and health.source not in required and streak >= threshold:
+        if not health.ok and not required_source and streak >= threshold:
+            source = health.source.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
             print(
                 "::warning title=Persistent optional source failure::"
-                f"{health.source} has failed for {streak} consecutive runs"
+                f"{source} has failed for {streak} consecutive runs"
             )
+
+    for health in run.health:
+        emit(health, required_source=health.source in required)
+    for health in [*run.attention_ingest_health, *run.producer_health]:
+        emit(health)
 
 
 def load_config(path: Path) -> dict:

--- a/src/benchmark_radar/cli.py
+++ b/src/benchmark_radar/cli.py
@@ -33,7 +33,7 @@ def _emit_persistent_source_warnings(run, config: dict) -> None:
         if source_config.get("enabled", True) and source_config.get("required", False)
     }
     streaks = run.discovery_state.get("source_failure_streaks") or {}
-    for health in [*run.health, *run.attention_ingest_health]:
+    for health in [*run.health, *run.attention_ingest_health, *run.producer_health]:
         streak = int(streaks.get(health.source, 0) or 0)
         if not health.ok and health.source not in required and streak >= threshold:
             print(

--- a/src/benchmark_radar/cli.py
+++ b/src/benchmark_radar/cli.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import yaml
 
-from .pipeline import run_pipeline, simulate_backfill
+from .pipeline import _failure_streak_key, run_pipeline, simulate_backfill
 from .report import render_markdown
 from .snapshots import (
     load_snapshots,
@@ -35,11 +35,7 @@ def _emit_persistent_source_warnings(run, config: dict) -> None:
     streaks = run.discovery_state.get("source_failure_streaks") or {}
 
     def emit(health, *, layer: str, required_source: bool = False) -> None:
-        streak_key = (
-            f"producer:{health.producer}:{health.source}"
-            if layer == "producer"
-            else f"{layer}:{health.source}"
-        )
+        streak_key = _failure_streak_key(layer, health)
         streak = int(streaks.get(streak_key, 0) or 0)
         if not health.ok and not required_source and streak >= threshold:
             source = health.source.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")

--- a/src/benchmark_radar/cli.py
+++ b/src/benchmark_radar/cli.py
@@ -33,7 +33,7 @@ def _emit_persistent_source_warnings(run, config: dict) -> None:
         if source_config.get("enabled", True) and source_config.get("required", False)
     }
     streaks = run.discovery_state.get("source_failure_streaks") or {}
-    for health in run.health:
+    for health in [*run.health, *run.attention_ingest_health]:
         streak = int(streaks.get(health.source, 0) or 0)
         if not health.ok and health.source not in required and streak >= threshold:
             print(

--- a/src/benchmark_radar/cli.py
+++ b/src/benchmark_radar/cli.py
@@ -34,8 +34,13 @@ def _emit_persistent_source_warnings(run, config: dict) -> None:
     }
     streaks = run.discovery_state.get("source_failure_streaks") or {}
 
-    def emit(health, *, required_source: bool = False) -> None:
-        streak = int(streaks.get(health.source, 0) or 0)
+    def emit(health, *, layer: str, required_source: bool = False) -> None:
+        streak_key = (
+            f"producer:{health.producer}:{health.source}"
+            if layer == "producer"
+            else f"{layer}:{health.source}"
+        )
+        streak = int(streaks.get(streak_key, 0) or 0)
         if not health.ok and not required_source and streak >= threshold:
             source = health.source.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
             print(
@@ -44,9 +49,11 @@ def _emit_persistent_source_warnings(run, config: dict) -> None:
             )
 
     for health in run.health:
-        emit(health, required_source=health.source in required)
-    for health in [*run.attention_ingest_health, *run.producer_health]:
-        emit(health)
+        emit(health, layer="evidence", required_source=health.source in required)
+    for health in run.attention_ingest_health:
+        emit(health, layer="attention")
+    for health in run.producer_health:
+        emit(health, layer="producer")
 
 
 def load_config(path: Path) -> dict:

--- a/src/benchmark_radar/cli.py
+++ b/src/benchmark_radar/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -16,6 +17,29 @@ from .snapshots import (
     rescore_snapshot_history,
     write_snapshot,
 )
+
+
+def _emit_persistent_source_warnings(run, config: dict) -> None:
+    """Raise visible Actions warnings for optional sources that keep failing."""
+    if os.getenv("GITHUB_ACTIONS") != "true":
+        return
+    threshold = max(
+        1,
+        int(config.get("radar", {}).get("optional_source_failure_warning_runs", 3)),
+    )
+    required = {
+        name
+        for name, source_config in config.get("sources", {}).items()
+        if source_config.get("enabled", True) and source_config.get("required", False)
+    }
+    streaks = run.discovery_state.get("source_failure_streaks") or {}
+    for health in run.health:
+        streak = int(streaks.get(health.source, 0) or 0)
+        if not health.ok and health.source not in required and streak >= threshold:
+            print(
+                "::warning title=Persistent optional source failure::"
+                f"{health.source} has failed for {streak} consecutive runs"
+            )
 
 
 def load_config(path: Path) -> dict:
@@ -134,6 +158,7 @@ def main() -> None:
         config,
         previous_snapshot=snapshots[-1] if snapshots else None,
     )
+    _emit_persistent_source_warnings(run, config)
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.json_output.parent.mkdir(parents=True, exist_ok=True)
     dashboard_url = config.get("publish", {}).get("dashboard_url")

--- a/src/benchmark_radar/pipeline.py
+++ b/src/benchmark_radar/pipeline.py
@@ -681,6 +681,20 @@ def run_pipeline(
         previous_observations=((previous_snapshot or {}).get("attention") or {}).get("observations")
         or [],
     )
+    previous_streaks = ((previous_snapshot or {}).get("discovery_state") or {}).get(
+        "source_failure_streaks"
+    ) or {}
+    failure_streaks: dict[str, int] = {}
+    for source_health in health:
+        if source_health.ok:
+            continue
+        previous = previous_streaks.get(source_health.source, 0)
+        try:
+            previous_count = max(0, int(previous))
+        except (TypeError, ValueError):
+            previous_count = 0
+        failure_streaks[source_health.source] = previous_count + 1
+
     return RadarRun(
         generated_at=now,
         since=since,
@@ -693,5 +707,6 @@ def run_pipeline(
         discovery_state={
             **discovery_state,
             "attention": attention_state,
+            "source_failure_streaks": failure_streaks,
         },
     )

--- a/src/benchmark_radar/pipeline.py
+++ b/src/benchmark_radar/pipeline.py
@@ -685,7 +685,7 @@ def run_pipeline(
         "source_failure_streaks"
     ) or {}
     failure_streaks: dict[str, int] = {}
-    for source_health in [*health, *attention_health]:
+    for source_health in [*health, *attention_health, *producer_health]:
         if source_health.ok:
             continue
         previous = previous_streaks.get(source_health.source, 0)

--- a/src/benchmark_radar/pipeline.py
+++ b/src/benchmark_radar/pipeline.py
@@ -13,7 +13,7 @@ from . import rubric
 from .attention import fetch_attention_feeds
 from .corpus import exact_artifact_keys
 from .models import RadarItem, RadarRun, SourceHealth
-from .sources import SOURCE_FETCHERS
+from .sources import FUTURE_TIMESTAMP_TOLERANCE, SOURCE_FETCHERS
 
 TRACKING_PARAMETERS = {"ref", "source", "utm_campaign", "utm_content", "utm_medium", "utm_source"}
 
@@ -314,7 +314,6 @@ def apply_watchlist(
 
 
 BOILERPLATE_THRESHOLD = 3
-FUTURE_TIMESTAMP_TOLERANCE = timedelta(minutes=5)
 
 
 def assert_no_boilerplate_summaries(items: list[RadarItem]) -> None:
@@ -600,10 +599,11 @@ def run_pipeline(
             continue
         fetcher = SOURCE_FETCHERS[source_name]
         try:
+            fetch_config = {**source_config, "_collection_now": now}
             if source_name == "openalex":
-                fetched = fetcher(source_config, since, limit, now=now)
+                fetched = fetcher(fetch_config, since, limit, now=now)
             else:
-                fetched = fetcher(source_config, since, limit)
+                fetched = fetcher(fetch_config, since, limit)
             fetched_count += len(fetched)
             fetched, rejected_future = _drop_future_dated_items(fetched, now=now)
             future_dated_count += rejected_future

--- a/src/benchmark_radar/pipeline.py
+++ b/src/benchmark_radar/pipeline.py
@@ -685,7 +685,7 @@ def run_pipeline(
         "source_failure_streaks"
     ) or {}
     failure_streaks: dict[str, int] = {}
-    for source_health in health:
+    for source_health in [*health, *attention_health]:
         if source_health.ok:
             continue
         previous = previous_streaks.get(source_health.source, 0)

--- a/src/benchmark_radar/pipeline.py
+++ b/src/benchmark_radar/pipeline.py
@@ -314,6 +314,7 @@ def apply_watchlist(
 
 
 BOILERPLATE_THRESHOLD = 3
+FUTURE_TIMESTAMP_TOLERANCE = timedelta(minutes=5)
 
 
 def assert_no_boilerplate_summaries(items: list[RadarItem]) -> None:
@@ -334,6 +335,22 @@ def assert_no_boilerplate_summaries(items: list[RadarItem]) -> None:
             f"summary {worst[0]!r}. Derive summaries from source metadata (see describe.py) "
             "and leave them empty when the source publishes none."
         )
+
+
+def _drop_future_dated_items(
+    items: list[RadarItem],
+    *,
+    now: datetime,
+) -> tuple[list[RadarItem], int]:
+    """Quarantine records whose source timestamps are materially in the future."""
+    latest_allowed = now + FUTURE_TIMESTAMP_TOLERANCE
+    accepted = [
+        item
+        for item in items
+        if item.published_at <= latest_allowed
+        and (item.updated_at is None or item.updated_at <= latest_allowed)
+    ]
+    return accepted, len(items) - len(accepted)
 
 
 def _date(value: str | None, *, fallback: datetime) -> datetime:
@@ -374,6 +391,7 @@ def _score_and_select(
     now: datetime,
     fetched_count: int,
     suppressed_count: int,
+    future_dated_count: int = 0,
 ) -> tuple[list[RadarItem], dict[str, Any]]:
     """Score, dedupe and select a fetched item pool as of a given moment.
 
@@ -424,6 +442,9 @@ def _score_and_select(
         "fetched": fetched_count,
         # arXiv records already seen in a previous run, dropped before dedupe.
         "suppressed_as_seen": suppressed_count,
+        # Invalid upstream dates are removed before scoring so they cannot get
+        # maximum recency or displace legitimate current records.
+        "suppressed_future_dated": future_dated_count,
         "deduplicated": len(unique),
         "scored": len(scored),
         "qualified": len(selected),
@@ -568,19 +589,36 @@ def run_pipeline(
     limit = int(settings["max_items_per_source"])
     items: list[RadarItem] = []
     health: list[SourceHealth] = []
-    # Counted before arXiv overlap suppression, so this always agrees with the
-    # per-source health table rather than silently excluding repeat records.
+    # Counted before arXiv overlap and future-date suppression. The selection
+    # funnel records both exclusions so every fetched row remains accounted for.
     fetched_count = 0
     suppressed_count = 0
+    future_dated_count = 0
     discovery_state = deepcopy((previous_snapshot or {}).get("discovery_state") or {})
     for source_name, source_config in config["sources"].items():
         if not source_config.get("enabled", True):
             continue
         fetcher = SOURCE_FETCHERS[source_name]
         try:
-            fetched = fetcher(source_config, since, limit)
+            if source_name == "openalex":
+                fetched = fetcher(source_config, since, limit, now=now)
+            else:
+                fetched = fetcher(source_config, since, limit)
             fetched_count += len(fetched)
-            health.append(SourceHealth(source=source_name, ok=True, item_count=len(fetched)))
+            fetched, rejected_future = _drop_future_dated_items(fetched, now=now)
+            future_dated_count += rejected_future
+            health.append(
+                SourceHealth(
+                    source=source_name,
+                    ok=True,
+                    item_count=len(fetched),
+                    error=(
+                        f"Discarded {rejected_future} future-dated record(s)"
+                        if rejected_future
+                        else None
+                    ),
+                )
+            )
             for item in fetched:
                 item.retrieved_at = item.retrieved_at or now
             if source_name == "arxiv":
@@ -633,6 +671,7 @@ def run_pipeline(
         now=now,
         fetched_count=fetched_count,
         suppressed_count=suppressed_count,
+        future_dated_count=future_dated_count,
     )
     attention, attention_health, producer_health, attention_state = fetch_attention_feeds(
         config.get("attention") or {},

--- a/src/benchmark_radar/pipeline.py
+++ b/src/benchmark_radar/pipeline.py
@@ -352,6 +352,12 @@ def _drop_future_dated_items(
     return accepted, len(items) - len(accepted)
 
 
+def _failure_streak_key(layer: str, health: Any) -> str:
+    if layer == "producer":
+        return f"producer:{health.producer}:{health.source}"
+    return f"{layer}:{health.source}"
+
+
 def _date(value: str | None, *, fallback: datetime) -> datetime:
     if not value:
         return fallback
@@ -685,15 +691,21 @@ def run_pipeline(
         "source_failure_streaks"
     ) or {}
     failure_streaks: dict[str, int] = {}
-    for source_health in [*health, *attention_health, *producer_health]:
+    monitored_health = [
+        *(("evidence", source_health) for source_health in health),
+        *(("attention", source_health) for source_health in attention_health),
+        *(("producer", source_health) for source_health in producer_health),
+    ]
+    for layer, source_health in monitored_health:
         if source_health.ok:
             continue
-        previous = previous_streaks.get(source_health.source, 0)
+        streak_key = _failure_streak_key(layer, source_health)
+        previous = previous_streaks.get(streak_key, 0)
         try:
             previous_count = max(0, int(previous))
         except (TypeError, ValueError):
             previous_count = 0
-        failure_streaks[source_health.source] = previous_count + 1
+        failure_streaks[streak_key] = previous_count + 1
 
     return RadarRun(
         generated_at=now,

--- a/src/benchmark_radar/pipeline.py
+++ b/src/benchmark_radar/pipeline.py
@@ -610,8 +610,10 @@ def run_pipeline(
                 fetched = fetcher(fetch_config, since, limit, now=now)
             else:
                 fetched = fetcher(fetch_config, since, limit)
-            fetched_count += len(fetched)
+            connector_rejected = int(fetch_config.get("_future_rejections", 0) or 0)
+            fetched_count += len(fetched) + connector_rejected
             fetched, rejected_future = _drop_future_dated_items(fetched, now=now)
+            rejected_future += connector_rejected
             future_dated_count += rejected_future
             health.append(
                 SourceHealth(

--- a/src/benchmark_radar/pipeline.py
+++ b/src/benchmark_radar/pipeline.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import math
 import re
 from collections import Counter
@@ -354,8 +355,10 @@ def _drop_future_dated_items(
 
 def _failure_streak_key(layer: str, health: Any) -> str:
     if layer == "producer":
-        return f"producer:{health.producer}:{health.source}"
-    return f"{layer}:{health.source}"
+        identity = [layer, health.producer, health.source]
+    else:
+        identity = [layer, health.source]
+    return json.dumps(identity, ensure_ascii=False, separators=(",", ":"))
 
 
 def _date(value: str | None, *, fallback: datetime) -> datetime:

--- a/src/benchmark_radar/report.py
+++ b/src/benchmark_radar/report.py
@@ -121,12 +121,18 @@ def render_markdown(
             + ")"
         )
         suppressed = int(selection.get("suppressed_as_seen") or 0)
+        suppressed_future = int(selection.get("suppressed_future_dated") or 0)
         suppressed_low_value = int(selection.get("suppressed_low_value") or 0)
         lines.extend(
             [
                 "- Selection: "
                 f"**{selection.get('fetched', 0)}** fetched → "
                 + (f"**{suppressed}** already seen → " if suppressed else "")
+                + (
+                    f"**{suppressed_future}** future-dated records quarantined → "
+                    if suppressed_future
+                    else ""
+                )
                 + f"**{selection.get('deduplicated', 0)}** after dedupe → "
                 + (
                     f"**{suppressed_low_value}** low-value artifacts suppressed → "

--- a/src/benchmark_radar/sources.py
+++ b/src/benchmark_radar/sources.py
@@ -460,16 +460,26 @@ def fetch_semantic_scholar(
     limit: int,
 ) -> list[RadarItem]:
     """Fetch structured scholarly records with exact external identifiers."""
-    api_key = os.getenv("SEMANTIC_SCHOLAR_API_KEY")
+    api_key = os.getenv("SEMANTIC_SCHOLAR_API_KEY", "").strip()
     headers = {"x-api-key": api_key} if api_key else {}
     found: dict[str, RadarItem] = {}
     searches = [str(value) for value in config.get("searches", []) if str(value).strip()]
     budget = max(1, int(config.get("max_requests", len(searches) or 1)))
     page_size = min(100, max(1, int(config.get("page_size", 100))))
+    # An individual Semantic Scholar key starts at one request per second.
+    # Pace proactively instead of making every request after the first rely on
+    # a 429 and retry. Anonymous callers remain on the shared pool and retain
+    # the old no-delay default unless the configuration says otherwise.
+    request_delay = max(
+        0.0,
+        float(config.get("request_delay_seconds", 1.1 if api_key else 0.0)),
+    )
     requests_made = 0
     for search in searches:
         offset = 0
         while requests_made < budget and len(found) < limit:
+            if requests_made and request_delay:
+                time.sleep(request_delay)
             payload = get_json(
                 "https://api.semanticscholar.org/graph/v1/paper/search",
                 params={

--- a/src/benchmark_radar/sources.py
+++ b/src/benchmark_radar/sources.py
@@ -644,10 +644,20 @@ def fetch_github_releases(
     return sorted(found.values(), key=lambda item: item.published_at, reverse=True)[:limit]
 
 
-def fetch_openalex(config: dict[str, Any], since: datetime, limit: int) -> list[RadarItem]:
-    api_key = os.getenv("OPENALEX_API_KEY")
+def fetch_openalex(
+    config: dict[str, Any],
+    since: datetime,
+    limit: int,
+    *,
+    now: datetime | None = None,
+) -> list[RadarItem]:
+    # OpenAlex replaced its mailto-based polite pool with free API keys in
+    # February 2026. Anonymous calls still have a small compatibility budget,
+    # but they are not the documented production path.
+    api_key = os.getenv("OPENALEX_API_KEY", "").strip()
     if not api_key:
         raise RuntimeError("OPENALEX_API_KEY is not configured")
+    now = now or datetime.now(UTC)
     found: dict[str, RadarItem] = {}
     for search in config.get("searches", []):
         payload = get_json(
@@ -655,7 +665,12 @@ def fetch_openalex(config: dict[str, Any], since: datetime, limit: int) -> list[
             params={
                 "api_key": api_key,
                 "search": search,
-                "filter": f"from_publication_date:{since.date().isoformat()}",
+                # The lower bound alone lets erroneous future records sort to
+                # the front and crowd real current work out of the first page.
+                "filter": (
+                    f"from_publication_date:{since.date().isoformat()},"
+                    f"to_publication_date:{now.date().isoformat()}"
+                ),
                 "sort": "publication_date:desc",
                 "per_page": min(limit, 100),
                 "select": "id,doi,display_name,publication_date,authorships,"
@@ -679,7 +694,14 @@ def fetch_openalex(config: dict[str, Any], since: datetime, limit: int) -> list[
             # resolution; an undated row is skipped rather than dated "now",
             # which would have handed it maximum recency.
             published = _optional_date(row.get("publication_date"))
-            if published is None or published.date() < since.date():
+            # Keep a defensive client-side bound as well as the API filter: a
+            # malformed or ignored upstream filter must not grant future work
+            # maximum recency in the shared scorer.
+            if (
+                published is None
+                or published.date() < since.date()
+                or published.date() > now.date()
+            ):
                 continue
             found[source_id] = RadarItem(
                 source="OpenAlex",

--- a/src/benchmark_radar/sources.py
+++ b/src/benchmark_radar/sources.py
@@ -27,10 +27,16 @@ def _latest_allowed(config: dict[str, Any]) -> datetime:
     return collection_now.astimezone(UTC) + FUTURE_TIMESTAMP_TOLERANCE
 
 
-def _reject_future(config: dict[str, Any], *timestamps: datetime | None) -> bool:
+def _reject_future(
+    config: dict[str, Any],
+    identity: str,
+    *timestamps: datetime | None,
+) -> bool:
     if not any(value is not None and value > _latest_allowed(config) for value in timestamps):
         return False
-    config["_future_rejections"] = int(config.get("_future_rejections", 0)) + 1
+    identities = config.setdefault("_future_rejection_ids", set())
+    identities.add(identity)
+    config["_future_rejections"] = len(identities)
     return True
 
 
@@ -146,7 +152,7 @@ def _fetch_arxiv_rss(
             ):
                 continue
             published = parsedate_to_datetime(published_text).astimezone(UTC)
-            if published < overlap_since or _reject_future(config, published):
+            if published < overlap_since or _reject_future(config, source_id, published):
                 continue
             announce_type = (
                 entry.findtext("arxiv:announce_type", namespaces=namespaces) or ""
@@ -209,16 +215,16 @@ def fetch_arxiv(config: dict[str, Any], since: datetime, limit: int) -> list[Rad
                 )
                 root = ET.fromstring(xml)
                 for entry in root.findall("atom:entry", namespace):
-                    published = _date(entry.findtext("atom:published", namespaces=namespace))
-                    updated = _date(entry.findtext("atom:updated", namespaces=namespace))
-                    if max(published, updated) < overlap_since or _reject_future(
-                        config, published, updated
-                    ):
-                        continue
                     url = (entry.findtext("atom:id", namespaces=namespace) or "").replace(
                         "http:", "https:"
                     )
                     source_id = _arxiv_source_id(url)
+                    published = _date(entry.findtext("atom:published", namespaces=namespace))
+                    updated = _date(entry.findtext("atom:updated", namespaces=namespace))
+                    if max(published, updated) < overlap_since or _reject_future(
+                        config, source_id, published, updated
+                    ):
+                        continue
                     title = " ".join(
                         (entry.findtext("atom:title", namespaces=namespace) or "").split()
                     )
@@ -283,14 +289,18 @@ def fetch_huggingface(config: dict[str, Any], since: datetime, limit: int) -> li
             if not isinstance(rows, list) or not all(isinstance(row, dict) for row in rows):
                 raise ConnectorPayloadError("Hugging Face Hub returned a non-array payload")
             for row in rows:
+                item_id = row.get("id") or row.get("modelId")
+                if not item_id:
+                    continue
                 # An undated repo is skipped rather than dated "now": the
                 # substitution both invented freshness and slipped past the
                 # `since` check below, which is what it was meant to enforce.
                 changed = _optional_date(row.get("lastModified") or row.get("createdAt"))
-                if changed is None or changed < since or _reject_future(config, changed):
-                    continue
-                item_id = row.get("id") or row.get("modelId")
-                if not item_id:
+                if (
+                    changed is None
+                    or changed < since
+                    or _reject_future(config, str(item_id), changed)
+                ):
                     continue
                 created = _optional_date(row.get("createdAt"))
                 found[item_id] = RadarItem(
@@ -368,10 +378,10 @@ def fetch_github(config: dict[str, Any], since: datetime, limit: int) -> list[Ra
             )
             rows = _payload_rows(payload, "items", "GitHub Search")
             for row in rows:
-                changed = _date(row.get("pushed_at") or row.get("updated_at"))
-                if changed < since or _reject_future(config, changed):
-                    continue
                 full_name = row["full_name"]
+                changed = _date(row.get("pushed_at") or row.get("updated_at"))
+                if changed < since or _reject_future(config, full_name, changed):
+                    continue
                 found[full_name] = RadarItem(
                     source="GitHub",
                     source_id=full_name,
@@ -438,7 +448,7 @@ def fetch_openreview(
                 if not note_id or not title or not created or not activity:
                     continue
                 oldest = min(oldest or activity, activity)
-                if activity < since or _reject_future(config, activity):
+                if activity < since or _reject_future(config, note_id, activity):
                     continue
                 abstract = str(_openreview_value(content, "abstract", "") or "").strip()
                 authors = _openreview_value(content, "authors", []) or []
@@ -537,7 +547,7 @@ def fetch_semantic_scholar(
                 if not paper_id or not title or not published_text:
                     continue
                 published = _date(str(published_text))
-                if published < since or _reject_future(config, published):
+                if published < since or _reject_future(config, paper_id, published):
                     continue
                 external = row.get("externalIds") or {}
                 if not isinstance(external, dict):
@@ -652,12 +662,12 @@ def fetch_github_releases(
                 oldest = min(oldest or published, published)
                 if published < since:
                     continue
-                if _reject_future(config, published):
-                    rejected_on_page += 1
-                    continue
                 tag = str(row.get("tag_name") or "").strip()
                 url = str(row.get("html_url") or "").strip()
                 if not tag or not url:
+                    continue
+                if _reject_future(config, f"{repository}@{tag}", published):
+                    rejected_on_page += 1
                     continue
                 author = row.get("author") or {}
                 assets = row.get("assets") or []
@@ -761,7 +771,7 @@ def fetch_openalex(
             if (
                 published is None
                 or published.date() < since.date()
-                or _reject_future(config, published)
+                or _reject_future(config, source_id, published)
             ):
                 continue
             found[source_id] = RadarItem(
@@ -824,7 +834,7 @@ def fetch_brave(config: dict[str, Any], since: datetime, limit: int) -> list[Rad
             # a freshness the response never asserted and awarded them full
             # recency, so an undated result is skipped instead.
             published = _optional_date(row.get("page_age"))
-            if published is None or _reject_future(config, published):
+            if published is None or _reject_future(config, url, published):
                 continue
             found[url] = RadarItem(
                 source="Brave Web",

--- a/src/benchmark_radar/sources.py
+++ b/src/benchmark_radar/sources.py
@@ -203,7 +203,7 @@ def fetch_arxiv(config: dict[str, Any], since: datetime, limit: int) -> list[Rad
                         ),
                         "start": 0,
                         "max_results": limit,
-                        "sortBy": "submittedDate",
+                        "sortBy": "lastUpdatedDate",
                         "sortOrder": "descending",
                     },
                 )
@@ -611,13 +611,20 @@ def fetch_github_releases(
     page_size = min(100, max(1, int(config.get("page_size", 30))))
     max_pages = max(1, int(config.get("max_pages_per_repository", 2)))
     budget = max(1, int(config.get("max_requests", len(repositories) or 1)))
-    requests_made = 0
+    replacement_budget = max(0, int(config.get("future_replacement_requests", 2)))
+    regular_requests = 0
+    replacement_requests = 0
     found: dict[str, RadarItem] = {}
     for repository in repositories:
         page = 1
         page_limit = max_pages
         while page <= page_limit:
-            if requests_made >= budget or len(found) >= limit:
+            is_replacement = page > max_pages
+            if (
+                (is_replacement and replacement_requests >= replacement_budget)
+                or (not is_replacement and regular_requests >= budget)
+                or len(found) >= limit
+            ):
                 break
             payload = get_json(
                 f"https://api.github.com/repos/{repository}/releases",
@@ -625,7 +632,10 @@ def fetch_github_releases(
                 headers=headers,
                 **_request_options(config),
             )
-            requests_made += 1
+            if is_replacement:
+                replacement_requests += 1
+            else:
+                regular_requests += 1
             if not isinstance(payload, list) or not all(isinstance(row, dict) for row in payload):
                 raise ConnectorPayloadError("GitHub Releases returned a non-array payload")
             if not payload:
@@ -689,7 +699,7 @@ def fetch_github_releases(
             if rejected_on_page:
                 page_limit += 1
             page += 1
-        if requests_made >= budget or len(found) >= limit:
+        if regular_requests >= budget or len(found) >= limit:
             break
     return sorted(found.values(), key=lambda item: item.published_at, reverse=True)[:limit]
 

--- a/src/benchmark_radar/sources.py
+++ b/src/benchmark_radar/sources.py
@@ -27,6 +27,13 @@ def _latest_allowed(config: dict[str, Any]) -> datetime:
     return collection_now.astimezone(UTC) + FUTURE_TIMESTAMP_TOLERANCE
 
 
+def _reject_future(config: dict[str, Any], *timestamps: datetime | None) -> bool:
+    if not any(value is not None and value > _latest_allowed(config) for value in timestamps):
+        return False
+    config["_future_rejections"] = int(config.get("_future_rejections", 0)) + 1
+    return True
+
+
 def _payload_dict(payload: Any, source: str) -> dict[str, Any]:
     if not isinstance(payload, dict):
         raise ConnectorPayloadError(f"{source} returned a non-object payload")
@@ -139,7 +146,7 @@ def _fetch_arxiv_rss(
             ):
                 continue
             published = parsedate_to_datetime(published_text).astimezone(UTC)
-            if published < overlap_since or published > _latest_allowed(config):
+            if published < overlap_since or _reject_future(config, published):
                 continue
             announce_type = (
                 entry.findtext("arxiv:announce_type", namespaces=namespaces) or ""
@@ -190,7 +197,7 @@ def fetch_arxiv(config: dict[str, Any], since: datetime, limit: int) -> list[Rad
                     "https://export.arxiv.org/api/query",
                     params={
                         "search_query": (
-                            f"({query}) AND submittedDate:"
+                            f"({query}) AND lastUpdatedDate:"
                             f"[{overlap_since:%Y%m%d%H%M} TO "
                             f"{_latest_allowed(config):%Y%m%d%H%M}]"
                         ),
@@ -204,9 +211,9 @@ def fetch_arxiv(config: dict[str, Any], since: datetime, limit: int) -> list[Rad
                 for entry in root.findall("atom:entry", namespace):
                     published = _date(entry.findtext("atom:published", namespaces=namespace))
                     updated = _date(entry.findtext("atom:updated", namespaces=namespace))
-                    if max(published, updated) < overlap_since or max(
-                        published, updated
-                    ) > _latest_allowed(config):
+                    if max(published, updated) < overlap_since or _reject_future(
+                        config, published, updated
+                    ):
                         continue
                     url = (entry.findtext("atom:id", namespaces=namespace) or "").replace(
                         "http:", "https:"
@@ -280,7 +287,7 @@ def fetch_huggingface(config: dict[str, Any], since: datetime, limit: int) -> li
                 # substitution both invented freshness and slipped past the
                 # `since` check below, which is what it was meant to enforce.
                 changed = _optional_date(row.get("lastModified") or row.get("createdAt"))
-                if changed is None or changed < since or changed > _latest_allowed(config):
+                if changed is None or changed < since or _reject_future(config, changed):
                     continue
                 item_id = row.get("id") or row.get("modelId")
                 if not item_id:
@@ -362,7 +369,7 @@ def fetch_github(config: dict[str, Any], since: datetime, limit: int) -> list[Ra
             rows = _payload_rows(payload, "items", "GitHub Search")
             for row in rows:
                 changed = _date(row.get("pushed_at") or row.get("updated_at"))
-                if changed < since:
+                if changed < since or _reject_future(config, changed):
                     continue
                 full_name = row["full_name"]
                 found[full_name] = RadarItem(
@@ -431,7 +438,7 @@ def fetch_openreview(
                 if not note_id or not title or not created or not activity:
                     continue
                 oldest = min(oldest or activity, activity)
-                if activity < since or activity > _latest_allowed(config):
+                if activity < since or _reject_future(config, activity):
                     continue
                 abstract = str(_openreview_value(content, "abstract", "") or "").strip()
                 authors = _openreview_value(content, "authors", []) or []
@@ -530,7 +537,7 @@ def fetch_semantic_scholar(
                 if not paper_id or not title or not published_text:
                     continue
                 published = _date(str(published_text))
-                if published < since or published > _latest_allowed(config):
+                if published < since or _reject_future(config, published):
                     continue
                 external = row.get("externalIds") or {}
                 if not isinstance(external, dict):
@@ -607,7 +614,9 @@ def fetch_github_releases(
     requests_made = 0
     found: dict[str, RadarItem] = {}
     for repository in repositories:
-        for page in range(1, max_pages + 1):
+        page = 1
+        page_limit = max_pages
+        while page <= page_limit:
             if requests_made >= budget or len(found) >= limit:
                 break
             payload = get_json(
@@ -622,6 +631,7 @@ def fetch_github_releases(
             if not payload:
                 break
             oldest: datetime | None = None
+            rejected_on_page = 0
             for row in payload:
                 if row.get("draft"):
                     continue
@@ -631,6 +641,9 @@ def fetch_github_releases(
                 published = _date(str(published_text))
                 oldest = min(oldest or published, published)
                 if published < since:
+                    continue
+                if _reject_future(config, published):
+                    rejected_on_page += 1
                     continue
                 tag = str(row.get("tag_name") or "").strip()
                 url = str(row.get("html_url") or "").strip()
@@ -673,6 +686,9 @@ def fetch_github_releases(
                 oldest is not None and oldest < since
             ):
                 break
+            if rejected_on_page:
+                page_limit += 1
+            page += 1
         if requests_made >= budget or len(found) >= limit:
             break
     return sorted(found.values(), key=lambda item: item.published_at, reverse=True)[:limit]
@@ -692,6 +708,7 @@ def fetch_openalex(
     if not api_key:
         raise RuntimeError("OPENALEX_API_KEY is not configured")
     now = now or _latest_allowed(config) - FUTURE_TIMESTAMP_TOLERANCE
+    config.setdefault("_collection_now", now)
     found: dict[str, RadarItem] = {}
     for search in config.get("searches", []):
         payload = get_json(
@@ -734,7 +751,7 @@ def fetch_openalex(
             if (
                 published is None
                 or published.date() < since.date()
-                or published.date() > now.date()
+                or _reject_future(config, published)
             ):
                 continue
             found[source_id] = RadarItem(
@@ -797,7 +814,7 @@ def fetch_brave(config: dict[str, Any], since: datetime, limit: int) -> list[Rad
             # a freshness the response never asserted and awarded them full
             # recency, so an undated result is skipped instead.
             published = _optional_date(row.get("page_age"))
-            if published is None or published > _latest_allowed(config):
+            if published is None or _reject_future(config, published):
                 continue
             found[url] = RadarItem(
                 source="Brave Web",

--- a/src/benchmark_radar/sources.py
+++ b/src/benchmark_radar/sources.py
@@ -17,6 +17,16 @@ class ConnectorPayloadError(ValueError):
     """Raised when a source returns a successful but incompatible payload."""
 
 
+FUTURE_TIMESTAMP_TOLERANCE = timedelta(minutes=5)
+
+
+def _latest_allowed(config: dict[str, Any]) -> datetime:
+    collection_now = config.get("_collection_now")
+    if not isinstance(collection_now, datetime):
+        collection_now = datetime.now(UTC)
+    return collection_now.astimezone(UTC) + FUTURE_TIMESTAMP_TOLERANCE
+
+
 def _payload_dict(payload: Any, source: str) -> dict[str, Any]:
     if not isinstance(payload, dict):
         raise ConnectorPayloadError(f"{source} returned a non-object payload")
@@ -129,7 +139,7 @@ def _fetch_arxiv_rss(
             ):
                 continue
             published = parsedate_to_datetime(published_text).astimezone(UTC)
-            if published < overlap_since:
+            if published < overlap_since or published > _latest_allowed(config):
                 continue
             announce_type = (
                 entry.findtext("arxiv:announce_type", namespaces=namespaces) or ""
@@ -179,7 +189,11 @@ def fetch_arxiv(config: dict[str, Any], since: datetime, limit: int) -> list[Rad
                 xml = get_text(
                     "https://export.arxiv.org/api/query",
                     params={
-                        "search_query": query,
+                        "search_query": (
+                            f"({query}) AND submittedDate:"
+                            f"[{overlap_since:%Y%m%d%H%M} TO "
+                            f"{_latest_allowed(config):%Y%m%d%H%M}]"
+                        ),
                         "start": 0,
                         "max_results": limit,
                         "sortBy": "submittedDate",
@@ -190,7 +204,9 @@ def fetch_arxiv(config: dict[str, Any], since: datetime, limit: int) -> list[Rad
                 for entry in root.findall("atom:entry", namespace):
                     published = _date(entry.findtext("atom:published", namespaces=namespace))
                     updated = _date(entry.findtext("atom:updated", namespaces=namespace))
-                    if max(published, updated) < overlap_since:
+                    if max(published, updated) < overlap_since or max(
+                        published, updated
+                    ) > _latest_allowed(config):
                         continue
                     url = (entry.findtext("atom:id", namespaces=namespace) or "").replace(
                         "http:", "https:"
@@ -250,7 +266,10 @@ def fetch_huggingface(config: dict[str, Any], since: datetime, limit: int) -> li
                     "search": search,
                     "sort": "lastModified",
                     "direction": -1,
-                    "limit": limit,
+                    # The Hub API has no upper-date filter. Fetch extra rows so
+                    # malformed future timestamps cannot consume the local cap
+                    # before they are rejected below.
+                    "limit": min(1000, max(limit * 2, limit + 50)),
                     "full": "true",
                 },
             )
@@ -261,7 +280,7 @@ def fetch_huggingface(config: dict[str, Any], since: datetime, limit: int) -> li
                 # substitution both invented freshness and slipped past the
                 # `since` check below, which is what it was meant to enforce.
                 changed = _optional_date(row.get("lastModified") or row.get("createdAt"))
-                if changed is None or changed < since:
+                if changed is None or changed < since or changed > _latest_allowed(config):
                     continue
                 item_id = row.get("id") or row.get("modelId")
                 if not item_id:
@@ -329,7 +348,10 @@ def fetch_github(config: dict[str, Any], since: datetime, limit: int) -> list[Ra
             payload = get_json(
                 "https://api.github.com/search/repositories",
                 params={
-                    "q": f"{query} pushed:>={date_filter}",
+                    "q": (
+                        f"{query} pushed:{date_filter}.."
+                        f"{_latest_allowed(config).date().isoformat()}"
+                    ),
                     "sort": "updated",
                     "order": "desc",
                     "per_page": min(limit, page_size),
@@ -409,7 +431,7 @@ def fetch_openreview(
                 if not note_id or not title or not created or not activity:
                     continue
                 oldest = min(oldest or activity, activity)
-                if activity < since:
+                if activity < since or activity > _latest_allowed(config):
                     continue
                 abstract = str(_openreview_value(content, "abstract", "") or "").strip()
                 authors = _openreview_value(content, "authors", []) or []
@@ -484,7 +506,9 @@ def fetch_semantic_scholar(
                 "https://api.semanticscholar.org/graph/v1/paper/search",
                 params={
                     "query": search,
-                    "publicationDateOrYear": f"{since.date().isoformat()}:",
+                    "publicationDateOrYear": (
+                        f"{since.date().isoformat()}:{_latest_allowed(config).date().isoformat()}"
+                    ),
                     "offset": offset,
                     "limit": min(page_size, limit - len(found)),
                     "fields": (
@@ -506,7 +530,7 @@ def fetch_semantic_scholar(
                 if not paper_id or not title or not published_text:
                     continue
                 published = _date(str(published_text))
-                if published < since:
+                if published < since or published > _latest_allowed(config):
                     continue
                 external = row.get("externalIds") or {}
                 if not isinstance(external, dict):
@@ -667,7 +691,7 @@ def fetch_openalex(
     api_key = os.getenv("OPENALEX_API_KEY", "").strip()
     if not api_key:
         raise RuntimeError("OPENALEX_API_KEY is not configured")
-    now = now or datetime.now(UTC)
+    now = now or _latest_allowed(config) - FUTURE_TIMESTAMP_TOLERANCE
     found: dict[str, RadarItem] = {}
     for search in config.get("searches", []):
         payload = get_json(
@@ -739,6 +763,10 @@ def fetch_brave(config: dict[str, Any], since: datetime, limit: int) -> list[Rad
     if not api_key:
         raise RuntimeError("BRAVE_API_KEY is not configured")
     found: dict[str, RadarItem] = {}
+    freshness_end = min(
+        since + timedelta(days=_BRAVE_RANGE_DAYS),
+        _latest_allowed(config),
+    ).date()
     for query in config.get("searches", []):
         payload = get_json(
             "https://api.search.brave.com/res/v1/web/search",
@@ -748,10 +776,7 @@ def fetch_brave(config: dict[str, Any], since: datetime, limit: int) -> list[Rad
                 # run reconstructs the same query. The end is padded past the
                 # lookback so the present day stays inside the range: reading
                 # the clock here made the request depend on when it was issued.
-                "freshness": (
-                    f"{since.date().isoformat()}to"
-                    f"{(since + timedelta(days=_BRAVE_RANGE_DAYS)).date().isoformat()}"
-                ),
+                "freshness": (f"{since.date().isoformat()}to{freshness_end.isoformat()}"),
                 "count": min(limit, 20),
                 "extra_snippets": "true",
             },
@@ -772,7 +797,7 @@ def fetch_brave(config: dict[str, Any], since: datetime, limit: int) -> list[Rad
             # a freshness the response never asserted and awarded them full
             # recency, so an undated result is skipped instead.
             published = _optional_date(row.get("page_age"))
-            if published is None:
+            if published is None or published > _latest_allowed(config):
                 continue
             found[url] = RadarItem(
                 source="Brave Web",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import yaml
 
 from benchmark_radar import cli
-from benchmark_radar.models import RadarItem, RadarRun, SourceHealth
+from benchmark_radar.models import ProducerHealth, RadarItem, RadarRun
 from benchmark_radar.pipeline import SOURCE_FETCHERS
 from benchmark_radar.snapshots import write_snapshot
 
@@ -133,15 +133,15 @@ def test_actions_warn_after_repeated_optional_source_failures(monkeypatch, capsy
         since=datetime(2026, 7, 31, tzinfo=UTC),
         items=[],
         health=[],
-        attention_ingest_health=[
-            SourceHealth(
-                source="Hacker News collector",
-                kind="attention",
+        producer_health=[
+            ProducerHealth(
+                producer="fixture-producer",
+                source="Hacker News",
                 ok=False,
                 error="HTTP 503",
             )
         ],
-        discovery_state={"source_failure_streaks": {"Hacker News collector": 3}},
+        discovery_state={"source_failure_streaks": {"Hacker News": 3}},
     )
     config = {
         "radar": {"optional_source_failure_warning_runs": 3},
@@ -152,5 +152,5 @@ def test_actions_warn_after_repeated_optional_source_failures(monkeypatch, capsy
 
     assert capsys.readouterr().out == (
         "::warning title=Persistent optional source failure::"
-        "Hacker News collector has failed for 3 consecutive runs\n"
+        "Hacker News has failed for 3 consecutive runs\n"
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -141,7 +141,9 @@ def test_actions_warn_after_repeated_optional_source_failures(monkeypatch, capsy
                 error="HTTP 503",
             )
         ],
-        discovery_state={"source_failure_streaks": {"producer:fixture-producer:Hacker News": 3}},
+        discovery_state={
+            "source_failure_streaks": {'["producer","fixture-producer","Hacker News"]': 3}
+        },
     )
     config = {
         "radar": {"optional_source_failure_warning_runs": 3},
@@ -165,7 +167,15 @@ def test_actions_escape_remote_source_names(monkeypatch, capsys):
         items=[],
         health=[],
         producer_health=[ProducerHealth(producer="fixture-producer", source=source, ok=False)],
-        discovery_state={"source_failure_streaks": {f"producer:fixture-producer:{source}": 3}},
+        discovery_state={
+            "source_failure_streaks": {
+                json.dumps(
+                    ["producer", "fixture-producer", source],
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                ): 3
+            }
+        },
     )
 
     cli._emit_persistent_source_warnings(run, {"radar": {}, "sources": {}})
@@ -184,7 +194,7 @@ def test_required_discovery_name_does_not_exempt_attention_failure(monkeypatch, 
         items=[],
         health=[],
         producer_health=[ProducerHealth(producer="fixture-producer", source="github", ok=False)],
-        discovery_state={"source_failure_streaks": {"producer:fixture-producer:github": 3}},
+        discovery_state={"source_failure_streaks": {'["producer","fixture-producer","github"]': 3}},
     )
     config = {"radar": {}, "sources": {"github": {"required": True}}}
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -154,3 +154,40 @@ def test_actions_warn_after_repeated_optional_source_failures(monkeypatch, capsy
         "::warning title=Persistent optional source failure::"
         "Hacker News has failed for 3 consecutive runs\n"
     )
+
+
+def test_actions_escape_remote_source_names(monkeypatch, capsys):
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    source = "safe%name\r\n::error::injected"
+    run = RadarRun(
+        generated_at=datetime(2026, 8, 2, tzinfo=UTC),
+        since=datetime(2026, 7, 31, tzinfo=UTC),
+        items=[],
+        health=[],
+        producer_health=[ProducerHealth(producer="fixture-producer", source=source, ok=False)],
+        discovery_state={"source_failure_streaks": {source: 3}},
+    )
+
+    cli._emit_persistent_source_warnings(run, {"radar": {}, "sources": {}})
+
+    assert capsys.readouterr().out == (
+        "::warning title=Persistent optional source failure::"
+        "safe%25name%0D%0A::error::injected has failed for 3 consecutive runs\n"
+    )
+
+
+def test_required_discovery_name_does_not_exempt_attention_failure(monkeypatch, capsys):
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    run = RadarRun(
+        generated_at=datetime(2026, 8, 2, tzinfo=UTC),
+        since=datetime(2026, 7, 31, tzinfo=UTC),
+        items=[],
+        health=[],
+        producer_health=[ProducerHealth(producer="fixture-producer", source="github", ok=False)],
+        discovery_state={"source_failure_streaks": {"github": 3}},
+    )
+    config = {"radar": {}, "sources": {"github": {"required": True}}}
+
+    cli._emit_persistent_source_warnings(run, config)
+
+    assert "github has failed for 3 consecutive runs" in capsys.readouterr().out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -141,7 +141,7 @@ def test_actions_warn_after_repeated_optional_source_failures(monkeypatch, capsy
                 error="HTTP 503",
             )
         ],
-        discovery_state={"source_failure_streaks": {"Hacker News": 3}},
+        discovery_state={"source_failure_streaks": {"producer:fixture-producer:Hacker News": 3}},
     )
     config = {
         "radar": {"optional_source_failure_warning_runs": 3},
@@ -165,7 +165,7 @@ def test_actions_escape_remote_source_names(monkeypatch, capsys):
         items=[],
         health=[],
         producer_health=[ProducerHealth(producer="fixture-producer", source=source, ok=False)],
-        discovery_state={"source_failure_streaks": {source: 3}},
+        discovery_state={"source_failure_streaks": {f"producer:fixture-producer:{source}": 3}},
     )
 
     cli._emit_persistent_source_warnings(run, {"radar": {}, "sources": {}})
@@ -184,7 +184,7 @@ def test_required_discovery_name_does_not_exempt_attention_failure(monkeypatch, 
         items=[],
         health=[],
         producer_health=[ProducerHealth(producer="fixture-producer", source="github", ok=False)],
-        discovery_state={"source_failure_streaks": {"github": 3}},
+        discovery_state={"source_failure_streaks": {"producer:fixture-producer:github": 3}},
     )
     config = {"radar": {}, "sources": {"github": {"required": True}}}
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import yaml
 
 from benchmark_radar import cli
-from benchmark_radar.models import RadarItem, RadarRun
+from benchmark_radar.models import RadarItem, RadarRun, SourceHealth
 from benchmark_radar.pipeline import SOURCE_FETCHERS
 from benchmark_radar.snapshots import write_snapshot
 
@@ -124,3 +124,25 @@ def test_simulate_history_marks_written_snapshots_as_simulated(monkeypatch, tmp_
 
     simulated = json.loads((tmp_path / "snapshots" / "2026-07-29.json").read_text(encoding="utf-8"))
     assert simulated["selection"]["simulated"] is True
+
+
+def test_actions_warn_after_repeated_optional_source_failures(monkeypatch, capsys):
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    run = RadarRun(
+        generated_at=datetime(2026, 8, 2, tzinfo=UTC),
+        since=datetime(2026, 7, 31, tzinfo=UTC),
+        items=[],
+        health=[SourceHealth(source="openreview", ok=False, error="ChallengeRequiredError")],
+        discovery_state={"source_failure_streaks": {"openreview": 3}},
+    )
+    config = {
+        "radar": {"optional_source_failure_warning_runs": 3},
+        "sources": {"openreview": {"enabled": True}},
+    }
+
+    cli._emit_persistent_source_warnings(run, config)
+
+    assert capsys.readouterr().out == (
+        "::warning title=Persistent optional source failure::"
+        "openreview has failed for 3 consecutive runs\n"
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -132,17 +132,25 @@ def test_actions_warn_after_repeated_optional_source_failures(monkeypatch, capsy
         generated_at=datetime(2026, 8, 2, tzinfo=UTC),
         since=datetime(2026, 7, 31, tzinfo=UTC),
         items=[],
-        health=[SourceHealth(source="openreview", ok=False, error="ChallengeRequiredError")],
-        discovery_state={"source_failure_streaks": {"openreview": 3}},
+        health=[],
+        attention_ingest_health=[
+            SourceHealth(
+                source="Hacker News collector",
+                kind="attention",
+                ok=False,
+                error="HTTP 503",
+            )
+        ],
+        discovery_state={"source_failure_streaks": {"Hacker News collector": 3}},
     )
     config = {
         "radar": {"optional_source_failure_warning_runs": 3},
-        "sources": {"openreview": {"enabled": True}},
+        "sources": {},
     }
 
     cli._emit_persistent_source_warnings(run, config)
 
     assert capsys.readouterr().out == (
         "::warning title=Persistent optional source failure::"
-        "openreview has failed for 3 consecutive runs\n"
+        "Hacker News collector has failed for 3 consecutive runs\n"
     )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from benchmark_radar.models import RadarItem
+from benchmark_radar.models import RadarItem, SourceHealth
 from benchmark_radar.pipeline import (
     apply_watchlist,
     assert_no_boilerplate_summaries,
@@ -515,6 +515,48 @@ def test_optional_source_failure_streak_persists_and_resets(monkeypatch):
         previous_snapshot=previous,
     )
     assert recovered.discovery_state["source_failure_streaks"] == {}
+
+
+def test_attention_failure_participates_in_persistent_streaks(monkeypatch):
+    pipeline = __import__("benchmark_radar.pipeline", fromlist=["fetch_attention_feeds"])
+    monkeypatch.setattr(
+        pipeline,
+        "fetch_attention_feeds",
+        lambda *args, **kwargs: (
+            [],
+            [
+                SourceHealth(
+                    source="Hacker News collector",
+                    kind="attention",
+                    ok=False,
+                    error="HTTP 503",
+                )
+            ],
+            [],
+            {},
+        ),
+    )
+    config = {
+        "radar": {
+            "lookback_hours": 48,
+            "max_items_per_source": 10,
+            "report_limit": 10,
+            "minimum_score": 0,
+        },
+        "taxonomy": {"benchmark": ["benchmark"]},
+        "sources": {},
+        "attention": {"hacker_news": {"enabled": True}},
+    }
+    previous = None
+    for hour in range(3):
+        run = run_pipeline(
+            config,
+            datetime(2026, 7, 27, hour, tzinfo=UTC),
+            previous_snapshot=previous,
+        )
+        previous = {"discovery_state": run.discovery_state}
+
+    assert run.discovery_state["source_failure_streaks"] == {"Hacker News collector": 3}
 
 
 def test_funnel_counts_suppressed_arxiv_records_as_fetched(monkeypatch):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -538,7 +538,7 @@ def test_optional_source_failure_streak_persists_and_resets(monkeypatch):
         )
         previous = {"discovery_state": run.discovery_state}
 
-    assert run.discovery_state["source_failure_streaks"] == {"evidence:optional_fixture": 3}
+    assert run.discovery_state["source_failure_streaks"] == {'["evidence","optional_fixture"]': 3}
 
     monkeypatch.setitem(pipeline.SOURCE_FETCHERS, "optional_fixture", lambda c, s, limit: [])
     recovered = run_pipeline(
@@ -588,7 +588,9 @@ def test_attention_failure_participates_in_persistent_streaks(monkeypatch):
         )
         previous = {"discovery_state": run.discovery_state}
 
-    assert run.discovery_state["source_failure_streaks"] == {"attention:Hacker News collector": 3}
+    assert run.discovery_state["source_failure_streaks"] == {
+        '["attention","Hacker News collector"]': 3
+    }
 
 
 def test_attention_producer_failure_participates_in_persistent_streaks(monkeypatch):
@@ -621,7 +623,9 @@ def test_attention_producer_failure_participates_in_persistent_streaks(monkeypat
         "sources": {},
     }
     previous = {
-        "discovery_state": {"source_failure_streaks": {"producer:fixture-producer:Hacker News": 2}}
+        "discovery_state": {
+            "source_failure_streaks": {'["producer","fixture-producer","Hacker News"]': 2}
+        }
     }
 
     run = run_pipeline(
@@ -631,7 +635,7 @@ def test_attention_producer_failure_participates_in_persistent_streaks(monkeypat
     )
 
     assert run.discovery_state["source_failure_streaks"] == {
-        "producer:fixture-producer:Hacker News": 3
+        '["producer","fixture-producer","Hacker News"]': 3
     }
 
 
@@ -665,7 +669,9 @@ def test_attention_producer_streaks_do_not_cross_producer_boundaries(monkeypatch
         "sources": {},
     }
     previous = {
-        "discovery_state": {"source_failure_streaks": {"producer:producer-a:Hacker News": 2}}
+        "discovery_state": {
+            "source_failure_streaks": {'["producer","producer-a","Hacker News"]': 2}
+        }
     }
 
     run = run_pipeline(
@@ -674,7 +680,18 @@ def test_attention_producer_streaks_do_not_cross_producer_boundaries(monkeypatch
         previous_snapshot=previous,
     )
 
-    assert run.discovery_state["source_failure_streaks"] == {"producer:producer-b:Hacker News": 1}
+    assert run.discovery_state["source_failure_streaks"] == {
+        '["producer","producer-b","Hacker News"]': 1
+    }
+
+
+def test_attention_producer_streak_key_is_unambiguous():
+    from benchmark_radar.pipeline import _failure_streak_key
+
+    first = ProducerHealth(producer="a:b", source="c", ok=False)
+    second = ProducerHealth(producer="a", source="b:c", ok=False)
+
+    assert _failure_streak_key("producer", first) != _failure_streak_key("producer", second)
 
 
 def test_funnel_counts_suppressed_arxiv_records_as_fetched(monkeypatch):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -480,6 +480,38 @@ def test_pipeline_quarantines_future_dated_records_before_scoring(monkeypatch):
     assert run.selection["suppressed_future_dated"] == 1
 
 
+def test_pipeline_accounts_for_future_records_rejected_inside_a_connector(monkeypatch):
+    current = item(
+        source="Hugging Face",
+        source_id="org/current",
+        published_at=datetime(2026, 7, 27, 11, tzinfo=UTC),
+    )
+
+    def fetch(config, since, limit):
+        config["_future_rejections"] = 1
+        return [current]
+
+    pipeline = __import__("benchmark_radar.pipeline", fromlist=["SOURCE_FETCHERS"])
+    monkeypatch.setitem(pipeline.SOURCE_FETCHERS, "huggingface", fetch)
+    config = {
+        "radar": {
+            "lookback_hours": 48,
+            "max_items_per_source": 10,
+            "report_limit": 10,
+            "minimum_score": 0,
+        },
+        "taxonomy": {"benchmark": ["benchmark"]},
+        "sources": {"huggingface": {"enabled": True, "required": True}},
+    }
+
+    run = run_pipeline(config, datetime(2026, 7, 27, 12, tzinfo=UTC))
+
+    assert run.health[0].item_count == 1
+    assert run.health[0].error == "Discarded 1 future-dated record(s)"
+    assert run.selection["fetched"] == 2
+    assert run.selection["suppressed_future_dated"] == 1
+
+
 def test_optional_source_failure_streak_persists_and_resets(monkeypatch):
     pipeline = __import__("benchmark_radar.pipeline", fromlist=["SOURCE_FETCHERS"])
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -442,6 +442,44 @@ def test_selection_counts_expose_the_published_gap(monkeypatch):
     assert len(run.items) == 2
 
 
+def test_pipeline_quarantines_future_dated_records_before_scoring(monkeypatch):
+    current = item(
+        source="GitHub",
+        source_id="org/current",
+        url="https://github.com/org/current",
+        published_at=datetime(2026, 7, 27, 11, tzinfo=UTC),
+    )
+    future = item(
+        source="GitHub",
+        source_id="org/future",
+        url="https://github.com/org/future",
+        published_at=datetime(2050, 1, 1, tzinfo=UTC),
+    )
+    monkeypatch.setitem(
+        __import__("benchmark_radar.pipeline", fromlist=["SOURCE_FETCHERS"]).SOURCE_FETCHERS,
+        "github",
+        lambda config, since, limit: [current, future],
+    )
+    config = {
+        "radar": {
+            "lookback_hours": 48,
+            "max_items_per_source": 10,
+            "report_limit": 10,
+            "minimum_score": 0,
+        },
+        "taxonomy": {"benchmark": ["benchmark"]},
+        "sources": {"github": {"enabled": True, "required": True}},
+    }
+
+    run = run_pipeline(config, datetime(2026, 7, 27, 12, tzinfo=UTC))
+
+    assert [record.source_id for record in run.items] == ["org/current"]
+    assert run.health[0].item_count == 1
+    assert run.health[0].error == "Discarded 1 future-dated record(s)"
+    assert run.selection["fetched"] == 2
+    assert run.selection["suppressed_future_dated"] == 1
+
+
 def test_funnel_counts_suppressed_arxiv_records_as_fetched(monkeypatch):
     # Source health counts these as fetched, so the funnel must agree rather
     # than reporting zero for a source that plainly returned records.

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -506,7 +506,7 @@ def test_optional_source_failure_streak_persists_and_resets(monkeypatch):
         )
         previous = {"discovery_state": run.discovery_state}
 
-    assert run.discovery_state["source_failure_streaks"] == {"optional_fixture": 3}
+    assert run.discovery_state["source_failure_streaks"] == {"evidence:optional_fixture": 3}
 
     monkeypatch.setitem(pipeline.SOURCE_FETCHERS, "optional_fixture", lambda c, s, limit: [])
     recovered = run_pipeline(
@@ -556,7 +556,7 @@ def test_attention_failure_participates_in_persistent_streaks(monkeypatch):
         )
         previous = {"discovery_state": run.discovery_state}
 
-    assert run.discovery_state["source_failure_streaks"] == {"Hacker News collector": 3}
+    assert run.discovery_state["source_failure_streaks"] == {"attention:Hacker News collector": 3}
 
 
 def test_attention_producer_failure_participates_in_persistent_streaks(monkeypatch):
@@ -588,7 +588,9 @@ def test_attention_producer_failure_participates_in_persistent_streaks(monkeypat
         "taxonomy": {"benchmark": ["benchmark"]},
         "sources": {},
     }
-    previous = {"discovery_state": {"source_failure_streaks": {"Hacker News": 2}}}
+    previous = {
+        "discovery_state": {"source_failure_streaks": {"producer:fixture-producer:Hacker News": 2}}
+    }
 
     run = run_pipeline(
         config,
@@ -596,7 +598,51 @@ def test_attention_producer_failure_participates_in_persistent_streaks(monkeypat
         previous_snapshot=previous,
     )
 
-    assert run.discovery_state["source_failure_streaks"] == {"Hacker News": 3}
+    assert run.discovery_state["source_failure_streaks"] == {
+        "producer:fixture-producer:Hacker News": 3
+    }
+
+
+def test_attention_producer_streaks_do_not_cross_producer_boundaries(monkeypatch):
+    pipeline = __import__("benchmark_radar.pipeline", fromlist=["fetch_attention_feeds"])
+    monkeypatch.setattr(
+        pipeline,
+        "fetch_attention_feeds",
+        lambda *args, **kwargs: (
+            [],
+            [],
+            [
+                ProducerHealth(
+                    producer="producer-b",
+                    source="Hacker News",
+                    ok=False,
+                    error="HTTP 503",
+                )
+            ],
+            {},
+        ),
+    )
+    config = {
+        "radar": {
+            "lookback_hours": 48,
+            "max_items_per_source": 10,
+            "report_limit": 10,
+            "minimum_score": 0,
+        },
+        "taxonomy": {},
+        "sources": {},
+    }
+    previous = {
+        "discovery_state": {"source_failure_streaks": {"producer:producer-a:Hacker News": 2}}
+    }
+
+    run = run_pipeline(
+        config,
+        datetime(2026, 7, 27, tzinfo=UTC),
+        previous_snapshot=previous,
+    )
+
+    assert run.discovery_state["source_failure_streaks"] == {"producer:producer-b:Hacker News": 1}
 
 
 def test_funnel_counts_suppressed_arxiv_records_as_fetched(monkeypatch):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -480,6 +480,43 @@ def test_pipeline_quarantines_future_dated_records_before_scoring(monkeypatch):
     assert run.selection["suppressed_future_dated"] == 1
 
 
+def test_optional_source_failure_streak_persists_and_resets(monkeypatch):
+    pipeline = __import__("benchmark_radar.pipeline", fromlist=["SOURCE_FETCHERS"])
+
+    def fail(config, since, limit):
+        raise RuntimeError("upstream unavailable")
+
+    monkeypatch.setitem(pipeline.SOURCE_FETCHERS, "optional_fixture", fail)
+    config = {
+        "radar": {
+            "lookback_hours": 48,
+            "max_items_per_source": 10,
+            "report_limit": 10,
+            "minimum_score": 0,
+        },
+        "taxonomy": {"benchmark": ["benchmark"]},
+        "sources": {"optional_fixture": {"enabled": True}},
+    }
+    previous = None
+    for hour in range(3):
+        run = run_pipeline(
+            config,
+            datetime(2026, 7, 27, hour, tzinfo=UTC),
+            previous_snapshot=previous,
+        )
+        previous = {"discovery_state": run.discovery_state}
+
+    assert run.discovery_state["source_failure_streaks"] == {"optional_fixture": 3}
+
+    monkeypatch.setitem(pipeline.SOURCE_FETCHERS, "optional_fixture", lambda c, s, limit: [])
+    recovered = run_pipeline(
+        config,
+        datetime(2026, 7, 27, 4, tzinfo=UTC),
+        previous_snapshot=previous,
+    )
+    assert recovered.discovery_state["source_failure_streaks"] == {}
+
+
 def test_funnel_counts_suppressed_arxiv_records_as_fetched(monkeypatch):
     # Source health counts these as fetched, so the funnel must agree rather
     # than reporting zero for a source that plainly returned records.

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from benchmark_radar.models import RadarItem, SourceHealth
+from benchmark_radar.models import ProducerHealth, RadarItem, SourceHealth
 from benchmark_radar.pipeline import (
     apply_watchlist,
     assert_no_boilerplate_summaries,
@@ -557,6 +557,46 @@ def test_attention_failure_participates_in_persistent_streaks(monkeypatch):
         previous = {"discovery_state": run.discovery_state}
 
     assert run.discovery_state["source_failure_streaks"] == {"Hacker News collector": 3}
+
+
+def test_attention_producer_failure_participates_in_persistent_streaks(monkeypatch):
+    pipeline = __import__("benchmark_radar.pipeline", fromlist=["fetch_attention_feeds"])
+    monkeypatch.setattr(
+        pipeline,
+        "fetch_attention_feeds",
+        lambda *args, **kwargs: (
+            [],
+            [SourceHealth(source="Fixture feed", kind="attention", ok=True)],
+            [
+                ProducerHealth(
+                    producer="fixture-producer",
+                    source="Hacker News",
+                    ok=False,
+                    error="HTTP 503",
+                )
+            ],
+            {},
+        ),
+    )
+    config = {
+        "radar": {
+            "lookback_hours": 48,
+            "max_items_per_source": 10,
+            "report_limit": 10,
+            "minimum_score": 0,
+        },
+        "taxonomy": {"benchmark": ["benchmark"]},
+        "sources": {},
+    }
+    previous = {"discovery_state": {"source_failure_streaks": {"Hacker News": 2}}}
+
+    run = run_pipeline(
+        config,
+        datetime(2026, 7, 27, tzinfo=UTC),
+        previous_snapshot=previous,
+    )
+
+    assert run.discovery_state["source_failure_streaks"] == {"Hacker News": 3}
 
 
 def test_funnel_counts_suppressed_arxiv_records_as_fetched(monkeypatch):

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -90,6 +90,23 @@ def test_report_shows_the_selection_funnel():
     assert "**30** published" in report
 
 
+def test_report_accounts_for_future_dated_quarantine_in_the_funnel():
+    run = _run([_record(1)])
+    run.selection = {
+        "fetched": 2,
+        "suppressed_future_dated": 1,
+        "deduplicated": 1,
+        "qualified": 1,
+        "published": 1,
+        "minimum_score": 0,
+    }
+
+    report = render_markdown(run)
+
+    assert "**2** fetched → **1** future-dated records quarantined" in report
+    assert "→ **1** after dedupe" in report
+
+
 def test_funnel_excludes_watchlist_bypasses_from_the_threshold_count():
     # A lone bypass must not read as "1 qualified (at or above 99)": nothing
     # met the threshold, so the two counts are reported separately.

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -386,6 +386,29 @@ def test_semantic_scholar_success_preserves_external_ids(monkeypatch):
     assert items[0].parser_version == "semantic-scholar-graph/1"
 
 
+def test_semantic_scholar_paces_an_individual_api_key(monkeypatch):
+    calls = []
+    delays = []
+    monkeypatch.setenv("SEMANTIC_SCHOLAR_API_KEY", "  key-with-newline\n")
+    monkeypatch.setattr(
+        "benchmark_radar.sources.get_json",
+        lambda url, **kwargs: calls.append(kwargs) or {"data": [], "next": None},
+    )
+    monkeypatch.setattr("benchmark_radar.sources.time.sleep", delays.append)
+
+    fetch_semantic_scholar(
+        {"searches": ["one", "two"], "max_requests": 2},
+        datetime(2026, 7, 26, tzinfo=UTC),
+        10,
+    )
+
+    assert [call["headers"] for call in calls] == [
+        {"x-api-key": "key-with-newline"},
+        {"x-api-key": "key-with-newline"},
+    ]
+    assert delays == [1.1]
+
+
 def test_github_releases_success_uses_release_notes(monkeypatch):
     payload = [
         {

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -69,6 +69,7 @@ def test_arxiv_uses_overlap_and_updated_timestamp(monkeypatch):
     )
 
     assert len(calls) == 3
+    assert all("lastUpdatedDate:" in call["search_query"] for call in calls)
     assert delays == [3, 3]
     assert len(items) == 1
     assert items[0].published_at == datetime(2026, 7, 23, 18, tzinfo=UTC)
@@ -441,6 +442,37 @@ def test_github_releases_success_uses_release_notes(monkeypatch):
     assert items[0].parser_version == "github-releases/1"
 
 
+def test_github_releases_replaces_a_page_consumed_by_future_rows(monkeypatch):
+    pages = []
+
+    def fake_get_json(url, params, **kwargs):
+        pages.append(params["page"])
+        published = "2050-01-01T00:00:00Z" if params["page"] == 1 else "2026-07-27T12:00:00Z"
+        tag = "future" if params["page"] == 1 else "current"
+        return [
+            {
+                "tag_name": tag,
+                "html_url": f"https://github.com/example/benchmark/releases/tag/{tag}",
+                "published_at": published,
+            }
+        ]
+
+    monkeypatch.setattr("benchmark_radar.sources.get_json", fake_get_json)
+    config = {
+        "repositories": ["example/benchmark"],
+        "page_size": 1,
+        "max_pages_per_repository": 1,
+        "max_requests": 2,
+        "_collection_now": datetime(2026, 7, 28, tzinfo=UTC),
+    }
+
+    items = fetch_github_releases(config, datetime(2026, 7, 26, tzinfo=UTC), 1)
+
+    assert pages == [1, 2]
+    assert [item.source_id for item in items] == ["example/benchmark@current"]
+    assert config["_future_rejections"] == 1
+
+
 @pytest.mark.parametrize(
     ("fetcher", "config", "empty_payload"),
     [
@@ -728,15 +760,17 @@ def test_huggingface_filters_future_rows_before_the_local_cap(monkeypatch):
 
     monkeypatch.setattr("benchmark_radar.sources.get_json", fake_get_json)
 
+    config = {
+        "kinds": ["datasets"],
+        "searches": ["benchmark"],
+        "_collection_now": datetime(2026, 7, 28, tzinfo=UTC),
+    }
     items = fetch_huggingface(
-        {
-            "kinds": ["datasets"],
-            "searches": ["benchmark"],
-            "_collection_now": datetime(2026, 7, 28, tzinfo=UTC),
-        },
+        config,
         datetime(2026, 7, 26, tzinfo=UTC),
         1,
     )
 
     assert seen_limit == [51]
     assert [item.source_id for item in items] == ["org/current"]
+    assert config["_future_rejections"] == 1

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -714,3 +714,29 @@ def test_huggingface_skips_undated_repositories(monkeypatch):
     )
 
     assert [item.source_id for item in items] == ["org/dated"]
+
+
+def test_huggingface_filters_future_rows_before_the_local_cap(monkeypatch):
+    seen_limit = []
+
+    def fake_get_json(url, params):
+        seen_limit.append(params["limit"])
+        return [
+            {"id": "org/future", "lastModified": "2050-01-01T00:00:00Z"},
+            {"id": "org/current", "lastModified": "2026-07-27T12:00:00Z"},
+        ]
+
+    monkeypatch.setattr("benchmark_radar.sources.get_json", fake_get_json)
+
+    items = fetch_huggingface(
+        {
+            "kinds": ["datasets"],
+            "searches": ["benchmark"],
+            "_collection_now": datetime(2026, 7, 28, tzinfo=UTC),
+        },
+        datetime(2026, 7, 26, tzinfo=UTC),
+        1,
+    )
+
+    assert seen_limit == [51]
+    assert [item.source_id for item in items] == ["org/current"]

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -804,7 +804,7 @@ def test_huggingface_filters_future_rows_before_the_local_cap(monkeypatch):
 
     config = {
         "kinds": ["datasets"],
-        "searches": ["benchmark"],
+        "searches": ["benchmark", "evaluation"],
         "_collection_now": datetime(2026, 7, 28, tzinfo=UTC),
     }
     items = fetch_huggingface(
@@ -813,6 +813,6 @@ def test_huggingface_filters_future_rows_before_the_local_cap(monkeypatch):
         1,
     )
 
-    assert seen_limit == [51]
+    assert seen_limit == [51, 51]
     assert [item.source_id for item in items] == ["org/current"]
     assert config["_future_rejections"] == 1

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -473,6 +473,48 @@ def test_github_releases_replaces_a_page_consumed_by_future_rows(monkeypatch):
     assert config["_future_rejections"] == 1
 
 
+def test_release_replacement_budget_preserves_later_repository_coverage(monkeypatch):
+    calls = []
+
+    def fake_get_json(url, params, **kwargs):
+        repository = url.split("/repos/", 1)[1].split("/releases", 1)[0]
+        calls.append((repository, params["page"]))
+        if repository == "org/repo0" and params["page"] == 1:
+            return [
+                {
+                    "tag_name": "future",
+                    "html_url": "https://example.test/future",
+                    "published_at": "2050-01-01T00:00:00Z",
+                }
+            ]
+        if repository == "org/repo0" and params["page"] == 2:
+            return [
+                {
+                    "tag_name": "current",
+                    "html_url": "https://example.test/current",
+                    "published_at": "2026-07-27T00:00:00Z",
+                }
+            ]
+        return []
+
+    monkeypatch.setattr("benchmark_radar.sources.get_json", fake_get_json)
+    repositories = [f"org/repo{index}" for index in range(8)]
+    config = {
+        "repositories": repositories,
+        "page_size": 1,
+        "max_pages_per_repository": 1,
+        "max_requests": 8,
+        "future_replacement_requests": 1,
+        "_collection_now": datetime(2026, 7, 28, tzinfo=UTC),
+    }
+
+    fetch_github_releases(config, datetime(2026, 7, 26, tzinfo=UTC), 300)
+
+    assert ("org/repo0", 2) in calls
+    assert ("org/repo7", 1) in calls
+    assert len(calls) == 9
+
+
 @pytest.mark.parametrize(
     ("fetcher", "config", "empty_payload"),
     [

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -539,6 +539,54 @@ def test_openalex_rejects_a_shapeless_payload(monkeypatch):
         fetch_openalex({"searches": ["benchmark"]}, datetime(2026, 7, 26, tzinfo=UTC), 10)
 
 
+@pytest.mark.parametrize("blank", ["", "   ", "\n", " \t\n"])
+def test_openalex_requires_a_nonblank_free_api_key(monkeypatch, blank):
+    monkeypatch.setenv("OPENALEX_API_KEY", blank)
+
+    with pytest.raises(RuntimeError, match="OPENALEX_API_KEY is not configured"):
+        fetch_openalex(
+            {"searches": ["benchmark"]},
+            datetime(2026, 7, 26, tzinfo=UTC),
+            10,
+        )
+
+
+def test_openalex_bounds_results_to_the_run_date(monkeypatch):
+    seen = []
+    monkeypatch.setenv("OPENALEX_API_KEY", "  free-key\n")
+
+    def fake_get_json(url, params):
+        seen.append(params)
+        return {
+            "results": [
+                {
+                    "id": "https://openalex.org/W2050",
+                    "display_name": "Erroneously future benchmark",
+                    "publication_date": "2050-01-01",
+                    "primary_location": {"landing_page_url": "https://example.com/future"},
+                },
+                {
+                    "id": "https://openalex.org/WNOW",
+                    "display_name": "Current benchmark",
+                    "publication_date": "2026-07-28",
+                    "primary_location": {"landing_page_url": "https://example.com/current"},
+                },
+            ]
+        }
+
+    monkeypatch.setattr("benchmark_radar.sources.get_json", fake_get_json)
+    items = fetch_openalex(
+        {"searches": ["benchmark"]},
+        datetime(2026, 7, 26, tzinfo=UTC),
+        10,
+        now=datetime(2026, 7, 28, 12, tzinfo=UTC),
+    )
+
+    assert [item.title for item in items] == ["Current benchmark"]
+    assert seen[0]["api_key"] == "free-key"
+    assert seen[0]["filter"] == ("from_publication_date:2026-07-26,to_publication_date:2026-07-28")
+
+
 def test_openalex_skips_undated_works(monkeypatch):
     monkeypatch.setenv("OPENALEX_API_KEY", "key")
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

- require and normalize the current free OpenAlex API key, bound scholarly queries by the collection date, and quarantine future-dated records before ranking
- preserve connector caps and repository coverage while counting unique quarantined artifacts in source health and the report funnel
- pace authenticated Semantic Scholar searches at the documented individual-key rate
- persist optional-source, attention-feed, and producer failure streaks and emit escaped GitHub Actions warnings after repeated failures

## Why

The existing OpenAlex fix in #77 was based on an outdated keyless/polite-pool assumption. Current OpenAlex guidance uses free API keys, while live source data also demonstrated future dates capable of receiving permanent maximum recency. Semantic Scholar and OpenReview failures need durable visibility even when the daily report remains publishable.

## Verification

- `196 passed`
- `ruff check .`
- `ruff format --check .`
- `git diff --check`
- Gemini CLI attempted with required file storage, but this environment has no configured auth method
- iterative Codex review addressed funnel accounting, attention/producer warning coverage, Actions annotation escaping, cap displacement, pagination budgets, and identity collisions; final review: no actionable regressions

Closes #86
References #78
References #79
References #80
References #81

Supersedes #77.