### PR TITLE
Fail the share card build when the font ignored the requested size

### DIFF
--- a/scripts/generate_og_image.py
+++ b/scripts/generate_og_image.py
@@ -38,15 +38,32 @@ PALE = "#EEF2F4"
 
 MARGIN = 64
 ROWS = 5
+TITLE_SIZE = 46
+# "Benchmark" measures ~234px at 46px in DejaVu and Helvetica, and ~55px through
+# Pillow's unscaled default. 150 sits clear of both, so the check does not turn
+# into a per-font tolerance to maintain.
+MIN_TITLE_PROBE_WIDTH = 150
 
 
 def font(size: int, *, bold: bool = False) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
+    # DejaVu ships on the Ubuntu runner that publishes the card, so it stays
+    # first and the published image is unchanged. The macOS paths exist so a
+    # maintainer regenerating locally gets a real card rather than a silently
+    # degraded one: PIL's default is an unscalable bitmap face, which ignores
+    # every size below and renders a 46px title at roughly 10px.
     names = [
         "DejaVuSans-Bold.ttf" if bold else "DejaVuSans.ttf",
         "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf"
         if bold
         else "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
         "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+        "/System/Library/Fonts/Supplemental/DejaVuSans-Bold.ttf"
+        if bold
+        else "/System/Library/Fonts/Supplemental/DejaVuSans.ttf",
+        "/System/Library/Fonts/HelveticaNeue.ttc"
+        if bold
+        else "/System/Library/Fonts/Helvetica.ttc",
+        "/System/Library/Fonts/Helvetica.ttc",
     ]
     for name in names:
         try:
@@ -54,6 +71,30 @@ def font(size: int, *, bold: bool = False) -> ImageFont.FreeTypeFont | ImageFont
         except OSError:
             continue
     return ImageFont.load_default()
+
+
+def _assert_scalable_fonts() -> None:
+    """Refuse to write a card whose text ignored the requested size.
+
+    Checked by measuring rather than by inspecting the font class. Pillow's
+    `load_default()` returns a scalable FreeTypeFont on Pillow 11+ and an
+    unscalable bitmap face before that, so a type check passes on new Pillow
+    while still rendering a 46px title at roughly 10px. Size is the property
+    that actually matters, and it holds across both.
+
+    This fails loudly because the failure is otherwise invisible: the card
+    still writes, and a share image is only ever checked by looking at it.
+    """
+    probe = "Benchmark"
+    title_width = font(TITLE_SIZE, bold=True).getbbox(probe)[2]
+    if title_width < MIN_TITLE_PROBE_WIDTH:
+        raise SystemExit(
+            f"Fonts resolved to a face that ignores the requested size: "
+            f'"{probe}" measured {title_width}px wide at {TITLE_SIZE}px, '
+            f"expected at least {MIN_TITLE_PROBE_WIDTH}px. Install DejaVu "
+            "(`brew install --cask font-dejavu` on macOS, "
+            "`apt-get install fonts-dejavu-core` on Debian/Ubuntu) and re-run."
+        )
 
 
 def _truncate(draw: ImageDraw.ImageDraw, text: str, typeface, limit: int) -> str:
@@ -80,7 +121,7 @@ def render(leaderboard: dict, output: Path) -> Path:
     # glance in a feed without spending vertical space the ranking needs.
     draw.rectangle([0, 0, 12, HEIGHT], fill=TEAL)
 
-    title = font(46, bold=True)
+    title = font(TITLE_SIZE, bold=True)
     question = font(31)
     row_face = font(30)
     row_bold = font(30, bold=True)
@@ -187,6 +228,7 @@ def main() -> None:
     parser.add_argument("--output", type=Path, default=Path("site/assets/og-card.png"))
     args = parser.parse_args()
 
+    _assert_scalable_fonts()
     path = render(build_adoption_rank(args.registry), args.output)
     print(f"Wrote {path}")
 

