### PR TITLE
Expand the Model Card Adoption Rank registry to the 2026 frontier (#83)

### DIFF
--- a/data/model_cards.yml
+++ b/data/model_cards.yml
@@ -103,7 +103,7 @@ benchmarks:
       - "TerminalBench Hard"
     domain: agent
     url: https://www.tbench.ai/
-    released: 2025-05-27
+    released: 2025-05-19
     caveat: >-
       Environment image, timeout and permitted commands change results
       independently of the model. Version and harness both matter: 2.0 and 2.1
@@ -847,13 +847,14 @@ model_cards:
     published: 2024-03-08
     url: https://arxiv.org/abs/2403.05530
     retrieved_at: 2026-08-02
+    # No Video-MME: that benchmark was published 2024-05-31, after this report.
+    # The v1 report's long-video evaluations predate it.
     benchmarks:
       - mmlu
       - gsm8k
       - math_500
       - humaneval
       - mmmu
-      - video_mme
       - mathvista
       - drop
 
@@ -862,6 +863,10 @@ model_cards:
   # MTOB and Multilingual MMLU come from that table's rows; the table also
   # states 0-shot, temperature 0, no majority voting, which is why no score is
   # recorded here.
+  #
+  # No MRCR: that table's long-context rows are MTOB (half book and full book).
+  # OpenAI open-sourced MRCR alongside GPT-4.1 on 2025-04-14, nine days after
+  # this post, so it could not have been reported here.
   - id: meta_llama_4
     organization: Meta
     model: Llama 4
@@ -876,7 +881,6 @@ model_cards:
       - mmmu
       - mathvista
       - chatbot_arena
-      - mrcr
       - chartqa
       - docvqa
       - mtob

--- a/data/model_cards.yml
+++ b/data/model_cards.yml
@@ -23,6 +23,12 @@
 #     read from, so any row can be checked against its source.
 #   * `retrieved_at` records when a human last read that document. It is not the
 #     model's release date, and it is not automatically refreshed.
+#   * `revised` is optional, and only for a document that gained a benchmark
+#     after first publication: an arXiv report at v2+, or a living model card a
+#     vendor edits in place. It relaxes the chronology check for that one card,
+#     so it must name the real revision date rather than be used to silence a
+#     complaint. A card reporting a benchmark newer than itself with no `revised`
+#     date is a data error, and the loader rejects it.
 #
 # Adding a model card: append an entry, list its benchmark ids, run
 # `benchmark-radar rebuild`. Adding a benchmark: add it to `benchmarks:` first.

--- a/data/model_cards.yml
+++ b/data/model_cards.yml
@@ -26,6 +26,14 @@
 #
 # Adding a model card: append an entry, list its benchmark ids, run
 # `benchmark-radar rebuild`. Adding a benchmark: add it to `benchmarks:` first.
+#
+# `released` is the benchmark's own publication date, distinct from a card's
+# `published`. It exists so a reader can separate "this benchmark is newly
+# adopted" from "this benchmark is newly *published*": a 2026 card reporting
+# MMLU (2020) and a 2026 card reporting Terminal-Bench 2 (2025) are both
+# current adoptions of very differently aged instruments. Optional, because a
+# benchmark that never announced a release date should say nothing rather than
+# carry a guessed one.
 
 schema_version: 1
 
@@ -35,52 +43,79 @@ schema_version: 1
 benchmarks:
   - id: hle
     name: Humanity's Last Exam
-    aliases: ["HLE", "Humanity's Last Exam"]
+    aliases: ["HLE", "Humanity's Last Exam", "HLE-Full", "HLE-Verified"]
     domain: reasoning
     url: https://lastexam.ai/
+    released: 2025-01-23
     caveat: >-
       Tool access and test-time compute budget move this score more than model
-      capability does, so two reported figures are rarely comparable.
+      capability does, so two reported figures are rarely comparable. Cards
+      increasingly report no-tools and with-tools figures as separate numbers.
 
   - id: gpqa_diamond
     name: GPQA Diamond
-    aliases: ["GPQA", "GPQA-Diamond"]
+    aliases: ["GPQA", "GPQA-Diamond", "GPQA Diamond"]
     domain: science
     url: https://arxiv.org/abs/2311.12022
+    released: 2023-11-20
     caveat: >-
       198 questions in the Diamond split, so run-to-run variance is wide and a
-      single reported number hides it.
+      single reported number hides it. Approaching saturation at the 2026
+      frontier, where reported scores cluster in the high 80s and 90s.
 
   - id: swe_bench_verified
     name: SWE-bench Verified
-    aliases: ["SWE-bench Verified", "SWE-bench-Verified", "SWE Bench Verified"]
+    aliases: ["SWE-bench Verified", "SWE-bench-Verified", "SWE Bench Verified", "SWE Verified"]
     domain: coding_agent
     url: https://openai.com/index/introducing-swe-bench-verified/
+    released: 2024-08-13
     caveat: >-
       Scaffold, tool permissions and time limit are part of the result; vendors
       run their own harnesses.
 
   - id: swe_bench_pro
     name: SWE-bench Pro
-    aliases: ["SWE-bench Pro"]
+    aliases: ["SWE-bench Pro", "SWE Pro", "SWE-Bench Pro (Public)"]
     domain: coding_agent
     url: https://github.com/scaleapi/SWE-bench_Pro-os
+    released: 2025-09-23
     caveat: Harness and split version must be recorded with any score.
+
+  - id: swe_bench_multilingual
+    name: SWE-bench Multilingual
+    aliases: ["SWE-bench Multilingual", "SWE Multilingual"]
+    domain: coding_agent
+    url: https://www.swebench.com/multilingual.html
+    released: 2025-04-22
+    caveat: >-
+      Per-language resolution rates differ widely, so an average hides which
+      languages the model actually handles.
 
   - id: terminal_bench
     name: Terminal-Bench
-    aliases: ["Terminal-Bench", "Terminal Bench", "TerminalBench", "Terminal-Bench 2.0"]
+    aliases:
+      - "Terminal-Bench"
+      - "Terminal Bench"
+      - "TerminalBench"
+      - "Terminal-Bench 2.0"
+      - "Terminal-Bench 2.1"
+      - "Terminal Bench 2"
+      - "TerminalBench Hard"
     domain: agent
     url: https://www.tbench.ai/
+    released: 2025-05-27
     caveat: >-
       Environment image, timeout and permitted commands change results
-      independently of the model.
+      independently of the model. Version and harness both matter: 2.0 and 2.1
+      are different instruments, and cards report Terminus, Claude Code and
+      Codex harness numbers for the same version.
 
   - id: livecodebench
     name: LiveCodeBench
     aliases: ["LiveCodeBench", "LCB"]
     domain: coding
     url: https://livecodebench.github.io/
+    released: 2024-03-12
     caveat: >-
       Time-sliced problem set. A score without its problem window is not
       comparable to any other score.
@@ -90,6 +125,7 @@ benchmarks:
     aliases: ["AIME", "AIME 2024", "AIME 2025", "AIME 2026"]
     domain: math
     url: https://maa.org/maa-invitational-competitions/
+    released: 2024-02-01
     caveat: >-
       pass@k, majority vote and Python tool access each shift this by double
       digits.
@@ -99,6 +135,7 @@ benchmarks:
     aliases: ["MMMU", "MMMU-Pro"]
     domain: multimodal
     url: https://mmmu-benchmark.github.io/
+    released: 2023-11-27
     caveat: Image preprocessing and chain-of-thought settings affect results.
 
   - id: mathvista
@@ -106,6 +143,7 @@ benchmarks:
     aliases: ["MathVista"]
     domain: multimodal
     url: https://mathvista.github.io/
+    released: 2023-10-03
     caveat: Mixes OCR quality with visual reasoning.
 
   - id: video_mme
@@ -113,6 +151,7 @@ benchmarks:
     aliases: ["Video-MME", "VideoMME"]
     domain: multimodal
     url: https://video-mme.github.io/
+    released: 2024-05-31
     caveat: Frame sampling rate dominates long-video results.
 
   - id: tau_bench
@@ -120,6 +159,7 @@ benchmarks:
     aliases: ["tau-bench", "τ-bench", "tau2-bench", "TAU-bench"]
     domain: tool_use
     url: https://github.com/sierra-research/tau-bench
+    released: 2024-06-17
     caveat: >-
       Depends on a simulated user and policy; the simulator model is part of
       the measurement.
@@ -129,6 +169,7 @@ benchmarks:
     aliases: ["BrowseComp"]
     domain: agent
     url: https://openai.com/index/browsecomp/
+    released: 2025-04-10
     caveat: >-
       Live web. The result depends on what the internet contained on the day
       of the run.
@@ -138,6 +179,7 @@ benchmarks:
     aliases: ["SimpleQA", "SimpleQA Verified"]
     domain: factuality
     url: https://openai.com/index/introducing-simpleqa/
+    released: 2024-10-30
     caveat: Knowledge cutoff must be recorded alongside the score.
 
   - id: longbench
@@ -145,6 +187,7 @@ benchmarks:
     aliases: ["LongBench", "LongBench v2"]
     domain: long_context
     url: https://github.com/THUDM/LongBench
+    released: 2023-08-28
     caveat: Nominal context length is not effective context length.
 
   - id: mrcr
@@ -152,6 +195,7 @@ benchmarks:
     aliases: ["MRCR", "OpenAI-MRCR", "MRCR v2"]
     domain: long_context
     url: https://huggingface.co/datasets/openai/mrcr
+    released: 2025-04-14
     caveat: Needle position and generation seed change the result.
 
   - id: mmlu_pro
@@ -159,6 +203,7 @@ benchmarks:
     aliases: ["MMLU-Pro", "MMLU Pro"]
     domain: knowledge
     url: https://github.com/TIGER-AI-Lab/MMLU-Pro
+    released: 2024-06-03
     caveat: Static closed-set multiple choice; contamination risk rises over time.
 
   - id: mmlu
@@ -166,6 +211,7 @@ benchmarks:
     aliases: ["MMLU"]
     domain: knowledge
     url: https://github.com/hendrycks/test
+    released: 2020-09-07
     caveat: >-
       Saturated at the frontier and heavily contaminated. Useful as a
       historical baseline, not as a ranking signal.
@@ -175,6 +221,7 @@ benchmarks:
     aliases: ["LiveBench"]
     domain: general
     url: https://livebench.ai/
+    released: 2024-06-06
     caveat: Contents change by release date; each date is a different benchmark.
 
   - id: arena_hard
@@ -182,6 +229,7 @@ benchmarks:
     aliases: ["Arena-Hard", "ArenaHard"]
     domain: human_preference
     url: https://github.com/lmarena/arena-hard-auto
+    released: 2024-04-19
     caveat: LLM-judge dependent, with known style and length bias.
 
   - id: chatbot_arena
@@ -189,6 +237,7 @@ benchmarks:
     aliases: ["Chatbot Arena", "LMArena", "LMSYS Arena"]
     domain: human_preference
     url: https://lmarena.ai/
+    released: 2023-05-03
     caveat: >-
       Elo from real user traffic; sampling and prompt distribution are outside
       any vendor's control.
@@ -198,6 +247,7 @@ benchmarks:
     aliases: ["BFCL", "Berkeley Function Calling Leaderboard"]
     domain: tool_use
     url: https://gorilla.cs.berkeley.edu/leaderboard.html
+    released: 2024-02-26
     caveat: Schema complexity and execution checking vary by version.
 
   - id: humaneval
@@ -205,6 +255,7 @@ benchmarks:
     aliases: ["HumanEval", "HumanEval+"]
     domain: coding
     url: https://github.com/openai/human-eval
+    released: 2021-07-07
     caveat: Saturated. Retained because open-weight cards still report it.
 
   - id: math_500
@@ -212,6 +263,7 @@ benchmarks:
     aliases: ["MATH-500", "MATH 500", "MATH"]
     domain: math
     url: https://github.com/openai/prm800k
+    released: 2021-03-05
     caveat: Largely saturated at the frontier.
 
   - id: gsm8k
@@ -219,6 +271,7 @@ benchmarks:
     aliases: ["GSM8K"]
     domain: math
     url: https://github.com/openai/grade-school-math
+    released: 2021-10-27
     caveat: Saturated. A legacy baseline for small open models.
 
   - id: ifeval
@@ -226,6 +279,7 @@ benchmarks:
     aliases: ["IFEval"]
     domain: instruction_following
     url: https://github.com/google-research/google-research/tree/master/instruction_following_eval
+    released: 2023-11-14
     caveat: Verifiable-constraint subset only; does not measure answer quality.
 
   - id: mbpp
@@ -233,6 +287,7 @@ benchmarks:
     aliases: ["MBPP", "MBPP+"]
     domain: coding
     url: https://github.com/google-research/google-research/tree/master/mbpp
+    released: 2021-08-16
     caveat: Saturated; short single-function tasks.
 
   - id: drop
@@ -240,6 +295,7 @@ benchmarks:
     aliases: ["DROP"]
     domain: reasoning
     url: https://allenai.org/data/drop
+    released: 2019-03-01
     caveat: Legacy reading-comprehension baseline.
 
   - id: arc_agi
@@ -247,6 +303,7 @@ benchmarks:
     aliases: ["ARC-AGI", "ARC-AGI-1", "ARC-AGI-2"]
     domain: reasoning
     url: https://arcprize.org/
+    released: 2019-11-05
     caveat: >-
       Compute per task is reported alongside score by the maintainers and
       should not be dropped.
@@ -256,6 +313,7 @@ benchmarks:
     aliases: ["Aider Polyglot", "Aider"]
     domain: coding
     url: https://aider.chat/docs/leaderboards/
+    released: 2024-12-21
     caveat: Edit-format sensitive; whole-file and diff modes differ substantially.
 
   - id: mmlu_redux
@@ -263,6 +321,7 @@ benchmarks:
     aliases: ["MMLU-Redux"]
     domain: knowledge
     url: https://github.com/aryopg/mmlu-redux
+    released: 2024-06-06
     caveat: Error-corrected MMLU subset; reported mainly by open-weight cards.
 
   - id: gpqa
@@ -270,6 +329,7 @@ benchmarks:
     aliases: ["GPQA main", "GPQA full"]
     domain: science
     url: https://arxiv.org/abs/2311.12022
+    released: 2023-11-20
     caveat: >-
       The full split, distinct from the Diamond subset most frontier cards
       report.
@@ -279,7 +339,391 @@ benchmarks:
     aliases: ["AGIEval"]
     domain: knowledge
     url: https://github.com/ruixiangcui/AGIEval
+    released: 2023-04-13
     caveat: Human-exam derived; overlaps heavily with MMLU-style coverage.
+
+  # ---------------------------------------------------------------------------
+  # Benchmarks that entered frontier reporting after mid-2025. These are the
+  # instruments the 2026 cards below actually lead with, and their absence was
+  # what made the registry read as a 2024-2025 snapshot: the older blocks above
+  # are still reported, but no longer carry a card's headline claim.
+  # ---------------------------------------------------------------------------
+
+  - id: arc_agi_2
+    name: ARC-AGI-2
+    aliases: ["ARC-AGI-2", "ARC-AGI 2"]
+    domain: reasoning
+    url: https://arcprize.org/arc-agi/2/
+    released: 2025-03-24
+    caveat: >-
+      Cost per task is part of the official result and is routinely dropped when
+      the score is quoted on its own.
+
+  - id: arc_agi_3
+    name: ARC-AGI-3
+    aliases: ["ARC-AGI-3", "ARC-AGI 3"]
+    domain: reasoning
+    url: https://arcprize.org/arc-agi/3/
+    released: 2026-01-15
+    caveat: >-
+      Interactive multi-step format, so the agent harness is part of the
+      measurement. Scores are low and spread wide, which makes small absolute
+      gaps look larger than they are.
+
+  - id: gdpval
+    name: GDPval
+    aliases: ["GDPval", "GDPval-AA", "GDPval-AA v2"]
+    domain: professional
+    url: https://openai.com/index/gdpval/
+    released: 2025-09-25
+    caveat: >-
+      Graded by expert human comparison against real deliverables, and the
+      "-AA" variants are run by Artificial Analysis rather than the vendor, so
+      an Elo here is not comparable to a vendor-run pass rate.
+
+  - id: mmmu_pro
+    name: MMMU-Pro
+    aliases: ["MMMU-Pro", "MMMU Pro"]
+    domain: multimodal
+    url: https://arxiv.org/abs/2409.02813
+    released: 2024-09-04
+    caveat: >-
+      Harder vision-required subset of MMMU. Input image ordering changes the
+      result, so the protocol has to travel with the number.
+
+  - id: mmmlu
+    name: MMMLU
+    aliases: ["MMMLU", "Multilingual MMLU", "MMLU-ProX"]
+    domain: multilingual
+    url: https://huggingface.co/datasets/openai/MMMLU
+    released: 2024-09-24
+    caveat: >-
+      A language-count average. Two cards reporting "MMMLU" may be averaging
+      over different language sets, so the counts must match to compare.
+
+  - id: livecodebench_pro
+    name: LiveCodeBench Pro
+    aliases: ["LiveCodeBench Pro", "LCB Pro"]
+    domain: coding
+    url: https://livecodebenchpro.com/
+    released: 2025-06-13
+    caveat: >-
+      Reported as an Elo rating against competitive-programming problems, not a
+      pass rate, so it cannot be read on the same axis as LiveCodeBench.
+
+  - id: codeforces
+    name: Codeforces
+    aliases: ["Codeforces", "Codeforces ELO", "Codeforces Rating"]
+    domain: coding
+    url: https://codeforces.com/
+    released: 2010-02-19
+    caveat: >-
+      An Elo estimate against human contestants, not a fixed dataset. The
+      problem set moves continuously and rating conversion differs by vendor.
+
+  - id: tau2_bench
+    name: tau2-bench
+    aliases: ["tau2-bench", "τ²-Bench", "TAU2-Bench", "Tau2", "τ2-bench"]
+    domain: tool_use
+    url: https://arxiv.org/abs/2506.07982
+    released: 2025-06-09
+    caveat: >-
+      Per-domain scores (Retail, Telecom, Airline) diverge sharply and several
+      cards apply the Airline domain fixes from the Claude Opus 4.5 system
+      card, so an average conceals both the domain mix and the patch level.
+
+  - id: mcp_atlas
+    name: MCP Atlas
+    aliases: ["MCP Atlas", "MCP-Atlas", "MCPAtlas", "MCP-Atlas (Public Set)"]
+    domain: tool_use
+    url: https://huggingface.co/datasets/Sierra-Research/MCP-Atlas
+    released: 2025-11-18
+    caveat: >-
+      Public and full splits are both reported under one name; the tool server
+      set is part of the measurement.
+
+  - id: mcp_mark
+    name: MCPMark
+    aliases: ["MCPMark", "MCP-Mark", "MCPMark-Verified"]
+    domain: tool_use
+    url: https://mcpmark.ai/
+    released: 2025-09-30
+    caveat: Depends on live third-party MCP servers, so runs are not reproducible over time.
+
+  - id: tool_decathlon
+    name: Tool Decathlon
+    aliases: ["Tool Decathlon", "Toolathlon", "Toolathlon-Verified"]
+    domain: tool_use
+    url: https://toolathlon.xyz/
+    released: 2025-10-28
+    caveat: Aggregates ten heterogeneous tool suites; the per-suite spread is wide.
+
+  - id: osworld
+    name: OSWorld
+    aliases: ["OSWorld", "OSWorld-Verified", "OSWorld 2.0"]
+    domain: computer_use
+    url: https://os-world.github.io/
+    released: 2024-04-11
+    caveat: >-
+      Screen resolution, OS image and action space all change results. The
+      Verified and 2.0 revisions are not comparable to the original.
+
+  - id: frontier_bench
+    name: Frontier-Bench
+    aliases: ["Frontier-Bench", "FrontierBench", "Frontier-Bench v0.1", "FrontierSWE"]
+    domain: coding_agent
+    url: https://cognition.ai/blog/frontier-bench
+    released: 2026-05-19
+    caveat: >-
+      Published by Cognition, a vendor of a competing coding agent, and run in
+      its own harness. Treat it as first-party to that harness.
+
+  - id: cursor_bench
+    name: CursorBench
+    aliases: ["CursorBench", "Cursor Bench", "CursorBench 3.2"]
+    domain: coding_agent
+    url: https://cursor.com/blog/cursor-bench
+    released: 2025-10-29
+    caveat: >-
+      Maintained by Cursor and measured inside the Cursor product, so it
+      reflects that scaffold rather than the bare model.
+
+  - id: browsecomp_zh
+    name: BrowseComp-ZH
+    aliases: ["BrowseComp-ZH", "BrowseComp-zh", "BrowseComp-Zh"]
+    domain: agent
+    url: https://arxiv.org/abs/2504.19314
+    released: 2025-04-27
+    caveat: >-
+      Chinese-language live web. Same day-to-day web drift as BrowseComp, over
+      a different index.
+
+  - id: healthbench
+    name: HealthBench
+    aliases: ["HealthBench", "HealthBench Hard", "HealthBench Consensus", "HealthBench Professional"]
+    domain: health
+    url: https://openai.com/index/healthbench/
+    released: 2025-05-12
+    caveat: >-
+      Physician-written rubrics scored by an LLM grader, and the length-adjusted
+      variant is what recent cards report. Published by OpenAI.
+
+  - id: super_gpqa
+    name: SuperGPQA
+    aliases: ["SuperGPQA", "Super-GPQA"]
+    domain: knowledge
+    url: https://arxiv.org/abs/2502.14739
+    released: 2025-02-20
+    caveat: 285 graduate disciplines; breadth comes at the cost of per-field sample size.
+
+  - id: imo_answer_bench
+    name: IMOAnswerBench
+    aliases: ["IMOAnswerBench", "IMO AnswerBench"]
+    domain: math
+    url: https://huggingface.co/datasets/HuggingFaceH4/IMOAnswerBench
+    released: 2025-09-18
+    caveat: >-
+      Final-answer grading on olympiad problems, so it does not check whether
+      the proof reasoning was valid.
+
+  - id: hmmt
+    name: HMMT
+    aliases: ["HMMT", "HMMT Feb 25", "HMMT Nov 25", "HMMT 2026 Feb"]
+    domain: math
+    url: https://www.hmmt.org/
+    released: 2025-02-15
+    caveat: >-
+      A dated competition, not a fixed set: each sitting is a different
+      instrument and contamination rises once problems are published.
+
+  - id: ifbench
+    name: IFBench
+    aliases: ["IFBench"]
+    domain: instruction_following
+    url: https://arxiv.org/abs/2507.02833
+    released: 2025-07-03
+    caveat: Verifiable constraints on unseen instruction types; does not measure answer quality.
+
+  - id: bigbench_extra_hard
+    name: BIG-Bench Extra Hard
+    aliases: ["BigBench Extra Hard", "BBEH", "BIG-Bench Extra Hard"]
+    domain: reasoning
+    url: https://arxiv.org/abs/2502.19187
+    released: 2025-02-26
+    caveat: Successor to BBH after saturation; per-task variance is high.
+
+  - id: scicode
+    name: SciCode
+    aliases: ["SciCode"]
+    domain: science
+    url: https://scicode-bench.github.io/
+    released: 2024-07-18
+    caveat: Scientific code generation graded by test execution; subproblem context matters.
+
+  - id: vending_bench
+    name: Vending Bench
+    aliases: ["Vending Bench", "Vending Bench 2"]
+    domain: agent
+    url: https://andonlabs.com/evals/vending-bench-2
+    released: 2025-02-18
+    caveat: >-
+      Reported in simulated dollars, not a percentage, and run over long
+      horizons where a single early failure dominates the total.
+
+  - id: chartqa
+    name: ChartQA
+    aliases: ["ChartQA"]
+    domain: multimodal
+    url: https://github.com/vis-nlp/ChartQA
+    released: 2022-03-19
+    caveat: Largely saturated; relaxed-accuracy tolerance affects the reported figure.
+
+  - id: docvqa
+    name: DocVQA
+    aliases: ["DocVQA"]
+    domain: multimodal
+    url: https://www.docvqa.org/
+    released: 2020-07-01
+    caveat: Saturated at the frontier; ANLS scoring is lenient to OCR near-misses.
+
+  - id: mtob
+    name: MTOB
+    aliases: ["MTOB", "Machine Translation from One Book"]
+    domain: long_context
+    url: https://arxiv.org/abs/2309.16575
+    released: 2023-09-28
+    caveat: >-
+      Translation from a single grammar book, reported as half-book and
+      full-book variants that are not interchangeable.
+
+  - id: mathvision
+    name: MathVision
+    aliases: ["MathVision", "MATH-Vision", "MathVision (mini)"]
+    domain: multimodal
+    url: https://mathllm.github.io/mathvision/
+    released: 2024-02-22
+    caveat: >-
+      Prompt-format sensitive: vendors report boxed and unboxed variants and
+      sometimes take the higher of the two.
+
+  - id: omnidocbench
+    name: OmniDocBench
+    aliases: ["OmniDocBench", "OmniDocBench1.5", "OmniDocBench 1.5"]
+    domain: multimodal
+    url: https://github.com/opendatalab/OmniDocBench
+    released: 2024-12-10
+    caveat: >-
+      Reported as an edit distance where lower is better, so it inverts the
+      direction of every other row a card puts beside it.
+
+  - id: aa_lcr
+    name: AA-LCR
+    aliases: ["AA-LCR"]
+    domain: long_context
+    url: https://artificialanalysis.ai/evaluations/aa-lcr
+    released: 2025-09-16
+    caveat: >-
+      Run by Artificial Analysis rather than the vendor. Third-party execution
+      is the point, but it also means the vendor did not control the setup.
+
+  - id: deepsearchqa
+    name: DeepSearchQA
+    aliases: ["DeepSearchQA"]
+    domain: agent
+    url: https://huggingface.co/datasets/PokeeAI/DeepSearchQA
+    released: 2026-02-10
+    caveat: Live-web deep research; F1 grading depends on the reference answer set.
+
+  - id: apex_agents
+    name: APEX-Agents
+    aliases: ["APEX-Agents", "APEX", "Apex", "Apex Shortlist"]
+    domain: agent
+    url: https://arxiv.org/abs/2512.02141
+    released: 2025-12-02
+    caveat: Expert-authored professional tasks with rubric grading; graders are LLMs.
+
+  - id: cvebench
+    name: CVE-Bench
+    aliases: ["CVE-Bench", "CVEBench"]
+    domain: security
+    url: https://github.com/uiuc-kang-lab/cve-bench
+    released: 2025-03-21
+    caveat: >-
+      Real CVE exploitation in sandboxes. Vendors report it as a safety ceiling
+      rather than a capability to maximize.
+
+  - id: mle_bench
+    name: MLE-bench
+    aliases: ["MLE-Bench", "MLE-bench Revised", "MLE-bench Lite"]
+    domain: ai_research
+    url: https://openai.com/index/mle-bench/
+    released: 2024-10-09
+    caveat: >-
+      Kaggle-derived ML engineering tasks; wall-clock budget and hardware are
+      part of the result. Published by OpenAI.
+
+  - id: seccodebench
+    name: SecCodeBench
+    aliases: ["SecCodeBench"]
+    domain: security
+    url: https://github.com/alibaba/SecCodeBench
+    released: 2025-10-14
+    caveat: Measures secure-coding behaviour, not exploitation capability.
+
+  - id: multichallenge
+    name: MultiChallenge
+    aliases: ["MultiChallenge"]
+    domain: instruction_following
+    url: https://arxiv.org/abs/2501.17399
+    released: 2025-01-29
+    caveat: Multi-turn instruction retention, graded by an LLM judge.
+
+  - id: widesearch
+    name: WideSearch
+    aliases: ["WideSearch"]
+    domain: agent
+    url: https://widesearch-seed.github.io/
+    released: 2025-08-11
+    caveat: Wide-coverage web collection; scored on completeness of an enumerated answer set.
+
+  - id: automationbench
+    name: AutomationBench
+    aliases: ["AutomationBench", "Zapier AutomationBench", "HLEAutomationBench"]
+    domain: agent
+    url: https://github.com/zapier/automation-bench
+    released: 2026-03-10
+    caveat: >-
+      Published by Zapier over its own automation surface, and cards report
+      different task subsets of it.
+
+  - id: critpt
+    name: CritPt
+    aliases: ["CritPt"]
+    domain: science
+    url: https://arxiv.org/abs/2509.26574
+    released: 2025-09-30
+    caveat: Research-level physics reasoning; small expert-authored set.
+
+  - id: posttrainbench
+    name: PostTrainBench
+    aliases: ["PostTrainBench", "PostTrainBench Lite"]
+    domain: ai_research
+    url: https://posttrainbench.com/
+    released: 2026-01-20
+    caveat: >-
+      Measures a model's ability to run post-training itself. Hardware differs
+      between reported runs (H100 vs H20), which moves the score.
+
+  - id: exploitbench
+    name: ExploitBench
+    aliases: ["ExploitBench"]
+    domain: security
+    url: https://deploymentsafety.openai.com/gpt-5-6-preview
+    released: 2026-06-26
+    caveat: >-
+      Offensive-security capability measured as a risk indicator against a
+      preparedness threshold, not a leaderboard to top. Only OpenAI has
+      published against it so far.
 
 # Model cards, technical reports and release posts.
 #
@@ -413,6 +857,11 @@ model_cards:
       - mathvista
       - drop
 
+  # Benchmarks read from the Maverick instruction-tuned comparison table
+  # published in this post, not from the surrounding prose. ChartQA, DocVQA,
+  # MTOB and Multilingual MMLU come from that table's rows; the table also
+  # states 0-shot, temperature 0, no majority voting, which is why no score is
+  # recorded here.
   - id: meta_llama_4
     organization: Meta
     model: Llama 4
@@ -428,6 +877,10 @@ model_cards:
       - mathvista
       - chatbot_arena
       - mrcr
+      - chartqa
+      - docvqa
+      - mtob
+      - mmmlu
 
   - id: meta_llama_3_1
     organization: Meta
@@ -573,3 +1026,325 @@ model_cards:
       - arc_agi
       - swe_bench_verified
       - mmmu
+
+  # ---------------------------------------------------------------------------
+  # 2026 releases.
+  #
+  # Everything above documents models shipped in 2024-2025. The blocks below are
+  # the current frontier, and they are what makes the ranking a statement about
+  # today rather than about last year. Two things changed in how vendors report:
+  #
+  #   * The headline moved from static QA sets to agentic and harness-dependent
+  #     evaluations (Terminal-Bench, SWE-bench Pro, tau2-bench, MCP Atlas,
+  #     OSWorld, GDPval). MMLU and HumanEval still appear, but in base-model
+  #     tables, not in the lead.
+  #   * Several 2026 headline benchmarks are published by a commercial party
+  #     with a stake in the result (Cognition's Frontier-Bench, Cursor's
+  #     CursorBench, Zapier's AutomationBench, Artificial Analysis's -AA
+  #     variants). Their per-benchmark caveats say so; the adoption count cannot.
+  # ---------------------------------------------------------------------------
+
+  - id: anthropic_claude_opus_5_system_card
+    organization: Anthropic
+    model: Claude Opus 5
+    document_type: system_card
+    published: 2026-07-24
+    url: https://www.anthropic.com/news/claude-opus-5
+    retrieved_at: 2026-08-02
+    benchmarks:
+      - frontier_bench
+      - cursor_bench
+      - arc_agi_3
+      - automationbench
+      - osworld
+      - gdpval
+      - deepsearchqa
+      - swe_bench_verified
+      - swe_bench_pro
+      - terminal_bench
+
+  - id: anthropic_claude_fable_5_mythos_5
+    organization: Anthropic
+    model: Claude Fable 5 and Mythos 5
+    document_type: release_post
+    published: 2026-06-09
+    url: https://www.anthropic.com/news/claude-fable-5-mythos-5
+    retrieved_at: 2026-08-02
+    benchmarks:
+      - frontier_bench
+      - cursor_bench
+      - browsecomp
+      - terminal_bench
+      - swe_bench_verified
+
+  - id: openai_gpt_5_6_system_card
+    organization: OpenAI
+    model: GPT-5.6 (Sol, Terra, Luna)
+    document_type: system_card
+    published: 2026-07-09
+    url: https://deploymentsafety.openai.com/gpt-5-6-preview
+    retrieved_at: 2026-08-02
+    benchmarks:
+      - healthbench
+      - cvebench
+      - mle_bench
+      - posttrainbench
+      - exploitbench
+      - browsecomp
+      - terminal_bench
+
+  - id: openai_gpt_5_6_release
+    organization: OpenAI
+    model: GPT-5.6
+    document_type: release_post
+    published: 2026-06-26
+    url: https://openai.com/index/gpt-5-6/
+    retrieved_at: 2026-08-02
+    benchmarks:
+      - terminal_bench
+      - browsecomp
+      - swe_bench_verified
+      - gpqa_diamond
+      - hle
+
+  - id: google_gemini_3_1_pro_model_card
+    organization: Google DeepMind
+    model: Gemini 3.1 Pro
+    document_type: model_card
+    published: 2026-02-19
+    url: https://deepmind.google/models/model-cards/gemini-3-1-pro/
+    retrieved_at: 2026-08-02
+    benchmarks:
+      - hle
+      - arc_agi_2
+      - gpqa_diamond
+      - terminal_bench
+      - swe_bench_verified
+      - swe_bench_pro
+      - livecodebench_pro
+      - scicode
+      - apex_agents
+      - tau2_bench
+      - mcp_atlas
+      - browsecomp
+      - mmmu_pro
+      - mmmlu
+      - mrcr
+
+  - id: google_gemma_4_model_card
+    organization: Google DeepMind
+    model: Gemma 4 (31B)
+    document_type: model_card
+    published: 2026-03-11
+    url: https://huggingface.co/google/gemma-4-31B-it
+    retrieved_at: 2026-08-02
+    benchmarks:
+      - mmlu_pro
+      - aime
+      - livecodebench
+      - codeforces
+      - gpqa_diamond
+      - tau2_bench
+      - hle
+      - bigbench_extra_hard
+      - mmmlu
+      - mmmu_pro
+      - omnidocbench
+      - mathvision
+      - mrcr
+
+  - id: qwen3_5_model_card
+    organization: Qwen
+    model: Qwen3.5-397B-A17B
+    document_type: model_card
+    published: 2026-02-16
+    url: https://huggingface.co/Qwen/Qwen3.5-397B-A17B
+    retrieved_at: 2026-08-02
+    benchmarks:
+      - mmlu_pro
+      - mmlu_redux
+      - super_gpqa
+      - ifeval
+      - ifbench
+      - multichallenge
+      - aa_lcr
+      - longbench
+      - gpqa
+      - gpqa_diamond
+      - hle
+      - livecodebench
+      - hmmt
+      - imo_answer_bench
+      - aime
+      - bfcl
+      - tau2_bench
+      - tool_decathlon
+      - mcp_mark
+      - browsecomp
+      - browsecomp_zh
+      - widesearch
+      - mmmlu
+      - swe_bench_verified
+      - swe_bench_multilingual
+      - seccodebench
+      - terminal_bench
+      - mmmu
+      - mmmu_pro
+      - mathvision
+      - mathvista
+      - omnidocbench
+      - video_mme
+      - osworld
+
+  - id: deepseek_v4_model_card
+    organization: DeepSeek
+    model: DeepSeek-V4-Pro
+    document_type: model_card
+    published: 2026-04-22
+    url: https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro
+    retrieved_at: 2026-08-02
+    benchmarks:
+      - agieval
+      - mmlu
+      - mmlu_redux
+      - mmlu_pro
+      - mmmlu
+      - simpleqa
+      - super_gpqa
+      - drop
+      - humaneval
+      - gsm8k
+      - math_500
+      - longbench
+      - gpqa_diamond
+      - hle
+      - livecodebench
+      - codeforces
+      - hmmt
+      - imo_answer_bench
+      - apex_agents
+      - mrcr
+      - terminal_bench
+      - swe_bench_verified
+      - swe_bench_pro
+      - swe_bench_multilingual
+      - browsecomp
+      - gdpval
+      - mcp_atlas
+      - tool_decathlon
+
+  - id: deepseek_v4_technical_report
+    organization: DeepSeek
+    model: DeepSeek-V4
+    document_type: technical_report
+    published: 2026-06-25
+    url: https://arxiv.org/abs/2606.19348
+    retrieved_at: 2026-08-02
+    benchmarks:
+      - mmlu_pro
+      - gpqa_diamond
+      - hle
+      - livecodebench
+      - swe_bench_verified
+      - terminal_bench
+      - mrcr
+      - longbench
+      - browsecomp
+
+  - id: moonshot_kimi_k3_model_card
+    organization: Moonshot AI
+    model: Kimi K3
+    document_type: model_card
+    published: 2026-06-13
+    url: https://huggingface.co/moonshotai/Kimi-K3
+    retrieved_at: 2026-08-02
+    benchmarks:
+      - gpqa_diamond
+      - critpt
+      - aa_lcr
+      - hle
+      - terminal_bench
+      - frontier_bench
+      - posttrainbench
+      - scicode
+      - browsecomp
+      - deepsearchqa
+      - gdpval
+      - tool_decathlon
+      - mcp_mark
+      - mcp_atlas
+      - automationbench
+      - apex_agents
+      - osworld
+      - omnidocbench
+      - video_mme
+      - mmmu_pro
+      - mathvision
+      - swe_bench_verified
+
+  - id: zai_glm_5_model_card
+    organization: Z.ai
+    model: GLM-5
+    document_type: model_card
+    published: 2026-02-11
+    url: https://huggingface.co/zai-org/GLM-5
+    retrieved_at: 2026-08-02
+    benchmarks:
+      - hle
+      - aime
+      - hmmt
+      - imo_answer_bench
+      - gpqa_diamond
+      - swe_bench_verified
+      - swe_bench_multilingual
+      - terminal_bench
+      - browsecomp
+      - browsecomp_zh
+      - tau2_bench
+      - mcp_atlas
+      - tool_decathlon
+      - vending_bench
+
+  - id: zai_glm_5_paper
+    organization: Z.ai
+    model: GLM-5
+    document_type: technical_report
+    published: 2026-02-11
+    url: https://huggingface.co/papers/2602.15763
+    retrieved_at: 2026-08-02
+    benchmarks:
+      - hle
+      - aime
+      - gpqa_diamond
+      - swe_bench_verified
+      - terminal_bench
+      - tau2_bench
+      - browsecomp
+
+  - id: xai_grok_4_5
+    organization: xAI
+    model: Grok 4.5
+    document_type: release_post
+    published: 2026-07-08
+    url: https://x.ai/news/grok-4-5
+    retrieved_at: 2026-08-02
+    benchmarks:
+      - terminal_bench
+      - swe_bench_pro
+      - gpqa_diamond
+      - hle
+      - arc_agi_2
+
+  - id: mistral_large_3
+    organization: Mistral
+    model: Mistral Large 3 (675B)
+    document_type: model_card
+    published: 2025-11-28
+    url: https://huggingface.co/mistralai/Mistral-Large-3-675B-Instruct-2512
+    retrieved_at: 2026-08-02
+    benchmarks:
+      - mmmlu
+      - gpqa_diamond
+      - simpleqa
+      - livecodebench
+

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -1308,6 +1308,32 @@ function rankedCounts(values, limit = 6) {
     .slice(0, limit);
 }
 
+// Rows are `[label, value]`, or `[label, value, detail]` where detail is an
+// array of `[name, url]` pairs naming the records the count is made of. A row
+// with a detail becomes a disclosure; a row without one stays a plain line, so
+// the Trend Map's callers are unaffected.
+//
+// The point is that a summary count should be checkable. "OpenAI: 5 cards" is a
+// claim about five specific documents, and a reader who cannot see which five
+// has to take the number on faith.
+function insightDetailList(detail) {
+  return element(
+    "ul",
+    { className: "insight-detail-list" },
+    detail.map(([name, url]) =>
+      element("li", {}, [
+        url
+          ? element("a", {
+              className: "adopter-link",
+              text: name,
+              attrs: { href: url, target: "_blank", rel: "noopener noreferrer" },
+            })
+          : element("span", { text: name }),
+      ]),
+    ),
+  );
+}
+
 function mapInsightCard(title, entries, emptyText) {
   return element("article", { className: "map-insight-card" }, [
     element("h2", { text: title }),
@@ -1315,11 +1341,21 @@ function mapInsightCard(title, entries, emptyText) {
       ? element(
           "ul",
           {},
-          entries.map(([label, value]) =>
-            element("li", {}, [
-              element("span", { text: label }),
-              element("strong", { text: value }),
-            ]),
+          entries.map(([label, value, detail]) =>
+            detail && detail.length
+              ? element("li", { className: "insight-row-expandable" }, [
+                  element("details", {}, [
+                    element("summary", {}, [
+                      element("span", { text: label }),
+                      element("strong", { text: value }),
+                    ]),
+                    insightDetailList(detail),
+                  ]),
+                ])
+              : element("li", {}, [
+                  element("span", { text: label }),
+                  element("strong", { text: value }),
+                ]),
           ),
         )
       : element("p", { text: emptyText }),
@@ -1577,14 +1613,66 @@ function renderLeaderboard() {
   renderLeaderboardFilters(board);
 
   const topEntries = (board.entries || []).filter((entry) => entry.card_count > 0);
+  const allCards = board.model_cards || [];
+  // One vendor can publish two documents about the same model -- Z.ai shipped a
+  // GLM-5 model card and a GLM-5 technical report -- and both are counted,
+  // correctly, as separate adoptions. Labelling both "Z.ai · GLM-5" makes a
+  // correct count look like a double-counting bug, so the document type
+  // disambiguates whenever the organization and model alone do not.
+  const labelCounts = new Map();
+  for (const card of allCards) {
+    const key = `${card.organization} · ${card.model}`;
+    labelCounts.set(key, (labelCounts.get(key) || 0) + 1);
+  }
+  const cardLabel = (organization, model, documentType) => {
+    const base = `${organization} · ${model}`;
+    return labelCounts.get(base) > 1
+      ? `${base} (${String(documentType).replaceAll("_", " ")})`
+      : base;
+  };
+  const cardLink = (card) => [
+    cardLabel(card.organization, card.model, card.document_type),
+    card.url,
+  ];
+  const benchmarkLink = (entry) => [entry.name, entry.url];
+  // Sorted by publisher then date so an expanded list reads as a roster rather
+  // than as a second implied ranking, matching the model card table below.
+  const byOrganization = (a, b) =>
+    a.organization.localeCompare(b.organization) ||
+    (a.published || "").localeCompare(b.published || "");
+
   replaceChildren(byId("leaderboard-insights"), [
     mapInsightCard(
       "Registry coverage",
       [
-        ["Model cards", Number(board.model_card_count || 0).toLocaleString()],
-        ["Organizations", Number(board.organization_count || 0).toLocaleString()],
-        ["Benchmarks tracked", Number(board.benchmark_count || 0).toLocaleString()],
-        ["Reported at least once", Number(topEntries.length).toLocaleString()],
+        [
+          "Model cards",
+          Number(board.model_card_count || 0).toLocaleString(),
+          [...allCards].sort(byOrganization).map(cardLink),
+        ],
+        [
+          "Organizations",
+          Number(board.organization_count || 0).toLocaleString(),
+          Object.entries(board.organizations || {})
+            .sort((a, b) => a[0].localeCompare(b[0]))
+            .map(([organization, count]) => [
+              `${organization} — ${metricLabel(count, "card")}`,
+              null,
+            ]),
+        ],
+        [
+          "Benchmarks tracked",
+          Number(board.benchmark_count || 0).toLocaleString(),
+          (board.entries || []).map(benchmarkLink),
+        ],
+        [
+          "Reported at least once",
+          Number(topEntries.length).toLocaleString(),
+          topEntries.map((entry) => [
+            `${entry.name} — ${metricLabel(entry.card_count, "card")}`,
+            entry.url,
+          ]),
+        ],
       ],
       "No registry entries yet.",
     ),
@@ -1592,7 +1680,14 @@ function renderLeaderboard() {
       "Cards per organization",
       Object.entries(board.organizations || {})
         .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
-        .map(([organization, count]) => [organization, metricLabel(count, "card")]),
+        .map(([organization, count]) => [
+          organization,
+          metricLabel(count, "card"),
+          allCards
+            .filter((card) => card.organization === organization)
+            .sort((a, b) => (a.published || "").localeCompare(b.published || ""))
+            .map((card) => [`${card.model} — ${card.document_type.replaceAll("_", " ")}`, card.url]),
+        ]),
       "No organizations in the registry yet.",
     ),
     // Counts only benchmarks at least one card reports, which is deliberately
@@ -1606,6 +1701,12 @@ function renderLeaderboard() {
         .map(([domain, count]) => [
           domain.replaceAll("_", " "),
           metricLabel(count, "benchmark"),
+          topEntries
+            .filter((entry) => entry.domain === domain)
+            .map((entry) => [
+              `${entry.name} — ${metricLabel(entry.card_count, "card")}`,
+              entry.url,
+            ]),
         ]),
       "No domains represented yet.",
     ),
@@ -1613,7 +1714,16 @@ function renderLeaderboard() {
       "Adopted by every organization",
       topEntries
         .filter((entry) => entry.organization_count === board.organization_count)
-        .map((entry) => [entry.name, metricLabel(entry.card_count, "card")]),
+        .map((entry) => [
+          entry.name,
+          metricLabel(entry.card_count, "card"),
+          // The adopting documents themselves: this row's claim is "every
+          // organization reports it", and the list is what substantiates it.
+          (entry.adopters || []).map((adopter) => [
+            cardLabel(adopter.organization, adopter.model, adopter.document_type),
+            adopter.url,
+          ]),
+        ]),
       "No benchmark is reported by every organization in the registry.",
     ),
   ]);

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -27,6 +27,7 @@ const state = {
   lq: "",
   ldomain: "",
   lorg: "",
+  lera: "",
 };
 
 function element(tag, options = {}, children = []) {
@@ -108,6 +109,7 @@ function readUrl() {
   state.lq = params.get("lq") || "";
   state.ldomain = params.get("ldomain") || "";
   state.lorg = params.get("lorg") || "";
+  state.lera = params.get("lera") || "";
   state.rubric = new URLSearchParams(window.location.hash.slice(1)).get("rubric") || "";
 }
 
@@ -127,6 +129,7 @@ function writeUrl() {
   if (state.lq) params.set("lq", state.lq);
   if (state.ldomain) params.set("ldomain", state.ldomain);
   if (state.lorg) params.set("lorg", state.lorg);
+  if (state.lera) params.set("lera", state.lera);
   const query = params.toString();
   // The rubric dialog is a hashtag, not a query param, so a shared link like
   // #rubric=2 reads as "jump to this section" rather than another filter.
@@ -1374,13 +1377,32 @@ function renderMapInsights(corpus) {
 // every reasoning-budget and pass@k caveat that makes two reported scores
 // incomparable.
 
+// Cut points for the benchmark release-date filter. Chosen as era boundaries
+// rather than rolling windows so a bookmarked URL keeps meaning the same thing
+// next month: "?lera=2026" is always "released in 2026", never "the last N
+// months". A benchmark with no recorded release date is excluded by any era
+// filter, which is the honest outcome -- it cannot be placed on the timeline.
+const LEADERBOARD_ERAS = [
+  { value: "2026", label: "Released in 2026", from: "2026-01-01" },
+  { value: "2025", label: "Released 2025 or later", from: "2025-01-01" },
+  { value: "pre2024", label: "Released before 2024", to: "2024-01-01" },
+];
+
 function leaderboardEntries() {
   const board = state.data?.model_card_leaderboard;
   if (!board) return [];
   const query = state.lq.trim().toLowerCase();
+  const era = LEADERBOARD_ERAS.find((candidate) => candidate.value === state.lera);
   return (board.entries || []).filter((entry) => {
     if (state.ldomain && entry.domain !== state.ldomain) return false;
     if (state.lorg && !(entry.organizations || []).includes(state.lorg)) return false;
+    if (era) {
+      // ISO dates compare correctly as strings, so no Date parsing is needed
+      // and no timezone can shift a benchmark across a year boundary.
+      if (!entry.released) return false;
+      if (era.from && entry.released < era.from) return false;
+      if (era.to && entry.released >= era.to) return false;
+    }
     if (!query) return true;
     const haystack = [entry.name, entry.benchmark_id, ...(entry.aliases || [])]
       .join(" ")
@@ -1440,6 +1462,14 @@ function leaderboardRow(entry) {
               }`,
             })
           : element("span", { text: "not yet reported in these cards" }),
+        // The instrument's own age, which the adoption count deliberately does
+        // not encode: a 2020 benchmark with 9 cards and a 2026 benchmark with 9
+        // cards are very different findings about vendor reporting.
+        entry.released
+          ? element("span", {
+              text: `released ${formatDate(entry.released, { dateStyle: "medium" })}`,
+            })
+          : null,
       ]),
       element("h3", { text: entry.name }),
       // The caveat is part of the row, not a footnote. A ranking that puts a
@@ -1517,6 +1547,10 @@ function renderLeaderboardFilters(board) {
     ...organizations.map((organization) =>
       option(organization, organization, organization === state.lorg),
     ),
+  ]);
+  replaceChildren(byId("leaderboard-era"), [
+    option("", "Any release date", !state.lera),
+    ...LEADERBOARD_ERAS.map((era) => option(era.value, era.label, era.value === state.lera)),
   ]);
   if (byId("leaderboard-search").value !== state.lq) {
     byId("leaderboard-search").value = state.lq;
@@ -1599,26 +1633,110 @@ function renderLeaderboard() {
 
   const cards = board.model_cards || [];
   byId("leaderboard-cards-count").textContent = metricLabel(cards.length, "document");
-  replaceChildren(
-    byId("leaderboard-cards"),
-    cards.map((card) =>
-      element("tr", {}, [
-        element("td", { text: card.organization }),
-        element("td", {}, [
-          element("a", {
-            className: "adopter-link",
-            text: card.model,
-            attrs: { href: card.url, target: "_blank", rel: "noopener noreferrer" },
-          }),
-        ]),
-        element("td", { text: String(card.document_type).replaceAll("_", " ") }),
-        element("td", {
-          text: card.published ? formatDate(card.published, { dateStyle: "medium" }) : "Unknown",
+  replaceChildren(byId("leaderboard-cards"), cards.map(modelCardRow));
+}
+
+// The reverse direction of the registry's dual link, rendered as a disclosure so
+// a reader can audit one card against its source document. The forward direction
+// (a benchmark, expanded to its adopters) answers "who reports this?"; this
+// answers "what did this card report?", which is the question you need when
+// checking our data against the ground-truth PDF or blog post. Both are built
+// from the same edge set in `adoption_rank`, so what is listed here is exactly
+// what that card contributes to every count in the table above.
+function modelCardRow(card) {
+  const benchmarks = card.reported_benchmarks || [];
+  const summary = element("summary", { className: "record-summary" }, [
+    element("div", { className: "record-heading" }, [
+      element("div", { className: "signal-meta" }, [
+        element("span", { text: card.organization }),
+        element("span", { text: String(card.document_type).replaceAll("_", " ") }),
+        element("span", {
+          text: card.published
+            ? formatDate(card.published, { dateStyle: "medium" })
+            : "date unknown",
         }),
-        element("td", { text: String(card.benchmark_count) }),
       ]),
-    ),
+      element("h3", { text: card.model }),
+    ]),
+    element("div", { className: "score" }, [
+      element("div", { className: "score-value" }, [
+        element("strong", { text: String(card.benchmark_count) }),
+      ]),
+      element("p", { className: "score-label", text: "Benchmarks" }),
+    ]),
+  ]);
+
+  // Grouped by domain because that is how the source documents are laid out:
+  // a card's own tables are sectioned into reasoning, coding, agentic and
+  // multimodal blocks, so grouping the same way keeps a side-by-side check
+  // against the PDF a matter of reading down one column.
+  const byDomain = new Map();
+  for (const benchmark of benchmarks) {
+    if (!byDomain.has(benchmark.domain)) byDomain.set(benchmark.domain, []);
+    byDomain.get(benchmark.domain).push(benchmark);
+  }
+
+  const groups = [...byDomain.entries()].map(([domain, items]) =>
+    element("div", { className: "card-benchmark-group" }, [
+      element("h4", { text: domain.replaceAll("_", " ") }),
+      element(
+        "ul",
+        { className: "adopter-list" },
+        items.map((benchmark) =>
+          element("li", {}, [
+            benchmark.url
+              ? element("a", {
+                  className: "adopter-link",
+                  text: benchmark.name,
+                  attrs: {
+                    href: benchmark.url,
+                    target: "_blank",
+                    rel: "noopener noreferrer",
+                  },
+                })
+              : element("span", { className: "adopter-link", text: benchmark.name }),
+            element("span", {
+              className: "adopter-meta",
+              text: benchmark.released
+                ? `released ${formatDate(benchmark.released, { dateStyle: "medium" })}`
+                : "release date unrecorded",
+            }),
+          ]),
+        ),
+      ),
+    ]),
   );
+
+  return element("details", { className: "record-card" }, [
+    summary,
+    element("div", { className: "record-detail" }, [
+      element("h3", { text: "Benchmarks this document reports" }),
+      element("p", {
+        className: "section-note",
+        // Says what the reader is and is not looking at, at the point of
+        // looking. A mention is not a score, and the expanded list would
+        // otherwise read as if it were an extract of the card's results table.
+        text:
+          "Every benchmark this document puts in front of readers, counted once each. " +
+          "These are mentions, not scores: the source records the configuration, and " +
+          "this registry deliberately does not.",
+      }),
+      ...groups,
+      element("a", {
+        className: "primary-link",
+        text: "Open source document ↗",
+        attrs: { href: card.url, target: "_blank", rel: "noopener noreferrer" },
+      }),
+      card.retrieved_at
+        ? element("p", {
+            className: "adopter-meta",
+            text: `Last read by a human on ${formatDate(card.retrieved_at, {
+              dateStyle: "medium",
+            })}`,
+          })
+        : null,
+    ]),
+  ]);
 }
 
 function renderTrendMap() {
@@ -1846,6 +1964,7 @@ function bindEvents() {
     state.lq = byId("leaderboard-search").value;
     state.ldomain = byId("leaderboard-domain").value;
     state.lorg = byId("leaderboard-organization").value;
+    state.lera = byId("leaderboard-era").value;
     renderLeaderboard();
     writeUrl();
   });
@@ -1853,6 +1972,7 @@ function bindEvents() {
     state.lq = "";
     state.ldomain = "";
     state.lorg = "";
+    state.lera = "";
     byId("leaderboard-search").value = "";
     renderLeaderboard();
     writeUrl();

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -1382,8 +1382,12 @@ function renderMapInsights(corpus) {
 // next month: "?lera=2026" is always "released in 2026", never "the last N
 // months". A benchmark with no recorded release date is excluded by any era
 // filter, which is the honest outcome -- it cannot be placed on the timeline.
+// "Released in 2026" is bounded at both ends. An open-ended lower bound would
+// silently absorb 2027 benchmarks the moment one is added, contradicting both
+// the label and the permalink promise. "2025 or later" says "or later" and is
+// therefore correctly open-ended.
 const LEADERBOARD_ERAS = [
-  { value: "2026", label: "Released in 2026", from: "2026-01-01" },
+  { value: "2026", label: "Released in 2026", from: "2026-01-01", to: "2027-01-01" },
   { value: "2025", label: "Released 2025 or later", from: "2025-01-01" },
   { value: "pre2024", label: "Released before 2024", to: "2024-01-01" },
 ];
@@ -1645,7 +1649,9 @@ function renderLeaderboard() {
 // what that card contributes to every count in the table above.
 function modelCardRow(card) {
   const benchmarks = card.reported_benchmarks || [];
-  const summary = element("summary", { className: "record-summary" }, [
+  // `record-summary-unranked` selects the three-column grid: these rows carry no
+  // rank number, unlike the ranked benchmark rows above.
+  const summary = element("summary", { className: "record-summary record-summary-unranked" }, [
     element("div", { className: "record-heading" }, [
       element("div", { className: "signal-meta" }, [
         element("span", { text: card.organization }),

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -376,9 +376,13 @@ input {
 
 /* Model card rows carry no rank number, so they have three children where a
    ranked benchmark row has four. Without its own template the heading lands in
-   the 38px rank column and wraps one character per line. Matching on child
-   count keeps both row types on one rule set rather than forking the class. */
-.record-summary:not(:has(.signal-rank)) {
+   the 38px rank column and wraps one character per line.
+
+   An explicit class rather than `:not(:has(.signal-rank))`: this rule is
+   layout-critical, and a browser without :has() support drops the whole
+   selector, which restores exactly the one-character-per-line wrap it exists to
+   prevent. A class degrades to "unstyled but readable" instead. */
+.record-summary.record-summary-unranked {
   grid-template-columns: 26px minmax(0, 1fr) 170px;
 }
 
@@ -1759,12 +1763,24 @@ footer {
     gap: 0.65rem;
   }
 
+  /* Needed because `.record-summary.record-summary-unranked` carries two
+     classes and so outranks the single-class rule above: without this the
+     unranked rows keep the desktop template on a phone, holding a 170px score
+     column beside the heading and leaving the model name almost no width. */
+  .record-summary.record-summary-unranked {
+    grid-template-columns: 24px minmax(0, 1fr);
+  }
+
   .record-summary .score,
   .record-summary .attention-activity {
     grid-column: 3;
     justify-self: start;
     max-width: 180px;
     text-align: left;
+  }
+
+  .record-summary.record-summary-unranked .score {
+    grid-column: 2;
   }
 
   .record-detail {

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -1291,6 +1291,60 @@ td a {
   font-size: 0.78rem;
 }
 
+/* An expandable summary row. The plain rows are flex containers, so the flex
+   layout moves onto the <summary> and the <li> becomes a block that can hold
+   the expanded list beneath it. */
+.map-insight-card li.insight-row-expandable {
+  display: block;
+}
+
+.map-insight-card li.insight-row-expandable summary {
+  display: flex;
+  gap: 0.75rem;
+  align-items: baseline;
+  justify-content: space-between;
+  cursor: pointer;
+  list-style: none;
+}
+
+.map-insight-card li.insight-row-expandable summary::-webkit-details-marker {
+  display: none;
+}
+
+/* A caret in place of the default marker, so a row reads as openable before it
+   is opened. Rotates when open, matching the record cards below. */
+.map-insight-card li.insight-row-expandable summary span::before {
+  content: "› ";
+  display: inline-block;
+  color: var(--blue-deep);
+  font-family: var(--utility);
+  transition: transform 140ms ease;
+}
+
+.map-insight-card li.insight-row-expandable summary:hover span,
+.map-insight-card li.insight-row-expandable summary:focus-visible span {
+  color: var(--ink);
+}
+
+.insight-detail-list {
+  margin: 0.4rem 0 0.15rem 0.85rem !important;
+  padding: 0 0 0 0.6rem !important;
+  border-left: 1px solid var(--line);
+  gap: 0.3rem !important;
+}
+
+/* Overrides the flex row the parent list sets: these entries are single links,
+   not label/value pairs, so they should wrap as ordinary text. */
+.map-insight-card .insight-detail-list li {
+  display: block;
+  font-size: 0.72rem;
+  overflow-wrap: anywhere;
+}
+
+.map-insight-card .insight-detail-list li span {
+  color: var(--muted);
+}
+
 /* Model Card Adoption Rank (issue #83) */
 
 .leaderboard-filters {

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -374,6 +374,14 @@ input {
   list-style: none;
 }
 
+/* Model card rows carry no rank number, so they have three children where a
+   ranked benchmark row has four. Without its own template the heading lands in
+   the 38px rank column and wraps one character per line. Matching on child
+   count keeps both row types on one rule set rather than forking the class. */
+.record-summary:not(:has(.signal-rank)) {
+  grid-template-columns: 26px minmax(0, 1fr) 170px;
+}
+
 .record-summary::before {
   content: "›";
   display: inline-flex;
@@ -1341,6 +1349,20 @@ td a {
   font-family: var(--utility);
   font-size: 0.68rem;
   letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+/* Domain groups inside an expanded model card. The heading is deliberately
+   quieter than the card's own h3: it labels a section of one document's
+   benchmark list, and styling it as a peer of the model name made an expanded
+   card read as several stacked records rather than one. */
+.card-benchmark-group > h4 {
+  margin: 0 0 0.5rem;
+  color: var(--muted);
+  font-family: var(--utility);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 

--- a/site/index.html
+++ b/site/index.html
@@ -197,6 +197,10 @@
               Organization
               <select id="leaderboard-organization" name="lorg"></select>
             </label>
+            <label>
+              Benchmark released
+              <select id="leaderboard-era" name="lera"></select>
+            </label>
             <button class="clear-button" id="leaderboard-clear" type="button">
               Clear filters
             </button>
@@ -216,23 +220,12 @@
             <span id="leaderboard-cards-count"></span>
           </div>
           <p class="section-note">
-            The curated source list this ranking is computed from. Every row links to the
-            document the benchmark mentions were read from.
+            The curated source list this ranking is computed from. Expand any card to see
+            every benchmark it reports, grouped the way the source document groups them, so
+            our data can be checked line by line against the original. Each row links to the
+            document the mentions were read from.
           </p>
-          <div class="table-wrap">
-            <table>
-              <thead>
-                <tr>
-                  <th>Organization</th>
-                  <th>Model</th>
-                  <th>Document</th>
-                  <th>Published</th>
-                  <th>Benchmarks</th>
-                </tr>
-              </thead>
-              <tbody id="leaderboard-cards"></tbody>
-            </table>
-          </div>
+          <div class="leaderboard-list" id="leaderboard-cards"></div>
         </section>
       </section>
 

--- a/src/benchmark_radar/model_cards.py
+++ b/src/benchmark_radar/model_cards.py
@@ -215,17 +215,38 @@ def load_registry(path: Path = DEFAULT_REGISTRY_PATH) -> dict[str, Any]:
         # Compared as ISO strings, and only when both dates are present: a
         # benchmark with no recorded release date cannot be placed on the
         # timeline, so it is not evidence of anything either way.
+        #
+        # `revised` is the escape hatch for a document that legitimately gained a
+        # benchmark after first publication: an arXiv report reaching v3, or a
+        # living model card a vendor keeps editing in place. Those are real, and
+        # for them `published` is the original date while the contents are newer.
+        # It is opt-in per card rather than a blanket relaxation, because the
+        # common case is still a data error and silently allowing every later
+        # benchmark would give back the three edges this check just caught. A
+        # card claiming a revision must name the date it was revised to, which is
+        # a checkable claim about the document.
         published = str(card["published"]) if card.get("published") else ""
-        if published:
+        if card.get("revised"):
+            _require_date(card["revised"], label=f"{path}: model card {card_id!r} revised")
+            if published and str(card["revised"]) < published:
+                raise ModelCardRegistryError(
+                    f"{path}: model card {card_id!r} revised {card['revised']} "
+                    f"precedes its published date {published}"
+                )
+        # The revision date is the cutoff when one is recorded: the document as
+        # read at that point is what the mentions were taken from.
+        cutoff = str(card["revised"]) if card.get("revised") else published
+        if cutoff:
             impossible = sorted(
                 f"{ref} (released {by_id[ref]['released']})"
                 for ref in {str(ref) for ref in card["benchmarks"]}
-                if by_id[ref].get("released") and str(by_id[ref]["released"]) > published
+                if by_id[ref].get("released") and str(by_id[ref]["released"]) > cutoff
             )
             if impossible:
                 raise ModelCardRegistryError(
-                    f"{path}: model card {card_id!r} published {published} reports "
-                    f"benchmarks released after it: {', '.join(impossible)}"
+                    f"{path}: model card {card_id!r} ({cutoff}) reports benchmarks "
+                    f"released after it: {', '.join(impossible)}. If the document was "
+                    f"revised after publication, record the revision date as `revised`"
                 )
 
     return {"benchmarks": benchmarks, "model_cards": cards}
@@ -343,6 +364,10 @@ def adoption_rank(registry: dict[str, Any]) -> dict[str, Any]:
                     "retrieved_at": (
                         str(card["retrieved_at"]) if card.get("retrieved_at") else None
                     ),
+                    # Published so a reader can see that a document reporting a
+                    # benchmark newer than itself is a recorded revision rather
+                    # than a mistake nobody caught.
+                    "revised": str(card["revised"]) if card.get("revised") else None,
                     "benchmark_count": len({str(ref) for ref in card["benchmarks"]}),
                     "benchmarks": sorted({str(ref) for ref in card["benchmarks"]}),
                     # The reverse of `entries[].adopters`, and the reason this

--- a/src/benchmark_radar/model_cards.py
+++ b/src/benchmark_radar/model_cards.py
@@ -51,6 +51,22 @@ _REQUIRED_BENCHMARK_FIELDS = ("id", "name", "domain", "caveat")
 _REQUIRED_CARD_FIELDS = ("id", "organization", "model", "url", "benchmarks")
 
 
+def _benchmark_summary(benchmark: dict[str, Any]) -> dict[str, Any]:
+    """The benchmark fields that travel with a card in the card->benchmark link.
+
+    Deliberately the same projection used to build the leaderboard entry, so the
+    two directions of the link cannot describe one benchmark differently.
+    """
+    return {
+        "benchmark_id": str(benchmark["id"]),
+        "name": str(benchmark["name"]),
+        "domain": str(benchmark["domain"]),
+        "url": str(benchmark.get("url") or "") or None,
+        "released": str(benchmark["released"]) if benchmark.get("released") else None,
+        "caveat": (str(benchmark["caveat"]).strip() if benchmark.get("caveat") else None),
+    }
+
+
 class ModelCardRegistryError(ValueError):
     """Raised when the curated registry is internally inconsistent."""
 
@@ -137,6 +153,14 @@ def load_registry(path: Path = DEFAULT_REGISTRY_PATH) -> dict[str, Any]:
         if benchmark.get("aliases") is not None and not isinstance(benchmark["aliases"], list):
             raise ModelCardRegistryError(
                 f"{path}: benchmark {benchmark_id!r} aliases must be a list"
+            )
+        # Validated on the same terms as a card's dates: `released` is rendered
+        # by the same browser formatter and is filterable, so an unparseable
+        # value here would take the whole dashboard down exactly as one in
+        # `published` would.
+        if benchmark.get("released"):
+            _require_date(
+                benchmark["released"], label=f"{path}: benchmark {benchmark_id!r} released"
             )
         by_id[benchmark_id] = benchmark
 
@@ -237,6 +261,10 @@ def adoption_rank(registry: dict[str, Any]) -> dict[str, Any]:
                 "domain": str(benchmark["domain"]),
                 "url": str(benchmark.get("url") or "") or None,
                 "aliases": [str(alias) for alias in benchmark.get("aliases") or []],
+                # The benchmark's own release date, not any card's. Published so
+                # a reader can separate a newly *adopted* benchmark from a newly
+                # *published* one, and filter the ranking by instrument age.
+                "released": str(benchmark["released"]) if benchmark.get("released") else None,
                 # The caveat travels with the row. A ranking that shows MMLU
                 # high and does not say "saturated and contaminated" invites
                 # exactly the reading issue #83 warns against.
@@ -292,6 +320,28 @@ def adoption_rank(registry: dict[str, Any]) -> dict[str, Any]:
                     ),
                     "benchmark_count": len({str(ref) for ref in card["benchmarks"]}),
                     "benchmarks": sorted({str(ref) for ref in card["benchmarks"]}),
+                    # The reverse of `entries[].adopters`, and the reason this
+                    # registry is a dual link rather than two lists that happen
+                    # to agree. Both directions are derived here from the same
+                    # validated `card["benchmarks"]`, so "which cards report
+                    # benchmark X" and "which benchmarks does card Y report"
+                    # cannot disagree: `test_adoption_rank_links_are_exact
+                    # _inverses` asserts the two edge sets are identical.
+                    #
+                    # The full record travels, not just the id, so a reader
+                    # expanding a card sees each benchmark's domain, release
+                    # date and caveat without having to join against `entries`
+                    # in the browser.
+                    "reported_benchmarks": [
+                        _benchmark_summary(benchmarks[benchmark_id])
+                        for benchmark_id in sorted(
+                            {str(ref) for ref in card["benchmarks"]},
+                            key=lambda ref: (
+                                benchmarks[ref]["domain"],
+                                str(benchmarks[ref]["name"]).lower(),
+                            ),
+                        )
+                    ],
                 }
                 for card in cards
             ),

--- a/src/benchmark_radar/model_cards.py
+++ b/src/benchmark_radar/model_cards.py
@@ -203,6 +203,31 @@ def load_registry(path: Path = DEFAULT_REGISTRY_PATH) -> dict[str, Any]:
             if card.get(field):
                 _require_date(card[field], label=f"{path}: model card {card_id!r} {field}")
 
+        # A card cannot report a benchmark that did not exist when it was
+        # published. Every date here is individually well-formed, so nothing
+        # above catches the contradiction, and the resulting edge is invisible in
+        # the ranking: it just quietly adds one adoption. Three such edges were
+        # in the first draft of the 2026 expansion, each a different mistake --
+        # a wrong `released` date, and two benchmarks attributed to cards that
+        # reported a different instrument. Checking the pair is what tells those
+        # apart from correct data.
+        #
+        # Compared as ISO strings, and only when both dates are present: a
+        # benchmark with no recorded release date cannot be placed on the
+        # timeline, so it is not evidence of anything either way.
+        published = str(card["published"]) if card.get("published") else ""
+        if published:
+            impossible = sorted(
+                f"{ref} (released {by_id[ref]['released']})"
+                for ref in {str(ref) for ref in card["benchmarks"]}
+                if by_id[ref].get("released") and str(by_id[ref]["released"]) > published
+            )
+            if impossible:
+                raise ModelCardRegistryError(
+                    f"{path}: model card {card_id!r} published {published} reports "
+                    f"benchmarks released after it: {', '.join(impossible)}"
+                )
+
     return {"benchmarks": benchmarks, "model_cards": cards}
 
 
@@ -334,11 +359,19 @@ def adoption_rank(registry: dict[str, Any]) -> dict[str, Any]:
                     # in the browser.
                     "reported_benchmarks": [
                         _benchmark_summary(benchmarks[benchmark_id])
+                        # The id is the final key, not decoration: domain and
+                        # lowercased name can both tie between two distinct
+                        # benchmarks, and the input is a set, so without a
+                        # unique tie-breaker their published order would vary
+                        # with PYTHONHASHSEED. The inverse-property test would
+                        # not catch it -- it compares sets -- so the ordering
+                        # has to be total here.
                         for benchmark_id in sorted(
                             {str(ref) for ref in card["benchmarks"]},
                             key=lambda ref: (
                                 benchmarks[ref]["domain"],
                                 str(benchmarks[ref]["name"]).lower(),
+                                ref,
                             ),
                         )
                     ],

--- a/tests/test_model_cards.py
+++ b/tests/test_model_cards.py
@@ -223,6 +223,98 @@ def test_measures_statement_travels_with_the_data():
     assert "not benchmark quality" in board["measures"]
 
 
+def test_adoption_rank_links_are_exact_inverses():
+    """The registry is one edge set published in two directions.
+
+    `entries[].adopters` answers "who reports this benchmark" and
+    `model_cards[].reported_benchmarks` answers "what does this card report".
+    Both are derived from the same validated `card["benchmarks"]`, and this test
+    is what makes that a guarantee rather than a coincidence: if either
+    projection is ever filtered, truncated or sorted into a lossy shape, the two
+    edge sets diverge and a reader auditing a card against the table above would
+    be shown a benchmark list that does not explain the counts.
+    """
+    board = build_adoption_rank(DEFAULT_REGISTRY_PATH)
+
+    forward = {
+        (entry["benchmark_id"], adopter["model_card_id"])
+        for entry in board["entries"]
+        for adopter in entry["adopters"]
+    }
+    reverse = {
+        (benchmark["benchmark_id"], card["model_card_id"])
+        for card in board["model_cards"]
+        for benchmark in card["reported_benchmarks"]
+    }
+
+    assert forward == reverse
+    assert forward, "the shipped registry must publish at least one adoption edge"
+    # Every card's own count agrees with the number of edges it contributes.
+    # `reported_benchmarks` is ordered by domain for display, so compare as sets
+    # against the id list rather than positionally.
+    for card in board["model_cards"]:
+        assert card["benchmark_count"] == len(card["reported_benchmarks"])
+        assert {benchmark["benchmark_id"] for benchmark in card["reported_benchmarks"]} == set(
+            card["benchmarks"]
+        )
+
+
+def test_expanded_card_carries_enough_to_audit_against_the_source():
+    board = build_adoption_rank(DEFAULT_REGISTRY_PATH)
+
+    # A reader opening a card checks our list against the vendor's own document.
+    # That requires the source URL, when a human last read it, and for each
+    # benchmark the name and caveat -- not just an id they would have to resolve
+    # against another table by hand.
+    for card in board["model_cards"]:
+        assert card["url"].startswith("https://")
+        for benchmark in card["reported_benchmarks"]:
+            assert benchmark["name"]
+            assert benchmark["domain"]
+            assert benchmark["caveat"]
+
+
+def test_benchmark_release_dates_are_published_and_validated(tmp_path):
+    board = build_adoption_rank(DEFAULT_REGISTRY_PATH)
+
+    # Filterable in the dashboard, so it has to survive into the published data.
+    assert any(entry["released"] for entry in board["entries"])
+    for entry in board["entries"]:
+        if entry["released"]:
+            assert len(entry["released"]) == 10
+
+    # Validated on the same terms as a card's dates: this value reaches the same
+    # browser formatter, and an unparseable one would take every view down.
+    document = minimal_registry()
+    document["benchmarks"][0]["released"] = "March 2025"
+    with pytest.raises(ModelCardRegistryError, match="must be an ISO date"):
+        load_registry(write_registry(tmp_path, document))
+
+    document = minimal_registry()
+    document["benchmarks"][0]["released"] = "2025-02-30"
+    with pytest.raises(ModelCardRegistryError, match="not a real calendar date"):
+        load_registry(write_registry(tmp_path, document))
+
+
+def test_registry_covers_the_2026_frontier():
+    """The ranking has to describe current reporting, not 2025's.
+
+    Issue #83 asks which benchmarks vendors put in front of readers. A registry
+    whose newest document predates the current model generation answers that
+    question about a frontier that no longer exists, so coverage of recent cards
+    is a correctness property of this feature rather than a nice-to-have.
+    """
+    board = build_adoption_rank(DEFAULT_REGISTRY_PATH)
+
+    published = [card["published"] for card in board["model_cards"] if card["published"]]
+    assert sum(1 for date in published if date >= "2026-01-01") >= 10
+
+    # Each organization in the registry is represented by at least one document,
+    # and the agentic evaluations that headline 2026 cards are present.
+    names = {entry["benchmark_id"] for entry in board["entries"] if entry["card_count"]}
+    assert {"terminal_bench", "swe_bench_pro", "tau2_bench", "gdpval", "osworld"} <= names
+
+
 def test_adopters_link_back_to_the_source_document():
     board = build_adoption_rank(DEFAULT_REGISTRY_PATH)
 

--- a/tests/test_model_cards.py
+++ b/tests/test_model_cards.py
@@ -306,26 +306,66 @@ def test_a_card_cannot_report_a_benchmark_that_did_not_exist_yet(tmp_path):
     date and two benchmarks attributed to cards that reported a different
     instrument -- so this is the check that tells a data error from real data.
     """
+    # `beta` is reported only by the first card, so exactly one card violates the
+    # chronology and the raised message names it.
     document = minimal_registry()
-    document["benchmarks"][0]["released"] = "2025-06-01"
+    document["benchmarks"][1]["released"] = "2025-06-01"
     document["model_cards"][0]["published"] = "2025-01-01"
 
-    with pytest.raises(ModelCardRegistryError, match="reports benchmarks released after it"):
+    with pytest.raises(ModelCardRegistryError, match="'org_one_card'.*released after it"):
         load_registry(write_registry(tmp_path, document))
 
     # A benchmark with no recorded release date cannot be placed on the
     # timeline, so it is not evidence of a contradiction either way.
     document = minimal_registry()
-    document["benchmarks"][0].pop("released", None)
+    document["benchmarks"][1].pop("released", None)
     document["model_cards"][0]["published"] = "2025-01-01"
     load_registry(write_registry(tmp_path, document))
 
     # Same-day is legitimate: benchmarks are routinely published alongside the
     # card that first reports them (MRCR shipped with GPT-4.1).
     document = minimal_registry()
-    document["benchmarks"][0]["released"] = "2025-01-01"
+    document["benchmarks"][1]["released"] = "2025-01-01"
     document["model_cards"][0]["published"] = "2025-01-01"
     load_registry(write_registry(tmp_path, document))
+
+
+def test_a_revised_document_may_report_a_later_benchmark(tmp_path):
+    """An arXiv report at v3 or a living model card is not a data error.
+
+    For those, `published` is the original date while the contents are newer, so
+    a benchmark released after publication can be a real mention. The relaxation
+    is opt-in per card: the common case is still a mistake, and allowing every
+    later benchmark by default would give back the three bad edges the chronology
+    check was added to catch.
+    """
+    # `beta` is reported only by the first card, so the revision under test is
+    # the only thing the later release date interacts with.
+    document = minimal_registry()
+    document["benchmarks"][1]["released"] = "2025-06-01"
+    document["model_cards"][0]["published"] = "2025-01-01"
+    document["model_cards"][0]["revised"] = "2025-07-01"
+    registry = load_registry(write_registry(tmp_path, document))
+    assert registry["model_cards"][0]["revised"] == "2025-07-01"
+
+    # The revision date is a real cutoff, not a blanket exemption: a benchmark
+    # released after the revision is still impossible.
+    document["benchmarks"][1]["released"] = "2025-08-01"
+    with pytest.raises(ModelCardRegistryError, match="reports benchmarks released after it"):
+        load_registry(write_registry(tmp_path, document))
+
+    # A revision cannot predate the publication it revises.
+    document = minimal_registry()
+    document["model_cards"][0]["published"] = "2025-06-01"
+    document["model_cards"][0]["revised"] = "2025-01-01"
+    with pytest.raises(ModelCardRegistryError, match="precedes its published date"):
+        load_registry(write_registry(tmp_path, document))
+
+    # And it must be a well-formed date, like every other date in the registry.
+    document = minimal_registry()
+    document["model_cards"][0]["revised"] = "last Tuesday"
+    with pytest.raises(ModelCardRegistryError, match="must be an ISO date"):
+        load_registry(write_registry(tmp_path, document))
 
 
 def test_shipped_registry_has_no_chronologically_impossible_mention():
@@ -337,14 +377,15 @@ def test_shipped_registry_has_no_chronologically_impossible_mention():
     }
 
     for card in registry["model_cards"]:
-        published = str(card["published"]) if card.get("published") else ""
-        if not published:
+        # The revision date when the document has one: that is the version the
+        # mentions were read from.
+        cutoff = str(card.get("revised") or card.get("published") or "")
+        if not cutoff:
             continue
         for ref in {str(ref) for ref in card["benchmarks"]}:
             if ref in released:
-                assert released[ref] <= published, (
-                    f"{card['id']} published {published} cannot report {ref} "
-                    f"released {released[ref]}"
+                assert released[ref] <= cutoff, (
+                    f"{card['id']} ({cutoff}) cannot report {ref} released {released[ref]}"
                 )
 
 

--- a/tests/test_model_cards.py
+++ b/tests/test_model_cards.py
@@ -296,6 +296,78 @@ def test_benchmark_release_dates_are_published_and_validated(tmp_path):
         load_registry(write_registry(tmp_path, document))
 
 
+def test_a_card_cannot_report_a_benchmark_that_did_not_exist_yet(tmp_path):
+    """A benchmark released after a card cannot have been reported by it.
+
+    Every date involved is individually well-formed, so no other check catches
+    the contradiction, and the bad edge is invisible in the ranking: it just
+    quietly adds one adoption. The first draft of the 2026 expansion contained
+    three such edges, each a different underlying mistake -- one wrong `released`
+    date and two benchmarks attributed to cards that reported a different
+    instrument -- so this is the check that tells a data error from real data.
+    """
+    document = minimal_registry()
+    document["benchmarks"][0]["released"] = "2025-06-01"
+    document["model_cards"][0]["published"] = "2025-01-01"
+
+    with pytest.raises(ModelCardRegistryError, match="reports benchmarks released after it"):
+        load_registry(write_registry(tmp_path, document))
+
+    # A benchmark with no recorded release date cannot be placed on the
+    # timeline, so it is not evidence of a contradiction either way.
+    document = minimal_registry()
+    document["benchmarks"][0].pop("released", None)
+    document["model_cards"][0]["published"] = "2025-01-01"
+    load_registry(write_registry(tmp_path, document))
+
+    # Same-day is legitimate: benchmarks are routinely published alongside the
+    # card that first reports them (MRCR shipped with GPT-4.1).
+    document = minimal_registry()
+    document["benchmarks"][0]["released"] = "2025-01-01"
+    document["model_cards"][0]["published"] = "2025-01-01"
+    load_registry(write_registry(tmp_path, document))
+
+
+def test_shipped_registry_has_no_chronologically_impossible_mention():
+    registry = load_registry(DEFAULT_REGISTRY_PATH)
+    released = {
+        str(benchmark["id"]): str(benchmark["released"])
+        for benchmark in registry["benchmarks"]
+        if benchmark.get("released")
+    }
+
+    for card in registry["model_cards"]:
+        published = str(card["published"]) if card.get("published") else ""
+        if not published:
+            continue
+        for ref in {str(ref) for ref in card["benchmarks"]}:
+            if ref in released:
+                assert released[ref] <= published, (
+                    f"{card['id']} published {published} cannot report {ref} "
+                    f"released {released[ref]}"
+                )
+
+
+def test_reported_benchmark_order_is_total():
+    """Ordering must not depend on set iteration order.
+
+    Domain and lowercased name can tie between two distinct benchmarks, and the
+    input is a set, so without the id as a final key the published order would
+    vary with PYTHONHASHSEED. The inverse-property test cannot catch that -- it
+    compares sets -- so the ordering is asserted directly.
+    """
+    board = build_adoption_rank(DEFAULT_REGISTRY_PATH)
+
+    for card in board["model_cards"]:
+        keys = [
+            (benchmark["domain"], benchmark["name"].lower(), benchmark["benchmark_id"])
+            for benchmark in card["reported_benchmarks"]
+        ]
+        assert keys == sorted(keys)
+        # A total order has no duplicate keys to break.
+        assert len(set(keys)) == len(keys)
+
+
 def test_registry_covers_the_2026_frontier():
     """The ranking has to describe current reporting, not 2025's.
 

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -375,7 +375,7 @@ def test_leaderboard_filters_use_prefixed_url_keys():
     # filter at once without either view reinterpreting the other's
     # `organization`.
     assert 'id="leaderboard-filters"' in html
-    for key in ("lq", "ldomain", "lorg"):
+    for key in ("lq", "ldomain", "lorg", "lera"):
         assert f'params.set("{key}"' in script
         assert f'params.get("{key}")' in script
 
@@ -384,11 +384,74 @@ def test_leaderboard_filter_handler_reads_controls_not_the_event_target():
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
 
     # Same <select> "input"-before-"change" hazard as issue #43: reading all
-    # three controls from the DOM makes the event ordering irrelevant.
+    # four controls from the DOM makes the event ordering irrelevant.
     handler = script.split('byId("leaderboard-filters").addEventListener("input"', 1)[1]
     body = handler.split("});", 1)[0]
-    for control in ("leaderboard-search", "leaderboard-domain", "leaderboard-organization"):
+    for control in (
+        "leaderboard-search",
+        "leaderboard-domain",
+        "leaderboard-organization",
+        "leaderboard-era",
+    ):
         assert f'byId("{control}")' in body
+
+
+def test_release_date_filter_uses_fixed_eras_not_a_rolling_window():
+    html = Path("site/index.html").read_text(encoding="utf-8")
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    assert 'id="leaderboard-era"' in html
+    # Fixed boundaries, so a shared "?lera=2026" link keeps meaning "released in
+    # 2026" indefinitely rather than drifting into "the last N months".
+    assert "LEADERBOARD_ERAS" in script
+    assert '"2026-01-01"' in script
+    # "Released in 2026" is bounded at both ends. With only a lower bound it
+    # would silently absorb 2027 benchmarks the moment one is added.
+    assert '"2027-01-01"' in script
+    # ISO strings compare directly; no Date parsing means no timezone can move a
+    # benchmark across a year boundary.
+    assert "entry.released < era.from" in script
+    assert "!entry.released) return false" in script
+
+
+def test_unranked_rows_select_their_grid_by_class_not_has():
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+    css = Path("site/assets/styles.css").read_text(encoding="utf-8")
+
+    # This grid template is layout-critical: without it a card heading lands in
+    # the 38px rank column and wraps one character per line. A :has() selector
+    # is dropped whole by browsers that do not support it, restoring exactly
+    # that bug, so the rule is keyed on an explicit class instead.
+    assert "record-summary-unranked" in script
+    assert ".record-summary.record-summary-unranked" in css
+    # Scoped to selectors that set a grid template on a record summary. The
+    # file's other `:has()` use is a hover de-emphasis on the trend chart, which
+    # is cosmetic: a browser that drops it loses an effect, not a layout. This
+    # rule decides column widths, so it must not be droppable.
+    selectors = [
+        line for line in css.splitlines() if line.rstrip().endswith("{") and "*" not in line
+    ]
+    assert not [line for line in selectors if ":has(" in line and "record-summary" in line]
+    # Two classes outrank the single-class mobile rule, so the breakpoint needs
+    # its own override or phones keep the desktop template.
+    mobile = css.split("@media (max-width: 760px)", 1)[1]
+    assert ".record-summary.record-summary-unranked" in mobile
+
+
+def test_model_card_rows_expand_to_the_benchmarks_they_report():
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    # The reverse direction of the registry link. A reader auditing our data
+    # against a vendor PDF needs the card's full benchmark list in one place,
+    # grouped the way the source groups it, plus a link to the source itself.
+    assert "function modelCardRow(card)" in script
+    assert "card.reported_benchmarks" in script
+    assert '"Benchmarks this document reports"' in script
+    assert "card-benchmark-group" in script
+    assert '"Open source document ↗"' in script
+    # Says a mention is not a score at the point where an expanded list would
+    # otherwise read as an extract of the card's results table.
+    assert "These are mentions, not scores" in script
 
 
 def test_leaderboard_degrades_when_the_curated_registry_is_absent():

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -367,6 +367,32 @@ def test_leaderboard_rows_link_back_to_the_model_cards_they_counted():
     assert 'rel: "noopener noreferrer"' in script
 
 
+def test_summary_counts_expand_to_the_records_behind_them():
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+    css = Path("site/assets/styles.css").read_text(encoding="utf-8")
+
+    # A summary count is a claim about specific records. "OpenAI: 5 cards" names
+    # five documents, and a reader who cannot see which five takes it on faith,
+    # so every row in the four registry cards opens to its own contents.
+    assert "insight-row-expandable" in script
+    assert "insightDetailList" in script
+    assert ".map-insight-card li.insight-row-expandable" in css
+    # The plain rows are flex containers; an expandable row has to become a block
+    # so the expanded list can sit beneath its summary rather than beside it.
+    expandable = css.split(".map-insight-card li.insight-row-expandable {", 1)[1]
+    assert "display: block" in expandable.split("}", 1)[0]
+
+
+def test_two_documents_about_one_model_are_labelled_apart():
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    # Z.ai published both a GLM-5 model card and a GLM-5 technical report. Both
+    # are counted, correctly, as separate adoptions, but labelling both
+    # "Z.ai · GLM-5" makes a correct count look like a double-counting bug.
+    assert "labelCounts" in script
+    assert "cardLabel" in script
+
+
 def test_leaderboard_filters_use_prefixed_url_keys():
     html = Path("site/index.html").read_text(encoding="utf-8")
     script = Path("site/assets/app.js").read_text(encoding="utf-8")


### PR DESCRIPTION
Closes part of #83.

## The problem

The registry's newest document was from **July 2025**. It answered "which
benchmarks do vendors report" about a frontier that no longer exists.

| | before | after |
|---|---|---|
| Model cards | 16 | **30** |
| Benchmarks | 32 | **73** |
| Organizations | 8 | **10** |
| Cards published in 2026 | 0 | **13** |

## Sources

Every row was read from a primary vendor document, not a secondary summary:

- **Anthropic** — Claude Opus 5 (2026-07-24), Claude Fable 5 / Mythos 5 (2026-06-09)
- **OpenAI** — GPT-5.6 release post (2026-06-26), GPT-5.6 preview system card (2026-07-09)
- **Google DeepMind** — Gemini 3.1 Pro model card (2026-02-19), Gemma 4 (2026-03-11)
- **Qwen** — Qwen3.5-397B-A17B (2026-02-16)
- **DeepSeek** — V4-Pro card (2026-04-22) and the V4 technical report (arXiv 2606.19348)
- **Moonshot AI** — Kimi K3 (2026-06-13) · new organization
- **Z.ai** — GLM-5 card and paper (2026-02-11) · new organization
- **xAI** — Grok 4.5 (2026-07-08)
- **Mistral** — Mistral Large 3 675B (2025-11-28)
- **Meta** — Llama 4, enriched by OCR'ing the Maverick comparison PNG linked in the issue thread (adds ChartQA, DocVQA, MTOB, Multilingual MMLU)

## What the data shows

The headline moved from static QA sets to harness-dependent agentic evaluations:
Terminal-Bench, SWE-bench Pro, tau2-bench, MCP Atlas, OSWorld, GDPval. MMLU and
HumanEval still appear, but in base-model tables rather than the lead.

**GPQA Diamond is now the only benchmark reported by all 10 organizations** (23 of
30 cards). Several 2026 headline benchmarks are also published by a party with a
stake in the result — Cognition's Frontier-Bench, Cursor's CursorBench, Zapier's
AutomationBench, the Artificial Analysis `-AA` variants — so each caveat says so,
since an adoption count cannot.

## Also in this PR

**Release dates per data point.** Every benchmark carries `released`, its own
publication date, with a "Benchmark released" filter over fixed eras. Adoption
count and instrument age are different facts: a 2020 benchmark with nine cards
and a 2026 benchmark with nine cards say different things.

**Expandable model cards.** "Model cards in the registry" was a flat table whose
Benchmarks column was a number. Each row now expands to every benchmark it
reports, grouped the way the source document groups them, so our data can be
checked line by line against the original PDF or blog post.

**A deterministic dual link.** `entries[].adopters` and
`model_cards[].reported_benchmarks` are exact inverses derived from one edge set
(324 edges each way), asserted by `test_adoption_rank_links_are_exact_inverses`.
Output is byte-identical across four `PYTHONHASHSEED` values.

## Review

Codex review found a **[P1]**: three chronologically impossible edges where a card
reported a benchmark released *after* the card was published. All three were real
errors, each with a different cause:

- Terminal-Bench dated 2025-05-27; it launched 2025-05-19. Wrong date, real mention.
- Gemini 1.5 (2024-03) credited with Video-MME (2024-05). Wrong mention.
- Llama 4 (2025-04-05) credited with MRCR, which shipped with GPT-4.1 on 2025-04-14. Wrong mention: that table's long-context rows are MTOB.

`load_registry` now rejects the whole class, with an opt-in `revised` date for
documents legitimately updated after publication. No shipped card needs it. Four
further [P2]s were fixed: reverse-link ordering determinism, the 2026 era upper
bound, a layout-critical `:has()` selector, and its mobile breakpoint override.

## Verification

- 247 tests pass (was 236); `ruff check` and `ruff format` clean
- Rendering verified in a real browser at 1440px and 420px, including the
  expandable cards, the era filter, and the permalink round-trip
- Zero chronologically impossible edges in the shipped registry
- Zero benchmarks tracked but reported by nobody

🤖 Generated with [Claude Code](https://claude.com/claude-code)