### PR TITLE
Explain why the Frontier-Bench merge left Terminal-Bench at 13 cards, and disclose OCR

### DIFF
--- a/data/model_cards.yml
+++ b/data/model_cards.yml
@@ -124,9 +124,13 @@ benchmarks:
       series' next version rather than a separate benchmark: frontierbench.ai
       now bills it as "Terminal-Bench 3.0 (formerly Frontier-Bench)", built by
       the makers of Harbor and Terminal-Bench, so its mentions are counted
-      here. Being a new version, its task set is not comparable to a 2.x
-      number. Not to be confused with Cognition's FrontierCode, a separate
-      instrument recorded separately despite the shared prefix.
+      here. Merging it did not raise this count: all three cards that named
+      Frontier-Bench (Claude Opus 5, Claude Fable 5 and Mythos 5, Kimi K3)
+      also report Terminal-Bench in the same document, and the counting unit
+      is the document, so each still adds one. Being a new version, its task
+      set is not comparable to a 2.x number. Not to be confused with
+      Cognition's FrontierCode, a separate instrument recorded separately
+      despite the shared prefix.
 
   - id: livecodebench
     name: LiveCodeBench

--- a/site/index.html
+++ b/site/index.html
@@ -170,6 +170,21 @@
             conclusion, so the correction has to arrive before the table does.
           -->
           <p class="heading-note" id="leaderboard-measures"></p>
+          <!--
+            Some cards publish their comparison table as an image, so those rows
+            were read by OCR and can disagree with the document. The honest place
+            to say so is here, next to the counts it affects, with a pointer to
+            the per-card listing below where any row can be checked against its
+            source link.
+          -->
+          <p class="heading-note leaderboard-ocr-note">
+            <strong>Disclaimer:</strong> some model cards publish their benchmark table
+            as an image, and those rows were transcribed by OCR. Transcription can be
+            wrong, so a count here may differ from the source document.
+            <a href="#leaderboard-cards-heading">Model cards in the registry</a>
+            below lists every benchmark we recorded for each card, with a link to the
+            original, so any row can be checked against it.
+          </p>
         </header>
 
         <div class="map-insights" id="leaderboard-insights" aria-label="Registry overview"></div>

--- a/tests/test_model_cards.py
+++ b/tests/test_model_cards.py
@@ -780,9 +780,7 @@ def test_merging_frontier_bench_did_not_double_count_terminal_bench():
     board = build_adoption_rank(DEFAULT_REGISTRY_PATH)
 
     # The merged id is gone, and no card can still reference it.
-    assert all(
-        "frontier_bench" not in card["benchmarks"] for card in board["model_cards"]
-    )
+    assert all("frontier_bench" not in card["benchmarks"] for card in board["model_cards"])
 
     by_card = {card["model_card_id"]: set(card["benchmarks"]) for card in board["model_cards"]}
     # The three cards that named Frontier-Bench, each already reporting the
@@ -794,9 +792,7 @@ def test_merging_frontier_bench_did_not_double_count_terminal_bench():
     ):
         assert "terminal_bench" in by_card[card_id]
 
-    entry = next(
-        row for row in board["entries"] if row["benchmark_id"] == "terminal_bench"
-    )
+    entry = next(row for row in board["entries"] if row["benchmark_id"] == "terminal_bench")
     # One adoption per citing document, not one per alias spelling it used.
     assert entry["card_count"] == len(
         [card for card in board["model_cards"] if "terminal_bench" in card["benchmarks"]]

--- a/tests/test_model_cards.py
+++ b/tests/test_model_cards.py
@@ -764,3 +764,42 @@ def test_a_fragment_does_not_make_one_document_look_like_two(tmp_path):
     )
     with pytest.raises(ModelCardRegistryError, match="repeats the document URL"):
         load_registry(write_registry(tmp_path, document))
