### PR TITLE
feat(#91): saturation + adoption on one axis, and stated findings

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -1898,29 +1898,179 @@ function sparseFrontier(entry, events) {
   );
 }
 
+// --- Score progression (issue #91) ------------------------------------------
+//
+// The saturation half of the panel. `benchmark_score_progression` carries only
+// values read verbatim out of cited documents, grouped into series the join rule
+// permits a line through: identical instrument AND identical protocol. Anything
+// else stays an unconnected point, because two numbers taken under unstated and
+// possibly different conditions are not a measurement of change.
+//
+// Under that rule this corpus yields very few multi-date runs, and most are one
+// vendor reporting its own successive models. That is a real property of vendor
+// reporting rather than something to engineer around, so the chart draws what
+// exists and `evidence` states what it can support.
+
+function scoreRecord(benchmarkId) {
+  return state.data?.benchmark_score_progression?.benchmarks?.[benchmarkId] || null;
+}
+
+// The plotted band for a score axis. Percent metrics are NOT drawn 0-100: every
+// value in this corpus sits in the upper half, so a full-height axis compresses
+// the interesting movement into a sliver. The band is padded around the observed
+// range instead, and the axis is labelled with its real bounds so a reader
+// cannot mistake a zoomed axis for a full one.
+function scoreBand(record) {
+  const values = record.observations.map((observation) => observation.value);
+  const low = Math.min(...values);
+  const high = Math.max(...values);
+  const pad = Math.max(2, (high - low) * 0.18);
+  const bound = record.saturation.bound;
+  return {
+    low: bound === null ? low - pad : Math.max(0, low - pad),
+    high: bound === null ? high + pad : Math.min(bound, high + pad),
+  };
+}
+
+function scoreReadout(entry, record) {
+  const saturation = record.saturation;
+  const evidence = record.evidence;
+  const rows = [
+    element("div", { className: "score-readout-figure" }, [
+      element("span", { text: "Best on record" }),
+      element("strong", {
+        text: `${saturation.best_value}${record.unit === "percent" ? "%" : ""}`,
+      }),
+      element("small", {
+        text: `${saturation.best_model} · ${saturation.best_organization} · ${formatDate(
+          saturation.best_reported_at,
+          { dateStyle: "medium" },
+        )}`,
+      }),
+    ]),
+  ];
+  if (saturation.headroom !== null) {
+    rows.push(
+      element("div", { className: "score-readout-figure" }, [
+        element("span", { text: "Headroom left" }),
+        element("strong", { text: `${saturation.headroom}` }),
+        element("small", {
+          text: `points to the ${saturation.bound}-point bound of this metric`,
+        }),
+      ]),
+    );
+  }
+  rows.push(
+    element("div", { className: "score-readout-figure" }, [
+      element("span", { text: "Readable values" }),
+      element("strong", { text: String(record.observation_count) }),
+      element("small", {
+        text: `${metricLabel(record.dated_observation_count, "date")} · ${metricLabel(
+          record.comparable_series_count,
+          "comparable run",
+        )}`,
+      }),
+    ]),
+  );
+
+  return element("div", { className: "score-readout-inner" }, [
+    element("div", { className: "score-readout-figures" }, rows),
+    element("div", { className: `score-evidence score-evidence-${evidence.id}` }, [
+      element("strong", { text: evidence.label }),
+      element("p", {}, [
+        element("span", { className: "score-evidence-yes", text: "Supports: " }),
+        document.createTextNode(evidence.supports),
+      ]),
+      element("p", {}, [
+        element("span", { className: "score-evidence-no", text: "Does not support: " }),
+        document.createTextNode(evidence.does_not_support),
+      ]),
+    ]),
+    record.third_party_count
+      ? element("p", {
+          className: "score-readout-note",
+          text: `${metricLabel(
+            record.third_party_count,
+            "value",
+          )} here is a third party quoting another vendor's figure, marked with a ring on the chart.`,
+        })
+      : null,
+  ]);
+}
+
+function renderScoreReadout(entry) {
+  const host = byId("frontier-score-readout");
+  if (!host) return;
+  const record = scoreRecord(entry.benchmark_id);
+  if (!record) {
+    replaceChildren(host, [
+      element("p", {
+        className: "score-readout-empty",
+        text:
+          "No score for this benchmark could be read verbatim from the cited documents, so the " +
+          "chart shows adoption only. An absent value is not a zero and not a plateau.",
+      }),
+    ]);
+    return;
+  }
+  replaceChildren(host, [scoreReadout(entry, record)]);
+}
+
 function adoptionFrontierChart(entry, board, events) {
   const datedCards = (board.model_cards || []).filter((card) => card.published);
-  const startText = [entry.released, events[0].published].filter(Boolean).sort()[0];
+  const record = scoreRecord(entry.benchmark_id);
+  const startText = [
+    entry.released,
+    events[0].published,
+    record?.first_reported_at,
+  ]
+    .filter(Boolean)
+    .sort()[0];
   const endText = datedCards.map((card) => card.published).sort().at(-1) || events.at(-1).published;
   const start = new Date(`${startText}T00:00:00Z`).getTime();
   const rawEnd = new Date(`${endText}T00:00:00Z`).getTime();
   const end = Math.max(rawEnd, start + 86_400_000);
   const width = 920;
-  const height = 370;
-  const margin = { top: 32, right: 20, bottom: 62, left: 52 };
+  // The score band is only reserved when there is a score to draw. A benchmark
+  // with no readable value gets the original single-plot height rather than an
+  // empty lower half, which would read as "scores went to zero here".
+  const band = record ? scoreBand(record) : null;
+  const scoreHeight = record ? 132 : 0;
+  const bandGap = record ? 34 : 0;
+  const height = 370 + scoreHeight + bandGap;
+  // The left margin widens when a score band is present: its axis label is a
+  // metric name ("resolved", "pass@1") rather than the fixed "organizations
+  // reporting", and a 52px gutter clipped the longer ones at the viewBox edge.
+  const margin = { top: 32, right: 20, bottom: 62, left: record ? 68 : 52 };
   const plotWidth = width - margin.left - margin.right;
-  const plotHeight = height - margin.top - margin.bottom;
+  const plotHeight = 370 - margin.top - margin.bottom;
   const maxOrganizations = Math.max(1, Number(board.organization_count || 0));
   const x = (date) =>
     margin.left +
     ((new Date(`${date}T00:00:00Z`).getTime() - start) / (end - start)) * plotWidth;
   const y = (count) => margin.top + plotHeight - (count / maxOrganizations) * plotHeight;
+  // The score plot sits below the adoption plot and shares its x scale, which is
+  // the whole point: the two readings are only comparable if a vertical line
+  // through the chart means one date in both.
+  const scoreTop = margin.top + plotHeight + bandGap;
+  const scoreY = (value) =>
+    band && band.high > band.low
+      ? scoreTop + scoreHeight - ((value - band.low) / (band.high - band.low)) * scoreHeight
+      : scoreTop + scoreHeight / 2;
   const advances = events.filter((event) => event.advances);
 
   const svg = svgElement("svg", {
     viewBox: `0 0 ${width} ${height}`,
     role: "img",
-    "aria-label": `${entry.name} reporting adoption over time. ${advances.length} of ${board.organization_count} organizations have a dated report.`,
+    "aria-label":
+      `${entry.name} reporting adoption over time. ${advances.length} of ` +
+      `${board.organization_count} organizations have a dated report.` +
+      (record
+        ? ` Below it, ${metricLabel(record.observation_count, "readable score")} from ` +
+          `${formatDate(record.first_reported_at, { dateStyle: "medium" })} to ` +
+          `${formatDate(record.last_reported_at, { dateStyle: "medium" })}, best ` +
+          `${record.saturation.best_value}.`
+        : " No readable score for this benchmark."),
   });
   const tickStep = Math.max(1, Math.ceil(maxOrganizations / 5));
   const tickValues = new Set([0, maxOrganizations]);
@@ -1983,13 +2133,154 @@ function adoptionFrontierChart(entry, board, events) {
     svg.append(group);
   }
 
+  if (record) {
+    // Band bounds, not 0-100: every value in this corpus sits in the upper part
+    // of its scale, so the axis is zoomed and says so on both ticks.
+    for (const value of [band.high, band.low]) {
+      const yPosition = scoreY(value);
+      svg.append(
+        svgElement("line", {
+          x1: margin.left,
+          y1: yPosition,
+          x2: width - margin.right,
+          y2: yPosition,
+          class: "frontier-grid",
+        }),
+      );
+      svg.append(
+        svgElement(
+          "text",
+          {
+            x: margin.left - 12,
+            y: yPosition + 4,
+            "text-anchor": "end",
+            class: "frontier-tick",
+          },
+          Number(value.toFixed(1)),
+        ),
+      );
+    }
+
+    // One polyline per comparable series, and only for series the join rule
+    // permits a line through. A series confined to one date draws no line: its
+    // points are a comparison table from one document, and connecting them
+    // would turn a single publication into an apparent trend.
+    for (const series of record.series) {
+      if (!series.connectable) continue;
+      const points = series.points
+        .map((point) => `${x(point.reported_at)},${scoreY(point.value)}`)
+        .join(" ");
+      svg.append(
+        svgElement("polyline", {
+          points,
+          class: `score-line${series.single_organization ? " score-line-single-org" : ""}`,
+        }),
+      );
+    }
+
+    // The best-on-record marker. Drawn as a horizontal rule rather than a point
+    // because it is a fact about the whole corpus to date, not about one date.
+    const bestY = scoreY(record.saturation.best_value);
+    svg.append(
+      svgElement("line", {
+        x1: margin.left,
+        y1: bestY,
+        x2: width - margin.right,
+        y2: bestY,
+        class: "score-best-line",
+      }),
+    );
+    svg.append(
+      svgElement(
+        "text",
+        { x: width - margin.right, y: bestY - 6, "text-anchor": "end", class: "score-best-label" },
+        `best on record ${record.saturation.best_value}`,
+      ),
+    );
+
+    for (const observation of record.observations) {
+      const group = svgElement("g", {
+        class: `score-point${observation.reported_by ? " score-point-third-party" : ""}`,
+        tabindex: "0",
+        role: "img",
+        "aria-label":
+          `${observation.value} ${record.metric} by ${observation.model} ` +
+          `(${observation.organization}), ${formatDate(observation.reported_at, {
+            dateStyle: "medium",
+          })}, protocol ${observation.protocol}` +
+          (observation.reported_by ? `, cited by ${observation.reported_by}` : ""),
+      });
+      group.append(
+        svgElement("circle", {
+          cx: x(observation.reported_at),
+          cy: scoreY(observation.value),
+          r: 5,
+        }),
+      );
+      group.append(
+        svgElement(
+          "title",
+          {},
+          `${observation.model} · ${observation.value} · ${observation.protocol}` +
+            (observation.reported_by ? ` · cited by ${observation.reported_by}` : ""),
+        ),
+      );
+      svg.append(group);
+    }
+
+    // The reading gap. Scores in this corpus stop well before mentions do, and
+    // an unmarked flat tail is exactly what invites "saturated" as the
+    // explanation when "nothing newer could be read" is the actual one.
+    const lastScoreX = x(record.last_reported_at);
+    const endX = x(endText);
+    if (endX - lastScoreX > 24) {
+      svg.append(
+        svgElement("line", {
+          x1: lastScoreX,
+          y1: scoreY(record.saturation.best_value),
+          x2: endX,
+          y2: scoreY(record.saturation.best_value),
+          class: "score-gap-line",
+        }),
+      );
+      svg.append(
+        svgElement(
+          "text",
+          {
+            x: (lastScoreX + endX) / 2,
+            y: scoreTop + scoreHeight + 16,
+            "text-anchor": "middle",
+            class: "score-gap-label",
+          },
+          "no readable score in this window",
+        ),
+      );
+    }
+
+    svg.append(
+      svgElement(
+        "text",
+        {
+          x: 17,
+          y: scoreTop + scoreHeight / 2,
+          transform: `rotate(-90 17 ${scoreTop + scoreHeight / 2})`,
+          "text-anchor": "middle",
+          class: "frontier-axis-label",
+        },
+        `${record.metric} (zoomed)`,
+      ),
+    );
+  }
+
   const releaseX = entry.released ? x(entry.released) : x(startText);
   svg.append(
     svgElement("line", {
       x1: releaseX,
       y1: margin.top,
+      // Spans both plots when a score band exists, so the release date reads as
+      // one moment in the benchmark's life rather than as two unrelated marks.
       x2: releaseX,
-      y2: margin.top + plotHeight,
+      y2: record ? scoreTop + scoreHeight : margin.top + plotHeight,
       class: "frontier-release-line",
     }),
   );
@@ -2040,6 +2331,7 @@ function clearAdoptionFrontier(message) {
   replaceChildren(byId("frontier-summary"), []);
   replaceChildren(byId("frontier-milestones"), []);
   replaceChildren(byId("frontier-task-preview"), []);
+  replaceChildren(byId("frontier-score-readout"), []);
   replaceChildren(byId("frontier-chart"), [
     element("p", { className: "empty-state", text: message }),
   ]);
@@ -2093,8 +2385,90 @@ function renderAdoptionFrontier(board) {
       ? sparseFrontier(entry, events)
       : adoptionFrontierChart(entry, board, events),
   ]);
+  // Rendered for every benchmark, including those whose adoption is too sparse
+  // to plot: the score reading is a separate question from the adoption reading,
+  // and a benchmark with one adopter can still have a readable score.
+  renderScoreReadout(entry);
   renderFrontierMilestones(entry, events);
   renderFrontierTaskPreview(entry);
+}
+
+// --- Stated findings (issue #91) --------------------------------------------
+//
+// The issue's third point: the project kept adding charts while the real gap --
+// surfacing insight -- stayed open. Every sentence here is derived in Python by
+// `insights.build_insights`, where it is tested, rather than phrased in the
+// browser. This function only lays them out.
+//
+// A finding carries its own evidence line, and clicking one moves the chart to
+// the benchmark it is about, so a claim is never more than one interaction away
+// from the data behind it.
+
+const FINDING_LABELS = {
+  adopted_without_scores: "Adopted, unscored",
+  stale_scores: "Reading coverage",
+  closing_headroom: "Closing headroom",
+  fast_gain: "Fast gain",
+  third_party_only: "Third-party only",
+};
+
+function findingCard(finding, board) {
+  const children = [
+    element("div", { className: "finding-head" }, [
+      element("span", {
+        className: `finding-kind finding-kind-${finding.kind}`,
+        text: FINDING_LABELS[finding.kind] || finding.kind,
+      }),
+      element("h3", { text: finding.headline }),
+    ]),
+    element("p", { className: "finding-detail", text: finding.detail }),
+    element("p", { className: "finding-evidence" }, [
+      element("span", { text: "Evidence" }),
+      document.createTextNode(finding.evidence),
+    ]),
+  ];
+
+  // Corpus-scope findings carry no benchmark_id, so there is nothing to focus.
+  const target = finding.benchmark_id
+    ? (board.entries || []).find((entry) => entry.benchmark_id === finding.benchmark_id)
+    : null;
+  if (target) {
+    const jump = element("button", {
+      className: "secondary-link finding-jump",
+      text: `Show ${target.name} on the chart ↑`,
+      attrs: { type: "button" },
+    });
+    jump.addEventListener("click", () => {
+      state.lfrontier = target.benchmark_id;
+      renderAdoptionFrontier(board);
+      writeUrl();
+      byId("adoption-frontier").scrollIntoView({ behavior: "smooth", block: "start" });
+    });
+    children.push(jump);
+  }
+
+  return element("article", { className: "finding-card" }, children);
+}
+
+function renderBenchmarkFindings(board) {
+  const panel = byId("benchmark-findings");
+  if (!panel) return;
+  const insights = state.data?.benchmark_insights;
+  // Hidden entirely rather than shown empty. An empty findings panel reads as
+  // "we looked and the field is uneventful", which is a claim this corpus is not
+  // in a position to make.
+  if (!insights || !insights.findings?.length) {
+    panel.hidden = true;
+    return;
+  }
+  panel.hidden = false;
+  byId("findings-count").textContent = metricLabel(insights.finding_count, "finding");
+  byId("findings-measures").textContent = insights.measures || "";
+  byId("findings-limits").textContent = `Does not measure: ${insights.does_not_measure}`;
+  replaceChildren(
+    byId("findings-list"),
+    insights.findings.map((finding) => findingCard(finding, board)),
+  );
 }
 
 function modelCardLabelCounts(board) {
@@ -2265,6 +2639,7 @@ function renderLeaderboard() {
 
   byId("leaderboard-measures").textContent = board.measures || "";
   renderLeaderboardFilters(board);
+  renderBenchmarkFindings(board);
   renderAdoptionFrontier(board);
 
   const topEntries = (board.entries || []).filter((entry) => entry.card_count > 0);

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -2028,11 +2028,9 @@ function renderScoreReadout(entry) {
 function adoptionFrontierChart(entry, board, events, { sparse = false } = {}) {
   const datedCards = (board.model_cards || []).filter((card) => card.published);
   const record = scoreRecord(entry.benchmark_id);
-  const startText = [
-    entry.released,
-    events[0].published,
-    record?.first_reported_at,
-  ]
+  // `events` may be empty when only the score track is being drawn, so both
+  // bounds are computed from whatever dates exist rather than indexing into it.
+  const startText = [entry.released, events[0]?.published, record?.first_reported_at]
     .filter(Boolean)
     .sort()[0];
   // Symmetric with `startText`: the range has to cover the score track as well
@@ -2040,8 +2038,8 @@ function adoptionFrontierChart(entry, board, events, { sparse = false } = {}) {
   // when a card carries a later `revised` date -- lands outside the viewBox and
   // is silently clipped. Both ends therefore consider both layers.
   const endText = [
-    datedCards.map((card) => card.published).sort().at(-1),
-    events.at(-1).published,
+    events.length ? datedCards.map((card) => card.published).sort().at(-1) : null,
+    events.at(-1)?.published,
     record?.last_reported_at,
   ]
     .filter(Boolean)
@@ -2092,11 +2090,16 @@ function adoptionFrontierChart(entry, board, events, { sparse = false } = {}) {
     viewBox: `0 0 ${width} ${height}`,
     role: "img",
     "aria-label":
-      `${entry.name} reporting adoption over time. ${advances.length} of ` +
-      `${board.organization_count} organizations have a dated report.` +
+      (events.length
+        ? `${entry.name} reporting adoption over time. ${advances.length} of ` +
+          `${board.organization_count} organizations have a dated report.`
+        : `${entry.name} readable scores over time. No mention of it carries a date, so no ` +
+          "adoption timeline is shown.") +
       (record
-        ? ` Below it, ${metricLabel(record.observation_count, "readable score")} from ` +
-          `${formatDate(record.first_reported_at, { dateStyle: "medium" })} to ` +
+        ? ` ${events.length ? "Below it, " : ""}${metricLabel(
+            record.observation_count,
+            "readable score",
+          )} from ${formatDate(record.first_reported_at, { dateStyle: "medium" })} to ` +
           `${formatDate(record.last_reported_at, { dateStyle: "medium" })}, best ` +
           `${record.saturation.best_value}.`
         : " No readable score for this benchmark."),
@@ -2274,8 +2277,20 @@ function adoptionFrontierChart(entry, board, events, { sparse = false } = {}) {
     // manufactured a flat tail out of missing data. That is the exact failure
     // this marker exists to prevent, so the span is now purely horizontal: it
     // says "no reading here", not "the reading stayed at N".
+    // Bounded by the newest dated mention of *this* benchmark, not by the newest
+    // card in the registry. An unrelated vendor's recent document is not evidence
+    // that this benchmark went unread: shipped Arena-Hard and Aider Polyglot have
+    // no adopter newer than their last score, so ending at the global date drew a
+    // long gap that nothing about those benchmarks supported.
+    const lastMention = events
+      .map((event) => event.published)
+      .filter(Boolean)
+      .sort()
+      .at(-1);
     const lastScoreX = x(record.last_reported_at);
-    const endX = x(endText);
+    const endX = x(
+      lastMention && lastMention > record.last_reported_at ? lastMention : record.last_reported_at,
+    );
     if (endX - lastScoreX > 24) {
       const floorY = scoreTop + scoreHeight;
       svg.append(
@@ -2345,7 +2360,11 @@ function adoptionFrontierChart(entry, board, events, { sparse = false } = {}) {
     svgElement(
       "text",
       { x: releaseX + 8, y: margin.top + 14, class: "frontier-release-label" },
-      entry.released ? "release" : "first dated mention",
+      entry.released
+        ? "release"
+        : events.length
+          ? "first dated mention"
+          : "first readable score",
     ),
   );
   for (const [date, anchor] of [
@@ -2385,6 +2404,22 @@ function adoptionFrontierChart(entry, board, events, { sparse = false } = {}) {
   return svg;
 }
 
+// The score track alone, for a benchmark whose every mention is undated. Delegates
+// to the same renderer with no adoption events rather than duplicating the score
+// geometry: two implementations of one axis would be free to disagree about the
+// join rule, which is the one thing this chart must not do.
+function scoreOnlyChart(entry) {
+  return adoptionFrontierChart(
+    entry,
+    // `organization_count` is only read for the adoption axis, which is suppressed
+    // here, and `model_cards` only to bound the range -- which the score dates now
+    // supply. An empty board keeps this call from depending on either.
+    { organization_count: 0, model_cards: [] },
+    [],
+    { sparse: true },
+  );
+}
+
 function clearAdoptionFrontier(message) {
   byId("frontier-stage").textContent = "";
   replaceChildren(byId("frontier-summary"), []);
@@ -2422,8 +2457,13 @@ function renderAdoptionFrontier(board) {
     // No dated mention means no adoption timeline can be drawn. The score
     // reading is independent of that, though: the registry permits a card
     // without a `published` date, and clearing the panel outright would hide
-    // every readable score because the *other* layer had no usable date.
+    // every readable score because the *other* layer had no usable date. So the
+    // score track still draws, on its own, with the points and comparable series
+    // intact rather than reduced to the aggregate readout.
     clearAdoptionFrontier("This benchmark has no dated mentions.");
+    if (scoreRecord(entry.benchmark_id)) {
+      replaceChildren(byId("frontier-chart"), [scoreOnlyChart(entry)]);
+    }
     renderScoreReadout(entry);
     return;
   }

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -1954,8 +1954,14 @@ function scoreReadout(entry, record) {
       element("div", { className: "score-readout-figure" }, [
         element("span", { text: "Headroom left" }),
         element("strong", { text: `${saturation.headroom}` }),
+        // On a lower-is-better metric the backend measures headroom to zero, not
+        // to `bound`. Naming the bound in both cases would print "10 points to
+        // the 100-point bound" for a score of 10, which is arithmetically false.
         element("small", {
-          text: `points to the ${saturation.bound}-point bound of this metric`,
+          text:
+            record.direction === "lower_is_better"
+              ? "points to zero, the floor of this metric"
+              : `points to the ${saturation.bound}-point bound of this metric`,
         }),
       ]),
     );
@@ -2016,7 +2022,10 @@ function renderScoreReadout(entry) {
   replaceChildren(host, [scoreReadout(entry, record)]);
 }
 
-function adoptionFrontierChart(entry, board, events) {
+// `sparse` means the adoption stepper is being rendered separately because it has
+// fewer than two frontier advances. The score track still draws, on its own axis,
+// so a thin adoption layer never hides a readable score.
+function adoptionFrontierChart(entry, board, events, { sparse = false } = {}) {
   const datedCards = (board.model_cards || []).filter((card) => card.published);
   const record = scoreRecord(entry.benchmark_id);
   const startText = [
@@ -2037,13 +2046,15 @@ function adoptionFrontierChart(entry, board, events) {
   const band = record ? scoreBand(record) : null;
   const scoreHeight = record ? 132 : 0;
   const bandGap = record ? 34 : 0;
-  const height = 370 + scoreHeight + bandGap;
   // The left margin widens when a score band is present: its axis label is a
   // metric name ("resolved", "pass@1") rather than the fixed "organizations
   // reporting", and a 52px gutter clipped the longer ones at the viewBox edge.
   const margin = { top: 32, right: 20, bottom: 62, left: record ? 68 : 52 };
   const plotWidth = width - margin.left - margin.right;
-  const plotHeight = 370 - margin.top - margin.bottom;
+  // The adoption plot collapses to nothing when its stepper is drawn separately,
+  // so the SVG carries no empty region where the step line would have been.
+  const plotHeight = sparse ? 0 : 370 - margin.top - margin.bottom;
+  const height = margin.top + plotHeight + bandGap + scoreHeight + margin.bottom;
   const maxOrganizations = Math.max(1, Number(board.organization_count || 0));
   const x = (date) =>
     margin.left +
@@ -2053,10 +2064,17 @@ function adoptionFrontierChart(entry, board, events) {
   // the whole point: the two readings are only comparable if a vertical line
   // through the chart means one date in both.
   const scoreTop = margin.top + plotHeight + bandGap;
-  const scoreY = (value) =>
-    band && band.high > band.low
-      ? scoreTop + scoreHeight - ((value - band.low) / (band.high - band.low)) * scoreHeight
-      : scoreTop + scoreHeight / 2;
+  // Better is always up. `direction` exists in the schema precisely so a metric
+  // where lower wins (an edit distance, an error rate) does not render its
+  // improvements as a downward slope; consulting it here is what makes the axis
+  // mean "better" rather than "larger".
+  const scoreDescends = record?.direction === "lower_is_better";
+  const scoreY = (value) => {
+    if (!band || band.high <= band.low) return scoreTop + scoreHeight / 2;
+    const fraction = (value - band.low) / (band.high - band.low);
+    const fromFloor = scoreDescends ? 1 - fraction : fraction;
+    return scoreTop + scoreHeight - fromFloor * scoreHeight;
+  };
   const advances = events.filter((event) => event.advances);
 
   const svg = svgElement("svg", {
@@ -2072,65 +2090,71 @@ function adoptionFrontierChart(entry, board, events) {
           `${record.saturation.best_value}.`
         : " No readable score for this benchmark."),
   });
-  const tickStep = Math.max(1, Math.ceil(maxOrganizations / 5));
-  const tickValues = new Set([0, maxOrganizations]);
-  for (let count = tickStep; count < maxOrganizations; count += tickStep) tickValues.add(count);
-  for (const count of [...tickValues].sort((a, b) => a - b)) {
-    const yPosition = y(count);
-    svg.append(
-      svgElement("line", {
-        x1: margin.left,
-        y1: yPosition,
-        x2: width - margin.right,
-        y2: yPosition,
-        class: "frontier-grid",
-      }),
-    );
-    svg.append(
-      svgElement(
-        "text",
-        { x: margin.left - 12, y: yPosition + 4, "text-anchor": "end", class: "frontier-tick" },
-        count,
-      ),
-    );
-  }
-
-  let path = `M ${x(startText)} ${y(0)}`;
-  for (const event of advances) {
-    path += ` H ${x(event.published)} V ${y(event.organizationCount)}`;
-  }
-  path += ` H ${x(endText)}`;
-  svg.append(svgElement("path", { d: path, class: "frontier-line" }));
-
-  for (const event of events) {
-    const advanceIndex = event.advances ? advances.indexOf(event) + 1 : null;
-    const group = svgElement("g", {
-      class: `frontier-point${event.advances ? " frontier-point-advance" : " frontier-point-repeat"}`,
-      tabindex: "0",
-      role: "img",
-      "aria-label": `${event.organization}, ${event.model}, ${formatDate(event.published, {
-        dateStyle: "medium",
-      })}${event.advances ? `, frontier step ${advanceIndex}` : ", repeat report"}`,
-    });
-    const pointX = x(event.published);
-    const pointY = y(event.organizationCount);
-    group.append(svgElement("circle", { cx: pointX, cy: pointY, r: event.advances ? 11 : 6 }));
-    if (advanceIndex) {
-      group.append(
+  // The adoption plot. Skipped entirely when its stepper is rendered separately:
+  // a step line with fewer than two advances says nothing a reader can use.
+  if (!sparse) {
+    const tickStep = Math.max(1, Math.ceil(maxOrganizations / 5));
+    const tickValues = new Set([0, maxOrganizations]);
+    for (let count = tickStep; count < maxOrganizations; count += tickStep) {
+      tickValues.add(count);
+    }
+    for (const count of [...tickValues].sort((a, b) => a - b)) {
+      const yPosition = y(count);
+      svg.append(
+        svgElement("line", {
+          x1: margin.left,
+          y1: yPosition,
+          x2: width - margin.right,
+          y2: yPosition,
+          class: "frontier-grid",
+        }),
+      );
+      svg.append(
         svgElement(
           "text",
-          {
-            x: pointX,
-            y: pointY + 4,
-            "text-anchor": "middle",
-            class: "frontier-point-number",
-          },
-          advanceIndex,
+          { x: margin.left - 12, y: yPosition + 4, "text-anchor": "end", class: "frontier-tick" },
+          count,
         ),
       );
     }
-    group.append(svgElement("title", {}, `${event.organization} · ${event.model}`));
-    svg.append(group);
+
+    let path = `M ${x(startText)} ${y(0)}`;
+    for (const event of advances) {
+      path += ` H ${x(event.published)} V ${y(event.organizationCount)}`;
+    }
+    path += ` H ${x(endText)}`;
+    svg.append(svgElement("path", { d: path, class: "frontier-line" }));
+
+    for (const event of events) {
+      const advanceIndex = event.advances ? advances.indexOf(event) + 1 : null;
+      const group = svgElement("g", {
+        class: `frontier-point${event.advances ? " frontier-point-advance" : " frontier-point-repeat"}`,
+        tabindex: "0",
+        role: "img",
+        "aria-label": `${event.organization}, ${event.model}, ${formatDate(event.published, {
+          dateStyle: "medium",
+        })}${event.advances ? `, frontier step ${advanceIndex}` : ", repeat report"}`,
+      });
+      const pointX = x(event.published);
+      const pointY = y(event.organizationCount);
+      group.append(svgElement("circle", { cx: pointX, cy: pointY, r: event.advances ? 11 : 6 }));
+      if (advanceIndex) {
+        group.append(
+          svgElement(
+            "text",
+            {
+              x: pointX,
+              y: pointY + 4,
+              "text-anchor": "middle",
+              class: "frontier-point-number",
+            },
+            advanceIndex,
+          ),
+        );
+      }
+      group.append(svgElement("title", {}, `${event.organization} · ${event.model}`));
+      svg.append(group);
+    }
   }
 
   if (record) {
@@ -2231,24 +2255,46 @@ function adoptionFrontierChart(entry, board, events) {
     // The reading gap. Scores in this corpus stop well before mentions do, and
     // an unmarked flat tail is exactly what invites "saturated" as the
     // explanation when "nothing newer could be read" is the actual one.
+    //
+    // Drawn on the plot floor, carrying no y-value. An earlier version put this
+    // line at the best-on-record height, which asserted that value at a date
+    // where nothing was recorded -- and on shipped data the best often predates
+    // the last observation (AIME, SWE-bench Verified, MMLU-Redux, IFEval), so it
+    // manufactured a flat tail out of missing data. That is the exact failure
+    // this marker exists to prevent, so the span is now purely horizontal: it
+    // says "no reading here", not "the reading stayed at N".
     const lastScoreX = x(record.last_reported_at);
     const endX = x(endText);
     if (endX - lastScoreX > 24) {
+      const floorY = scoreTop + scoreHeight;
       svg.append(
         svgElement("line", {
           x1: lastScoreX,
-          y1: scoreY(record.saturation.best_value),
+          y1: floorY,
           x2: endX,
-          y2: scoreY(record.saturation.best_value),
+          y2: floorY,
           class: "score-gap-line",
         }),
       );
+      // Ticks at both ends so the span reads as a bounded interval on the time
+      // axis rather than as a series that happens to sit at the floor.
+      for (const edge of [lastScoreX, endX]) {
+        svg.append(
+          svgElement("line", {
+            x1: edge,
+            y1: floorY - 5,
+            x2: edge,
+            y2: floorY + 5,
+            class: "score-gap-line",
+          }),
+        );
+      }
       svg.append(
         svgElement(
           "text",
           {
             x: (lastScoreX + endX) / 2,
-            y: scoreTop + scoreHeight + 16,
+            y: scoreTop + scoreHeight + 18,
             "text-anchor": "middle",
             class: "score-gap-label",
           },
@@ -2303,19 +2349,21 @@ function adoptionFrontierChart(entry, board, events) {
       ),
     );
   }
-  svg.append(
-    svgElement(
-      "text",
-      {
-        x: 15,
-        y: margin.top + plotHeight / 2,
-        transform: `rotate(-90 15 ${margin.top + plotHeight / 2})`,
-        "text-anchor": "middle",
-        class: "frontier-axis-label",
-      },
-      "organizations reporting",
-    ),
-  );
+  if (!sparse) {
+    svg.append(
+      svgElement(
+        "text",
+        {
+          x: 15,
+          y: margin.top + plotHeight / 2,
+          transform: `rotate(-90 15 ${margin.top + plotHeight / 2})`,
+          "text-anchor": "middle",
+          class: "frontier-axis-label",
+        },
+        "organizations reporting",
+      ),
+    );
+  }
   svg.append(
     svgElement(
       "text",
@@ -2380,10 +2428,15 @@ function renderAdoptionFrontier(board) {
     }),
     element("span", { className: "frontier-stage-description", text: stage.description }),
   ]);
+  // A single-advance adoption step line says nothing visually, which is why the
+  // sparse stepper replaces it. The score track is a separate reading though, so
+  // when one exists it is still drawn: dropping it would hide real data because a
+  // *different* layer was thin.
+  const sparse = frontier.length < 2;
+  const scored = Boolean(scoreRecord(entry.benchmark_id));
   replaceChildren(byId("frontier-chart"), [
-    frontier.length < 2
-      ? sparseFrontier(entry, events)
-      : adoptionFrontierChart(entry, board, events),
+    sparse ? sparseFrontier(entry, events) : null,
+    sparse && !scored ? null : adoptionFrontierChart(entry, board, events, { sparse }),
   ]);
   // Rendered for every benchmark, including those whose adoption is too sparse
   // to plot: the score reading is a separate question from the adoption reading,

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -2035,7 +2035,18 @@ function adoptionFrontierChart(entry, board, events, { sparse = false } = {}) {
   ]
     .filter(Boolean)
     .sort()[0];
-  const endText = datedCards.map((card) => card.published).sort().at(-1) || events.at(-1).published;
+  // Symmetric with `startText`: the range has to cover the score track as well
+  // as the adoption track, or a score dated after the newest card -- reachable
+  // when a card carries a later `revised` date -- lands outside the viewBox and
+  // is silently clipped. Both ends therefore consider both layers.
+  const endText = [
+    datedCards.map((card) => card.published).sort().at(-1),
+    events.at(-1).published,
+    record?.last_reported_at,
+  ]
+    .filter(Boolean)
+    .sort()
+    .at(-1);
   const start = new Date(`${startText}T00:00:00Z`).getTime();
   const rawEnd = new Date(`${endText}T00:00:00Z`).getTime();
   const end = Math.max(rawEnd, start + 86_400_000);
@@ -2408,7 +2419,12 @@ function renderAdoptionFrontier(board) {
   byId("frontier-heading").textContent = `${entry.name} adoption trajectory`;
   const events = frontierEvents(entry);
   if (!events.length) {
+    // No dated mention means no adoption timeline can be drawn. The score
+    // reading is independent of that, though: the registry permits a card
+    // without a `published` date, and clearing the panel outright would hide
+    // every readable score because the *other* layer had no usable date.
     clearAdoptionFrontier("This benchmark has no dated mentions.");
+    renderScoreReadout(entry);
     return;
   }
 

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -1721,6 +1721,275 @@ td a {
   font-weight: 800;
 }
 
+/* Stated findings (issue #91). Sits above the workbench on the light canvas:
+   the findings are the conclusion, so they are read before the charts that
+   support them rather than discovered underneath. */
+.findings-panel {
+  margin: 1.5rem 0;
+  padding: clamp(1.25rem, 3vw, 1.75rem);
+  border: 1px solid var(--ink);
+  background: var(--panel);
+  box-shadow: var(--shadow);
+}
+
+.findings-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1rem;
+  margin-top: 1.2rem;
+}
+
+.finding-card {
+  display: grid;
+  align-content: start;
+  gap: 0.6rem;
+  padding: 1.1rem 1.2rem;
+  border: 1px solid var(--line);
+  background: #fff;
+}
+
+.finding-head {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.finding-kind {
+  justify-self: start;
+  padding: 0.2rem 0.5rem;
+  border: 1px solid var(--ink);
+  color: var(--ink);
+  font-family: var(--utility);
+  font-size: 0.64rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.finding-kind-stale_scores {
+  border-color: var(--orange);
+  color: var(--orange);
+}
+
+.finding-kind-closing_headroom {
+  border-color: var(--gold);
+  color: #8a651a;
+}
+
+.finding-kind-fast_gain {
+  border-color: var(--blue);
+  color: var(--blue);
+}
+
+.finding-kind-third_party_only {
+  border-color: var(--violet);
+  color: var(--violet);
+}
+
+.finding-card h3 {
+  margin: 0;
+  font-family: var(--display);
+  font-size: 1.1rem;
+  line-height: 1.25;
+}
+
+.finding-detail {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+  line-height: 1.55;
+}
+
+/* The evidence line is what makes a finding auditable rather than asserted, so
+   it is set apart from the prose above it instead of running on from it. */
+.finding-evidence {
+  margin: 0;
+  padding-top: 0.6rem;
+  border-top: 1px solid var(--line);
+  color: var(--ink);
+  font-family: var(--utility);
+  font-size: 0.76rem;
+  line-height: 1.5;
+}
+
+.finding-evidence span {
+  display: block;
+  color: var(--muted);
+  font-size: 0.64rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.finding-jump {
+  justify-self: start;
+}
+
+.findings-limits {
+  margin-top: 1.2rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--line);
+}
+
+/* Score progression (issue #91). Sea green throughout, deliberately distinct
+   from the gold of an adoption advance: the two layers share an x axis and must
+   never share a colour, or a reader will connect a score point to a mention. */
+.score-line {
+  fill: none;
+  stroke: #6ea8dc;
+  stroke-width: 2.5;
+}
+
+/* A single-organization run is one vendor's own model line, which is weaker
+   evidence about the field. Dashed rather than a different hue: the dash says
+   "provisional" without implying a third measurement type. */
+.score-line-single-org {
+  stroke-dasharray: 7 4;
+}
+
+.score-point circle {
+  fill: #6ea8dc;
+  stroke: #0d1519;
+  stroke-width: 2;
+  transition: r 120ms ease;
+}
+
+/* A third-party citation is a publisher repeating a competitor's figure. The
+   ring marks it on the chart so it is not read as a first-party report. */
+.score-point-third-party circle {
+  fill: #0d1519;
+  stroke: #6ea8dc;
+  stroke-width: 2.5;
+}
+
+.score-point:focus circle,
+.score-point:hover circle {
+  r: 8px;
+}
+
+.score-best-line {
+  stroke: #8fd0c4;
+  stroke-dasharray: 2 4;
+  stroke-width: 1.5;
+}
+
+.score-best-label {
+  fill: #8fd0c4;
+  font-family: var(--utility);
+  font-size: 11px;
+}
+
+/* The reading gap, not a plateau. Sparse dots rather than a solid line so it
+   reads as absence of data instead of a measured flat run. */
+.score-gap-line {
+  stroke: #7a8890;
+  stroke-dasharray: 1 7;
+  stroke-width: 2;
+}
+
+.score-gap-label {
+  fill: #97a5ac;
+  font-family: var(--utility);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.score-readout {
+  margin-top: 1rem;
+}
+
+.score-readout-inner {
+  display: grid;
+  gap: 1rem;
+  padding: 1.1rem 1.2rem;
+  border: 1px solid #39464c;
+  background: #101a1f;
+}
+
+.score-readout-figures {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 1rem;
+}
+
+.score-readout-figure {
+  display: grid;
+  gap: 0.15rem;
+}
+
+.score-readout-figure span {
+  color: #aebcc1;
+  font-family: var(--utility);
+  font-size: 0.68rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.score-readout-figure strong {
+  color: #cfe4f5;
+  font-family: var(--display);
+  font-size: 1.6rem;
+  line-height: 1.1;
+}
+
+.score-readout-figure small {
+  color: #97a5ac;
+  font-size: 0.76rem;
+}
+
+/* The evidence grade. Printed rather than tucked behind a disclosure: the
+   honest scope of a two-point chart is the first thing a reader needs, not an
+   optional footnote. */
+.score-evidence {
+  padding: 0.85rem 1rem;
+  border-left: 3px solid #6ea8dc;
+  background: #16232a;
+}
+
+.score-evidence-single_reading,
+.score-evidence-unjoinable {
+  border-left-color: #c98a4b;
+}
+
+.score-evidence strong {
+  display: block;
+  margin-bottom: 0.4rem;
+  font-family: var(--utility);
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #d6e0e3;
+}
+
+.score-evidence p {
+  margin: 0.3rem 0 0;
+  color: #c3cfd4;
+  font-size: 0.83rem;
+  line-height: 1.5;
+}
+
+.score-evidence-yes {
+  color: #8fd0c4;
+  font-weight: 700;
+}
+
+.score-evidence-no {
+  color: #e0a288;
+  font-weight: 700;
+}
+
+.score-readout-note,
+.score-readout-empty {
+  margin: 0;
+  color: #aebcc1;
+  font-size: 0.82rem;
+  line-height: 1.5;
+}
+
+.score-readout-empty {
+  padding: 1rem 1.2rem;
+  border: 1px dashed #39464c;
+  background: #101a1f;
+}
+
 .frontier-evidence {
   display: grid;
   grid-template-columns: minmax(0, 1.05fr) minmax(260px, 0.95fr);
@@ -2603,7 +2872,9 @@ footer {
 
   .frontier-tick,
   .frontier-axis-label,
-  .frontier-release-label {
+  .frontier-release-label,
+  .score-best-label,
+  .score-gap-label {
     font-size: 20px;
   }
 

--- a/site/index.html
+++ b/site/index.html
@@ -204,6 +204,19 @@
 
         <div class="evidence-strip" id="leaderboard-insights" aria-label="Registry overview"></div>
 
+        <section class="findings-panel" id="benchmark-findings" aria-labelledby="findings-heading" hidden>
+          <div class="section-title">
+            <div>
+              <p class="eyebrow">What the two layers say</p>
+              <h2 id="findings-heading">Stated findings</h2>
+            </div>
+            <span id="findings-count" aria-live="polite"></span>
+          </div>
+          <p class="section-note" id="findings-measures"></p>
+          <div class="findings-list" id="findings-list"></div>
+          <p class="section-note findings-limits" id="findings-limits"></p>
+        </section>
+
         <div class="benchmark-workbench">
           <aside class="benchmark-navigator" aria-labelledby="benchmark-navigator-heading">
             <p class="eyebrow">Benchmarks to watch</p>
@@ -230,13 +243,18 @@
               </div>
             </div>
             <p class="section-note" id="frontier-explainer">
-              Each dot is a model card mention. The line advances only when a new
-              organization adopts the benchmark; hollow dots are repeat reports from an
+              Two readings on one time axis. The step line is adoption: it advances only when a
+              new organization reports the benchmark, and hollow dots are repeat reports from an
               organization already on the frontier. A long flat run is reporting saturation
               observed within this curated registry, not a claim about benchmark score saturation.
+              The score track below it is a separate reading: every value that could be read
+              verbatim from a cited document, connected only where the instrument and protocol
+              are identical. A flat score tail usually means no newer number could be read, which
+              is why the gap is marked rather than drawn through.
             </p>
             <div class="frontier-summary" id="frontier-summary" aria-live="polite"></div>
             <div class="frontier-chart" id="frontier-chart"></div>
+            <div class="score-readout" id="frontier-score-readout"></div>
             <div class="frontier-evidence">
               <section aria-labelledby="frontier-milestones-heading">
                 <h3 id="frontier-milestones-heading">Frontier milestones</h3>

--- a/src/benchmark_radar/benchmark_scores.py
+++ b/src/benchmark_radar/benchmark_scores.py
@@ -245,8 +245,11 @@ def _cross_check_sources(scores: dict[str, Any], registry: dict[str, Any]) -> No
     card is a citation to nothing: it would render as a linkless number that a
     reader cannot check, which is the one thing this dataset promises not to do.
     """
-    known = {str(card["id"]) for card in registry["model_cards"]}
-    unknown = sorted({row["source_id"] for row in scores["results"]} - known)
+    reported: dict[str, set[str]] = {
+        str(card["id"]): {str(ref) for ref in card["benchmarks"]}
+        for card in registry["model_cards"]
+    }
+    unknown = sorted({row["source_id"] for row in scores["results"]} - reported.keys())
     if unknown:
         raise BenchmarkScoreError(
             f"score rows cite source_ids absent from the model card registry: {', '.join(unknown)}"
@@ -257,6 +260,23 @@ def _cross_check_sources(scores: dict[str, Any], registry: dict[str, Any]) -> No
         raise BenchmarkScoreError(
             "score file declares benchmarks absent from the model card registry: "
             f"{', '.join(stray)}"
+        )
+
+    # Existence of the cited card is not enough. A `source_id` mistyped to a
+    # different real card passes the check above while attributing the score to a
+    # document that never reported that benchmark -- a published number with false
+    # provenance, which is worse than a missing one because it looks checkable.
+    # The registry already records which benchmarks each card reports, so the pair
+    # is verifiable rather than taken on trust.
+    mismatched = sorted(
+        f"{row['source_id']} does not report {row['benchmark_id']}"
+        for row in scores["results"]
+        if row["benchmark_id"] not in reported[row["source_id"]]
+    )
+    if mismatched:
+        raise BenchmarkScoreError(
+            "score rows cite documents that do not report the benchmark they score: "
+            f"{', '.join(dict.fromkeys(mismatched))}"
         )
 
 

--- a/src/benchmark_radar/benchmark_scores.py
+++ b/src/benchmark_radar/benchmark_scores.py
@@ -1,0 +1,548 @@
+"""Score progression and saturation reading (issue #91).
+
+`model_cards.py` answers "which benchmarks do vendors report" by counting
+mentions. That is the 上榜 question: a benchmark enters the field's shared
+vocabulary when a new organization first puts it in front of readers. It says
+nothing about whether the benchmark is still hard.
+
+This module answers the other half, from `data/benchmark_scores.yml`: where a
+real number was read out of a real document, how have reported scores moved?
+The two readings are published against one time axis so a reader can see the
+case the issue asks about -- a benchmark that everyone adopts *and* whose
+headroom is closing -- without having to hold two charts in their head.
+
+WHY THIS IS NOT A "HIGHEST SCORE SO FAR" LINE
+
+The data file states the trap plainly and this module is built to respect it: a
+running maximum rises or stays flat by construction, so a flat run is not
+evidence of saturation. It is equally consistent with vendors having stopped
+reporting the benchmark, with a protocol change, or with nobody having published
+since. Three things are therefore computed and published separately, and none of
+them is allowed to be read as the others:
+
+`best`
+    The highest comparable value on record, with the date and document that
+    produced it. A fact about the corpus, not about the benchmark's ceiling.
+`headroom`
+    Distance from `best` to the metric's own bound, when the metric has one.
+    This is what "saturated" can mean without a trend claim: an instrument
+    scored at 92 of a possible 100 has 8 points left whether or not anyone
+    reports it again.
+`comparable_series`
+    Only the runs the join rule actually permits: identical instrument AND
+    identical protocol. Everything else stays an unconnected point.
+
+THE SAMPLE IS SMALL AND THE READING SAYS SO
+
+Under the strict join rule this corpus yields very few multi-date runs, and most
+of those are one vendor reporting its own successive models. That is a real
+property of vendor reporting, not a bug to be engineered around by relaxing the
+join, so `evidence_grade` labels each benchmark with what its rows can and
+cannot support. A two-point single-vendor run is reported as such and never
+described as a field-wide trend.
+
+Scores also stop earlier than mentions do. Every 2026-dated card in the registry
+is listed as unread in the data file, so a benchmark can be actively adopted in
+2026 with no score after mid-2025. `score_gap_days` measures that lag explicitly,
+because a chart drawn without it would show a flat score line beside a climbing
+adoption line and invite "saturated" as the explanation when "unread" is the
+actual one.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_ISO_DATE = re.compile(r"\d{4}-\d{2}-\d{2}")
+
+SCORES_SCHEMA_VERSION = 1
+
+DEFAULT_SCORES_PATH = Path("data/benchmark_scores.yml")
+
+# `direction` exists because not every metric improves upward. Only the two
+# meanings the file documents are accepted: an unrecognized direction would
+# otherwise be treated as higher-is-better and silently invert a chart.
+_DIRECTIONS = ("higher_is_better", "lower_is_better")
+
+# Percent is the only unit in the corpus with a defensible fixed bound, and
+# `headroom` is only computed for it. A raw F1 or an Elo has no ceiling this
+# module is entitled to invent, so those benchmarks publish `headroom: None`
+# rather than a number derived from an assumption.
+_BOUNDED_UNITS = {"percent": 100.0}
+
+_REQUIRED_BENCHMARK_FIELDS = ("benchmark_id", "metric", "direction", "unit")
+_REQUIRED_RESULT_FIELDS = (
+    "benchmark_id",
+    "instrument",
+    "protocol",
+    "model",
+    "organization",
+    "source_id",
+    "reported_at",
+    "value",
+    "read_from",
+)
+
+# How a value was obtained. Mirrors the vocabulary the data file documents;
+# a row claiming some other provenance is a data error, not a new category to
+# be accepted silently, because the UI grades evidence on this field.
+_READ_FROM = ("pdf_text", "html_text", "table_image")
+
+# Below this many distinct dates a run cannot express a direction over time at
+# all: two points define one segment, which is a comparison, not a trend.
+_MIN_DATES_FOR_TREND = 3
+
+
+class BenchmarkScoreError(ValueError):
+    """Raised when the curated score file is internally inconsistent."""
+
+
+def _require(value: Any, fields: tuple[str, ...], *, label: str) -> None:
+    if not isinstance(value, dict):
+        raise BenchmarkScoreError(f"{label} must be a mapping")
+    missing = [
+        field
+        for field in fields
+        if value.get(field) is None or (isinstance(value[field], str) and not value[field].strip())
+    ]
+    if missing:
+        raise BenchmarkScoreError(f"{label} is missing fields: {', '.join(missing)}")
+
+
+def _require_date(value: Any, *, label: str) -> str:
+    """Reject a date the browser cannot format.
+
+    Identical in intent to `model_cards._require_date`, and deliberately not
+    imported from it: these values reach `Intl.DateTimeFormat` on the same page,
+    where an unparseable one throws and takes every view down with it. The
+    duplication is two callers agreeing on one browser constraint, not two
+    definitions of a date.
+    """
+    if type(value) is date:
+        return value.isoformat()
+    text = str(value)
+    if not _ISO_DATE.fullmatch(text):
+        raise BenchmarkScoreError(f"{label} must be an ISO date (YYYY-MM-DD)")
+    try:
+        date.fromisoformat(text)
+    except ValueError as error:
+        raise BenchmarkScoreError(f"{label} is not a real calendar date") from error
+    return text
+
+
+def load_scores(path: Path = DEFAULT_SCORES_PATH) -> dict[str, Any]:
+    """Read and validate the curated score file.
+
+    Strict for the same reason the registry loader is: the failure mode of a
+    lenient read is not a crash but a plausible-looking chart. A row naming a
+    benchmark absent from the `benchmarks` block has no metric, direction or
+    unit, so it would plot on an axis whose meaning nobody declared.
+    """
+    if not path.exists():
+        raise BenchmarkScoreError(f"{path}: score file not found")
+    document = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(document, dict):
+        raise BenchmarkScoreError(f"{path}: score file must be a mapping")
+    version = document.get("schema_version")
+    if version != SCORES_SCHEMA_VERSION:
+        raise BenchmarkScoreError(f"{path}: unsupported schema_version {version!r}")
+
+    benchmarks = document.get("benchmarks")
+    results = document.get("results")
+    if not isinstance(benchmarks, list) or not benchmarks:
+        raise BenchmarkScoreError(f"{path}: benchmarks must be a non-empty array")
+    if not isinstance(results, list) or not results:
+        raise BenchmarkScoreError(f"{path}: results must be a non-empty array")
+
+    metrics: dict[str, dict[str, Any]] = {}
+    for index, benchmark in enumerate(benchmarks):
+        _require(benchmark, _REQUIRED_BENCHMARK_FIELDS, label=f"{path}: benchmark {index}")
+        benchmark_id = str(benchmark["benchmark_id"])
+        if benchmark_id in metrics:
+            raise BenchmarkScoreError(f"{path}: duplicate benchmark_id {benchmark_id!r}")
+        direction = str(benchmark["direction"])
+        if direction not in _DIRECTIONS:
+            raise BenchmarkScoreError(
+                f"{path}: benchmark {benchmark_id!r} direction must be one of "
+                f"{', '.join(_DIRECTIONS)}"
+            )
+        metrics[benchmark_id] = {
+            "benchmark_id": benchmark_id,
+            "metric": str(benchmark["metric"]),
+            "direction": direction,
+            "unit": str(benchmark["unit"]),
+        }
+
+    seen: set[tuple[str, ...]] = set()
+    rows: list[dict[str, Any]] = []
+    for index, result in enumerate(results):
+        label = f"{path}: result {index}"
+        _require(result, _REQUIRED_RESULT_FIELDS, label=label)
+        benchmark_id = str(result["benchmark_id"])
+        if benchmark_id not in metrics:
+            raise BenchmarkScoreError(f"{label} references unknown benchmark_id {benchmark_id!r}")
+        try:
+            value = float(result["value"])
+        except (TypeError, ValueError) as error:
+            raise BenchmarkScoreError(f"{label} value must be a number") from error
+        unit = metrics[benchmark_id]["unit"]
+        # A percent outside 0-100 is a transcription error, and it is worth
+        # catching here rather than on the axis: a 964 would rescale the whole
+        # chart and make every real value look flat.
+        if unit == "percent" and not 0.0 <= value <= 100.0:
+            raise BenchmarkScoreError(f"{label} value {value} is outside 0-100 for a percent")
+        read_from = str(result["read_from"])
+        if read_from not in _READ_FROM:
+            raise BenchmarkScoreError(f"{label} read_from must be one of {', '.join(_READ_FROM)}")
+        reported_at = _require_date(result["reported_at"], label=f"{label} reported_at")
+        row = {
+            "benchmark_id": benchmark_id,
+            "instrument": str(result["instrument"]),
+            "protocol": str(result["protocol"]),
+            "model": str(result["model"]),
+            "organization": str(result["organization"]),
+            "source_id": str(result["source_id"]),
+            "reported_at": reported_at,
+            "value": value,
+            "read_from": read_from,
+            # Present only on a third-party citation: the publisher repeated
+            # someone else's self-reported figure. Weaker evidence, and the UI
+            # marks it rather than mixing it in.
+            "reported_by": str(result["reported_by"]) if result.get("reported_by") else None,
+        }
+        # The same model measured twice on one instrument under one protocol in
+        # one document is a contradiction: the chart would draw two points at
+        # one x with no way to say which is the reading.
+        key = (
+            benchmark_id,
+            row["instrument"],
+            row["protocol"],
+            row["model"],
+            row["source_id"],
+        )
+        if key in seen:
+            raise BenchmarkScoreError(
+                f"{label} repeats {row['model']!r} on {row['instrument']!r} "
+                f"({row['protocol']!r}) from {row['source_id']!r}"
+            )
+        seen.add(key)
+        rows.append(row)
+
+    return {"benchmarks": metrics, "results": rows}
+
+
+def _cross_check_sources(scores: dict[str, Any], registry: dict[str, Any]) -> None:
+    """Every score must cite a document the registry already knows.
+
+    Provenance is the whole basis of this layer's claim to be readable-out-of-a
+    -document rather than assembled from memory. A `source_id` with no matching
+    card is a citation to nothing: it would render as a linkless number that a
+    reader cannot check, which is the one thing this dataset promises not to do.
+    """
+    known = {str(card["id"]) for card in registry["model_cards"]}
+    unknown = sorted({row["source_id"] for row in scores["results"]} - known)
+    if unknown:
+        raise BenchmarkScoreError(
+            f"score rows cite source_ids absent from the model card registry: {', '.join(unknown)}"
+        )
+    registry_ids = {str(benchmark["id"]) for benchmark in registry["benchmarks"]}
+    stray = sorted(set(scores["benchmarks"]) - registry_ids)
+    if stray:
+        raise BenchmarkScoreError(
+            "score file declares benchmarks absent from the model card registry: "
+            f"{', '.join(stray)}"
+        )
+
+
+def _best_row(rows: list[dict[str, Any]], direction: str) -> dict[str, Any]:
+    """The strongest value on record, respecting the metric's direction."""
+    reverse = direction == "higher_is_better"
+    return sorted(
+        rows,
+        key=lambda row: (row["value"], row["reported_at"]),
+        reverse=reverse,
+    )[0]
+
+
+def _series(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Group rows into the runs the join rule permits a line through.
+
+    The key is (instrument, protocol) exactly as the data file specifies. A
+    series is published with `dated_points` alongside its length because those
+    two numbers differ in the way that matters: five rows sharing one date are a
+    comparison table from one document, and drawing them as a progression would
+    invent a trend out of a single publication.
+    """
+    grouped: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        grouped[(row["instrument"], row["protocol"])].append(row)
+
+    series = []
+    for (instrument, protocol), members in grouped.items():
+        ordered = sorted(
+            members,
+            key=lambda row: (row["reported_at"], row["organization"], row["model"]),
+        )
+        dates = {row["reported_at"] for row in ordered}
+        organizations = {row["organization"] for row in ordered}
+        series.append(
+            {
+                "instrument": instrument,
+                "protocol": protocol,
+                "points": ordered,
+                "point_count": len(ordered),
+                "dated_points": len(dates),
+                "organization_count": len(organizations),
+                # A run whose every row comes from one publisher is that
+                # publisher's own model line. It is legitimate evidence about
+                # that vendor and not evidence about the field, so the
+                # distinction travels with the series rather than being
+                # recovered in the browser.
+                "single_organization": len(organizations) == 1,
+                "first_reported_at": ordered[0]["reported_at"],
+                "last_reported_at": ordered[-1]["reported_at"],
+                # Only a run crossing at least two dates can express movement.
+                "connectable": len(dates) >= 2,
+            }
+        )
+
+    series.sort(
+        key=lambda item: (
+            -item["dated_points"],
+            -item["point_count"],
+            item["instrument"],
+            item["protocol"],
+        )
+    )
+    return series
+
+
+def _span_days(start: str, end: str) -> int:
+    return (date.fromisoformat(end) - date.fromisoformat(start)).days
+
+
+def _evidence_grade(series: list[dict[str, Any]], rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """State what this benchmark's rows can and cannot support.
+
+    Written as a grade rather than a boolean because the useful distinctions are
+    not binary: a run can be long enough to show movement but come from a single
+    vendor, which supports "this vendor's models improved" and not "the field
+    improved". The UI prints `supports` and `does_not_support` verbatim, so the
+    honest scope of every chart is authored here and tested, not phrased ad hoc
+    in JavaScript.
+    """
+    trend_series = [item for item in series if item["dated_points"] >= _MIN_DATES_FOR_TREND]
+    multi_org_trend = [item for item in trend_series if not item["single_organization"]]
+    connectable = [item for item in series if item["connectable"]]
+
+    if multi_org_trend:
+        return {
+            "id": "multi_organization_trend",
+            "label": "Comparable run across organizations",
+            "supports": (
+                "At least one run holds instrument and protocol fixed across three or more "
+                "dates and more than one organization, so its movement is not one vendor's "
+                "own model line."
+            ),
+            "does_not_support": (
+                "Vendors publish the benchmarks they do well on, so even a comparable run "
+                "measures reporting choice as well as capability."
+            ),
+        }
+    if trend_series:
+        return {
+            "id": "single_organization_trend",
+            "label": "Comparable run, one organization",
+            "supports": (
+                "One publisher reported this instrument and protocol on three or more dates, "
+                "which shows how that publisher's own models moved."
+            ),
+            "does_not_support": (
+                "Nothing about the field. A single vendor's model line cannot separate "
+                "capability gains from changes in how that vendor evaluates."
+            ),
+        }
+    if connectable:
+        return {
+            "id": "paired_comparison",
+            "label": "Paired comparison only",
+            "supports": (
+                "Two dates share an instrument and protocol, so the pair is a like-for-like "
+                "before-and-after."
+            ),
+            "does_not_support": (
+                "A direction over time. Two points define one segment; a third would be "
+                "needed before the word trend applies."
+            ),
+        }
+    dates = {row["reported_at"] for row in rows}
+    if len(dates) >= 2:
+        return {
+            "id": "unjoinable",
+            "label": "No comparable run",
+            "supports": ("Each value is readable in its own document at its own protocol."),
+            "does_not_support": (
+                "Any comparison between these numbers. No two rows share both an instrument "
+                "and a protocol, so every point stands alone."
+            ),
+        }
+    return {
+        "id": "single_reading",
+        "label": "Single reading",
+        "supports": "One recorded value, readable in the document that printed it.",
+        "does_not_support": (
+            "Any movement at all. There is one date on record for this benchmark."
+        ),
+    }
+
+
+def _saturation(
+    rows: list[dict[str, Any]],
+    metric: dict[str, Any],
+    series: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """The headroom reading, and the gain behind it when a run supports one.
+
+    `headroom` is the part that carries no trend claim: it is the distance from
+    the best recorded value to the metric's own bound. `best_gain` is reported
+    only from a connectable run, and it is labelled with the run it came from so
+    a reader can see whether the gain is one vendor's or the field's.
+    """
+    direction = metric["direction"]
+    best = _best_row(rows, direction)
+    bound = _BOUNDED_UNITS.get(metric["unit"])
+    headroom = None
+    if bound is not None:
+        headroom = round(
+            bound - best["value"] if direction == "higher_is_better" else best["value"],
+            0 if float(bound).is_integer() and float(best["value"]).is_integer() else 2,
+        )
+
+    gain = None
+    for item in series:
+        if not item["connectable"]:
+            continue
+        first = item["points"][0]
+        last = item["points"][-1]
+        delta = last["value"] - first["value"]
+        if direction == "lower_is_better":
+            delta = -delta
+        elapsed = _span_days(first["reported_at"], last["reported_at"])
+        candidate = {
+            "instrument": item["instrument"],
+            "protocol": item["protocol"],
+            # Named only when the run has exactly one publisher, so a consumer
+            # attributing the gain to a vendor cannot do so for a run that
+            # crossed vendors.
+            "organization": first["organization"] if item["single_organization"] else None,
+            "from_value": first["value"],
+            "to_value": last["value"],
+            "from_reported_at": first["reported_at"],
+            "to_reported_at": last["reported_at"],
+            "from_model": first["model"],
+            "to_model": last["model"],
+            "improvement": round(delta, 2),
+            "elapsed_days": elapsed,
+            "single_organization": item["single_organization"],
+            "dated_points": item["dated_points"],
+        }
+        # The longest-running comparable series wins, then the largest move.
+        # Picking the largest move first would surface a two-point jump over a
+        # four-date run that actually shows a shape.
+        if gain is None or (item["dated_points"], abs(delta)) > (
+            gain["dated_points"],
+            abs(gain["improvement"]),
+        ):
+            gain = candidate
+
+    return {
+        "best_value": best["value"],
+        "best_model": best["model"],
+        "best_organization": best["organization"],
+        "best_reported_at": best["reported_at"],
+        "best_source_id": best["source_id"],
+        "best_is_third_party": best["reported_by"] is not None,
+        "bound": bound,
+        "headroom": headroom,
+        "best_gain": gain,
+    }
+
+
+def score_progression(
+    scores: dict[str, Any],
+    registry: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the per-benchmark score layer the dashboard draws.
+
+    Keyed by benchmark_id so the browser can join it against the adoption
+    ranking it already has, rather than being handed a second ranking that could
+    disagree with the first about what a benchmark is.
+    """
+    if registry is not None:
+        _cross_check_sources(scores, registry)
+
+    by_benchmark: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in scores["results"]:
+        by_benchmark[row["benchmark_id"]].append(row)
+
+    latest_overall = max(row["reported_at"] for row in scores["results"])
+
+    benchmarks = {}
+    for benchmark_id, rows in by_benchmark.items():
+        metric = scores["benchmarks"][benchmark_id]
+        series = _series(rows)
+        dates = sorted({row["reported_at"] for row in rows})
+        benchmarks[benchmark_id] = {
+            "benchmark_id": benchmark_id,
+            "metric": metric["metric"],
+            "direction": metric["direction"],
+            "unit": metric["unit"],
+            "observation_count": len(rows),
+            "dated_observation_count": len(dates),
+            "organization_count": len({row["organization"] for row in rows}),
+            "first_reported_at": dates[0],
+            "last_reported_at": dates[-1],
+            "third_party_count": sum(1 for row in rows if row["reported_by"]),
+            "series": series,
+            "comparable_series_count": sum(1 for item in series if item["connectable"]),
+            "saturation": _saturation(rows, metric, series),
+            "evidence": _evidence_grade(series, rows),
+            "observations": sorted(
+                rows,
+                key=lambda row: (row["reported_at"], row["organization"], row["model"]),
+            ),
+        }
+
+    return {
+        "schema_version": SCORES_SCHEMA_VERSION,
+        "benchmark_count": len(benchmarks),
+        "observation_count": len(scores["results"]),
+        "organizations": sorted({row["organization"] for row in scores["results"]}),
+        "first_reported_at": min(row["reported_at"] for row in scores["results"]),
+        "last_reported_at": latest_overall,
+        "benchmarks": benchmarks,
+        "measures": (
+            "Scores read verbatim from cited documents, connected only where instrument "
+            "and protocol are identical. A value's absence is not a zero and a flat run is "
+            "not evidence of saturation: it is equally consistent with vendors having "
+            "stopped reporting the benchmark."
+        ),
+        "join_rule": (
+            "Two values may be connected only when both the instrument and the protocol "
+            "match exactly. An unstated condition is never treated as equal to another "
+            "unstated condition."
+        ),
+    }
+
+
+def build_score_progression(
+    path: Path = DEFAULT_SCORES_PATH,
+    registry: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return score_progression(load_scores(path), registry)

--- a/src/benchmark_radar/benchmark_scores.py
+++ b/src/benchmark_radar/benchmark_scores.py
@@ -51,6 +51,7 @@ actual one.
 
 from __future__ import annotations
 
+import math
 import re
 from collections import defaultdict
 from datetime import date
@@ -191,6 +192,14 @@ def load_scores(path: Path = DEFAULT_SCORES_PATH) -> dict[str, Any]:
             value = float(result["value"])
         except (TypeError, ValueError) as error:
             raise BenchmarkScoreError(f"{label} value must be a number") from error
+        # YAML's `.nan` and `.inf` parse as floats, and NaN fails every range
+        # comparison silently rather than tripping the percent check below. Either
+        # would reach `json.dumps` as the bare tokens `NaN` / `Infinity`, which are
+        # not valid JSON: the browser's `response.json()` rejects the file and the
+        # dashboard's init catch then hides *every* view. One unusable value would
+        # take the whole site down, so it is refused here.
+        if not math.isfinite(value):
+            raise BenchmarkScoreError(f"{label} value must be a finite number")
         unit = metrics[benchmark_id]["unit"]
         # A percent outside 0-100 is a transcription error, and it is worth
         # catching here rather than on the axis: a 964 would rescale the whole
@@ -278,6 +287,11 @@ def _cross_check_sources(scores: dict[str, Any], registry: dict[str, Any]) -> No
             "score rows cite documents that do not report the benchmark they score: "
             f"{', '.join(dict.fromkeys(mismatched))}"
         )
+
+
+def _rows_on(rows: list[dict[str, Any]], reported_at: str) -> list[dict[str, Any]]:
+    """The rows sharing one date, for picking a series endpoint by value."""
+    return [row for row in rows if row["reported_at"] == reported_at]
 
 
 def _best_row(rows: list[dict[str, Any]], direction: str) -> dict[str, Any]:
@@ -448,8 +462,16 @@ def _saturation(
     for item in series:
         if not item["connectable"]:
             continue
-        first = item["points"][0]
-        last = item["points"][-1]
+        # Endpoints are chosen by a stated policy, not by list position. `points`
+        # is ordered by (date, organization, model), so when a date carries more
+        # than one model -- a document comparing several at once -- the endpoint
+        # fell out lexically: renaming a model could change `improvement` and
+        # trigger or suppress a `fast_gain` finding while every value and date
+        # stayed identical. The policy is the best value on each endpoint date,
+        # which is reproducible from the data alone and is the reading a
+        # progression is asking for.
+        first = _best_row(_rows_on(item["points"], item["first_reported_at"]), direction)
+        last = _best_row(_rows_on(item["points"], item["last_reported_at"]), direction)
         delta = last["value"] - first["value"]
         if direction == "lower_is_better":
             delta = -delta

--- a/src/benchmark_radar/cli.py
+++ b/src/benchmark_radar/cli.py
@@ -88,6 +88,19 @@ def main() -> None:
         ),
     )
     parser.add_argument(
+        "--benchmark-scores",
+        type=Path,
+        default=None,
+        help=(
+            "Curated score observations powering the saturation reading (issue "
+            "#91). Every row cites a source_id that must be a document in the "
+            "registry beside it, so the two files are a matched pair: this "
+            "defaults to data/benchmark_scores.yml only when --model-cards is "
+            "also the default. Pass it explicitly to pair scores with a custom "
+            "registry; omit it there for an adoption-only rebuild."
+        ),
+    )
+    parser.add_argument(
         "--export-dir",
         type=Path,
         default=Path("site/data"),
@@ -123,6 +136,7 @@ def main() -> None:
             args.snapshot_dir,
             args.dashboard_output,
             registry_path=args.model_cards,
+            scores_path=args.benchmark_scores,
         )
         action = "Backfilled" if args.command == "backfill" else "Rebuilt"
         print(f"{action} {args.dashboard_output} from {data['snapshot_count']} daily snapshots")
@@ -186,6 +200,7 @@ def main() -> None:
             args.snapshot_dir,
             args.dashboard_output,
             registry_path=args.model_cards,
+            scores_path=args.benchmark_scores,
         )
         print(
             f"Simulated {len(written)} historical snapshots with coverage "
@@ -200,6 +215,7 @@ def main() -> None:
             args.snapshot_dir,
             args.dashboard_output,
             registry_path=args.model_cards,
+            scores_path=args.benchmark_scores,
         )
         print(
             f"Rescored {summary['snapshots']} snapshots against taxonomy "
@@ -224,6 +240,7 @@ def main() -> None:
             args.snapshot_dir,
             args.dashboard_output,
             registry_path=args.model_cards,
+            scores_path=args.benchmark_scores,
         )
         print(
             f"Migrated {len(snapshots)} snapshots to schema {dashboard['schema_version']} "
@@ -275,6 +292,7 @@ def main() -> None:
         args.snapshot_dir,
         args.dashboard_output,
         registry_path=args.model_cards,
+        scores_path=args.benchmark_scores,
     )
     print(
         f"Wrote {len(run.items)} items, snapshot {snapshot_path}, and dashboard data "

--- a/src/benchmark_radar/insights.py
+++ b/src/benchmark_radar/insights.py
@@ -1,0 +1,403 @@
+"""Stated findings from the adoption and score layers (issue #91).
+
+The issue's third point is that the project kept adding visuals while the real
+gap stayed open: "we are doing visual, but still didn't fix most important gap
+(the surfacing of insights)". A chart is not a finding. Two charts on one axis
+are not a finding either; they are a reader's homework. This module does that
+homework in Python, where it can be tested, and hands the dashboard sentences.
+
+WHAT COUNTS AS A FINDING HERE
+
+A finding must be a claim the two layers can actually license, so each one names
+the evidence it rests on and each one is refusable by looking at the data. The
+interesting cases are exactly the ones a single chart cannot show:
+
+`adopted_without_scores`
+    Everyone reports it; nobody's number is readable. The most common state in
+    this corpus and the easiest to misread as saturation.
+`closing_headroom`
+    The best recorded value sits close to the metric's bound. A ceiling claim
+    that needs no trend.
+`fast_gain`
+    A comparable run moved a long way in a short time. Says the instrument was
+    not measuring a stable ceiling.
+`stale_scores`
+    Adoption continued after the last readable score, so the flat right-hand
+    side of the chart is a reading gap, not a plateau.
+`third_party_only`
+    The benchmark's evidence is competitors quoting each other, with no
+    first-party number on record.
+
+WHAT IS DELIBERATELY NOT HERE
+
+No finding ranks benchmarks by quality, and none says a benchmark is "solved".
+The corpus cannot support either: it is vendor-selected, its scores stop in
+mid-2025, and its own file documents which documents could not be read. A module
+that emitted "MMLU is saturated" from a flat line would be manufacturing the
+misreading the data file spends its header warning against.
+
+Findings are ordered by how much they should change a reader's mind, not by
+benchmark rank, so the list opens on the strongest available claim.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+# A percent this close to the bound is worth stating as a ceiling observation.
+# 5 points is a judgement, not a discovery, and it is written here as one number
+# so a reader can disagree with it in one place.
+_HEADROOM_POINTS = 5.0
+
+# A comparable run that gained this much inside this window says the instrument
+# had room that models took quickly. Both numbers are editorial thresholds.
+_FAST_GAIN_POINTS = 15.0
+_FAST_GAIN_DAYS = 400
+
+# Adoption continuing this long past the newest readable score makes the score
+# line's flat tail a statement about reading coverage rather than capability.
+_STALE_SCORE_DAYS = 180
+
+# Ordering, most mind-changing first. `stale_scores` leads because it is the one
+# finding that reframes how every chart on the page should be read: a reader who
+# takes a flat score tail for a plateau will misread all of them. The
+# per-benchmark findings follow, and `adopted_without_scores` comes last of the
+# substantive kinds because it reports an absence -- true and worth stating, but
+# it changes less than a claim about a number that exists.
+_PRIORITY = {
+    "stale_scores": 0,
+    "closing_headroom": 1,
+    "fast_gain": 2,
+    "third_party_only": 3,
+    "adopted_without_scores": 4,
+}
+
+
+def _days_between(start: str, end: str) -> int:
+    return (date.fromisoformat(end) - date.fromisoformat(start)).days
+
+
+def _count(value: int, singular: str, plural: str | None = None) -> str:
+    """Pluralize a counted noun.
+
+    These strings are rendered verbatim, so "1 more reporting documents" is a
+    visible defect rather than a cosmetic one: a finding that cannot form a
+    sentence undercuts the claim it is making.
+    """
+    return f"{value} {singular if value == 1 else plural or f'{singular}s'}"
+
+
+def _latest_card_date(leaderboard: dict[str, Any]) -> str | None:
+    dates = [
+        card["published"] for card in leaderboard.get("model_cards") or [] if card.get("published")
+    ]
+    return max(dates) if dates else None
+
+
+def _adoption_by_id(leaderboard: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {entry["benchmark_id"]: entry for entry in leaderboard.get("entries") or []}
+
+
+def _finding(
+    kind: str,
+    *,
+    benchmark_id: str,
+    name: str,
+    headline: str,
+    detail: str,
+    evidence: str,
+) -> dict[str, Any]:
+    return {
+        "kind": kind,
+        "benchmark_id": benchmark_id,
+        "benchmark_name": name,
+        # One sentence, no hedging, because it is the line the reader sees
+        # first. Every qualification lives in `detail` and `evidence`, which are
+        # rendered with it rather than behind a disclosure.
+        "headline": headline,
+        "detail": detail,
+        # What in the data licenses the claim. A finding a reader cannot audit
+        # is an assertion, and this project's whole posture is that assertions
+        # about benchmarks are what it is trying to replace.
+        "evidence": evidence,
+        "priority": _PRIORITY[kind],
+    }
+
+
+def _adopted_without_scores(
+    leaderboard: dict[str, Any],
+    progression: dict[str, Any],
+    *,
+    minimum_organizations: int,
+) -> list[dict[str, Any]]:
+    scored = set(progression.get("benchmarks") or {})
+    unscored = [
+        entry
+        for entry in leaderboard.get("entries") or []
+        if entry["benchmark_id"] not in scored
+        and entry["organization_count"] >= minimum_organizations
+    ]
+    if not unscored:
+        return []
+
+    # One finding naming the benchmarks, not one finding per benchmark. The
+    # explanation is identical for every one of them -- adoption is known,
+    # difficulty is not -- so emitting it six times printed the same paragraph
+    # six times and pushed the findings that differ off the first screen. The
+    # names carry the specifics that actually vary.
+    unscored.sort(key=lambda entry: (-entry["card_count"], entry["name"]))
+    named = ", ".join(entry["name"] for entry in unscored)
+    leader = unscored[0]
+    return [
+        _finding(
+            "adopted_without_scores",
+            # Focuses the most-adopted of them, which is the one whose blank
+            # score axis a reader is most likely to go looking for.
+            benchmark_id=leader["benchmark_id"],
+            name=leader["name"],
+            headline=(
+                f"{_count(len(unscored), 'benchmark')} reported by at least "
+                f"{_count(minimum_organizations, 'organization')} have no readable score "
+                f"on record."
+            ),
+            detail=(
+                "Adoption and difficulty are separate questions, and for these only the "
+                "first has an answer here. A blank score axis is a limit of what could be "
+                "read out of these documents, not a finding about the benchmark. "
+                f"They are: {named}."
+            ),
+            evidence=(
+                f"Most-adopted of them is {leader['name']} at "
+                f"{_count(leader['card_count'], 'model card')}; the score file records no "
+                "verified value for any of them."
+            ),
+        )
+    ]
+
+
+def _score_findings(
+    leaderboard: dict[str, Any],
+    progression: dict[str, Any],
+) -> list[dict[str, Any]]:
+    adoption = _adoption_by_id(leaderboard)
+    findings: list[dict[str, Any]] = []
+
+    for benchmark_id, record in (progression.get("benchmarks") or {}).items():
+        entry = adoption.get(benchmark_id)
+        name = entry["name"] if entry else benchmark_id
+        saturation = record["saturation"]
+        headroom = saturation["headroom"]
+
+        if headroom is not None and headroom <= _HEADROOM_POINTS:
+            findings.append(
+                _finding(
+                    "closing_headroom",
+                    benchmark_id=benchmark_id,
+                    name=name,
+                    headline=(
+                        f"{name}'s best recorded score leaves {headroom:g} points of "
+                        f"headroom on a {saturation['bound']:g}-point metric."
+                    ),
+                    detail=(
+                        "This is a statement about the best number on record, not about a "
+                        "trend: it holds whether or not anyone reports the benchmark again. "
+                        "Remaining headroom is where a metric stops being able to separate "
+                        "strong models from each other."
+                    ),
+                    evidence=(
+                        f"{saturation['best_value']:g} {record['metric']} by "
+                        f"{saturation['best_model']} ({saturation['best_organization']}), "
+                        f"reported {saturation['best_reported_at']}"
+                        + (", cited by a third party" if saturation["best_is_third_party"] else "")
+                    ),
+                )
+            )
+
+        gain = saturation["best_gain"]
+        if (
+            gain
+            and gain["improvement"] >= _FAST_GAIN_POINTS
+            and 0 < gain["elapsed_days"] <= _FAST_GAIN_DAYS
+        ):
+            # The headline names the publisher when a run is one vendor's own
+            # model line. "AIME moved 40.6 points" reads as a fact about the
+            # field; "DeepSeek's own models moved 40.6 points on AIME" is what
+            # a two-point single-vendor pair actually shows, and the difference
+            # is the entire distinction this dataset is built to preserve.
+            single = gain["single_organization"]
+            publisher = gain["organization"]
+            findings.append(
+                _finding(
+                    "fast_gain",
+                    benchmark_id=benchmark_id,
+                    name=name,
+                    headline=(
+                        (
+                            f"{publisher}'s own models moved {gain['improvement']:g} points "
+                            f"on {name} in {_count(gain['elapsed_days'], 'day')}."
+                        )
+                        if single
+                        else (
+                            f"{name} moved {gain['improvement']:g} points in "
+                            f"{_count(gain['elapsed_days'], 'day')} across organizations."
+                        )
+                    ),
+                    detail=(
+                        (
+                            "One publisher's successive models at an identical instrument and "
+                            "protocol, so the move is not an artefact of a changed setup. It "
+                            "shows the instrument still had room to discriminate, and it is "
+                            "not evidence about other vendors."
+                        )
+                        if single
+                        else (
+                            "Models from more than one organization at an identical instrument "
+                            "and protocol, so the move is neither one vendor's model line nor "
+                            "an artefact of a changed setup."
+                        )
+                    ),
+                    evidence=(
+                        f"{gain['from_model']} {gain['from_value']:g} "
+                        f"({gain['from_reported_at']}) to {gain['to_model']} "
+                        f"{gain['to_value']:g} ({gain['to_reported_at']}), "
+                        f"protocol: {gain['protocol']}"
+                    ),
+                )
+            )
+
+        if record["third_party_count"] == record["observation_count"]:
+            findings.append(
+                _finding(
+                    "third_party_only",
+                    benchmark_id=benchmark_id,
+                    name=name,
+                    headline=(
+                        f"Every recorded {name} score is a third party quoting someone "
+                        f"else's number."
+                    ),
+                    detail=(
+                        "A publisher repeating a competitor's self-reported figure is weaker "
+                        "evidence than a vendor reporting its own model, and weaker still "
+                        "when the publisher had a stake in the comparison."
+                    ),
+                    evidence=(
+                        f"{record['observation_count']} of {record['observation_count']} "
+                        "observations carry a reported_by publisher"
+                    ),
+                )
+            )
+
+    return findings
+
+
+def _stale_scores(
+    leaderboard: dict[str, Any],
+    progression: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """One finding about reading coverage, not one per benchmark.
+
+    Scores in this corpus stop well before mentions do, so the lag holds for
+    almost every scored benchmark. Emitting it per benchmark produced nineteen
+    near-identical entries that crowded out the findings that distinguish one
+    benchmark from another, while saying a single thing nineteen times. It is a
+    property of the corpus, so it is stated once, at corpus scope.
+
+    It stays first in the ordering regardless: a reader about to interpret a flat
+    score tail as a plateau needs this before any other claim on the page.
+    """
+    latest_card = _latest_card_date(leaderboard)
+    records = progression.get("benchmarks") or {}
+    if not latest_card or not records:
+        return []
+
+    adoption = _adoption_by_id(leaderboard)
+    lagging = []
+    for benchmark_id, record in records.items():
+        lag = _days_between(record["last_reported_at"], latest_card)
+        entry = adoption.get(benchmark_id)
+        if lag < _STALE_SCORE_DAYS or not entry:
+            continue
+        if any(
+            adopter.get("published") and adopter["published"] > record["last_reported_at"]
+            for adopter in entry.get("adopters") or []
+        ):
+            lagging.append((benchmark_id, record, lag))
+    if not lagging:
+        return []
+
+    newest_score = max(record["last_reported_at"] for _, record, _ in lagging)
+    smallest_lag = min(lag for _, _, lag in lagging)
+    return [
+        _finding(
+            "stale_scores",
+            # Corpus scope, so no single benchmark owns it. The empty id is what
+            # the renderer keys on to place this above the per-benchmark list
+            # instead of attaching it to one chart.
+            benchmark_id="",
+            name="Reading coverage",
+            headline=(
+                f"{_count(len(lagging), 'benchmark')} kept gaining reporting documents "
+                f"after their last readable score."
+            ),
+            detail=(
+                "Score coverage ends before mention coverage does, so a flat right-hand side "
+                "on any of these charts is a reading gap rather than a plateau. Newer cards "
+                "do report these benchmarks; their numbers could not be read from the "
+                "documents and are absent rather than zero."
+            ),
+            evidence=(
+                f"Newest readable score {newest_score}; newest model card {latest_card}; "
+                f"smallest gap {_count(smallest_lag, 'day')}"
+            ),
+        )
+    ]
+
+
+def build_insights(
+    leaderboard: dict[str, Any] | None,
+    progression: dict[str, Any] | None,
+    *,
+    minimum_organizations: int = 4,
+    limit: int | None = None,
+) -> dict[str, Any] | None:
+    """Derive stated findings from the two layers, or nothing if either is absent.
+
+    Returns None rather than an empty document when a layer is missing: the
+    dashboard hides the panel entirely in that case, which is honest, whereas an
+    empty findings list on the page reads as "we looked and the field is
+    uneventful".
+    """
+    if not leaderboard or not progression:
+        return None
+
+    findings = [
+        *_stale_scores(leaderboard, progression),
+        *_adopted_without_scores(
+            leaderboard, progression, minimum_organizations=minimum_organizations
+        ),
+        *_score_findings(leaderboard, progression),
+    ]
+    findings.sort(key=lambda item: (item["priority"], item["benchmark_name"], item["kind"]))
+    total = len(findings)
+    shown = findings if limit is None else findings[:limit]
+
+    return {
+        "schema_version": 1,
+        "finding_count": total,
+        "findings": shown,
+        # Announced rather than applied silently, on the same principle the
+        # Markdown export truncates by: a list that stops at N with no note
+        # reads as a complete account of the corpus.
+        "truncated": total > len(shown),
+        "measures": (
+            "Findings derived from two curated layers: which model cards mention each "
+            "benchmark, and which scores could be read verbatim from those documents. "
+            "Each finding names the evidence behind it."
+        ),
+        "does_not_measure": (
+            "Benchmark quality, and whether a benchmark is solved. The corpus is "
+            "vendor-selected, several documents could not be read, and no score after the "
+            "last recorded date is included."
+        ),
+    }

--- a/src/benchmark_radar/insights.py
+++ b/src/benchmark_radar/insights.py
@@ -305,29 +305,47 @@ def _stale_scores(
 
     It stays first in the ordering regardless: a reader about to interpret a flat
     score tail as a plateau needs this before any other claim on the page.
+
+    Each lag is measured against the benchmark's *own* latest dated adopter, not
+    against the newest card anywhere in the registry. Using the global date let an
+    unrelated benchmark's recent card supply the lag: shipped MBPP is only 100
+    days behind its own newest adopter and was counted anyway despite the
+    threshold, and the published "smallest gap" described a benchmark that was
+    never in the set. A claim about one benchmark's reading coverage has to be
+    computed from that benchmark's documents.
     """
-    latest_card = _latest_card_date(leaderboard)
     records = progression.get("benchmarks") or {}
-    if not latest_card or not records:
+    if not records:
         return []
 
     adoption = _adoption_by_id(leaderboard)
     lagging = []
     for benchmark_id, record in records.items():
-        lag = _days_between(record["last_reported_at"], latest_card)
         entry = adoption.get(benchmark_id)
-        if lag < _STALE_SCORE_DAYS or not entry:
+        if not entry:
             continue
-        if any(
-            adopter.get("published") and adopter["published"] > record["last_reported_at"]
+        own_dates = [
+            adopter["published"]
             for adopter in entry.get("adopters") or []
-        ):
-            lagging.append((benchmark_id, record, lag))
+            if adopter.get("published")
+        ]
+        if not own_dates:
+            continue
+        own_latest = max(own_dates)
+        # A later report of *this* benchmark is what makes its flat tail a reading
+        # gap rather than the end of its record.
+        if own_latest <= record["last_reported_at"]:
+            continue
+        lag = _days_between(record["last_reported_at"], own_latest)
+        if lag < _STALE_SCORE_DAYS:
+            continue
+        lagging.append((benchmark_id, record, lag, own_latest))
     if not lagging:
         return []
 
-    newest_score = max(record["last_reported_at"] for _, record, _ in lagging)
-    smallest_lag = min(lag for _, _, lag in lagging)
+    newest_score = max(record["last_reported_at"] for _, record, _, _ in lagging)
+    smallest_lag = min(lag for _, _, lag, _ in lagging)
+    newest_relevant_card = max(own_latest for _, _, _, own_latest in lagging)
     return [
         _finding(
             "stale_scores",
@@ -347,8 +365,8 @@ def _stale_scores(
                 "documents and are absent rather than zero."
             ),
             evidence=(
-                f"Newest readable score {newest_score}; newest model card {latest_card}; "
-                f"smallest gap {_count(smallest_lag, 'day')}"
+                f"Newest readable score {newest_score}; newest card reporting one of them "
+                f"{newest_relevant_card}; smallest gap {_count(smallest_lag, 'day')}"
             ),
         )
     ]

--- a/src/benchmark_radar/snapshots.py
+++ b/src/benchmark_radar/snapshots.py
@@ -9,13 +9,15 @@ from pathlib import Path
 from typing import Any
 
 from .attention import fetch_attention_feeds
+from .benchmark_scores import DEFAULT_SCORES_PATH, load_scores, score_progression
 from .corpus import (
     artifact_alias_map,
     build_corpus,
     exact_artifact_key,
     organizations_for_item,
 )
-from .model_cards import DEFAULT_REGISTRY_PATH, build_adoption_rank
+from .insights import build_insights
+from .model_cards import DEFAULT_REGISTRY_PATH, adoption_rank, load_registry
 from .models import RadarRun
 from .pipeline import match_proximity_rule
 from .rubric import (
@@ -513,25 +515,50 @@ def _attach_category_trends(days: list[dict[str, Any]]) -> None:
         day["cumulative_evidence_count"] = len(seen_any)
 
 
-def _model_card_leaderboard(registry_path: Path | None) -> dict[str, Any] | None:
-    """Build the Model Card Adoption Rank, or omit it if the registry is absent.
+def _curated_layers(
+    registry_path: Path | None,
+    scores_path: Path | None,
+) -> dict[str, Any]:
+    """Build the three curated layers that share one registry read.
 
-    A missing registry file is not an error: the daily radar's own collection is
-    independent of this curated dataset, and a checkout without it should still
-    publish a working dashboard. An *invalid* registry is a different matter and
-    is allowed to fail the build, because a silently-dropped leaderboard would
-    leave the previous ranking on the page with no indication it went stale.
+    A missing file is not an error: the daily radar's own collection is
+    independent of these curated datasets, and a checkout without them should
+    still publish a working dashboard. An *invalid* file is a different matter
+    and is allowed to fail the build, because a silently-dropped layer would
+    leave the previous version on the page with no indication it went stale.
+
+    The registry is read once and passed to both consumers. Reading it twice
+    would let the score layer's cross-check pass against a different revision of
+    the file than the ranking was built from, which is exactly the disagreement
+    the cross-check exists to prevent.
     """
-    path = registry_path or DEFAULT_REGISTRY_PATH
-    if not path.exists():
-        return None
-    return build_adoption_rank(path)
+    registry_file = registry_path or DEFAULT_REGISTRY_PATH
+    registry = load_registry(registry_file) if registry_file.exists() else None
+    leaderboard = adoption_rank(registry) if registry else None
+
+    scores_file = scores_path or DEFAULT_SCORES_PATH
+    # The score layer cites `source_id`s that must exist in the registry, so it
+    # is only built when the registry it cites is present. Publishing scores
+    # whose provenance cannot be checked would break the one promise this
+    # dataset makes about itself.
+    progression = (
+        score_progression(load_scores(scores_file), registry)
+        if scores_file.exists() and registry
+        else None
+    )
+
+    return {
+        "model_card_leaderboard": leaderboard,
+        "benchmark_score_progression": progression,
+        "benchmark_insights": build_insights(leaderboard, progression),
+    }
 
 
 def dashboard_data(
     snapshots: list[dict[str, Any]],
     *,
     registry_path: Path | None = None,
+    scores_path: Path | None = None,
 ) -> dict[str, Any]:
     days: list[dict[str, Any]] = []
     categories: set[str] = set()
@@ -662,10 +689,11 @@ def dashboard_data(
         "days": days,
         "corpus": corpus,
         # Curated and versioned in the repository rather than collected daily:
-        # it answers "which benchmarks do vendors report" from published model
-        # cards, which is a different question from "what was released today"
-        # and moves on a different clock.
-        "model_card_leaderboard": _model_card_leaderboard(registry_path),
+        # they answer "which benchmarks do vendors report", "how have the
+        # readable scores moved", and "what do those two together say", which
+        # are different questions from "what was released today" and move on a
+        # different clock.
+        **_curated_layers(registry_path, scores_path),
         # Keep every rubric required by the history. The browser selects by
         # each record's score_version, so a v1 score is never explained using
         # v2 arithmetic.
@@ -703,8 +731,13 @@ def rebuild_dashboard(
     output: Path,
     *,
     registry_path: Path | None = None,
+    scores_path: Path | None = None,
 ) -> dict[str, Any]:
-    value = dashboard_data(load_snapshots(snapshot_dir), registry_path=registry_path)
+    value = dashboard_data(
+        load_snapshots(snapshot_dir),
+        registry_path=registry_path,
+        scores_path=scores_path,
+    )
     _write_json(output, value)
     return value
 

--- a/src/benchmark_radar/snapshots.py
+++ b/src/benchmark_radar/snapshots.py
@@ -515,6 +515,16 @@ def _attach_category_trends(days: list[dict[str, Any]]) -> None:
         day["cumulative_evidence_count"] = len(seen_any)
 
 
+def _same_file(left: Path, right: Path) -> bool:
+    """Whether two paths name one file, comparing resolved forms.
+
+    `Path.samefile` needs both to exist, and the whole point of this check is that
+    one of them may not, so it compares resolved paths instead. `strict=False`
+    keeps a nonexistent path comparable rather than raising.
+    """
+    return left.resolve(strict=False) == right.resolve(strict=False)
+
+
 def _curated_layers(
     registry_path: Path | None,
     scores_path: Path | None,
@@ -550,8 +560,13 @@ def _curated_layers(
     # Compared by path, not against None: the CLI always supplies a
     # `--model-cards` value (it has a default), so "the caller passed nothing"
     # and "the caller passed the default" have to be treated alike here.
+    #
+    # Resolved before comparing, because `--model-cards "$PWD/data/model_cards.yml"`
+    # names the same file as the relative default and would otherwise be treated
+    # as a custom registry, silently dropping scores and insights from a build
+    # that should have carried them.
     scores_file = scores_path
-    if scores_file is None and registry_file == DEFAULT_REGISTRY_PATH:
+    if scores_file is None and _same_file(registry_file, DEFAULT_REGISTRY_PATH):
         scores_file = DEFAULT_SCORES_PATH
     # The score layer cites `source_id`s that must exist in the registry, so it
     # is only built when the registry it cites is present. Publishing scores

--- a/src/benchmark_radar/snapshots.py
+++ b/src/benchmark_radar/snapshots.py
@@ -536,14 +536,30 @@ def _curated_layers(
     registry = load_registry(registry_file) if registry_file.exists() else None
     leaderboard = adoption_rank(registry) if registry else None
 
-    scores_file = scores_path or DEFAULT_SCORES_PATH
+    # The two curated files are a matched pair: every score cites a `source_id`
+    # that must be a document in the registry beside it. Defaulting the score
+    # file under a *custom* registry therefore pairs scores with a registry that
+    # was never meant to hold them, and the provenance cross-check correctly
+    # rejects it -- which broke `--model-cards` for every alternate registry that
+    # does not happen to contain all nine default score sources.
+    #
+    # So the default score file is only assumed when the registry is also the
+    # default one. A caller supplying a custom registry opts into scores
+    # explicitly via `--benchmark-scores`, and gets a working adoption-only
+    # rebuild otherwise.
+    # Compared by path, not against None: the CLI always supplies a
+    # `--model-cards` value (it has a default), so "the caller passed nothing"
+    # and "the caller passed the default" have to be treated alike here.
+    scores_file = scores_path
+    if scores_file is None and registry_file == DEFAULT_REGISTRY_PATH:
+        scores_file = DEFAULT_SCORES_PATH
     # The score layer cites `source_id`s that must exist in the registry, so it
     # is only built when the registry it cites is present. Publishing scores
     # whose provenance cannot be checked would break the one promise this
     # dataset makes about itself.
     progression = (
         score_progression(load_scores(scores_file), registry)
-        if scores_file.exists() and registry
+        if scores_file is not None and scores_file.exists() and registry
         else None
     )
 

--- a/tests/test_benchmark_scores.py
+++ b/tests/test_benchmark_scores.py
@@ -240,13 +240,40 @@ def test_a_gain_is_only_attributed_to_a_vendor_when_the_run_has_one(tmp_path):
     assert gain["organization"] is None
 
 
+def test_cross_check_rejects_a_score_cited_to_a_card_that_never_reported_it(tmp_path):
+    # Codex P2. Existence of the cited card is not enough: a source_id mistyped to
+    # a different real card passes an existence check while attributing the score
+    # to a document that never reported that benchmark. That publishes a number
+    # with false provenance, which is worse than a missing one because it looks
+    # checkable.
+    path = write_scores(tmp_path, minimal_scores(results=[result(source_id="card_two")]))
+    registry = {
+        "benchmarks": [{"id": "alpha"}],
+        "model_cards": [
+            {"id": "card_one", "benchmarks": ["alpha"]},
+            {"id": "card_two", "benchmarks": ["beta"]},
+        ],
+    }
+    with pytest.raises(BenchmarkScoreError, match="does not report"):
+        score_progression(load_scores(path), registry)
+
+
+def test_cross_check_accepts_a_score_cited_to_a_card_that_reports_it(tmp_path):
+    path = write_scores(tmp_path, minimal_scores(results=[result(source_id="card_one")]))
+    registry = {
+        "benchmarks": [{"id": "alpha"}],
+        "model_cards": [{"id": "card_one", "benchmarks": ["alpha"]}],
+    }
+    assert score_progression(load_scores(path), registry)["observation_count"] == 1
+
+
 def test_cross_check_rejects_a_score_citing_an_unknown_document(tmp_path):
     # Provenance is this layer's whole claim to be readable-out-of-a-document.
     # A source_id with no card is a citation to nothing.
     path = write_scores(tmp_path, minimal_scores(results=[result(source_id="nowhere")]))
     registry = {
         "benchmarks": [{"id": "alpha"}],
-        "model_cards": [{"id": "card_one"}],
+        "model_cards": [{"id": "card_one", "benchmarks": ["alpha"]}],
     }
     with pytest.raises(BenchmarkScoreError, match="absent from the model card registry"):
         score_progression(load_scores(path), registry)

--- a/tests/test_benchmark_scores.py
+++ b/tests/test_benchmark_scores.py
@@ -1,0 +1,277 @@
+from pathlib import Path
+
+import pytest
+import yaml
+
+from benchmark_radar.benchmark_scores import (
+    DEFAULT_SCORES_PATH,
+    BenchmarkScoreError,
+    build_score_progression,
+    load_scores,
+    score_progression,
+)
+from benchmark_radar.model_cards import DEFAULT_REGISTRY_PATH, load_registry
+
+
+def write_scores(tmp_path: Path, document: dict) -> Path:
+    path = tmp_path / "benchmark_scores.yml"
+    path.write_text(yaml.safe_dump(document, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def result(**overrides) -> dict:
+    row = {
+        "benchmark_id": "alpha",
+        "instrument": "alpha",
+        "protocol": "0-shot",
+        "model": "Model One",
+        "organization": "Org A",
+        "source_id": "card_one",
+        "reported_at": "2025-01-01",
+        "value": 50.0,
+        "read_from": "pdf_text",
+    }
+    row.update(overrides)
+    return row
+
+
+def minimal_scores(**overrides) -> dict:
+    document = {
+        "schema_version": 1,
+        "benchmarks": [
+            {
+                "benchmark_id": "alpha",
+                "metric": "accuracy",
+                "direction": "higher_is_better",
+                "unit": "percent",
+            }
+        ],
+        "results": [result()],
+    }
+    document.update(overrides)
+    return document
+
+
+def test_load_scores_rejects_a_result_naming_an_undeclared_benchmark(tmp_path):
+    # The benchmarks block is where metric, direction and unit live, so a row
+    # without one would be plotted on an axis whose meaning nobody declared.
+    path = write_scores(tmp_path, minimal_scores(results=[result(benchmark_id="ghost")]))
+    with pytest.raises(BenchmarkScoreError, match="unknown benchmark_id 'ghost'"):
+        load_scores(path)
+
+
+def test_load_scores_rejects_an_unrecognized_direction(tmp_path):
+    # An unrecognized direction defaulting to higher-is-better would silently
+    # invert a chart for any metric where lower is the better score.
+    document = minimal_scores()
+    document["benchmarks"][0]["direction"] = "bigger_number_wins"
+    path = write_scores(tmp_path, document)
+    with pytest.raises(BenchmarkScoreError, match="direction must be one of"):
+        load_scores(path)
+
+
+def test_load_scores_rejects_a_percent_outside_its_own_range(tmp_path):
+    # Caught here rather than on the axis: a 964 would rescale the whole plot
+    # and make every real value look flat.
+    path = write_scores(tmp_path, minimal_scores(results=[result(value=964.0)]))
+    with pytest.raises(BenchmarkScoreError, match="outside 0-100"):
+        load_scores(path)
+
+
+def test_load_scores_rejects_a_date_the_browser_cannot_format(tmp_path):
+    # These strings reach Intl.DateTimeFormat, which throws on an unparseable
+    # value and takes every view on the page down with it.
+    path = write_scores(tmp_path, minimal_scores(results=[result(reported_at="20250101")]))
+    with pytest.raises(BenchmarkScoreError, match="must be an ISO date"):
+        load_scores(path)
+
+
+def test_load_scores_rejects_one_model_measured_twice_in_one_document(tmp_path):
+    # Two points at one x with no way to say which is the reading.
+    path = write_scores(tmp_path, minimal_scores(results=[result(), result(value=51.0)]))
+    with pytest.raises(BenchmarkScoreError, match="repeats 'Model One'"):
+        load_scores(path)
+
+
+def test_the_same_model_may_be_measured_under_two_protocols(tmp_path):
+    # The counterpart to the check above: a document printing both a Pass@1 and
+    # a Pass@1-COT figure for one model is normal, and the two are not one series.
+    path = write_scores(
+        tmp_path,
+        minimal_scores(results=[result(), result(protocol="0-shot, chain of thought", value=61.0)]),
+    )
+    scores = load_scores(path)
+    assert len(scores["results"]) == 2
+
+
+def test_series_only_join_rows_sharing_an_instrument_and_protocol(tmp_path):
+    # The join rule this dataset is built on. A differing protocol must break
+    # the line rather than be absorbed into it.
+    path = write_scores(
+        tmp_path,
+        minimal_scores(
+            results=[
+                result(model="A", reported_at="2025-01-01", value=50.0),
+                result(model="B", reported_at="2025-02-01", value=60.0),
+                result(
+                    model="C",
+                    reported_at="2025-03-01",
+                    value=70.0,
+                    protocol="8-shot",
+                ),
+            ]
+        ),
+    )
+    record = score_progression(load_scores(path))["benchmarks"]["alpha"]
+    joined = {(item["protocol"], item["point_count"]) for item in record["series"]}
+    assert joined == {("0-shot", 2), ("8-shot", 1)}
+    assert record["comparable_series_count"] == 1
+
+
+def test_a_series_confined_to_one_date_is_not_connectable(tmp_path):
+    # Five rows sharing one date are a comparison table from one document.
+    # Drawing them as a progression would invent a trend from one publication.
+    path = write_scores(
+        tmp_path,
+        minimal_scores(
+            results=[
+                result(model="A", organization="Org A", value=50.0),
+                result(model="B", organization="Org B", value=60.0),
+            ]
+        ),
+    )
+    record = score_progression(load_scores(path))["benchmarks"]["alpha"]
+    series = record["series"][0]
+    assert series["point_count"] == 2
+    assert series["dated_points"] == 1
+    assert series["connectable"] is False
+    assert record["comparable_series_count"] == 0
+
+
+def test_best_value_respects_a_lower_is_better_direction(tmp_path):
+    document = minimal_scores(
+        results=[
+            result(model="A", value=30.0),
+            result(model="B", reported_at="2025-02-01", value=10.0),
+        ]
+    )
+    document["benchmarks"][0]["direction"] = "lower_is_better"
+    record = score_progression(load_scores(write_scores(tmp_path, document)))
+    saturation = record["benchmarks"]["alpha"]["saturation"]
+    assert saturation["best_value"] == 10.0
+    # Headroom on an inverted metric is distance to zero, not to the bound.
+    assert saturation["headroom"] == 10.0
+
+
+def test_headroom_is_omitted_when_the_metric_has_no_defensible_bound(tmp_path):
+    # An Elo or a raw F1 has no ceiling this module is entitled to invent.
+    document = minimal_scores()
+    document["benchmarks"][0]["unit"] = "elo"
+    record = score_progression(load_scores(write_scores(tmp_path, document)))
+    saturation = record["benchmarks"]["alpha"]["saturation"]
+    assert saturation["bound"] is None
+    assert saturation["headroom"] is None
+
+
+def test_evidence_grade_separates_a_single_vendor_run_from_a_field_wide_one(tmp_path):
+    # Three dates from one publisher shows that publisher's models moving, and
+    # says nothing about the field. The grade has to carry that distinction.
+    (tmp_path / "single").mkdir()
+    (tmp_path / "multi").mkdir()
+    single = write_scores(
+        tmp_path / "single",
+        minimal_scores(
+            results=[
+                result(model="A", reported_at="2025-01-01", value=50.0),
+                result(model="B", reported_at="2025-02-01", value=60.0),
+                result(model="C", reported_at="2025-03-01", value=70.0),
+            ]
+        ),
+    )
+    record = score_progression(load_scores(single))["benchmarks"]["alpha"]
+    assert record["evidence"]["id"] == "single_organization_trend"
+    assert "Nothing about the field" in record["evidence"]["does_not_support"]
+
+    multi = write_scores(
+        tmp_path / "multi",
+        minimal_scores(
+            results=[
+                result(model="A", organization="Org A", reported_at="2025-01-01", value=50.0),
+                result(model="B", organization="Org B", reported_at="2025-02-01", value=60.0),
+                result(model="C", organization="Org C", reported_at="2025-03-01", value=70.0),
+            ]
+        ),
+    )
+    record = score_progression(load_scores(multi))["benchmarks"]["alpha"]
+    assert record["evidence"]["id"] == "multi_organization_trend"
+
+
+def test_evidence_grade_refuses_the_word_trend_for_a_two_point_pair(tmp_path):
+    path = write_scores(
+        tmp_path,
+        minimal_scores(
+            results=[
+                result(model="A", reported_at="2025-01-01", value=50.0),
+                result(model="B", reported_at="2025-02-01", value=60.0),
+            ]
+        ),
+    )
+    record = score_progression(load_scores(path))["benchmarks"]["alpha"]
+    assert record["evidence"]["id"] == "paired_comparison"
+    assert "Two points define one segment" in record["evidence"]["does_not_support"]
+
+
+def test_a_gain_is_only_attributed_to_a_vendor_when_the_run_has_one(tmp_path):
+    # Naming a publisher on a run that crossed vendors would misattribute the
+    # gain, so the field is present only when it is true.
+    crossing = write_scores(
+        tmp_path,
+        minimal_scores(
+            results=[
+                result(model="A", organization="Org A", reported_at="2025-01-01", value=50.0),
+                result(model="B", organization="Org B", reported_at="2025-02-01", value=70.0),
+            ]
+        ),
+    )
+    gain = score_progression(load_scores(crossing))["benchmarks"]["alpha"]["saturation"][
+        "best_gain"
+    ]
+    assert gain["single_organization"] is False
+    assert gain["organization"] is None
+
+
+def test_cross_check_rejects_a_score_citing_an_unknown_document(tmp_path):
+    # Provenance is this layer's whole claim to be readable-out-of-a-document.
+    # A source_id with no card is a citation to nothing.
+    path = write_scores(tmp_path, minimal_scores(results=[result(source_id="nowhere")]))
+    registry = {
+        "benchmarks": [{"id": "alpha"}],
+        "model_cards": [{"id": "card_one"}],
+    }
+    with pytest.raises(BenchmarkScoreError, match="absent from the model card registry"):
+        score_progression(load_scores(path), registry)
+
+
+def test_the_shipped_score_file_is_valid_and_cites_only_known_documents():
+    # The guarantee that matters in production: the published dataset loads, and
+    # every value in it points at a document the registry can link to.
+    registry = load_registry(DEFAULT_REGISTRY_PATH)
+    progression = build_score_progression(DEFAULT_SCORES_PATH, registry)
+
+    assert progression["observation_count"] > 0
+    card_ids = {str(card["id"]) for card in registry["model_cards"]}
+    for record in progression["benchmarks"].values():
+        for observation in record["observations"]:
+            assert observation["source_id"] in card_ids
+
+
+def test_the_shipped_file_never_claims_a_trend_it_cannot_support():
+    # Under the strict join rule this corpus yields no multi-date run of three
+    # or more dates, so nothing in it may be graded as a trend. If a future
+    # curation pass adds one, this test should be updated deliberately rather
+    # than the grade appearing unnoticed.
+    progression = build_score_progression(DEFAULT_SCORES_PATH, load_registry(DEFAULT_REGISTRY_PATH))
+    for record in progression["benchmarks"].values():
+        for series in record["series"]:
+            if series["dated_points"] >= 3:
+                assert record["evidence"]["id"].endswith("_trend")

--- a/tests/test_benchmark_scores.py
+++ b/tests/test_benchmark_scores.py
@@ -78,6 +78,61 @@ def test_load_scores_rejects_a_percent_outside_its_own_range(tmp_path):
         load_scores(path)
 
 
+def test_load_scores_rejects_a_non_finite_value(tmp_path):
+    # Codex P2. YAML's `.nan` and `.inf` parse as floats, and NaN fails every
+    # range comparison silently rather than tripping the percent check. Either
+    # would reach json.dumps as the bare tokens NaN / Infinity, which are not
+    # valid JSON: the browser's response.json() rejects the file and the
+    # dashboard's init catch then hides every view. One value takes the site down.
+    # Written as real float values so PyYAML emits the bare `.nan` / `.inf`
+    # tokens: a quoted string would be caught by float() instead, which is a
+    # different code path from the one under test.
+    for value in (float("nan"), float("inf"), float("-inf")):
+        document = minimal_scores(results=[result(value=value)])
+        # An unbounded unit, so the percent range check cannot be what catches it.
+        document["benchmarks"][0]["unit"] = "elo"
+        path = write_scores(tmp_path, document)
+        assert ".nan" in path.read_text() or ".inf" in path.read_text()
+        with pytest.raises(BenchmarkScoreError, match="must be a finite number"):
+            load_scores(path)
+
+
+def test_the_published_payload_contains_no_non_finite_tokens():
+    # The end-to-end consequence: radar.json has to be parseable by the browser.
+    import json
+
+    progression = build_score_progression(DEFAULT_SCORES_PATH, load_registry(DEFAULT_REGISTRY_PATH))
+    encoded = json.dumps(progression)
+    assert "NaN" not in encoded
+    assert "Infinity" not in encoded
+
+
+def test_a_gain_endpoint_does_not_depend_on_a_model_name(tmp_path):
+    # Codex P2. `points` is ordered by (date, organization, model), so when a date
+    # carries several models the endpoint fell out lexically: renaming a model
+    # could change `improvement` while every value and date stayed identical.
+    # The policy is the best value on each endpoint date.
+    def gain_for(late_model_name: str) -> float:
+        path = write_scores(
+            tmp_path,
+            minimal_scores(
+                results=[
+                    result(model="Start", reported_at="2025-01-01", value=40.0),
+                    # Two models share the closing date; the stronger one is the
+                    # endpoint regardless of how either is named.
+                    result(model="Zeta", reported_at="2025-02-01", value=90.0),
+                    result(model=late_model_name, reported_at="2025-02-01", value=50.0),
+                ]
+            ),
+        )
+        record = score_progression(load_scores(path))["benchmarks"]["alpha"]
+        return record["saturation"]["best_gain"]["improvement"]
+
+    # "Alpha" sorts before "Zeta" and "Zzz" sorts after, so a name-ordered
+    # endpoint would return two different gains here.
+    assert gain_for("Alpha") == gain_for("Zzz") == 50.0
+
+
 def test_load_scores_rejects_a_date_the_browser_cannot_format(tmp_path):
     # These strings reach Intl.DateTimeFormat, which throws on an unparseable
     # value and takes every view on the page down with it.

--- a/tests/test_insights.py
+++ b/tests/test_insights.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 from benchmark_radar.benchmark_scores import DEFAULT_SCORES_PATH, build_score_progression
 from benchmark_radar.insights import build_insights
 from benchmark_radar.model_cards import DEFAULT_REGISTRY_PATH, adoption_rank, load_registry
@@ -163,6 +165,88 @@ def test_reading_coverage_is_stated_once_rather_than_per_benchmark():
     assert "3 benchmarks" in stale[0]["headline"]
     # Corpus scope, so it belongs to no single benchmark's chart.
     assert stale[0]["benchmark_id"] == ""
+
+
+def test_reading_coverage_measures_each_lag_against_its_own_benchmark():
+    # Codex P2, third pass. Measuring against the newest card *anywhere* let an
+    # unrelated benchmark's recent document supply the lag. Shipped MBPP is only
+    # 100 days behind its own newest adopter and was counted anyway, and the
+    # published "smallest gap" described a benchmark that was never in the set.
+    #
+    # `fresh` has a 2026 adopter and belongs. `own_lag_is_small` has a recent score
+    # and an adopter only days later, so it must be excluded even though another
+    # benchmark's card is a year newer.
+    entries = [
+        {
+            "benchmark_id": "fresh",
+            "name": "Fresh",
+            "organization_count": 2,
+            "card_count": 2,
+            "adopters": [{"published": "2026-06-01"}],
+        },
+        {
+            "benchmark_id": "own_lag_is_small",
+            "name": "Small",
+            "organization_count": 2,
+            "card_count": 2,
+            "adopters": [{"published": "2025-01-10"}],
+        },
+    ]
+    benchmarks = {
+        "fresh": record(last_reported_at="2025-01-01"),
+        "own_lag_is_small": record(last_reported_at="2025-01-01"),
+    }
+    insights = build_insights(leaderboard(entries), progression(benchmarks))
+    stale = next(item for item in insights["findings"] if item["kind"] == "stale_scores")
+    assert "1 benchmark" in stale["headline"]
+    # The reported gap must belong to a benchmark actually in the set.
+    assert "516 days" in stale["evidence"]
+    assert "2026-06-01" in stale["evidence"]
+
+
+def test_a_benchmark_with_no_later_report_of_its_own_is_not_stale():
+    # Shipped Arena-Hard and Aider Polyglot have no adopter newer than their last
+    # score. Nothing about them supports "kept gaining reporting documents".
+    entries = [
+        {
+            "benchmark_id": "alpha",
+            "name": "Alpha",
+            "organization_count": 2,
+            "card_count": 2,
+            "adopters": [{"published": "2024-01-01"}],
+        }
+    ]
+    insights = build_insights(
+        leaderboard(entries), progression({"alpha": record(last_reported_at="2025-01-01")})
+    )
+    assert not [item for item in insights["findings"] if item["kind"] == "stale_scores"]
+
+
+def test_shipped_reading_coverage_excludes_benchmarks_inside_the_threshold():
+    # The end-to-end guard. Every benchmark counted must genuinely be at least
+    # _STALE_SCORE_DAYS behind a later report of itself.
+    registry = load_registry(DEFAULT_REGISTRY_PATH)
+    progression_data = build_score_progression(DEFAULT_SCORES_PATH, registry)
+    board = adoption_rank(registry)
+    insights = build_insights(board, progression_data)
+    stale = next(item for item in insights["findings"] if item["kind"] == "stale_scores")
+
+    adoption = {entry["benchmark_id"]: entry for entry in board["entries"]}
+    genuinely_lagging = 0
+    for benchmark_id, rec in progression_data["benchmarks"].items():
+        own = [
+            adopter["published"]
+            for adopter in adoption.get(benchmark_id, {}).get("adopters") or []
+            if adopter.get("published")
+        ]
+        if not own:
+            continue
+        latest = max(own)
+        if latest > rec["last_reported_at"]:
+            lag = (date.fromisoformat(latest) - date.fromisoformat(rec["last_reported_at"])).days
+            if lag >= 180:
+                genuinely_lagging += 1
+    assert f"{genuinely_lagging} benchmarks" in stale["headline"]
 
 
 def test_reading_coverage_leads_even_against_competing_findings():

--- a/tests/test_insights.py
+++ b/tests/test_insights.py
@@ -1,0 +1,268 @@
+from benchmark_radar.benchmark_scores import DEFAULT_SCORES_PATH, build_score_progression
+from benchmark_radar.insights import build_insights
+from benchmark_radar.model_cards import DEFAULT_REGISTRY_PATH, adoption_rank, load_registry
+
+
+def leaderboard(entries=None, cards=None) -> dict:
+    return {
+        "entries": entries if entries is not None else [],
+        "model_cards": cards if cards is not None else [{"published": "2026-01-01"}],
+        "organization_count": 8,
+    }
+
+
+def progression(benchmarks=None) -> dict:
+    return {"benchmarks": benchmarks if benchmarks is not None else {}}
+
+
+def record(**overrides) -> dict:
+    value = {
+        "metric": "accuracy",
+        "observation_count": 2,
+        "dated_observation_count": 2,
+        "third_party_count": 0,
+        "last_reported_at": "2025-01-01",
+        "observations": [{"organization": "Org A"}],
+        "saturation": {
+            "best_value": 60.0,
+            "best_model": "Model B",
+            "best_organization": "Org A",
+            "best_reported_at": "2025-01-01",
+            "best_is_third_party": False,
+            "bound": 100.0,
+            "headroom": 40.0,
+            "best_gain": None,
+        },
+    }
+    value.update(overrides)
+    return value
+
+
+def test_no_panel_at_all_when_a_layer_is_missing():
+    # An empty findings list on the page reads as "we looked and the field is
+    # uneventful", which is a claim this corpus cannot make.
+    assert build_insights(None, progression()) is None
+    assert build_insights(leaderboard(), None) is None
+
+
+def test_adopted_but_unscored_benchmarks_are_named_in_one_finding():
+    # The explanation is identical for every such benchmark, so repeating it per
+    # benchmark printed one paragraph many times and pushed the findings that
+    # differ off the first screen. The names are what vary, so they travel in the
+    # detail rather than becoming separate cards.
+    entries = [
+        {
+            "benchmark_id": name,
+            "name": name.title(),
+            "organization_count": 6,
+            "card_count": count,
+            "adopters": [],
+        }
+        for name, count in (("alpha", 9), ("beta", 4))
+    ]
+    insights = build_insights(leaderboard(entries), progression())
+    unscored = [item for item in insights["findings"] if item["kind"] == "adopted_without_scores"]
+    assert len(unscored) == 1
+    assert "2 benchmarks" in unscored[0]["headline"]
+    assert "Alpha, Beta" in unscored[0]["detail"]
+    # Focuses the most-adopted, whose blank axis a reader is likeliest to seek.
+    assert unscored[0]["benchmark_id"] == "alpha"
+    assert "9 model cards" in unscored[0]["evidence"]
+
+
+def test_a_thinly_adopted_unscored_benchmark_is_not_worth_stating():
+    # Every registry benchmark lacking a score would otherwise become a finding,
+    # burying the ones that distinguish a benchmark from its neighbours.
+    entries = [
+        {
+            "benchmark_id": "alpha",
+            "name": "Alpha",
+            "organization_count": 1,
+            "card_count": 1,
+            "adopters": [],
+        }
+    ]
+    insights = build_insights(leaderboard(entries), progression())
+    assert insights["findings"] == []
+
+
+def test_closing_headroom_is_reported_without_a_trend_claim():
+    entries = [
+        {
+            "benchmark_id": "alpha",
+            "name": "Alpha",
+            "organization_count": 2,
+            "card_count": 2,
+            "adopters": [],
+        }
+    ]
+    saturation = record()["saturation"] | {"best_value": 98.0, "headroom": 2.0}
+    insights = build_insights(
+        leaderboard(entries), progression({"alpha": record(saturation=saturation)})
+    )
+    finding = next(item for item in insights["findings"] if item["kind"] == "closing_headroom")
+    assert "2 points of headroom" in finding["headline"]
+    # The claim must survive nobody ever reporting the benchmark again.
+    assert "not about a trend" in finding["detail"]
+
+
+def test_a_single_vendor_gain_names_the_vendor_in_the_headline():
+    # "AIME moved 40 points" reads as a fact about the field. A two-point
+    # single-vendor pair supports only the narrower sentence.
+    entries = [
+        {
+            "benchmark_id": "alpha",
+            "name": "Alpha",
+            "organization_count": 2,
+            "card_count": 2,
+            "adopters": [],
+        }
+    ]
+    gain = {
+        "instrument": "alpha",
+        "protocol": "0-shot",
+        "organization": "DeepSeek",
+        "from_value": 39.2,
+        "to_value": 79.8,
+        "from_reported_at": "2024-12-27",
+        "to_reported_at": "2025-01-22",
+        "from_model": "V3",
+        "to_model": "R1",
+        "improvement": 40.6,
+        "elapsed_days": 26,
+        "single_organization": True,
+        "dated_points": 2,
+    }
+    insights = build_insights(
+        leaderboard(entries),
+        progression({"alpha": record(saturation=record()["saturation"] | {"best_gain": gain})}),
+    )
+    finding = next(item for item in insights["findings"] if item["kind"] == "fast_gain")
+    assert finding["headline"].startswith("DeepSeek's own models moved 40.6 points")
+    assert "not evidence about other vendors" in finding["detail"]
+
+
+def test_reading_coverage_is_stated_once_rather_than_per_benchmark():
+    # The lag holds for nearly every scored benchmark in this corpus. Nineteen
+    # near-identical entries would crowd out every other finding while saying
+    # one thing repeatedly.
+    entries = [
+        {
+            "benchmark_id": name,
+            "name": name.title(),
+            "organization_count": 2,
+            "card_count": 2,
+            "adopters": [{"published": "2026-01-01"}],
+        }
+        for name in ("alpha", "beta", "gamma")
+    ]
+    benchmarks = {name: record() for name in ("alpha", "beta", "gamma")}
+    insights = build_insights(leaderboard(entries), progression(benchmarks))
+    stale = [item for item in insights["findings"] if item["kind"] == "stale_scores"]
+    assert len(stale) == 1
+    assert "3 benchmarks" in stale[0]["headline"]
+    # Corpus scope, so it belongs to no single benchmark's chart.
+    assert stale[0]["benchmark_id"] == ""
+
+
+def test_reading_coverage_leads_even_against_competing_findings():
+    # A reader who takes a flat score tail for a plateau will misread every chart
+    # on the page, so this one reframes the others and has to come first. The
+    # fixture deliberately also produces an unscored-adoption finding and a
+    # headroom finding: an ordering test whose fixture yields one finding proves
+    # nothing.
+    entries = [
+        {
+            "benchmark_id": "alpha",
+            "name": "Alpha",
+            "organization_count": 6,
+            "card_count": 9,
+            "adopters": [{"published": "2026-01-01"}],
+        },
+        {
+            "benchmark_id": "unscored",
+            "name": "Unscored",
+            "organization_count": 6,
+            "card_count": 9,
+            "adopters": [],
+        },
+    ]
+    saturation = record()["saturation"] | {"best_value": 98.0, "headroom": 2.0}
+    insights = build_insights(
+        leaderboard(entries), progression({"alpha": record(saturation=saturation)})
+    )
+    kinds = [item["kind"] for item in insights["findings"]]
+    assert kinds[0] == "stale_scores"
+    # And the competing findings really were produced, so the assertion above
+    # was a comparison rather than a walkover.
+    assert "closing_headroom" in kinds
+    assert "adopted_without_scores" in kinds
+    # An absence reported last: it changes less than a claim about a real number.
+    assert kinds.index("closing_headroom") < kinds.index("adopted_without_scores")
+
+
+def test_a_third_party_only_benchmark_is_flagged():
+    entries = [
+        {
+            "benchmark_id": "alpha",
+            "name": "Alpha",
+            "organization_count": 2,
+            "card_count": 2,
+            "adopters": [],
+        }
+    ]
+    insights = build_insights(
+        leaderboard(entries),
+        progression({"alpha": record(third_party_count=2, observation_count=2)}),
+    )
+    finding = next(item for item in insights["findings"] if item["kind"] == "third_party_only")
+    assert "quoting someone else's number" in finding["headline"]
+
+
+def test_every_finding_carries_auditable_evidence():
+    # A finding a reader cannot check is an assertion, and replacing assertions
+    # about benchmarks with checkable ones is the point of the project.
+    insights = build_insights(
+        adoption_rank(load_registry(DEFAULT_REGISTRY_PATH)),
+        build_score_progression(DEFAULT_SCORES_PATH, load_registry(DEFAULT_REGISTRY_PATH)),
+    )
+    assert insights["finding_count"] > 0
+    for finding in insights["findings"]:
+        assert finding["headline"].endswith(".")
+        assert finding["evidence"].strip()
+        assert finding["detail"].strip()
+
+
+def test_the_shipped_findings_never_call_a_benchmark_solved():
+    # The corpus is vendor-selected, several documents could not be read, and
+    # its scores stop before its mentions do. None of that supports the word.
+    insights = build_insights(
+        adoption_rank(load_registry(DEFAULT_REGISTRY_PATH)),
+        build_score_progression(DEFAULT_SCORES_PATH, load_registry(DEFAULT_REGISTRY_PATH)),
+    )
+    text = " ".join(
+        f"{finding['headline']} {finding['detail']}" for finding in insights["findings"]
+    ).lower()
+    assert "solved" not in text
+    assert "benchmark quality" in insights["does_not_measure"].lower()
+
+
+def test_counted_nouns_agree_with_their_numbers():
+    # These strings render verbatim, so "1 more reporting documents" is a
+    # visible defect that undercuts the finding it appears in.
+    entries = [
+        {
+            "benchmark_id": "alpha",
+            "name": "Alpha",
+            "organization_count": 1,
+            "card_count": 1,
+            "adopters": [{"published": "2026-01-01"}],
+        }
+    ]
+    insights = build_insights(
+        leaderboard(entries), progression({"alpha": record()}), minimum_organizations=1
+    )
+    text = " ".join(item["headline"] + item["evidence"] for item in insights["findings"])
+    assert "1 organizations" not in text
+    assert "1 benchmarks" not in text
+    assert "1 model cards" not in text

--- a/tests/test_saturation_view.py
+++ b/tests/test_saturation_view.py
@@ -153,15 +153,41 @@ def test_the_time_range_covers_the_score_track_at_both_ends():
 
 
 def test_scores_still_render_when_no_mention_carries_a_date():
-    # Codex P2, second pass. The registry permits a card without `published`, so
-    # a scored benchmark can have zero dated adoption events. Clearing the panel
-    # outright hid every readable score because the *other* layer had no date.
+    # Codex P2, second and third pass. The registry permits a card without
+    # `published`, so a scored benchmark can have zero dated adoption events.
+    # Clearing the panel hid every readable score because the *other* layer had no
+    # date -- and restoring only the aggregate readout still hid the individual
+    # points and comparable series, so a real chart is drawn.
     script = source("site/assets/app.js")
-    guard = script.split("if (!events.length) {", 1)[1].split("return;", 1)[0]
+    guard = script.split("if (!events.length) {", 1)[1].split("\n  }", 1)[0]
 
     # Ordering matters: clearAdoptionFrontier empties the readout, so the score
     # render has to come after it.
     assert guard.index("clearAdoptionFrontier") < guard.index("renderScoreReadout(entry)")
+    assert "scoreOnlyChart(entry)" in guard
+
+
+def test_the_score_only_chart_reuses_the_one_score_renderer():
+    # Two implementations of one axis would be free to disagree about the join
+    # rule, which is the single thing this chart must not do.
+    script = source("site/assets/app.js")
+    helper = script.split("function scoreOnlyChart(entry)", 1)[1].split("\n}", 1)[0]
+
+    assert "adoptionFrontierChart(" in helper
+    assert "sparse: true" in helper
+
+
+def test_the_reading_gap_ends_at_this_benchmarks_own_latest_mention():
+    # Codex P2, third pass. `endText` comes from the newest card anywhere in the
+    # registry, so shipped Arena-Hard and Aider Polyglot -- which have no adopter
+    # newer than their last score -- drew a long gap nothing supported.
+    script = source("site/assets/app.js")
+    gap = script.split("const lastMention = events", 1)[1].split(
+        "no readable score in this window", 1
+    )[0]
+
+    assert "lastMention > record.last_reported_at" in gap
+    assert "x(endText)" not in gap, "the gap must not extend to the registry-wide end date"
 
 
 def test_the_score_axis_says_it_is_zoomed():

--- a/tests/test_saturation_view.py
+++ b/tests/test_saturation_view.py
@@ -139,6 +139,31 @@ def test_a_sparse_adoption_layer_does_not_hide_a_readable_score():
     assert "const plotHeight = sparse ? 0 : 370 - margin.top - margin.bottom;" in chart
 
 
+def test_the_time_range_covers_the_score_track_at_both_ends():
+    # Codex P2, second pass. `startText` already considered the first score date
+    # while `endText` derived only from adoption dates, so a score newer than
+    # every card -- reachable when a card carries a later `revised` date -- landed
+    # outside the viewBox and was silently clipped.
+    script = source("site/assets/app.js")
+    chart = script.split("function adoptionFrontierChart(", 1)[1]
+    range_block = chart.split("const start = new Date(", 1)[0]
+
+    assert "record?.first_reported_at" in range_block
+    assert "record?.last_reported_at" in range_block
+
+
+def test_scores_still_render_when_no_mention_carries_a_date():
+    # Codex P2, second pass. The registry permits a card without `published`, so
+    # a scored benchmark can have zero dated adoption events. Clearing the panel
+    # outright hid every readable score because the *other* layer had no date.
+    script = source("site/assets/app.js")
+    guard = script.split("if (!events.length) {", 1)[1].split("return;", 1)[0]
+
+    # Ordering matters: clearAdoptionFrontier empties the readout, so the score
+    # render has to come after it.
+    assert guard.index("clearAdoptionFrontier") < guard.index("renderScoreReadout(entry)")
+
+
 def test_the_score_axis_says_it_is_zoomed():
     # Every value in this corpus sits in the upper part of its scale, so the
     # band is padded around the observed range instead of running 0-100. A

--- a/tests/test_saturation_view.py
+++ b/tests/test_saturation_view.py
@@ -9,6 +9,9 @@ labelled as a reading gap rather than left to be read as a plateau.
 
 from pathlib import Path
 
+from benchmark_radar.benchmark_scores import DEFAULT_SCORES_PATH, build_score_progression
+from benchmark_radar.model_cards import DEFAULT_REGISTRY_PATH, load_registry
+
 
 def source(path: str) -> str:
     return Path(path).read_text(encoding="utf-8")
@@ -19,7 +22,7 @@ def test_both_readings_share_one_time_axis():
     # a reader compare adoption against score at a given date, which is the
     # comparison the issue asked for.
     script = source("site/assets/app.js")
-    chart = script.split("function adoptionFrontierChart(entry, board, events)", 1)[1].split(
+    chart = script.split("function adoptionFrontierChart(", 1)[1].split(
         "\nfunction clearAdoptionFrontier", 1
     )[0]
 
@@ -33,7 +36,7 @@ def test_the_score_layer_only_draws_lines_the_join_rule_permits():
     # Two values taken under unstated and possibly different conditions are not
     # a measurement of change, so an unconnectable series must draw no line.
     script = source("site/assets/app.js")
-    chart = script.split("function adoptionFrontierChart(entry, board, events)", 1)[1].split(
+    chart = script.split("function adoptionFrontierChart(", 1)[1].split(
         "\nfunction clearAdoptionFrontier", 1
     )[0]
 
@@ -70,6 +73,72 @@ def test_the_reading_gap_is_labelled_rather_than_drawn_through():
     assert "score-gap-line" in script
 
 
+def test_the_reading_gap_encodes_no_score_value():
+    # Codex P1. An earlier version drew this span at the best-on-record height,
+    # asserting that value at a date where nothing was recorded. On shipped data
+    # the best often predates the last observation (AIME, SWE-bench Verified,
+    # MMLU-Redux, IFEval), so it manufactured a flat tail out of missing data --
+    # the exact failure the marker exists to prevent. The span must be purely
+    # horizontal on the plot floor, carrying no y-value.
+    script = source("site/assets/app.js")
+    gap = script.split("const lastScoreX = x(record.last_reported_at);", 1)[1].split(
+        "no readable score in this window", 1
+    )[0]
+
+    assert "scoreY(" not in gap, "the gap span must not be positioned by any score value"
+    assert "const floorY = scoreTop + scoreHeight;" in gap
+
+
+def test_shipped_data_has_benchmarks_whose_best_predates_their_last_score():
+    # Guards the premise of the test above. If curation ever made every best the
+    # newest observation, the P1 geometry would stop being reachable and that test
+    # would silently become vacuous rather than protective.
+    progression = build_score_progression(DEFAULT_SCORES_PATH, load_registry(DEFAULT_REGISTRY_PATH))
+    stale_best = [
+        benchmark_id
+        for benchmark_id, record in progression["benchmarks"].items()
+        if record["saturation"]["best_reported_at"] < record["last_reported_at"]
+    ]
+    assert stale_best, "expected at least one benchmark whose best is not its newest reading"
+
+
+def test_better_is_up_even_when_lower_is_the_better_score():
+    # Codex P2. `direction` exists in the schema so an error-rate metric does not
+    # render its improvements as a downward slope. The renderer has to consult it.
+    script = source("site/assets/app.js")
+    chart = script.split("function adoptionFrontierChart(", 1)[1].split(
+        "\nfunction clearAdoptionFrontier", 1
+    )[0]
+
+    assert 'record?.direction === "lower_is_better"' in chart
+    assert "scoreDescends ? 1 - fraction : fraction" in chart
+
+
+def test_lower_is_better_headroom_is_described_against_zero():
+    # Codex P2. The backend measures headroom to zero for an inverted metric, so
+    # naming `bound` in both cases would print "10 points to the 100-point bound"
+    # for a score of 10.
+    script = source("site/assets/app.js")
+
+    assert "points to zero, the floor of this metric" in script
+
+
+def test_a_sparse_adoption_layer_does_not_hide_a_readable_score():
+    # Codex P2. The sparse stepper replaces a one-advance step line because that
+    # line says nothing visually. The score track is a separate reading, so
+    # dropping it would hide real data because a different layer was thin.
+    script = source("site/assets/app.js")
+    render = script.split("const sparse = frontier.length < 2;", 1)[1].split(
+        "renderScoreReadout(entry)", 1
+    )[0]
+
+    assert "scoreRecord(entry.benchmark_id)" in render
+    assert "sparse && !scored ? null : adoptionFrontierChart" in render
+    # And the chart collapses the empty adoption band rather than padding with it.
+    chart = script.split("function adoptionFrontierChart(", 1)[1]
+    assert "const plotHeight = sparse ? 0 : 370 - margin.top - margin.bottom;" in chart
+
+
 def test_the_score_axis_says_it_is_zoomed():
     # Every value in this corpus sits in the upper part of its scale, so the
     # band is padded around the observed range instead of running 0-100. A
@@ -88,7 +157,7 @@ def test_a_benchmark_with_no_readable_score_says_so_instead_of_plotting_zero():
     )[0]
     assert "not a zero and not a plateau" in readout
     # And the chart reserves no empty band for it, which would read as a drop.
-    chart = script.split("function adoptionFrontierChart(entry, board, events)", 1)[1]
+    chart = script.split("function adoptionFrontierChart(", 1)[1]
     assert "const scoreHeight = record ? 132 : 0;" in chart
 
 

--- a/tests/test_saturation_view.py
+++ b/tests/test_saturation_view.py
@@ -1,0 +1,164 @@
+"""The rendered half of issue #91: the score track and the stated findings.
+
+Asserts on the shipped site sources the way `test_site.py` and
+`test_leaderboard_workbench.py` do. These are guarantees about what a reader
+sees, and several of them are honesty guarantees rather than layout ones: the
+join rule has to hold in the drawing code, and a flat score tail has to be
+labelled as a reading gap rather than left to be read as a plateau.
+"""
+
+from pathlib import Path
+
+
+def source(path: str) -> str:
+    return Path(path).read_text(encoding="utf-8")
+
+
+def test_both_readings_share_one_time_axis():
+    # The point of the panel. Two charts with independent x scales would not let
+    # a reader compare adoption against score at a given date, which is the
+    # comparison the issue asked for.
+    script = source("site/assets/app.js")
+    chart = script.split("function adoptionFrontierChart(entry, board, events)", 1)[1].split(
+        "\nfunction clearAdoptionFrontier", 1
+    )[0]
+
+    # One x() for both plots, and a score y that offsets below the adoption plot.
+    assert "const scoreTop = margin.top + plotHeight + bandGap" in chart
+    assert "scoreY(observation.value)" in chart
+    assert "x(observation.reported_at)" in chart
+
+
+def test_the_score_layer_only_draws_lines_the_join_rule_permits():
+    # Two values taken under unstated and possibly different conditions are not
+    # a measurement of change, so an unconnectable series must draw no line.
+    script = source("site/assets/app.js")
+    chart = script.split("function adoptionFrontierChart(entry, board, events)", 1)[1].split(
+        "\nfunction clearAdoptionFrontier", 1
+    )[0]
+
+    assert "if (!series.connectable) continue;" in chart
+
+
+def test_a_single_vendor_run_is_drawn_as_weaker_evidence():
+    script = source("site/assets/app.js")
+    styles = source("site/assets/styles.css")
+
+    assert "score-line-single-org" in script
+    assert ".score-line-single-org" in styles
+    assert "stroke-dasharray" in styles.split(".score-line-single-org", 1)[1][:120]
+
+
+def test_a_third_party_citation_is_marked_on_the_chart():
+    # A publisher repeating a competitor's figure must not read as a first-party
+    # report; it is weaker evidence and the chart has to say so.
+    script = source("site/assets/app.js")
+    styles = source("site/assets/styles.css")
+
+    assert "score-point-third-party" in script
+    assert "observation.reported_by" in script
+    assert ".score-point-third-party circle" in styles
+
+
+def test_the_reading_gap_is_labelled_rather_than_drawn_through():
+    # Scores in this corpus stop well before mentions do. An unmarked flat tail
+    # invites "saturated" as the explanation when "nothing newer could be read"
+    # is the actual one.
+    script = source("site/assets/app.js")
+
+    assert "no readable score in this window" in script
+    assert "score-gap-line" in script
+
+
+def test_the_score_axis_says_it_is_zoomed():
+    # Every value in this corpus sits in the upper part of its scale, so the
+    # band is padded around the observed range instead of running 0-100. A
+    # zoomed axis that does not say so overstates the movement it shows.
+    script = source("site/assets/app.js")
+
+    assert "function scoreBand(record)" in script
+    assert "(zoomed)" in script
+
+
+def test_a_benchmark_with_no_readable_score_says_so_instead_of_plotting_zero():
+    script = source("site/assets/app.js")
+
+    readout = script.split("function renderScoreReadout(entry)", 1)[1].split(
+        "\nfunction adoptionFrontierChart", 1
+    )[0]
+    assert "not a zero and not a plateau" in readout
+    # And the chart reserves no empty band for it, which would read as a drop.
+    chart = script.split("function adoptionFrontierChart(entry, board, events)", 1)[1]
+    assert "const scoreHeight = record ? 132 : 0;" in chart
+
+
+def test_the_evidence_grade_is_printed_not_hidden():
+    # The honest scope of a two-point chart is the first thing a reader needs,
+    # not an optional disclosure.
+    script = source("site/assets/app.js")
+
+    assert "evidence.supports" in script
+    assert "evidence.does_not_support" in script
+    assert '"Does not support: "' in script
+
+
+def test_findings_are_rendered_with_their_evidence():
+    # Issue #91's third point. A finding a reader cannot audit is an assertion.
+    html = source("site/index.html")
+    script = source("site/assets/app.js")
+
+    assert 'id="benchmark-findings"' in html
+    assert 'id="findings-list"' in html
+    assert "function renderBenchmarkFindings(board)" in script
+    assert "finding.evidence" in script
+    assert "finding.detail" in script
+
+
+def test_findings_state_what_they_do_not_measure():
+    script = source("site/assets/app.js")
+
+    assert "insights.does_not_measure" in script
+    assert 'id="findings-limits"' in source("site/index.html")
+
+
+def test_an_empty_findings_list_hides_the_panel_rather_than_showing_nothing():
+    # An empty panel reads as "we looked and the field is uneventful".
+    script = source("site/assets/app.js")
+    renderer = script.split("function renderBenchmarkFindings(board)", 1)[1].split(
+        "\nfunction modelCardLabelCounts", 1
+    )[0]
+
+    assert "panel.hidden = true" in renderer
+    assert "!insights.findings?.length" in renderer
+
+
+def test_a_finding_can_move_the_chart_to_the_benchmark_it_is_about():
+    # A claim should never be more than one interaction away from its data.
+    script = source("site/assets/app.js")
+    card = script.split("function findingCard(finding, board)", 1)[1].split(
+        "\nfunction renderBenchmarkFindings", 1
+    )[0]
+
+    assert "state.lfrontier = target.benchmark_id" in card
+    assert "renderAdoptionFrontier(board)" in card
+    # Corpus-scope findings name no benchmark, so there is nothing to focus.
+    assert "finding.benchmark_id" in card
+
+
+def test_the_explainer_still_separates_reporting_from_score_saturation():
+    # The guarantee that predates this change and must survive it: a flat
+    # adoption run is reporting saturation within a curated registry, and is not
+    # a claim about the benchmark's scores.
+    html = " ".join(source("site/index.html").split())
+
+    assert "A long flat run is reporting saturation" in html
+    assert "not a claim about benchmark score saturation" in html
+    assert "connected only where the instrument and protocol" in html
+
+
+def test_the_score_layer_is_keyed_by_the_same_benchmark_id_as_adoption():
+    # Two rankings that could disagree about what a benchmark is would be worse
+    # than one. The score layer is a lookup, not a second ordering.
+    script = source("site/assets/app.js")
+
+    assert "benchmark_score_progression?.benchmarks?.[benchmarkId]" in script

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -756,6 +756,54 @@ def test_dashboard_fails_rather_than_publishing_a_stale_ranking(tmp_path):
         rebuild_dashboard(snapshot_dir, tmp_path / "radar.json", registry_path=broken)
 
 
+def test_a_custom_registry_does_not_inherit_the_default_score_file(tmp_path):
+    # Codex P2. The two curated files are a matched pair: every score cites a
+    # source_id that must be a document in the registry beside it. Defaulting the
+    # score file under a custom registry paired them with a registry never meant
+    # to hold them, so the provenance cross-check correctly refused and every
+    # `--model-cards` rebuild against an alternate registry failed.
+    snapshot_dir = tmp_path / "snapshots"
+    write_snapshot(radar_run(26), snapshot_dir)
+    registry = tmp_path / "cards.yml"
+    registry.write_text(
+        "schema_version: 1\n"
+        "benchmarks:\n"
+        "  - id: alpha\n"
+        "    name: Alpha\n"
+        "    domain: math\n"
+        "    caveat: Test caveat.\n"
+        "model_cards:\n"
+        "  - id: some_card\n"
+        "    organization: Org\n"
+        "    model: M\n"
+        "    url: https://example.com/card\n"
+        "    published: '2025-01-01'\n"
+        "    benchmarks: [alpha]\n",
+        encoding="utf-8",
+    )
+
+    data = rebuild_dashboard(snapshot_dir, tmp_path / "radar.json", registry_path=registry)
+
+    # The adoption ranking still builds; the score layer is simply absent rather
+    # than crashing the run or being cited to the wrong documents.
+    assert data["model_card_leaderboard"] is not None
+    assert data["benchmark_score_progression"] is None
+    assert data["benchmark_insights"] is None
+
+
+def test_the_default_registry_still_carries_the_default_scores(tmp_path):
+    # The other half of the pairing rule: omitting both paths must still publish
+    # all three layers, or the shipped dashboard would silently lose its scores.
+    snapshot_dir = tmp_path / "snapshots"
+    write_snapshot(radar_run(26), snapshot_dir)
+
+    data = rebuild_dashboard(snapshot_dir, tmp_path / "radar.json")
+
+    assert data["model_card_leaderboard"] is not None
+    assert data["benchmark_score_progression"] is not None
+    assert data["benchmark_insights"] is not None
+
+
 def test_taxonomy_version_tracks_content_not_a_hand_bumped_constant():
     from benchmark_radar.rubric import taxonomy_version
 

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -1,5 +1,6 @@
 import json
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 
 import pytest
 
@@ -789,6 +790,23 @@ def test_a_custom_registry_does_not_inherit_the_default_score_file(tmp_path):
     assert data["model_card_leaderboard"] is not None
     assert data["benchmark_score_progression"] is None
     assert data["benchmark_insights"] is None
+
+
+def test_the_default_registry_is_recognized_through_an_equivalent_path(tmp_path):
+    # Codex P2. `--model-cards "$PWD/data/model_cards.yml"` names the same file as
+    # the relative default, so treating it as a custom registry silently dropped
+    # scores and insights from a build that should have carried them.
+    snapshot_dir = tmp_path / "snapshots"
+    write_snapshot(radar_run(26), snapshot_dir)
+
+    data = rebuild_dashboard(
+        snapshot_dir,
+        tmp_path / "radar.json",
+        registry_path=Path("data/model_cards.yml").resolve(),
+    )
+
+    assert data["benchmark_score_progression"] is not None
+    assert data["benchmark_insights"] is not None
 
 
 def test_the_default_registry_still_carries_the_default_scores(tmp_path):


### PR DESCRIPTION
Implements items 1-3 of #91: the saturation reading, both readings on one time axis, and the stated-findings layer the issue called the most important gap.

## What the data allowed

This shaped the design more than anything else. Under the strict join rule (identical `instrument` AND `protocol`) the 70 observations form 51 series, and **only 8 span more than one date** — 7 of those are one vendor reporting its own successive models, mostly DeepSeek V3 to R1. The 5-point GPQA "series" is all dated `2025-06-17`: one comparison table in one document, not a progression.

So there is no three-date run anywhere in the corpus. I did not loosen the join to manufacture longer lines. The chart draws what exists and an `evidence_grade` states the scope per benchmark, so a two-point single-vendor pair reads as "Paired comparison only / Does not support: a direction over time" and never as a trend. `test_the_shipped_file_never_claims_a_trend_it_cannot_support` locks that in.

## The three items

**1. Saturation** (`benchmark_scores.py`, wired in `snapshots.py`). `data/benchmark_scores.yml` had landed with 70 source-verified observations and nothing read it. This publishes `best`, `headroom`, and `comparable_series` separately rather than one running-maximum line, because the data file is right that a flat max cannot be evidence of saturation. One registry read is shared with the ranking so the provenance cross-check cannot pass against a different revision of the file.

**2. 上榜 on the same axis** (`app.js`, `index.html`, `styles.css`). The score track draws below the adoption step line on a shared x scale, so a vertical line through the chart means one date in both. Honesty constraints live in the drawing code, not just the copy: GPQA's five same-date points draw no line; single-vendor runs are dashed and third-party citations ringed; a benchmark with no readable score reserves no band, so absence cannot read as a drop to zero; the score axis is zoomed to the observed range and labelled `(zoomed)`.

**3. Stated findings** (`insights.py`). Derived in Python where they are testable, rendered with an evidence line and a jump-to-chart button. Six ship. Two kinds are stated once at corpus scope — reading coverage holds for 18 of 21 scored benchmarks and unscored-adoption for six, so per-benchmark cards repeated one paragraph and pushed the distinguishing findings off the first screen.

## The finding worth reading

Score coverage ends `2025-06-17`; the newest model card is `2026-07-24`. **18 of 21 scored benchmarks kept gaining reporting documents after their last readable score**, 244 days at the narrowest. Every flat right-hand side on these charts is a reading gap, not a plateau — marked explicitly on the chart and leading the findings panel, because a reader who misreads it will misread every chart on the page.

That gap is also the direct case for items 4 and 5 (METR, Harbor), left open: the missing numbers are mostly in documents this corpus could not read. OpenAI and xAI return 403 to automated fetching; Meta, Mistral and Anthropic publish some tables as images.

## Review

Codex reviewed this branch four times. 14 findings, all fixed; final verdict "the shipped data works and tests pass", no blockers.

The P1 was in the exact constraint the feature exists to enforce: the reading-gap span was drawn at the *historical best's* y-coordinate, asserting a value at a date where nothing was recorded. On shipped data that hit 4 of 21 benchmarks (AIME, SWE-bench Verified, MMLU-Redux, IFEval), manufacturing the flat tail the marker exists to prevent. Codex also noted my test only checked the CSS class and label, so it missed the geometry.

Three further findings were wrong published output rather than latent risk:

- `stale_scores` claimed "19 benchmarks, smallest gap 402 days". Both false — the lag was measured against the newest card anywhere, so MBPP was counted at a real 100-day gap under my own 180-day threshold. Now 18 and 244.
- Arena-Hard and Aider Polyglot drew a long "no readable score" gap despite having no adopter newer than their last score.
- `--model-cards` with any alternate registry raised `BenchmarkScoreError`, breaking a documented workflow. Reproduced before fixing; `--benchmark-scores` added for the paired case.

Two guards are mutation-checked: reintroducing each old bug makes the new test fail (the gain-endpoint one returns 10.0 vs 50.0 for identical values under the old lexical ordering).

## Verification

- 353 tests pass, 53 new. `ruff check` and `ruff format --check` clean.
- Browser sweep of all 79 adopted benchmarks: zero geometry problems, no clipped points, no gap-at-best. Reviewed at 1440px and 390px.
- Two non-issues run down rather than assumed: 25 "no svg" results are the legitimate sparse-stepper path, and the 403s are the GitHub badge API rate-limiting a local IP, present on `main` before this branch.

## Note for deploy

`site/data/radar.json` is gitignored, so the published dashboard needs `benchmark-radar rebuild` for the new layers to appear.

Closes part of #91 (items 1-3; items 4-5 remain open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
