### PR TITLE
Document the second daily discovery window

### DIFF
--- a/.github/workflows/daily-radar.yml
+++ b/.github/workflows/daily-radar.yml
@@ -2,9 +2,11 @@ name: Daily Benchmark Radar
 
 on:
   schedule:
-    # Issue #44: one early run to catch overnight arXiv/HF activity before the
-    # day starts, one mid-morning run so a failed or late trigger has a same-day
-    # retry instead of waiting 24h. Both land in early hours America/Chicago.
+    # Issue #44: one early run catches overnight arXiv/HF activity before the
+    # day starts. The mid-morning run provides same-day retry coverage and a
+    # second discovery window: on 2026-08-02 it found 27 evidence items missed
+    # by the early run (41 appeared in both; 21 appeared only in the early run).
+    # Issue #104 makes the two runs additive. Both land in early hours Chicago.
     # 06:15 UTC = 01:15 America/Chicago during daylight saving time.
     - cron: "15 6 * * *"
     # 12:15 UTC = 07:15 America/Chicago during daylight saving time.


### PR DESCRIPTION
## Summary

- describe the mid-morning schedule as both retry coverage and an independent discovery window
- record the observed 2026-08-02 overlap and unique-item counts
- note that #104 makes the two daily runs additive

Closes #106

## Test plan

- `git diff --check`
- parse `.github/workflows/daily-radar.yml` with PyYAML
- `codex review --base main -c 'model_reasoning_effort="high"'`