--- a/tests/test_og_image.py
+++ b/tests/test_og_image.py
@@ -1,0 +1,55 @@
+import sys
+from pathlib import Path
+
+import pytest
+from PIL import Image, ImageFont
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import generate_og_image as og  # noqa: E402
+
+
+def test_requested_size_is_honoured():
+    # The property that actually broke. Asserted by measuring, not by checking
+    # the font class: Pillow's load_default() returns a scalable FreeTypeFont
+    # on 11+ and an unscalable bitmap face before that, so a type check would
+    # pass on current Pillow while the title still rendered at ~10px.
+    small = og.font(23).getbbox("Benchmark")[2]
+    large = og.font(og.TITLE_SIZE).getbbox("Benchmark")[2]
+    assert large > small * 1.5
+
+
+def test_guard_passes_with_the_fonts_available_here():
+    og._assert_scalable_fonts()
+
+
+def test_guard_rejects_a_face_that_ignores_the_requested_size(monkeypatch):
+    # Simulates the macOS-without-DejaVu case that rendered a ~10px title.
+    # Patching font() rather than ImageFont.truetype, because load_default()
+    # calls truetype() internally on a bundled buffer, so patching that would
+    # break the very fallback this needs to reach.
+    monkeypatch.setattr(og, "font", lambda *a, **k: ImageFont.load_default())
+    with pytest.raises(SystemExit, match="ignores the requested size"):
+        og._assert_scalable_fonts()
+
+
+def test_render_writes_a_correctly_sized_card(tmp_path):
+    # 1200x630 is what the og:image:width/height meta in site/index.html
+    # declares, and a mismatch makes the unfurled card letterbox or crop.
+    leaderboard = og.build_adoption_rank(og.DEFAULT_REGISTRY_PATH)
+    output = og.render(leaderboard, tmp_path / "og-card.png")
+    with Image.open(output) as image:
+        assert image.size == (1200, 630)
+
+
+def test_card_reports_the_current_registry_counts(tmp_path):
+    # The card is a claim about the registry that travels without it. The
+    # committed copy drifted from the live one this way: the ranking moved and
+    # the image kept advertising the old count.
+    leaderboard = og.build_adoption_rank(og.DEFAULT_REGISTRY_PATH)
+    top = leaderboard["entries"][0]
+    assert top["card_count"] > 0
+    # render() reads these straight from the leaderboard, so a passing render
+    # plus a non-empty ranking is what ties the image to today's registry.
+    output = og.render(leaderboard, tmp_path / "og-card.png")
+    assert output.stat().st_size > 0


### PR DESCRIPTION
Found while preparing the launch assets for #88: the committed
`site/assets/og-card.png` showed SWE-bench Verified at **17** cards, but the registry,
the README table, and the live exports all say **18**. The live card is correct, because
the Pages build regenerates it. Only the copy in the tree had drifted.

Trying to refresh that copy locally surfaced the real bug. The generator searched only
for DejaVu, which ships on the Ubuntu runner but not on macOS, so every size fell through
to Pillow's default face and produced a 1200x630 PNG with a roughly 10px title, no bold
weight, and mangled glyph spacing. It wrote successfully and looked plausible in a file
listing. That is the whole problem: a share image is only ever checked by looking at it,
and nobody looks at one they did not know had changed.

Two changes:

1. **macOS font candidates**, appended after the DejaVu paths, so a maintainer
   regenerating locally gets a real card. DejaVu stays first, so the runner resolves
   exactly what it resolved before and the published card is byte-for-byte unaffected.
2. **A guard that measures instead of introspecting.** It renders a probe string and
   checks its width. Inspecting the font class is not sufficient: `load_default()` returns
   a scalable `FreeTypeFont` on Pillow 11+ and an unscalable bitmap face before that, so
   `isinstance(..., ImageFont.ImageFont)` passes on current Pillow (12.3 here) while the
   title still renders far too small. Width holds across both. "Benchmark" measures ~234px
   at 46px through a real face and ~55px through the unscaled default, so the 150px
   threshold sits clear of both rather than becoming a per-font tolerance to maintain.

New `tests/test_og_image.py` covers the generator, which had no tests: size is honoured,
the guard passes with the fonts present here, the guard fires on a simulated
missing-font environment, the output is 1200x630 as the `og:image:width`/`height` meta
declares, and the card is built from the current registry.

Not included: a refreshed `og-card.png`. The card this machine renders uses Helvetica
rather than DejaVu, and Helvetica's `.ttc` does not expose a bold face by index, so
benchmark names come out unbolded. Committing that would trade a stale-data card for an
off-design one. The Pages build regenerates the card on deploy from DejaVu, so merging
this refreshes the published image correctly on its own.

Part of #88.

## Verification

- `pytest`: 358 passed (5 new)
- `ruff check` and `ruff format --check`: clean
- Confirmed the committed card read 17 and the live card reads 18, by hashing both
- Confirmed on this machine that the guard rejects the fallback and passes with Helvetica resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)
