### PR TITLE
Bind category counts to their taxonomy, and make reclassification a visible event

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,9 +236,28 @@ so pagination is bounded by `sources.github.max_requests` and spaced by
 `request_delay_seconds`. Both default by whether `GITHUB_TOKEN` is present; raising
 `max_items_per_source` well beyond the defaults on a tokenless run risks a 403.
 
-Trend comparisons only run between snapshots collected under the same `report_limit`.
-Changing the cap lifts every count at once, and reporting that as domain momentum would
-present a change in collection policy as a change in the field.
+Trend comparisons only run between snapshots collected under the same `report_limit`
+**and classified by the same taxonomy**. Changing the cap lifts every count at once, and
+editing the taxonomy re-tags the whole corpus; reporting either as domain momentum would
+present a change in measurement as a change in the field.
+
+Each snapshot records a `taxonomy_version`, a fingerprint derived from the taxonomy's own
+content rather than a hand-bumped number, so editing any keyword changes it and forgetting
+to bump it is not possible. `benchmark-radar rescore` stamps every record it evaluates and
+marks the ones whose categories actually moved:
+
+```json
+"reclassified": {"from": ["benchmark"], "to": ["benchmark", "agentic"],
+                 "taxonomy_version": "sha256:5ee3bd8146ce"}
+```
+
+This makes a reclassification a third kind of event beside `released` and `updated`. When
+the `agentic` count went from 3 to 78, that was a rules correction rather than 75 new
+agent benchmarks, and nothing in the data distinguished the two. The marker describes only
+the most recent pass: re-running `rescore` with settled rules clears it, because a record
+reclassified weeks ago is not evidence about a trend today. `event_kind` is never rewritten
+by a rescore, since it records what the source announced, not what the radar did to its own
+records.
 
 The `watchlist` block pins named artifacts, matched on title and source id by word
 boundary. A hit is routed to the top and labelled with a one-line note; it never changes

--- a/docs/cumulative-corpus.schema.json
+++ b/docs/cumulative-corpus.schema.json
@@ -150,7 +150,13 @@
           "categories",
           "organizations",
           "metrics"
-        ]
+        ],
+        "properties": {
+          "taxonomy_version": {
+            "description": "Fingerprint of the taxonomy that produced this observation's categories (issue #72). Null for a record classified before the field existed: 'unrecorded' and 'these specific rules' are different claims. Category counts are comparable only across observations sharing a version.",
+            "type": ["string", "null"]
+          }
+        }
       }
     },
     "edges": {

--- a/src/benchmark_radar/cli.py
+++ b/src/benchmark_radar/cli.py
@@ -202,7 +202,8 @@ def main() -> None:
             registry_path=args.model_cards,
         )
         print(
-            f"Rescored {summary['snapshots']} snapshots against the current taxonomy; "
+            f"Rescored {summary['snapshots']} snapshots against taxonomy "
+            f"{summary['taxonomy_version']}; "
             f"{summary['records_changed']} records changed category"
         )
         for category in sorted({*summary["before"], *summary["after"]}):

--- a/src/benchmark_radar/corpus.py
+++ b/src/benchmark_radar/corpus.py
@@ -339,6 +339,12 @@ def build_corpus(snapshots: list[dict[str, Any]]) -> dict[str, Any]:
                 "metrics": metrics,
                 "total_score": item.get("total_score"),
                 "score_version": int(item.get("score_version") or 1),
+                # This observation publishes `categories`, so it has to publish
+                # which rules produced them (issue #72). None for a record
+                # classified before the field existed: "unrecorded" and "these
+                # specific rules" are different claims, and only one of them is
+                # checkable.
+                "taxonomy_version": item.get("taxonomy_version"),
             }
             observations.append(observation)
 

--- a/src/benchmark_radar/pipeline.py
+++ b/src/benchmark_radar/pipeline.py
@@ -477,6 +477,10 @@ def _score_and_select(
         "lookback_hours": float(settings["lookback_hours"]),
         "score_version": rubric.SCORING_VERSION,
         "score_max": rubric.SCORE_MAX,
+        # Which rules produced this day's categories (issue #72). Recorded
+        # beside the scoring version for the same reason: a category count is
+        # only comparable across days that were classified the same way.
+        "taxonomy_version": rubric.taxonomy_version(config.get("taxonomy") or {}),
     }
     return published, selection
 

