### PR TITLE
Read the Fable 5 / Mythos 5 benchmark table and order the registry by date

### DIFF
--- a/data/model_cards.yml
+++ b/data/model_cards.yml
@@ -722,14 +722,115 @@ benchmarks:
 
   - id: exploitbench
     name: ExploitBench
-    aliases: ["ExploitBench"]
+    aliases: ["ExploitBench", "ExploitBench (Cap%)"]
     domain: security
     url: https://deploymentsafety.openai.com/gpt-5-6-preview
-    released: 2026-06-26
+    # Dated to the earliest document observed reporting it, Anthropic's
+    # 2026-06-09 Fable 5 / Mythos 5 comparison table, not to the GPT-5.6 preview
+    # the URL points at. The previous 2026-06-26 date was that preview's own
+    # publication date, which is a claim about when OpenAI reported the
+    # benchmark rather than when the instrument existed, and it post-dated a
+    # card that demonstrably measures against it.
+    released: 2026-06-09
     caveat: >-
       Offensive-security capability measured as a risk indicator against a
-      preparedness threshold, not a leaderboard to top. Only OpenAI has
-      published against it so far.
+      preparedness threshold, not a leaderboard to top. Reported as a
+      capability percentage, and no public specification of the task set has
+      been published, so the number cannot be independently reproduced.
+
+  # ---------------------------------------------------------------------------
+  # Instruments first observed in Anthropic's 2026-06-09 Claude Fable 5 /
+  # Mythos 5 comparison table (issue #90). That table is published as an image,
+  # so these names are absent from the page text and were missed by every
+  # text-based pass over the release.
+  #
+  # Several are vendor-internal: Anthropic names them in its own comparison
+  # table without publishing a task specification, so there is nothing to link
+  # to and nothing a third party can reproduce. They are recorded because the
+  # adoption count measures what vendors put in front of readers, and an
+  # unreproducible instrument in a headline table is exactly that. Their
+  # caveats carry the warning the missing URL would otherwise leave implicit.
+  # ---------------------------------------------------------------------------
+
+  - id: frontiercode
+    name: FrontierCode
+    aliases: ["FrontierCode", "FrontierCode (Diamond)"]
+    domain: coding_agent
+    url: https://cognition.ai/blog/frontier-bench
+    released: 2026-05-19
+    caveat: >-
+      Cognition's production-standard coding evaluation, distinct from that
+      vendor's Frontier-Bench despite the shared prefix and blog. Reported per
+      reasoning-effort setting (the Diamond subset at xhigh), so the effort
+      level has to travel with the number. First-party to a competing coding
+      agent's vendor.
+
+  - id: blueprint_bench_2
+    name: Blueprint-Bench 2
+    aliases: ["Blueprint-Bench 2", "Blueprint-Bench", "BlueprintBench 2"]
+    domain: spatial_reasoning
+    url: null
+    released: 2026-06-09
+    caveat: >-
+      Spatial-reasoning set named in Anthropic's comparison table with no
+      published task specification, so scores cannot be reproduced or audited
+      outside the vendor.
+
+  - id: legal_agent_benchmark
+    name: Legal Agent Benchmark
+    aliases: ["Legal Agent Benchmark"]
+    domain: legal
+    url: null
+    released: 2026-06-09
+    caveat: >-
+      Absolute scores are very low across all models (0-13%), so ordering at
+      the top is decided by a handful of tasks and small gaps are noise. No
+      public task specification.
+
+  - id: biomysterybench
+    name: BioMysteryBench
+    aliases: ["BioMysteryBench"]
+    domain: biology
+    url: null
+    released: 2026-06-09
+    caveat: >-
+      Reported in two splits ("hard" and "human solved") that differ by more
+      than 35 points, so a bare score is unreadable without its split.
+      Anthropic notes its own safety refusals depress this number, which means
+      the score mixes capability with policy.
+
+  - id: gdp_pdf
+    name: GDP.pdf
+    aliases: ["GDP.pdf"]
+    domain: multimodal
+    url: null
+    released: 2026-06-09
+    caveat: >-
+      Vision-based knowledge work, reported no-tools. Named in Anthropic's
+      table without a published specification; the name resembles GDPval but
+      the two are separate instruments and must not be merged.
+
+  - id: vibench
+    name: ViBench
+    aliases: ["ViBench"]
+    domain: coding_agent
+    url: null
+    released: 2026-06-09
+    caveat: >-
+      Anthropic's own end-to-end vibe-coding benchmark, described in prose
+      rather than scored in the table. First-party to the vendor reporting it,
+      with no published task set.
+
+  - id: healthbench_professional
+    name: HealthBench Professional
+    aliases: ["HealthBench Professional"]
+    domain: health
+    url: https://openai.com/index/healthbench/
+    released: 2026-06-09
+    caveat: >-
+      A distinct, harder split from the HealthBench variants recorded
+      separately in this registry, so its scores are not comparable to them.
+      Graded by an LLM against physician-written rubrics.
 
 # Model cards, technical reports and release posts.
 #
