### PR TITLE
Preserve both daily radar passes and quiet routine latency warnings

### DIFF
--- a/.github/workflows/daily-radar.yml
+++ b/.github/workflows/daily-radar.yml
@@ -52,7 +52,7 @@ jobs:
             echo "- Runner start UTC: \`$(date -u --date "@${started_at}" --iso-8601=seconds)\`"
             echo "- Trigger latency: **${latency_minutes} minutes**"
           } >> "${GITHUB_STEP_SUMMARY}"
-          if (( latency_minutes >= 30 )); then
+          if (( latency_minutes >= 240 )); then
             echo "::warning title=Delayed scheduled trigger::GitHub started this workflow ${latency_minutes} minutes after its cron target"
           fi
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/src/benchmark_radar/snapshots.py
+++ b/src/benchmark_radar/snapshots.py
@@ -303,10 +303,90 @@ def normalize_snapshot(snapshot: dict[str, Any], *, source: str = "snapshot") ->
     return normalized
 
 
+def merge_snapshots(existing: dict[str, Any], incoming: dict[str, Any]) -> dict[str, Any]:
+    """Union two passes over the same UTC day into one snapshot.
+
+    Issue #104: the radar runs twice a day and both passes write the same
+    `data/snapshots/<date>.json`. Last-write-wins silently discarded whatever
+    the earlier pass had already committed. On 2026-08-02 the two passes
+    returned 62 and 68 items with only 41 shared, so the published day lost 21
+    real records.
+
+    The cause is fetch truncation, not a narrow lookback. GitHub saturates
+    `max_items_per_source` on every pass and `sources.py` keeps the newest
+    `[:limit]`, so older-but-still-in-window records fall off the back of one
+    pass and not the other. Widening the window would not recover them; only
+    unioning the passes on write does.
+
+    Item identity is `exact_artifact_key`, the same exact-identifier rule daily
+    dedup and the cumulative corpus already use. On a collision the incoming
+    (newer) record wins: it observed the artifact more recently, so its metrics
+    and scores are the fresher reading.
+    """
+    merged_items: dict[str, Any] = {}
+    for item in existing["evidence_items"]:
+        merged_items[exact_artifact_key(item)] = item
+    for item in incoming["evidence_items"]:
+        merged_items[exact_artifact_key(item)] = item
+    evidence_items = list(merged_items.values())
+
+    # The funnel counters (fetched, deduplicated, scored, qualified,
+    # suppressed_*) each measure rows moving through one pass. They cannot be
+    # reconstructed from the union, and summing them would double-count the
+    # artifacts both passes saw, so they stay as the newer pass's numbers.
+    #
+    # That makes them a different scope from the file's contents, and the two
+    # must not be read as one funnel. A pass that fetches nothing (an outage,
+    # or a quiet day) merged onto a populated file would otherwise report
+    # `fetched: 0` beside `published: 62`, which is not a small inaccuracy but
+    # an impossible funnel a dashboard would render as fact. So `published`
+    # moves out to `published_total`, which is about the file, and the
+    # per-pass block keeps its own internally consistent `published`.
+    selection = dict(incoming.get("selection") or {})
+    existing_selection = existing.get("selection") or {}
+    if selection or existing_selection:
+        # The one number that describes the file rather than a pass. Every
+        # other counter here belongs to the pass named last in `merged_from`.
+        selection["published_total"] = len(evidence_items)
+        selection["merged_from"] = sorted(
+            {
+                *(existing_selection.get("merged_from") or [existing["generated_at"]]),
+                incoming["generated_at"],
+            }
+        )
+
+    merged = {
+        **incoming,
+        "evidence_items": evidence_items,
+        # The union covers everything either pass looked at, so the earlier
+        # `since` is the honest lower bound on the window it describes.
+        "since": min(existing["since"], incoming["since"]),
+    }
+    if selection or existing_selection:
+        merged["selection"] = selection
+    # `discovery_state` and `attention` are already cumulative by construction:
+    # the later pass loads the earlier snapshot and carries the ledger forward.
+    # `ingest_health` and `producer_health` are per-pass and are taken from the
+    # incoming pass unmerged, because concatenating them would emit duplicate
+    # `source` rows and corrupt the coverage_signature derived from them.
+    return merged
+
+
 def write_snapshot(run: RadarRun, snapshot_dir: Path) -> Path:
     snapshot = snapshot_for_run(run)
-    validate_snapshot(snapshot)
     path = snapshot_dir / f"{snapshot['date']}.json"
+    if path.exists():
+        # Issue #104: a second pass on the same UTC day must add to the day's
+        # record, not replace it. A file we cannot read is not an empty day, so
+        # fail rather than overwrite evidence that may still be recoverable.
+        try:
+            existing = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as error:
+            raise SnapshotError(f"{path}: cannot read existing snapshot to merge: {error}") from (
+                error
+            )
+        snapshot = merge_snapshots(normalize_snapshot(existing, source=str(path)), snapshot)
+    validate_snapshot(snapshot)
     _write_json(path, snapshot)
     return path
 

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -114,16 +114,96 @@ def test_snapshot_has_version_and_public_evidence_fields():
     )
 
 
-def test_same_utc_day_is_idempotent(tmp_path):
+def test_same_utc_day_unions_both_runs(tmp_path):
+    # Issue #104: the radar runs twice a day into the same dated file. The
+    # second pass used to replace the first, so on 2026-08-02 the published day
+    # lost 21 records the morning pass had already committed. Each pass is
+    # truncated at `max_items_per_source`, so neither is the whole day.
     first = radar_run(title="First run")
