### PR TITLE
Merge Frontier-Bench into the Terminal-Bench series

### DIFF
--- a/data/model_cards.yml
+++ b/data/model_cards.yml
@@ -107,6 +107,10 @@ benchmarks:
       - "Terminal-Bench 2.1"
       - "Terminal Bench 2"
       - "TerminalBench Hard"
+      - "Frontier-Bench"
+      - "FrontierBench"
+      - "Frontier-Bench v0.1"
+      - "FrontierSWE"
     domain: agent
     url: https://www.tbench.ai/
     released: 2025-05-19
@@ -114,7 +118,11 @@ benchmarks:
       Environment image, timeout and permitted commands change results
       independently of the model. Version and harness both matter: 2.0 and 2.1
       are different instruments, and cards report Terminus, Claude Code and
-      Codex harness numbers for the same version.
+      Codex harness numbers for the same version. Frontier-Bench is the
+      successor instrument in the same series, from the same maintainers and
+      the same harbor-framework repository, and its scores are counted here;
+      it is a distinct task set, so a Frontier-Bench number is not comparable
+      to a Terminal-Bench 2.x number.
 
   - id: livecodebench
     name: LiveCodeBench
@@ -473,16 +481,6 @@ benchmarks:
     caveat: >-
       Screen resolution, OS image and action space all change results. The
       Verified and 2.0 revisions are not comparable to the original.
-
-  - id: frontier_bench
-    name: Frontier-Bench
-    aliases: ["Frontier-Bench", "FrontierBench", "Frontier-Bench v0.1", "FrontierSWE"]
-    domain: coding_agent
-    url: https://cognition.ai/blog/frontier-bench
-    released: 2026-05-19
-    caveat: >-
-      Published by Cognition, a vendor of a competing coding agent, and run in
-      its own harness. Treat it as first-party to that harness.
 
   - id: cursor_bench
     name: CursorBench
@@ -1049,9 +1047,9 @@ model_cards:
   #     OSWorld, GDPval). MMLU and HumanEval still appear, but in base-model
   #     tables, not in the lead.
   #   * Several 2026 headline benchmarks are published by a commercial party
-  #     with a stake in the result (Cognition's Frontier-Bench, Cursor's
-  #     CursorBench, Zapier's AutomationBench, Artificial Analysis's -AA
-  #     variants). Their per-benchmark caveats say so; the adoption count cannot.
+  #     with a stake in the result (Cursor's CursorBench, Zapier's
+  #     AutomationBench, Artificial Analysis's -AA variants). Their
+  #     per-benchmark caveats say so; the adoption count cannot.
   # ---------------------------------------------------------------------------
 
   - id: anthropic_claude_opus_5_system_card
@@ -1062,7 +1060,6 @@ model_cards:
     url: https://www.anthropic.com/news/claude-opus-5
     retrieved_at: 2026-08-02
     benchmarks:
-      - frontier_bench
       - cursor_bench
       - arc_agi_3
       - automationbench
@@ -1081,7 +1078,6 @@ model_cards:
     url: https://www.anthropic.com/news/claude-fable-5-mythos-5
     retrieved_at: 2026-08-02
     benchmarks:
-      - frontier_bench
       - cursor_bench
       - browsecomp
       - terminal_bench
@@ -1274,7 +1270,6 @@ model_cards:
       - aa_lcr
       - hle
       - terminal_bench
-      - frontier_bench
       - posttrainbench
       - scicode
       - browsecomp


### PR DESCRIPTION
Closes #94.

## Verification

The issue's claim holds, though not for the reason the registry assumed:

- `harbor-framework/frontier-bench` is in the **same GitHub org** as `terminal-bench`, `terminal-bench-2`, `terminal-bench-2-1`, and `terminal-bench-science`.
- Its README calls it "the successor project to Terminal-Bench", led by the Terminal-Bench maintainers (Konwinski, Schmidt) and co-hosted by the Laude Institute.
- It is listed on tbench.ai's own benchmarks page.

## Two errors found along the way

The standalone entry was wrong beyond simply being unmerged:

- It credited **Cognition** as publisher and told readers to treat the scores as vendor first-party. Cognition has no involvement in this benchmark.
- Its URL `cognition.ai/blog/frontier-bench` **404s**.

Both claims also appeared in the 2026 header comment, which is corrected here.

## The change

Only `data/model_cards.yml`:

- Frontier-Bench's four aliases move onto `terminal_bench`, so existing mentions still resolve.
- The standalone `frontier_bench` entry is removed.
- `frontier_bench` is dropped from the three cards that cited it.
- The caveat records that a Frontier-Bench number is a different task set than a Terminal-Bench 2.x number, even though both now count toward one series.

Adoption counts are unchanged because all three cards citing `frontier_bench` (`anthropic_claude_opus_5_system_card`, `anthropic_claude_fable_5_mythos_5`, `moonshot_kimi_k3_model_card`) **already** cited `terminal_bench`, and counting dedupes per card via a set (`model_cards.py:285`). So the merge neither double-counts nor drops an adopter.

## Results

- Tests: **249 passed**, matching the pre-change baseline.
- `terminal_bench`: **13 cards / 8 orgs**, identical before and after.
- `benchmark_count`: 73 to 72; all 30 cards intact.
- Rebuilt `site/data/radar.json`: zero `frontier_bench` occurrences, a single Terminal-Bench row at rank 5 of 72 in `?view=leaderboard`. (Generated and gitignored, so not in this diff.)

## One judgement call to confirm

tbench.ai gives Frontier-Bench distinct branding and its own domain (frontierbench.ai), and it is a genuinely different task set rather than a Terminal-Bench version bump. I merged it as the issue asked and preserved that distinction in the caveat. If you would rather model it as related-but-separate, reverting the entry removal is a one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