@@ -1073,6 +1174,13 @@ model_cards:
       - swe_bench_pro
       - terminal_bench
 
+  # The headline comparison table in this release is published as an image, so
+  # a text-only reading of the page sees only the benchmarks named in prose.
+  # The first pass recorded five entries, two of which (BrowseComp, SWE-bench
+  # Verified) appear nowhere in the release at all, and missed the thirteen
+  # instruments the table actually leads with. Issue #90 asked for the table to
+  # be read directly; the list below is transcribed from it, plus the three
+  # benchmarks named only in the surrounding prose.
   - id: anthropic_claude_fable_5_mythos_5
     organization: Anthropic
     model: Claude Fable 5 and Mythos 5
@@ -1081,11 +1189,24 @@ model_cards:
     url: https://www.anthropic.com/news/claude-fable-5-mythos-5
     retrieved_at: 2026-08-02
     benchmarks:
+      # From the comparison table, in the order it lists them.
+      - swe_bench_pro
+      - frontiercode
+      - gdpval
+      - gdp_pdf
+      - blueprint_bench_2
+      - automationbench
+      - osworld
+      - legal_agent_benchmark
+      - hle
+      - biomysterybench
+      - terminal_bench
+      - exploitbench
+      - healthbench_professional
+      # Named in prose rather than scored in the table.
       - frontier_bench
       - cursor_bench
-      - browsecomp
-      - terminal_bench
-      - swe_bench_verified
+      - vibench
 
   - id: openai_gpt_5_6_system_card
     organization: OpenAI

--- a/data/model_cards.yml
+++ b/data/model_cards.yml
@@ -728,18 +728,20 @@ benchmarks:
     aliases: ["ExploitBench", "ExploitBench (Cap%)"]
     domain: security
     url: https://deploymentsafety.openai.com/gpt-5-6-preview
-    # Dated to the earliest document observed reporting it, Anthropic's
-    # 2026-06-09 Fable 5 / Mythos 5 comparison table, not to the GPT-5.6 preview
-    # the URL points at. The previous 2026-06-26 date was that preview's own
-    # publication date, which is a claim about when OpenAI reported the
-    # benchmark rather than when the instrument existed, and it post-dated a
-    # card that demonstrably measures against it.
-    released: 2026-06-09
+    # Unset rather than guessed. This previously carried 2026-06-26, the
+    # publication date of the GPT-5.6 preview the URL points at, which records
+    # when OpenAI reported the benchmark rather than when the instrument was
+    # published. That reading was demonstrably wrong: Anthropic's 2026-06-09
+    # table already measures against it. The earlier date is evidence the
+    # benchmark existed by then, but "first seen" is not a release date, and
+    # this field's contract is to say nothing rather than carry a guess.
+    released: null
     caveat: >-
       Offensive-security capability measured as a risk indicator against a
       preparedness threshold, not a leaderboard to top. Reported as a
       capability percentage, and no public specification of the task set has
-      been published, so the number cannot be independently reproduced.
+      been published, so the number cannot be independently reproduced. In use
+      by 2026-06-09; no announced publication date.
 
   # ---------------------------------------------------------------------------
   # Instruments first observed in Anthropic's 2026-06-09 Claude Fable 5 /
@@ -760,7 +762,10 @@ benchmarks:
     aliases: ["FrontierCode", "FrontierCode (Diamond)"]
     domain: coding_agent
     url: https://cognition.ai/blog/frontier-bench
