### PR TITLE
Merge Frontier-Bench into the Terminal-Bench series

### DIFF
--- a/data/model_cards.yml
+++ b/data/model_cards.yml
@@ -107,6 +107,12 @@ benchmarks:
       - "Terminal-Bench 2.1"
       - "Terminal Bench 2"
       - "TerminalBench Hard"
+      - "Terminal-Bench 3.0"
+      - "Terminal Bench 3"
+      - "Frontier-Bench"
+      - "FrontierBench"
+      - "Frontier-Bench v0.1"
+      - "FrontierSWE"
     domain: agent
     url: https://www.tbench.ai/
     released: 2025-05-19
@@ -114,7 +120,13 @@ benchmarks:
       Environment image, timeout and permitted commands change results
       independently of the model. Version and harness both matter: 2.0 and 2.1
       are different instruments, and cards report Terminus, Claude Code and
-      Codex harness numbers for the same version.
+      Codex harness numbers for the same version. Frontier-Bench is this
+      series' next version rather than a separate benchmark: frontierbench.ai
+      now bills it as "Terminal-Bench 3.0 (formerly Frontier-Bench)", built by
+      the makers of Harbor and Terminal-Bench, so its mentions are counted
+      here. Being a new version, its task set is not comparable to a 2.x
+      number. Not to be confused with Cognition's FrontierCode, a separate
+      instrument recorded separately despite the shared prefix.
 
   - id: livecodebench
     name: LiveCodeBench
@@ -474,16 +486,6 @@ benchmarks:
       Screen resolution, OS image and action space all change results. The
       Verified and 2.0 revisions are not comparable to the original.
 
-  - id: frontier_bench
-    name: Frontier-Bench
-    aliases: ["Frontier-Bench", "FrontierBench", "Frontier-Bench v0.1", "FrontierSWE"]
-    domain: coding_agent
-    url: https://cognition.ai/blog/frontier-bench
-    released: 2026-05-19
-    caveat: >-
-      Published by Cognition, a vendor of a competing coding agent, and run in
-      its own harness. Treat it as first-party to that harness.
-
   - id: cursor_bench
     name: CursorBench
     aliases: ["CursorBench", "Cursor Bench", "CursorBench 3.2"]
@@ -761,17 +763,19 @@ benchmarks:
     name: FrontierCode
     aliases: ["FrontierCode", "FrontierCode (Diamond)"]
     domain: coding_agent
-    url: https://cognition.ai/blog/frontier-bench
-    # Unset: 2026-05-19 is Frontier-Bench's release date, and assuming this
-    # shares it because both are Cognition's would be a guess about a separate
-    # instrument.
-    released: null
+    # Its own announcement post. This previously pointed at
+    # cognition.ai/blog/frontier-bench, which 404s and is not Cognition's:
+    # Frontier-Bench is Terminal-Bench's, and is recorded under terminal_bench.
+    url: https://cognition.com/blog/frontier-code
+    released: 2026-06-08
     caveat: >-
-      Cognition's production-standard coding evaluation, distinct from that
-      vendor's Frontier-Bench despite the shared prefix and blog. Reported per
+      Cognition's production-standard coding evaluation, asking whether models
+      write *good* code rather than merely correct code. Unrelated to
+      Terminal-Bench's Frontier-Bench despite the shared prefix. Reported per
       reasoning-effort setting (the Diamond subset at xhigh), so the effort
       level has to travel with the number. First-party to a competing coding
-      agent's vendor.
+      agent's vendor, and revised as 1.1 on 2026-07-07, so the methodology
+      version has to travel with the number too.
 
   - id: blueprint_bench_2
     name: Blueprint-Bench 2
@@ -1161,9 +1165,9 @@ model_cards:
   #     OSWorld, GDPval). MMLU and HumanEval still appear, but in base-model
   #     tables, not in the lead.
   #   * Several 2026 headline benchmarks are published by a commercial party
-  #     with a stake in the result (Cognition's Frontier-Bench, Cursor's
-  #     CursorBench, Zapier's AutomationBench, Artificial Analysis's -AA
-  #     variants). Their per-benchmark caveats say so; the adoption count cannot.
+  #     with a stake in the result (Cursor's CursorBench, Zapier's
+  #     AutomationBench, Artificial Analysis's -AA variants). Their
+  #     per-benchmark caveats say so; the adoption count cannot.
   # ---------------------------------------------------------------------------
 
   - id: anthropic_claude_opus_5_system_card
@@ -1174,7 +1178,6 @@ model_cards:
     url: https://www.anthropic.com/news/claude-opus-5
     retrieved_at: 2026-08-02
     benchmarks:
-      - frontier_bench
       - cursor_bench
       - arc_agi_3
       - automationbench
@@ -1211,11 +1214,11 @@ model_cards:
       - legal_agent_benchmark
       - hle
       - biomysterybench
+      # Frontier-Bench, named in the prose, is folded into this id.
       - terminal_bench
       - exploitbench
       - healthbench_professional
       # Named in prose rather than scored in the table.
-      - frontier_bench
       - cursor_bench
       - vibench
 
@@ -1406,7 +1409,6 @@ model_cards:
       - aa_lcr
       - hle
       - terminal_bench
-      - frontier_bench
       - posttrainbench
       - scicode
       - browsecomp

--- a/tests/test_model_cards.py
+++ b/tests/test_model_cards.py
@@ -558,8 +558,13 @@ def test_fable_mythos_card_records_its_full_comparison_table():
         "exploitbench",
         "healthbench_professional",
     } <= reported
-    # Named in the prose but not scored in the table.
-    assert {"frontier_bench", "cursor_bench", "vibench"} <= reported
+    # Named in the prose but not scored in the table. The prose also names
+    # Frontier-Bench, which is Terminal-Bench 3.0 under its former name and so
+    # resolves to `terminal_bench` (asserted above) rather than an id of its
+    # own. FrontierCode, in the table above, is Cognition's separate
+    # instrument and keeps its own id despite the shared prefix.
+    assert {"cursor_bench", "vibench"} <= reported
+    assert "frontier_bench" not in reported
     # Recorded by an earlier pass but absent from the release entirely.
     assert not ({"browsecomp", "swe_bench_verified"} & reported)
 


### PR DESCRIPTION
Closes #94. Replaces #95, which was opened before #90/#92/#93 landed and could not be updated in place (resolving the conflict required a rebase, and force-pushing is blocked in my environment). Same change, rebased onto current `main` with the conflict resolved.

## Verification

- frontierbench.ai now bills the benchmark as **"Terminal-Bench 3.0 (formerly Frontier-Bench)"**, built by the makers of Harbor and Terminal-Bench.
- `harbor-framework/frontier-bench` sits in the **same GitHub org** as `terminal-bench`, `terminal-bench-2`, `terminal-bench-2-1` and `terminal-bench-science`.
- Its README calls it the successor project to Terminal-Bench, led by the Terminal-Bench maintainers (Konwinski, Schmidt) and co-hosted by the Laude Institute.

So it is not a sibling benchmark, it is the next version of this one under its former name.

## The conflict

`main` rewrote the Fable 5 / Mythos 5 card from its comparison table (#90) and added a new `frontiercode` entry. Resolved by keeping `main`'s full transcribed list and dropping only the `frontier_bench` line; that card already lists `terminal_bench`, so nothing is lost.

## Two errors corrected

The standalone entry misattributed Frontier-Bench to **Cognition** and pointed at `cognition.ai/blog/frontier-bench`, which **404s**. Both claims also appeared in the 2026 header comment.

`frontiercode` (added by #92) is a genuinely separate Cognition instrument and keeps its own id, but it had **inherited both errors**: it pointed at that same dead URL, and left `released` unset reasoning that the date belonged to Cognition's Frontier-Bench. It now points at its own announcement post (`cognition.com/blog/frontier-code`, HTTP 200) and is dated 2026-06-08 from that post, which also satisfies the chronology check against the 2026-06-09 card reporting it.

## The change

- Frontier-Bench's aliases move onto `terminal_bench`, plus the new `Terminal-Bench 3.0` spellings.
- The standalone `frontier_bench` entry is removed.
- The caveat notes that a 3.0 task set is not comparable to a 2.x number, and that Cognition's FrontierCode is a different instrument despite the shared prefix.
- `test_fable_mythos_card_records_its_full_comparison_table` asserted the card reports `frontier_bench`. The intent (the prose names Frontier-Bench) is preserved: that mention now resolves to `terminal_bench`, already asserted in the same test.

## Results

- Tests: **255 passed**.
- `terminal_bench`: **13 cards / 8 orgs**, unchanged, since every card citing `frontier_bench` already cited it.
- `benchmark_count`: 80 to 79; all 30 cards intact.
- Rebuilt `site/data/radar.json`: zero `frontier_bench` occurrences, one Terminal-Bench row in `?view=leaderboard`. (Generated and gitignored, so not in this diff.)

## One judgement call

Frontier-Bench has its own domain and a distinct task set, so if you would rather track 3.0 as its own row than fold it in, reverting the entry removal is a one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
