### PR TITLE
Bump the version to 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "benchmark-radar"
-version = "0.2.0"
+version = "0.3.0"
 description = "Daily evidence-first radar for AI benchmarks, evaluations, datasets, and data quality."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/benchmark_radar/__init__.py
+++ b/src/benchmark_radar/__init__.py
@@ -1,3 +1,3 @@
 """Evidence-first daily radar for AI benchmarks and data."""
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"


### PR DESCRIPTION
Prepares the v0.3.0 release.

v0.2.0 shipped the landscape report. Since then the Model Card Adoption Rank leaderboard landed as a new user-facing view, which makes this a minor release rather than a patch.

Two version strings move together: `pyproject.toml` is what the package publishes, `benchmark_radar.__version__` is what the code reports.

## Test plan

- `pytest -q` — 255 pass
- `ruff check .` — clean
- Confirmed both version strings read `0.3.0` and agree

🤖 Generated with [Claude Code](https://claude.com/claude-code)