-    released: 2026-05-19
+    # Unset: 2026-05-19 is Frontier-Bench's release date, and assuming this
+    # shares it because both are Cognition's would be a guess about a separate
+    # instrument.
+    released: null
     caveat: >-
       Cognition's production-standard coding evaluation, distinct from that
       vendor's Frontier-Bench despite the shared prefix and blog. Reported per
@@ -773,7 +778,7 @@ benchmarks:
     aliases: ["Blueprint-Bench 2", "Blueprint-Bench", "BlueprintBench 2"]
     domain: spatial_reasoning
     url: null
-    released: 2026-06-09
+    released: null
     caveat: >-
       Spatial-reasoning set named in Anthropic's comparison table with no
       published task specification, so scores cannot be reproduced or audited
@@ -784,7 +789,7 @@ benchmarks:
     aliases: ["Legal Agent Benchmark"]
     domain: legal
     url: null
-    released: 2026-06-09
+    released: null
     caveat: >-
       Absolute scores are very low across all models (0-13%), so ordering at
       the top is decided by a handful of tasks and small gaps are noise. No
@@ -795,7 +800,7 @@ benchmarks:
     aliases: ["BioMysteryBench"]
     domain: biology
     url: null
-    released: 2026-06-09
+    released: null
     caveat: >-
       Reported in two splits ("hard" and "human solved") that differ by more
       than 35 points, so a bare score is unreadable without its split.
@@ -807,7 +812,7 @@ benchmarks:
     aliases: ["GDP.pdf"]
     domain: multimodal
     url: null
-    released: 2026-06-09
+    released: null
     caveat: >-
       Vision-based knowledge work, reported no-tools. Named in Anthropic's
       table without a published specification; the name resembles GDPval but
@@ -818,7 +823,7 @@ benchmarks:
     aliases: ["ViBench"]
     domain: coding_agent
     url: null
-    released: 2026-06-09
+    released: null
     caveat: >-
       Anthropic's own end-to-end vibe-coding benchmark, described in prose
       rather than scored in the table. First-party to the vendor reporting it,
@@ -829,7 +834,10 @@ benchmarks:
     aliases: ["HealthBench Professional"]
     domain: health
     url: https://openai.com/index/healthbench/
-    released: 2026-06-09
+    # Unset: the Professional split postdates HealthBench's own 2025-05-12
+    # release, but no announcement dates it, and the 2026-06-09 table that
+    # reports it only establishes when it was first seen in use.
+    released: null
     caveat: >-
       A distinct, harder split from the HealthBench variants recorded
       separately in this registry, so its scores are not comparable to them.

--- a/data/model_cards.yml
+++ b/data/model_cards.yml
@@ -506,7 +506,10 @@ benchmarks:
 
   - id: healthbench
     name: HealthBench
-    aliases: ["HealthBench", "HealthBench Hard", "HealthBench Consensus", "HealthBench Professional"]
+    # "HealthBench Professional" is deliberately absent: it is a distinct
+    # harder split with its own id, and leaving it here would let an extractor
+    # resolve one spelling to two benchmarks.
+    aliases: ["HealthBench", "HealthBench Hard", "HealthBench Consensus"]
     domain: health
     url: https://openai.com/index/healthbench/
     released: 2025-05-12

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -1635,11 +1635,20 @@ function renderLeaderboard() {
     card.url,
   ];
   const benchmarkLink = (entry) => [entry.name, entry.url];
-  // Sorted by publisher then date so an expanded list reads as a roster rather
-  // than as a second implied ranking, matching the model card table below.
-  const byOrganization = (a, b) =>
+  // Newest first, matching the model card table below (issue #90). This list
+  // and that table are two views of one roster, so they have to agree: sorting
+  // this one by publisher while the table ran by date made the same registry
+  // look like two different registries depending on where you read it.
+  //
+  // A card with no date sorts last here for the same reason it does in
+  // `adoption_rank`: an unknown date is not evidence of recency. Organization
+  // then model break ties so the order is total rather than dependent on the
+  // input sequence.
+  const byNewestFirst = (a, b) =>
+    Number(!a.published) - Number(!b.published) ||
+    (b.published || "").localeCompare(a.published || "") ||
     a.organization.localeCompare(b.organization) ||