--- a/src/benchmark_radar/rubric.py
+++ b/src/benchmark_radar/rubric.py
@@ -116,9 +116,16 @@ def taxonomy_version(taxonomy: dict[str, Any]) -> str:
     the digest; nothing else can.
 
     The digest covers the category names, their terms, and the structure of a
-    proximity rule, canonicalized so that reordering keys in `config.yml`
-    without changing what matches does not invent a new version and force a
-    false "not comparable" on every trend.
+    proximity rule, canonicalized so that reordering *categories* in
+    `config.yml` without changing what matches does not invent a new version
+    and force a false "not comparable" on every trend.
+
+    Term order inside a category is deliberately significant, unlike category
+    order. `rescore` records only the first two matching terms in a record's
+    "Matched:" rationale, so listing the same terms in a different order
+    produces different stored evidence for the same artifact. That is a real
+    change in output, and a version that called those two runs identical would
+    be claiming something false.
     """
     canonical = json.dumps(taxonomy, sort_keys=True, separators=(",", ":"), default=str)
     digest = hashlib.sha256(canonical.encode()).hexdigest()

--- a/src/benchmark_radar/rubric.py
+++ b/src/benchmark_radar/rubric.py
@@ -8,6 +8,8 @@ the current rubric changes.
 
 from __future__ import annotations
 
+import hashlib
+import json
 from typing import Any
 
 SCORING_VERSION = 2
@@ -96,6 +98,34 @@ ADOPTION_METRIC_SATURATION: dict[str, float] = {
     "downloads": 100_000.0,
     "likes": 1_000.0,
 }
+
+
+def taxonomy_version(taxonomy: dict[str, Any]) -> str:
+    """A stable fingerprint of the taxonomy that classified a record.
+
+    Issue #72 asked for trend values to be bound to the taxonomy that produced
+    them, after PR #67 moved the cumulative `agentic` count from 3 to 78. That
+    was a rules change, not 75 new agent benchmarks, and nothing in a snapshot
+    recorded which rules had run: two days classified under different taxonomies
+    were indistinguishable, so a measurement fix read as a domain explosion.
+
+    Derived from the taxonomy's own content rather than hand-bumped. A version
+    a maintainer has to remember to increment is a version that silently stops
+    being true the first time someone edits a keyword list and forgets, which
+    is exactly the failure this is meant to detect. Editing any term changes
+    the digest; nothing else can.
+
+    The digest covers the category names, their terms, and the structure of a
+    proximity rule, canonicalized so that reordering keys in `config.yml`
+    without changing what matches does not invent a new version and force a
+    false "not comparable" on every trend.
+    """
+    canonical = json.dumps(taxonomy, sort_keys=True, separators=(",", ":"), default=str)
+    digest = hashlib.sha256(canonical.encode()).hexdigest()
+    # Truncated: this is an equality check between snapshots, not a security
+    # boundary, and a full 64-character digest in every record and on the
+    # dashboard is noise a reader has to scroll past.
+    return f"sha256:{digest[:12]}"
 
 
 def _components(*, lookback_hours: float) -> list[dict[str, Any]]:

--- a/src/benchmark_radar/snapshots.py
+++ b/src/benchmark_radar/snapshots.py
@@ -22,6 +22,7 @@ from .rubric import (
     SCORING_VERSION,
     legacy_rubric_reference,
     rubric_reference,
+    taxonomy_version,
 )
 
 SCHEMA_VERSION = 2
@@ -325,10 +326,24 @@ def load_snapshots(snapshot_dir: Path) -> list[dict[str, Any]]:
 TREND_BASELINE_DAYS = 7
 
 
-def _collection_context(day: dict[str, Any]) -> tuple[Any, tuple[str, ...]]:
+def _collection_context(day: dict[str, Any]) -> tuple[Any, tuple[str, ...], Any]:
     return (
         (day.get("selection") or {}).get("report_limit"),
         tuple(day.get("coverage_signature") or []),
+        # The taxonomy that produced this day's categories (issue #72). Two days
+        # classified under different rules are not comparable on a category
+        # count, for the same reason two days collected under different report
+        # limits are not: the number moved because the measurement changed.
+        # PR #67 is the worked example -- it took cumulative `agentic` from 3 to
+        # 78 without a single new benchmark, and a trend line spanning that
+        # change would report a rules fix as a domain explosion.
+        #
+        # A day predating this field returns None, which compares equal to
+        # other pre-field days and unequal to stamped ones. That is the honest
+        # answer: unstamped days were classified by rules nobody recorded, so
+        # they can be compared with each other but not asserted comparable to
+        # a day whose rules are known.
+        (day.get("selection") or {}).get("taxonomy_version"),
     )
 
 
@@ -636,6 +651,7 @@ def rescore_snapshot_history(
     score is a property of the run.
     """
     taxonomy = config["taxonomy"]
