### PR TITLE
Show the coverage badge where someone would copy it

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **Which AI benchmarks do frontier labs actually report when they ship a model?**
 
+[![model cards tracked](https://img.shields.io/endpoint?url=https%3A%2F%2Fkoutian.is-a.dev%2Fbenchmark-radar%2Fdata%2Fleaderboard-badge.json)](https://koutian.is-a.dev/benchmark-radar/?view=leaderboard)
+
 Not which benchmarks exist, and not which are cited most in papers: which ones a
 vendor chooses to put in front of readers in a model card. That is a question about
 what the field currently treats as the standard set, and it is answered here by
@@ -30,6 +32,17 @@ carries its own caveat.
 Take it with you: [`leaderboard.json`][json] · [`leaderboard.csv`][csv] ·
 [`leaderboard.md`][md] (paste-ready table). Every artifact restates the caveat, so the
 ranking cannot be separated from what it means.
+
+The coverage badge above reads the same registry, so it reports the current denominator
+rather than whatever it was when someone copied it:
+
+```markdown
+[![model cards tracked](https://img.shields.io/endpoint?url=https%3A%2F%2Fkoutian.is-a.dev%2Fbenchmark-radar%2Fdata%2Fleaderboard-badge.json)](https://koutian.is-a.dev/benchmark-radar/?view=leaderboard)
+```
+
+It deliberately shows coverage and not a rank: a badge is a single number read without
+context, and "GPQA Diamond is #1" seen that way is the quality claim this ranking does
+not make.
 
 [json]: https://ktwu01.github.io/benchmark-radar/data/leaderboard.json
 [csv]: https://ktwu01.github.io/benchmark-radar/data/leaderboard.csv

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -1,6 +1,9 @@
 import re
+import tempfile
 from pathlib import Path
+from urllib.parse import quote
 
+from benchmark_radar.export import write_exports
 from benchmark_radar.model_cards import build_adoption_rank
 
 README = Path("README.md")
@@ -56,6 +59,28 @@ def test_readme_headline_totals_match_the_registry():
         f"and technical reports from {leaderboard['organization_count']}\n"
         f"organizations, tracking {leaderboard['benchmark_count']} benchmarks."
     ) in text
+
+
+def test_readme_badge_points_at_the_published_endpoint():
+    # The badge is the one artifact whose whole purpose is to be copied by
+    # someone else, so its URL is quoted twice: once rendered, once as a
+    # copyable snippet. Both are hand-written, and a badge pointing at a path
+    # the export layer no longer writes fails as a broken image on every README
+    # that copied it -- including other people's.
+    if not README.exists():  # pragma: no cover
+        return
+    text = README.read_text(encoding="utf-8")
+
+    url = "https://koutian.is-a.dev/benchmark-radar/data/leaderboard-badge.json"
+    quoted = quote(url, safe="")
+    assert text.count(f"https://img.shields.io/endpoint?url={quoted}") == 2
+
+
+def test_readme_badge_endpoint_filename_matches_the_exporter():
+    # Ties the name above to the writer, so renaming the artifact breaks a test
+    # here rather than silently breaking every embedded badge.
+    written = write_exports(Path(tempfile.mkdtemp()), source_url=None)
+    assert written["badge"].name == "leaderboard-badge.json"
 
 
 def test_readme_headline_keeps_the_quality_caveat():


### PR DESCRIPTION
`benchmark-radar export` has published a Shields endpoint at
`site/data/leaderboard-badge.json` since #101, currently returning
`30 cards · 79 benchmarks`. The README rendered it nowhere.

That is backwards for the one artifact whose entire purpose is to be copied. A badge is
an invitation to embed, and the place someone copies it from is the README of the project
it describes. Until now a reader had to know the endpoint existed to use it.

This adds the badge under the headline question, and the copyable Markdown next to the
existing export links, where a reader already looking for takeable artifacts will find it.

The badge reports coverage rather than a rank, for the reason `leaderboard_badge` already
documents in its docstring: a badge is a single number read without context, and "GPQA
Diamond is #1" seen that way is exactly the quality claim this ranking does not make.
Coverage carries no such reading, and it is the number that actually moves as the
registry grows.

Both the rendered badge and the snippet are hand-written URLs, so `tests/test_readme.py`
pins them to the filename the exporter actually writes. A badge pointing at a path the
export layer no longer produces fails as a broken image on every README that copied it,
including other people's. That is a worse failure than the usual stale link, because it
breaks on someone else's page rather than on ours.

Also adds five repository topics for discovery, applied directly since topics are not a
file in the tree: `llm-evaluation`, `model-cards`, `leaderboard`, `benchmarking`, `llm`.
The existing four (`ai-benchmark`, `datasets`, `evaluation`, `research-radar`) missed the
terms this audience searches.

Part of #88.

## Verification

- `pytest`: 355 passed, including two new badge tests
- `ruff check` and `ruff format --check`: clean
- `curl` on the Shields render URL returns 200 `image/svg+xml`
- Live endpoint returns `{"message": "30 cards · 79 benchmarks"}`, matching the rendered badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