+
+
+def test_merging_frontier_bench_did_not_double_count_terminal_bench():
+    """Issue #94: the merge must absorb those mentions, not add them.
+
+    Frontier-Bench was folded into `terminal_bench` as Terminal-Bench 3.0 under
+    its former name. Three cards had named it, which invites the reading that
+    the merge should lift Terminal-Bench's count by three. It must not: all
+    three also report Terminal-Bench in the same document, and the counting
+    unit is the document, so each contributes exactly one adoption either way.
+    Counting the merged alias separately would put the series above instruments
+    that genuinely appear in more cards.
+    """
+    board = build_adoption_rank(DEFAULT_REGISTRY_PATH)
+
+    # The merged id is gone, and no card can still reference it.
+    assert all(
+        "frontier_bench" not in card["benchmarks"] for card in board["model_cards"]
+    )
+
+    by_card = {card["model_card_id"]: set(card["benchmarks"]) for card in board["model_cards"]}
+    # The three cards that named Frontier-Bench, each already reporting the
+    # series under its own name -- which is why the merge is absorptive.
+    for card_id in (
+        "anthropic_claude_opus_5_system_card",
+        "anthropic_claude_fable_5_mythos_5",
+        "moonshot_kimi_k3_model_card",
+    ):
+        assert "terminal_bench" in by_card[card_id]
+
+    entry = next(
+        row for row in board["entries"] if row["benchmark_id"] == "terminal_bench"
+    )
+    # One adoption per citing document, not one per alias spelling it used.
+    assert entry["card_count"] == len(
+        [card for card in board["model_cards"] if "terminal_bench" in card["benchmarks"]]
+    )
+    # The merged spellings still resolve, so a future extractor can map them.
+    assert {"Frontier-Bench", "Terminal-Bench 3.0"} <= set(entry["aliases"])


### PR DESCRIPTION
Follows up on #94 (comment: https://github.com/ktwu01/benchmark-radar/issues/94#issuecomment-5161020804), which asks why folding Frontier-Bench into Terminal-Bench did not pull the three Frontier-Bench citations across: Terminal-Bench is still 13 cards and rank 6, where merging three more would make it 16 and rank 3.

## What I found

The merge was already complete, and the count is right. The three cards that named Frontier-Bench each **also** report Terminal-Bench in the same document:

| Card | cites `terminal_bench` |
| --- | --- |
| Claude Opus 5 system card | yes |
| Claude Fable 5 and Mythos 5 | yes |
| Kimi K3 model card | yes |

The counted unit is the document, not the result row, so a card naming both spellings adds one adoption, exactly as it did before the merge. Raising the count to 16 would count those three documents twice and rank the series above LiveCodeBench (15), which genuinely appears in more cards. The registry side of the merge was verified as done: `frontier_bench` no longer exists as an id, no card references it, and its spellings survive as aliases on `terminal_bench`.

So the bug was not in the data, it was that nothing on the page said any of this. The caveat claimed the mentions "are counted here" without saying they came from cards already counted, which is exactly the reading that makes 16 look correct.

## Changes

- **`data/model_cards.yml`** — the Terminal-Bench caveat now names the three cards and states that the merge was absorptive, so the leaderboard explains the count next to the count itself.
- **`tests/test_model_cards.py`** — pins the invariant: merged id absent, each of the three cards still reports the series, the entry's count equals the number of citing documents, and the merged spellings still resolve as aliases. Nothing failed when the count stayed flat, and nothing would have failed if a later change made it climb.
- **`site/index.html`** — adds the requested OCR disclaimer to the leaderboard heading, pointing at "Model cards in the registry" below, where every recorded benchmark is listed with a link to the original for line-by-line checking.

## Test plan

- `pytest tests/` — 256 passed.
- Mutation-checked the new test: re-introducing a separate `frontier_bench` entry and citation makes it fail, so it is not vacuous.
- Rebuilt `site/data/radar.json` and confirmed the leaderboard still reads Terminal-Bench rank 6 / 13 cards with the updated caveat.
- Rendered the leaderboard view in Chrome and confirmed the disclaimer displays in the heading with a working anchor to the card list.

Note: the `/wkt` Codex review step could not run, the Codex CLI returned a usage-limit error (resets Aug 8). Gemini has no API key configured in this environment. Reviewed the diff manually and added the mutation check above in place of that pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)