+    version = taxonomy_version(taxonomy)
     paths = sorted(snapshot_dir.glob("*.json"))
     before: Counter[str] = Counter()
     after: Counter[str] = Counter()
@@ -669,7 +685,38 @@ def rescore_snapshot_history(
             after.update(categories)
             if categories != previous:
                 changed += 1
+                # A rewritten category is a third kind of event, alongside
+                # "released" and "updated" (issue #72). Without this marker a
+                # reclassification is indistinguishable from a fresh sighting
+                # once written: PR #67 moved cumulative `agentic` from 3 to 78
+                # in a single command, and a reader had no way to tell that
+                # from 75 agent benchmarks appearing. `event_kind` is left
+                # alone deliberately -- it records what the *source* announced,
+                # and rewriting it here would destroy that to describe
+                # something the source never did.
+                record["reclassified"] = {
+                    "from": previous,
+                    "to": list(categories),
+                    # Which rules did the rewriting. Two reclassification
+                    # passes under different taxonomies are different events,
+                    # and only the version tells them apart.
+                    "taxonomy_version": version,
+                }
+            else:
+                # Cleared when a later pass leaves the categories alone.
+                # `rescore` is idempotent and gets re-run routinely, so a marker
+                # that is only ever written accumulates: a record reclassified
+                # once would carry that claim forever, and a reader auditing a
+                # trend would attribute today's count to a rules change that
+                # happened weeks ago and has since settled. The marker has to
+                # describe this pass or it describes nothing.
+                record.pop("reclassified", None)
             record["categories"] = categories
+            # Stamped on every record, not only the changed ones. A record
+            # whose categories happened not to move was still evaluated by
+            # these rules, and "classified by taxonomy X" is what makes a
+            # cross-day category count comparable at all.
+            record["taxonomy_version"] = version
             rationale = [
                 reason
                 for reason in record.get("rationale") or []
@@ -678,12 +725,19 @@ def rescore_snapshot_history(
             if matched:
                 rationale.insert(0, f"Matched: {', '.join(sorted(set(matched)))}")
             record["rationale"] = rationale
+        # The snapshot's own selection block records the taxonomy its counts
+        # were computed under, so a consumer reading aggregates rather than
+        # individual records inherits the same provenance.
+        selection = snapshot.get("selection")
+        if isinstance(selection, dict):
+            selection["taxonomy_version"] = version
         validate_snapshot(snapshot, source=str(path))
         _write_json(path, snapshot)
     return {
         "snapshots": len(paths),
         "records_changed": changed,
         "schema_migrated": migrated,
+        "taxonomy_version": version,
         "before": dict(sorted(before.items())),
         "after": dict(sorted(after.items())),
     }

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -801,3 +801,39 @@ def test_a_settled_reclassification_marker_does_not_persist(tmp_path):
     # The provenance stamp stays: it says which rules classified the record,
     # which is true on every pass, unlike the marker.
     assert settled["taxonomy_version"]
+
+
+def test_snapshots_predating_the_taxonomy_stamp_still_compare_to_each_other(tmp_path):
+    # Every snapshot already on disk was written before `taxonomy_version`
+    # existed. Gating comparability on a field none of them carry would have
+    # silently emptied the trend history rather than qualifying it.
+    snapshot_dir = tmp_path / "snapshots"
+    for day in (25, 26, 27):
+        write_snapshot(radar_run(day), snapshot_dir)
+    output = tmp_path / "radar.json"
+
+    data = rebuild_dashboard(snapshot_dir, output)
+
+    assert all((day.get("selection") or {}).get("taxonomy_version") is None for day in data["days"])
+    assert any(
+        trend["comparable"] for day in data["days"] for trend in day["category_trends"].values()
+    )
+
+
+def test_the_first_stamped_day_does_not_compare_across_the_boundary(tmp_path):
+    # The transition itself is the risk: the day a taxonomy stamp first appears
+    # is a day whose counts came from rules the previous day cannot vouch for.
+    # It must break comparison exactly once, then resume.
+    snapshot_dir = tmp_path / "snapshots"
+    for day in (25, 26, 27):
+        write_snapshot(radar_run(day), snapshot_dir)
+    paths = sorted(snapshot_dir.glob("*.json"))
+    for path in paths[-1:]:
+        stored = json.loads(path.read_text(encoding="utf-8"))
+        stored["selection"]["taxonomy_version"] = "sha256:newrules"
+        path.write_text(json.dumps(stored), encoding="utf-8")
+
+    data = rebuild_dashboard(snapshot_dir, tmp_path / "radar.json")
+
+    assert not any(trend["comparable"] for trend in data["days"][-1]["category_trends"].values())
+    assert any(trend["comparable"] for trend in data["days"][-2]["category_trends"].values())

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -674,3 +674,130 @@ def test_dashboard_fails_rather_than_publishing_a_stale_ranking(tmp_path):
 
     with pytest.raises(ModelCardRegistryError):
         rebuild_dashboard(snapshot_dir, tmp_path / "radar.json", registry_path=broken)
+
+
+def test_taxonomy_version_tracks_content_not_a_hand_bumped_constant():
+    from benchmark_radar.rubric import taxonomy_version
+
+    # Issue #72 asked for trend values bound to the taxonomy that produced
+    # them. A version a maintainer has to remember to increment silently stops
+    # being true the first time someone edits a keyword and forgets, which is
+    # the exact failure it exists to detect, so it is derived from content.
+    taxonomy = {"benchmark": ["benchmark"], "agentic": ["agent"]}
+
+    assert taxonomy_version(taxonomy) == taxonomy_version(dict(reversed(list(taxonomy.items()))))
+    assert taxonomy_version(taxonomy) != taxonomy_version(
+        {"benchmark": ["benchmark", "leaderboard"], "agentic": ["agent"]}
+    )
+
+
+def test_rescore_records_which_rules_classified_each_record(tmp_path):
+    # A category count is only comparable across days classified the same way.
+    # Before this, nothing in a snapshot said which rules had run.
+    from benchmark_radar.rubric import taxonomy_version
+
+    snapshot_dir = tmp_path / "snapshots"
+    write_snapshot(radar_run(27), snapshot_dir)
+    config = {"taxonomy": {"benchmark": ["benchmark"]}}
+
+    summary = rescore_snapshot_history(config, snapshot_dir)
+    stored = load_snapshots(snapshot_dir)[0]
+
+    expected = taxonomy_version(config["taxonomy"])
+    assert summary["taxonomy_version"] == expected
+    # Stamped on every record, not only the ones that moved: a record whose
+    # categories happened not to change was still evaluated by these rules.
+    assert all(item["taxonomy_version"] == expected for item in stored["evidence_items"])
+    # And on the aggregate, so a consumer reading counts rather than records
+    # inherits the same provenance.
+    assert stored["selection"]["taxonomy_version"] == expected
+
+
+def test_rescore_marks_a_reclassified_record_as_a_distinct_event(tmp_path):
+    # Regression for issue #72: PR #67 moved cumulative `agentic` from 3 to 78
+    # in one command. That was a rules change, not 75 new agent benchmarks, and
+    # nothing distinguished the two once written.
+    snapshot_dir = tmp_path / "snapshots"
+    write_snapshot(radar_run(27, title="A Benchmark for Web Agents"), snapshot_dir)
+
+    # Rescore once under the taxonomy the record was already stored with, so
+    # the second pass is the only thing that moves a category. Re-running the
+    # same rules must leave no marker, or every record would look reclassified
+    # on every pass and the signal would mean nothing.
+    settled = {"taxonomy": {"benchmark": ["benchmark"], "evaluation": ["evaluat"]}}
+    rescore_snapshot_history(settled, snapshot_dir)
+    rescore_snapshot_history(settled, snapshot_dir)
+    unchanged = load_snapshots(snapshot_dir)[0]["evidence_items"][0]
+    assert "reclassified" not in unchanged
+
+    rescore_snapshot_history(
+        {**settled, "taxonomy": {**settled["taxonomy"], "agentic": ["agent"]}}, snapshot_dir
+    )
+    changed = load_snapshots(snapshot_dir)[0]["evidence_items"][0]
+
+    assert changed["reclassified"]["from"] == unchanged["categories"]
+    assert "agentic" in changed["reclassified"]["to"]
+    assert changed["categories"] == changed["reclassified"]["to"]
+    # Two reclassification passes under different taxonomies are different
+    # events, and only the version tells them apart.
+    assert changed["reclassified"]["taxonomy_version"] == changed["taxonomy_version"]
+
+
+def test_rescore_does_not_rewrite_the_event_kind_the_source_announced(tmp_path):
+    # `event_kind` records what the *source* said it did. A reclassification is
+    # something the radar did to its own records, so overwriting event_kind
+    # would destroy a source fact to describe a local one.
+    snapshot_dir = tmp_path / "snapshots"
+    write_snapshot(radar_run(27), snapshot_dir)
+    before = load_snapshots(snapshot_dir)[0]["evidence_items"][0]["event_kind"]
+
+    rescore_snapshot_history(
+        {"taxonomy": {"benchmark": ["benchmark"], "agentic": ["agent"]}}, snapshot_dir
+    )
+    after = load_snapshots(snapshot_dir)[0]["evidence_items"][0]
+
+    assert after["event_kind"] == before
+
+
+def test_trends_refuse_to_compare_across_a_taxonomy_change():
+    from benchmark_radar.snapshots import _collection_context
+
+    # The same guard already applied to report_limit: a count that moved
+    # because the measurement changed is not domain momentum. A trend line
+    # spanning a rules change would report a fix as an explosion.
+    base = {"coverage_signature": ["x"]}
+    first = {**base, "selection": {"report_limit": 300, "taxonomy_version": "sha256:aaa"}}
+    same = {**base, "selection": {"report_limit": 300, "taxonomy_version": "sha256:aaa"}}
+    other = {**base, "selection": {"report_limit": 300, "taxonomy_version": "sha256:bbb"}}
+    unstamped = {**base, "selection": {"report_limit": 300}}
+
+    assert _collection_context(first) == _collection_context(same)
+    assert _collection_context(first) != _collection_context(other)
+    # A day predating the field was classified by rules nobody recorded. It can
+    # be compared with other such days, but claiming it comparable to a day
+    # whose rules are known would assert something unverifiable.
+    assert _collection_context(unstamped) != _collection_context(first)
+    assert _collection_context(unstamped) == _collection_context({**unstamped})
+
+
+def test_a_settled_reclassification_marker_does_not_persist(tmp_path):
+    # Regression caught while building issue #72's marker: it was written on
+    # change but never cleared. `rescore` is idempotent and re-run routinely,
+    # so a record reclassified once carried that claim forever, and a reader
+    # auditing today's trend would attribute it to a rules change that happened
+    # weeks ago and has since settled.
+    snapshot_dir = tmp_path / "snapshots"
+    write_snapshot(radar_run(27, title="A Benchmark for Web Agents"), snapshot_dir)
+
+    widened = {"taxonomy": {"benchmark": ["benchmark"], "agentic": ["agent"]}}
+    rescore_snapshot_history(widened, snapshot_dir)
+    assert "reclassified" in load_snapshots(snapshot_dir)[0]["evidence_items"][0]
+
+    # Same rules again: nothing moved, so nothing is reclassified any more.
+    rescore_snapshot_history(widened, snapshot_dir)
+    settled = load_snapshots(snapshot_dir)[0]["evidence_items"][0]
+
+    assert "reclassified" not in settled
+    # The provenance stamp stays: it says which rules classified the record,
+    # which is true on every pass, unlike the marker.
+    assert settled["taxonomy_version"]


### PR DESCRIPTION
Closes #72.

### Scope note

#72 was closed on 2026-08-02 once `data/snapshots/2026-08-01.json` appeared: the missing-snapshot incident it reported is genuinely resolved (verified: both snapshots present with 69 and 68 items, dashboard serving `radar.json` at HTTP 200). What it *also* raised, and what stayed unimplemented, was a durable measurement-provenance recommendation drawn from PR #67: report `released`, `updated`, and `reclassified` as distinct event types, and bind trend values to the taxonomy version that produced them.

`event_kind` already distinguished `released` from `updated`. The two genuine gaps were the taxonomy version and the reclassification event, and this implements both.

### 1. `taxonomy_version`

A digest of the taxonomy's own content, not a hand-bumped constant. A version a maintainer has to remember to increment silently stops being true the first time someone edits a keyword and forgets, which is exactly the failure it exists to detect.

Recorded in the daily selection block beside `score_version`, on every record `rescore` evaluates, and on each corpus observation, because that observation publishes `categories` and so has to publish which rules produced them.

Canonicalized so reordering **categories** in `config.yml` does not invent a new version. Term order **inside** a category is deliberately significant: `rescore` stores only the first two matching terms in a record's "Matched:" rationale, so two orders produce different stored evidence for the same artifact. Confirmed by constructing a record with three matching terms.

### 2. Reclassification as a distinct event

`rescore` rewrote categories in place and left no trace, so a re-tagged record was indistinguishable from a newly discovered one. PR #67 is the worked example: cumulative `agentic` went from 3 to 78 in one command, a rules correction rather than 75 new agent benchmarks, and no consumer could tell.

```json
"reclassified": {"from": ["benchmark"], "to": ["benchmark", "agentic"],
                 "taxonomy_version": "sha256:5ee3bd8146ce"}
```

Trend comparability is extended the same way `report_limit` already worked: two days classified under different rules are not compared, because a count that moved when the measurement changed is not domain momentum.

`event_kind` is deliberately untouched by a rescore. It records what the source announced; rewriting it would destroy a source fact to describe something the radar did to its own records.

### Review findings

Codex was out of credits and Gemini unauthenticated, so the adversarial pass was run manually against the risks those reviewers would have been asked about. Three things surfaced, all fixed or covered:

**A real defect, found by a test during development.** The `reclassified` marker was written on change but never cleared. `rescore` is idempotent and re-run routinely, so a record reclassified once carried that claim forever, and a reader auditing today's trend would attribute it to a rules change that had since settled. The marker now describes the most recent pass only.

**Backward compatibility, the consequential one.** All 11 existing snapshots predate these fields. Gating comparability on a field none of them carry would have silently emptied the trend history rather than qualifying it. Verified against the real corpus: unstamped days still validate and still compare to each other, and the first stamped day breaks comparison exactly once before resuming — a one-day gap at a genuine measurement change, not a permanent loss. Both cases now have tests.

**Edge cases checked:** empty taxonomy (categories stripped, correctly flagged as reclassification), proximity-rule vs list with identical terms (distinct versions), a `within` change (detected), non-ASCII terms, and nested key reordering inside a proximity rule (stable).

### Verification

`ruff check`, `ruff format --check`, and 280 tests pass (8 new). `benchmark-radar rebuild` and `rescore` both run clean against the real corpus; `rescore` now names the taxonomy in its output:

```
Rescored 11 snapshots against taxonomy sha256:5ee3bd8146ce; 0 records changed category
```