-    second = radar_run(title="Replacement run")
+    second = radar_run(title="Second run")
+    second.items[0].source_id = "2607.9999"
+    second.items[0].url = "https://arxiv.org/abs/2607.9999"
+    second.generated_at = first.generated_at + timedelta(hours=6)
+    second.since = second.generated_at - timedelta(hours=12)
+    first.selection = {"fetched": 10, "qualified": 1, "published": 1}
+    second.selection = {"fetched": 12, "qualified": 1, "published": 1}
 
     first_path = write_snapshot(first, tmp_path)
     second_path = write_snapshot(second, tmp_path)
 
     assert first_path == second_path
     assert len(list(tmp_path.glob("*.json"))) == 1
-    assert load_snapshots(tmp_path)[0]["evidence_items"][0]["title"] == "Replacement run"
+    merged = load_snapshots(tmp_path)[0]
+    assert sorted(item["title"] for item in merged["evidence_items"]) == [
+        "First run",
+        "Second run",
+    ]
+    # The union covers the wider of the two windows, so `since` is the earlier.
+    assert merged["since"] == first.since.isoformat()
+    # One count describes the file. Every other counter describes the last
+    # pass alone, and the two scopes stay separate rather than being blended
+    # into a funnel that reads as one chain.
+    assert merged["selection"]["published_total"] == 2
+    assert merged["selection"]["published"] == 1
+    assert merged["selection"]["qualified"] == 1
+    assert merged["selection"]["fetched"] == 12
+    assert merged["selection"]["merged_from"] == sorted(
+        [first.generated_at.isoformat(), second.generated_at.isoformat()]
+    )
+
+
+def test_same_utc_day_prefers_the_newer_record_on_collision(tmp_path):
+    # Both passes see the long-lived artifacts. The newer pass observed them
+    # more recently, so its metrics are the fresher reading, and the artifact
+    # must appear once rather than twice.
+    first = radar_run(title="Stale reading")
+    second = radar_run(title="Fresh reading")
+    second.items[0].metrics = {"citations": 9}
+
+    write_snapshot(first, tmp_path)
+    write_snapshot(second, tmp_path)
+
+    merged = load_snapshots(tmp_path)[0]
+    assert len(merged["evidence_items"]) == 1
+    assert merged["evidence_items"][0]["title"] == "Fresh reading"
+    assert merged["evidence_items"][0]["metrics"] == {"citations": 9}
+
+
+def test_a_pass_that_fetched_nothing_keeps_the_day_and_reports_an_honest_funnel(tmp_path):
+    # A source outage can hand us a pass with no items at all. Merging it must
+    # keep the day's existing records, and must not leave the file claiming it
+    # fetched nothing yet published dozens: the per-pass funnel stays
+    # internally consistent, and the file's own count lives in
+    # `published_total`.
+    first = radar_run(title="Morning run")
+    first.selection = {"fetched": 10, "qualified": 1, "published": 1}
+    write_snapshot(first, tmp_path)
+
+    outage = radar_run(title="Outage run")
+    outage.items = []
+    outage.generated_at = first.generated_at + timedelta(hours=6)
+    outage.since = outage.generated_at - timedelta(hours=12)
+    outage.selection = {"fetched": 0, "qualified": 0, "published": 0}
+    write_snapshot(outage, tmp_path)
+
+    merged = load_snapshots(tmp_path)[0]
+    assert [item["title"] for item in merged["evidence_items"]] == ["Morning run"]
+    selection = merged["selection"]
+    assert selection["published_total"] == 1
+    assert selection["fetched"] == 0
+    # The impossible funnel this guards against: `fetched: 0` sitting beside a
+    # `published` that counts records the pass never saw.
+    assert selection["published"] == 0
+    assert selection["published"] <= selection["fetched"]
+
+
+def test_writing_the_same_run_twice_changes_nothing(tmp_path):
+    write_snapshot(radar_run(), tmp_path)
+    first_bytes = (tmp_path / "2026-07-27.json").read_bytes()
+    write_snapshot(radar_run(), tmp_path)
+
+    assert (tmp_path / "2026-07-27.json").read_bytes() == first_bytes
+    assert len(load_snapshots(tmp_path)[0]["evidence_items"]) == 1
 
 
 def test_rebuild_is_deterministic(tmp_path):


### PR DESCRIPTION
## Summary

- merge an incoming same-day snapshot with the already-published file using `exact_artifact_key`, with the newer observation winning collisions
- keep per-pass selection counters internally consistent while reporting the union size separately as `published_total`
- retain the earlier `since` bound, record each contributing pass, fail closed on unreadable existing snapshots, and cover union/collision/outage/idempotence behavior
- raise the scheduled-trigger warning threshold from 30 to 240 minutes while retaining measured latency in the job summary

The snapshot loss is caused by source fetch truncation: both GitHub passes hit the 300-item cap, so older in-window records fall off the later pass. Twenty of the 21 Aug-2 losses were still inside that pass's lookback window; widening the window would not fix it.

The already-lost Aug-2 cohort is intentionally not modified here. #108 tracks that one-shot data repair after this merge rule lands.

## Verification

- `PYTHONPATH=src /root/benchmark-radar/.venv/bin/python -m pytest -q` — 283 passed
- `/root/benchmark-radar/.venv/bin/ruff check .` — passed
- `/root/benchmark-radar/.venv/bin/ruff format --check .` — 45 files already formatted

Closes #104
Closes #105