-    (a.published || "").localeCompare(b.published || "");
+    String(a.model).localeCompare(String(b.model));
 
   replaceChildren(byId("leaderboard-insights"), [
     mapInsightCard(
@@ -1648,7 +1657,7 @@ function renderLeaderboard() {
         [
           "Model cards",
           Number(board.model_card_count || 0).toLocaleString(),
-          [...allCards].sort(byOrganization).map(cardLink),
+          [...allCards].sort(byNewestFirst).map(cardLink),
         ],
         [
           "Organizations",

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -1644,11 +1644,16 @@ function renderLeaderboard() {
   // `adoption_rank`: an unknown date is not evidence of recency. Organization
   // then model break ties so the order is total rather than dependent on the
   // input sequence.
+  // The trailing document_type and id keys match the backend's: Z.ai's GLM-5
+  // model card and technical report tie on date, organization and model, so
+  // without them the two rosters could disagree on that pair.
   const byNewestFirst = (a, b) =>
     Number(!a.published) - Number(!b.published) ||
     (b.published || "").localeCompare(a.published || "") ||
     a.organization.localeCompare(b.organization) ||
-    String(a.model).localeCompare(String(b.model));
+    String(a.model).localeCompare(String(b.model)) ||
+    String(a.document_type).localeCompare(String(b.document_type)) ||
+    String(a.model_card_id).localeCompare(String(b.model_card_id));
 
   replaceChildren(byId("leaderboard-insights"), [
     mapInsightCard(

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -1694,7 +1694,10 @@ function renderLeaderboard() {
           metricLabel(count, "card"),
           allCards
             .filter((card) => card.organization === organization)
-            .sort((a, b) => (a.published || "").localeCompare(b.published || ""))
+            // Newest first, like every other roster on this view. Sorting a
+            // vendor's own history the other way put its oldest release at the
+            // top of the one list where the comparison is easiest to make.
+            .sort(byNewestFirst)
             .map((card) => [`${card.model} — ${card.document_type.replaceAll("_", " ")}`, card.url]),
         ]),
       "No organizations in the registry yet.",

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -1647,13 +1647,20 @@ function renderLeaderboard() {
   // The trailing document_type and id keys match the backend's: Z.ai's GLM-5
   // model card and technical report tie on date, organization and model, so
   // without them the two rosters could disagree on that pair.
+  //
+  // Compared by codepoint rather than with `localeCompare`, because the
+  // backend sorts Python strings and the two disagree on case: `localeCompare`
+  // puts "xAI" before "Xai", Python puts it after. No two registry entries
+  // currently differ only in capitalization, so this changes nothing today --
+  // it stops the same class of split-ordering bug the tie-breakers above fix.
+  const codepoint = (a, b) => (a < b ? -1 : a > b ? 1 : 0);
   const byNewestFirst = (a, b) =>
     Number(!a.published) - Number(!b.published) ||
-    (b.published || "").localeCompare(a.published || "") ||
-    a.organization.localeCompare(b.organization) ||
-    String(a.model).localeCompare(String(b.model)) ||
-    String(a.document_type).localeCompare(String(b.document_type)) ||
-    String(a.model_card_id).localeCompare(String(b.model_card_id));
+    codepoint(b.published || "", a.published || "") ||
+    codepoint(String(a.organization), String(b.organization)) ||
+    codepoint(String(a.model), String(b.model)) ||
+    codepoint(String(a.document_type), String(b.document_type)) ||
+    codepoint(String(a.model_card_id), String(b.model_card_id));
 
   replaceChildren(byId("leaderboard-insights"), [
     mapInsightCard(

--- a/src/benchmark_radar/model_cards.py
+++ b/src/benchmark_radar/model_cards.py
@@ -67,6 +67,30 @@ def _benchmark_summary(benchmark: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+class _descending:
+    """Sort one key in reverse while its tie-breakers stay ascending.
+
+    `sorted(reverse=True)` reverses the whole tuple, which would also flip
+    organization and model into Z-to-A for cards sharing a date. Negating the
+    key is the usual alternative and is unavailable here: these are ISO date
+    strings, not numbers. Wrapping just the date inverts that one comparison
+    and leaves the rest of the tuple alone.
+    """
+
+    __slots__ = ("value",)
+
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, _descending):
+            return NotImplemented
+        return self.value == other.value
+
+    def __lt__(self, other: _descending) -> bool:
+        return other.value < self.value
+
+
 class ModelCardRegistryError(ValueError):
     """Raised when the curated registry is internally inconsistent."""
 
@@ -350,8 +374,17 @@ def adoption_rank(registry: dict[str, Any]) -> dict[str, Any]:
         "organization_count": len(organization_totals),
         "organizations": dict(sorted(organization_totals.items())),
         "domains": dict(sorted(domain_totals.items())),
-        # Sorted by publisher then date so the model list reads as a roster
-        # rather than as a second, implied ranking.
+        # Sorted newest first (issue #90). The previous publisher-then-date
+        # order grouped a vendor's whole history together, which buried this
+        # month's frontier cards under whichever organization sorted first
+        # alphabetically: the newest document in the registry sat halfway down
+        # the list. Date is what a reader scanning this roster is actually
+        # looking for, and it is the one key that is comparable across vendors.
+        #
+        # A card with no published date sorts last rather than first: `None`
+        # means the date was never established, and an unknown date is not
+        # evidence of recency. Organization then model break ties so the order
+        # stays total and deterministic for cards sharing a date.
         "model_cards": sorted(
             (
                 {
@@ -403,7 +436,12 @@ def adoption_rank(registry: dict[str, Any]) -> dict[str, Any]:
                 }
                 for card in cards
             ),
-            key=lambda card: (card["organization"], card["published"] or "", card["model"]),
+            key=lambda card: (
+                card["published"] is None,
+                _descending(card["published"] or ""),
+                card["organization"],
+                card["model"],
+            ),
         ),
         "entries": entries,
         # Stated in the data rather than only in the UI, so any consumer of

--- a/src/benchmark_radar/model_cards.py
+++ b/src/benchmark_radar/model_cards.py
@@ -441,6 +441,14 @@ def adoption_rank(registry: dict[str, Any]) -> dict[str, Any]:
                 _descending(card["published"] or ""),
                 card["organization"],
                 card["model"],
+                # Z.ai published a GLM-5 model card and a GLM-5 technical
+                # report on the same day, which ties every key above. Without
+                # a unique final key their order would follow their position in
+                # the YAML file, so editing an unrelated part of the registry
+                # could reorder the published roster. The id is the only field
+                # guaranteed distinct.
+                card["document_type"],
+                card["model_card_id"],
             ),
         ),
         "entries": entries,

--- a/tests/test_model_cards.py
+++ b/tests/test_model_cards.py
@@ -428,6 +428,110 @@ def test_registry_covers_the_2026_frontier():
     assert {"terminal_bench", "swe_bench_pro", "tau2_bench", "gdpval", "osworld"} <= names
 
 
+def test_model_cards_are_listed_newest_first(tmp_path):
+    """Issue #90: the roster is ordered by date, not by publisher.
+
+    Grouping by organization first buried the newest documents behind whichever
+    vendor sorted earliest alphabetically, which is the opposite of what a
+    reader scanning a registry of frontier releases wants.
+    """
+    document = minimal_registry()
+    # A third card from the alphabetically-first organization, published last.
+    # Under the old publisher-then-date order this sorted second; the date is
+    # what has to decide it now.
+    document["model_cards"].append(
+        {
+            "id": "org_one_newer",
+            "organization": "Org One",
+            "model": "One Point One",
+            "document_type": "model_card",
+            "published": "2025-06-01",
+            "url": "https://example.com/one-newer",
+            "benchmarks": ["beta"],
+        }
+    )
+    board = adoption_rank(load_registry(write_registry(tmp_path, document)))
+
+    assert [card["model_card_id"] for card in board["model_cards"]] == [
+        "org_one_newer",
+        "org_two_card",
+        "org_one_card",
+    ]
+
+
+def test_undated_model_cards_sort_last_not_first(tmp_path):
+    """An unknown date is not evidence of recency.
+
+    A missing `published` normalises to the empty string, which would sort
+    ahead of every real date under a plain descending comparison and put the
+    least-known documents at the top of a list that claims to be newest-first.
+    """
+    document = minimal_registry()
+    document["model_cards"].append(
+        {
+            "id": "undated_card",
+            "organization": "Org Three",
+            "model": "Three",
+            "document_type": "model_card",
+            "url": "https://example.com/three",
+            "benchmarks": ["alpha"],
+        }
+    )
+    board = adoption_rank(load_registry(write_registry(tmp_path, document)))
+
+    assert board["model_cards"][-1]["model_card_id"] == "undated_card"
+    assert board["model_cards"][-1]["published"] is None
+
+
+def test_shipped_registry_is_ordered_by_date():
+    board = build_adoption_rank(DEFAULT_REGISTRY_PATH)
+
+    published = [card["published"] for card in board["model_cards"]]
+    dated = [value for value in published if value]
+    # Every dated card precedes every undated one, and the dated run descends.
+    assert published[: len(dated)] == dated
+    assert dated == sorted(dated, reverse=True)
+
+
+def test_fable_mythos_card_records_its_full_comparison_table():
+    """Issue #90: the release's benchmark table is an image.
+
+    A text-only reading of the page saw three benchmarks named in prose and
+    invented two more that appear nowhere in the release. The table itself
+    carries thirteen, and they are the ones the release leads with, so their
+    absence understated the adoption of every instrument in it.
+    """
+    board = build_adoption_rank(DEFAULT_REGISTRY_PATH)
+
+    card = next(
+        entry
+        for entry in board["model_cards"]
+        if entry["model_card_id"] == "anthropic_claude_fable_5_mythos_5"
+    )
+    reported = set(card["benchmarks"])
+
+    # Transcribed from the comparison table in the release post.
+    assert {
+        "swe_bench_pro",
+        "frontiercode",
+        "gdpval",
+        "gdp_pdf",
+        "blueprint_bench_2",
+        "automationbench",
+        "osworld",
+        "legal_agent_benchmark",
+        "hle",
+        "biomysterybench",
+        "terminal_bench",
+        "exploitbench",
+        "healthbench_professional",
+    } <= reported
+    # Named in the prose but not scored in the table.
+    assert {"frontier_bench", "cursor_bench", "vibench"} <= reported
+    # Recorded by an earlier pass but absent from the release entirely.
+    assert not ({"browsecomp", "swe_bench_verified"} & reported)
+
+
 def test_adopters_link_back_to_the_source_document():
     board = build_adoption_rank(DEFAULT_REGISTRY_PATH)
 

--- a/tests/test_model_cards.py
+++ b/tests/test_model_cards.py
@@ -459,6 +459,38 @@ def test_model_cards_are_listed_newest_first(tmp_path):
     ]
 
 
+def test_card_order_does_not_depend_on_registry_file_order(tmp_path):
+    """Two documents about one model on one day must still order totally.
+
+    Z.ai published a GLM-5 model card and a GLM-5 technical report on the same
+    date, tying organization, model and published. Without a unique final key
+    their relative order follows their position in the YAML file, so editing an
+    unrelated part of the registry could silently reorder the roster.
+    """
+    document = minimal_registry()
+    for suffix in ("model_card", "technical_report"):
+        document["model_cards"].append(
+            {
+                "id": f"org_one_{suffix}",
+                "organization": "Org One",
+                "model": "Twin",
+                "document_type": suffix,
+                "published": "2025-03-01",
+                "url": f"https://example.com/twin-{suffix}",
+                "benchmarks": ["alpha"],
+            }
+        )
+    forward = adoption_rank(load_registry(write_registry(tmp_path, document)))
+
+    reversed_document = minimal_registry()
+    reversed_document["model_cards"].extend(reversed(document["model_cards"][2:]))
+    backward = adoption_rank(load_registry(write_registry(tmp_path, reversed_document)))
+
+    assert [card["model_card_id"] for card in forward["model_cards"]] == [
+        card["model_card_id"] for card in backward["model_cards"]
+    ]
+
+
 def test_undated_model_cards_sort_last_not_first(tmp_path):
     """An unknown date is not evidence of recency.
 

--- a/tests/test_model_cards.py
+++ b/tests/test_model_cards.py
@@ -532,6 +532,35 @@ def test_fable_mythos_card_records_its_full_comparison_table():
     assert not ({"browsecomp", "swe_bench_verified"} & reported)
 
 
+def test_new_benchmarks_do_not_reuse_an_existing_benchmarks_alias():
+    """A spelling must not resolve to two different benchmarks.
+
+    Aliases exist so a future extractor can map vendor spellings onto one id.
+    Splitting a benchmark out of a broader entry -- HealthBench Professional
+    out of HealthBench -- leaves that spelling claimed by both unless it is
+    removed from the entry it left, and the extractor would then have no way
+    to decide which id a card meant.
+
+    Scoped to the benchmarks touched here: three older collisions predate this
+    change and resolving them means deciding what those cards actually
+    reported, which is a separate piece of work.
+    """
+    registry = load_registry(DEFAULT_REGISTRY_PATH)
+
+    claimed: dict[str, set[str]] = {}
+    for benchmark in registry["benchmarks"]:
+        spellings = {str(benchmark["name"])} | {
+            str(alias) for alias in benchmark.get("aliases") or []
+        }
+        for spelling in spellings:
+            claimed.setdefault(spelling.strip().lower(), set()).add(str(benchmark["id"]))
+
+    for spelling in ("healthbench professional", "frontiercode", "vibench"):
+        assert len(claimed.get(spelling, set())) == 1, (
+            f"{spelling!r} resolves to more than one benchmark id"
+        )
+
+
 def test_adopters_link_back_to_the_source_document():
     board = build_adoption_rank(DEFAULT_REGISTRY_PATH)
 


### PR DESCRIPTION
Fixes #90.

## The image table

The release states its headline results in an image, so the pass that built this card could only see the benchmarks named in prose. It recorded five, two of which appear nowhere in the release.

Reading the table directly gives 13 benchmarks. Combined with the three named only in prose, the card goes from 5 to 16.

| | Benchmarks |
|---|---|
| Added from the table | SWE-bench Pro, FrontierCode, GDPval, GDP.pdf, Blueprint-Bench 2, AutomationBench, OSWorld, Legal Agent Benchmark, HLE, BioMysteryBench, Terminal-Bench, ExploitBench, HealthBench Professional |
| Kept, named in prose | Frontier-Bench, CursorBench, ViBench |
| Removed, absent from the release | BrowseComp, SWE-bench Verified |

Two things the transcription turned up:

- **FrontierCode and Frontier-Bench are two different Cognition evaluations.** The release scores them separately. Merging them on the shared prefix would double one adoption and erase the other.
- **ExploitBench carried a wrong release date.** It was dated from the GPT-5.6 preview it links to, which post-dates a table that measures against it. That date is now unset rather than re-guessed, along with seven others (see below).

Five of the new benchmarks are vendor-internal, with no published task specification. They carry no URL, and their caveats say why the score cannot be reproduced rather than leaving the gap unexplained.

## Ordering

`model_cards` sorted by publisher then date, which grouped each vendor's whole history together and left the newest document in the registry halfway down the list. It now sorts newest first.

Details worth noting:

- Descending needs a `_descending` wrapper, not `reverse=True` — the latter would also flip the tie-breakers to Z-to-A.
- Undated cards sort last. An unknown date is not evidence of recency.
- The key ends in `document_type` and the id. Z.ai's GLM-5 model card and technical report tie on every other key, so without them the roster followed YAML file order.
- The dashboard had two more copies of the old ordering (the "Registry coverage" list, and the per-organization roster). All three now agree, and the JS comparator compares by codepoint so it cannot diverge from the Python sort on case.

## Test plan

- `pytest -q` — 255 pass (6 new tests)
- `ruff check .` and `ruff format --check .` — clean
- Each new test verified to fail against the pre-change behavior, so they are real regression guards
- Output is byte-identical across `PYTHONHASHSEED` 0/7/99
- The JS comparator is extracted verbatim from `app.js` and checked against the generated `radar.json`: both rosters produce identical order

## Not done

**No browser visual review.** This environment has no display, and headless Chrome could not render the 7.9MB `radar.json`. The JS was verified under Node against real data, but nobody has looked at the page. Worth a visual check on the leaderboard view before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)