### PR TITLE
fix(#91): make the adoption staircase legible

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -2251,27 +2251,35 @@ function adoptionFrontierChart(entry, board, events, { sparse = false } = {}) {
         class: "card-rug-baseline",
       }),
     );
-    // Cards sharing a publication date are fanned apart by a fixed offset. Using
-    // x(date) alone gave them identical coordinates, so they overpainted: the
-    // visible tick count came out short and only the last one drawn was
-    // hoverable. Seven shipped benchmarks have a same-day pair (2026-02-11), so
-    // this is the common case, not an edge one -- and "cards on one date stay
-    // visible" is the rug's entire reason for existing.
-    const sameDateCounts = new Map();
+    // Tick positions are allocated across every card at once, not per date. Two
+    // earlier versions were wrong in the same way at different scales: x(date)
+    // alone overpainted cards sharing a date, and fanning each date independently
+    // then pushed those ticks into a *neighbouring* date's -- on shipped GPQA
+    // Diamond at the narrow viewBox a fanned 2026-02-11 tick landed 0.04 units
+    // from the 2026-02-16 tick, inside a 2.5-unit stroke, so one still vanished
+    // and swallowed the other's hover target. One-day-apart pairs collided at
+    // desktop width too.
+    //
+    // So this is a single left-to-right sweep that keeps every tick at least a
+    // stroke-width apart, then shifts the whole run back by half its total drift
+    // to keep the group centred on the dates it represents. Ticks stay in date
+    // order and no two can occupy the same pixel, which is the guarantee the rug
+    // exists to make; a tick may sit a fraction of a unit off its exact date, and
+    // that is the honest trade, since a hidden card is a lost observation while a
+    // 3px nudge is not.
+    const MIN_TICK_GAP = 3.5;
+    const positions = [];
+    let previous = -Infinity;
     for (const event of events) {
-      sameDateCounts.set(event.published, (sameDateCounts.get(event.published) || 0) + 1);
+      const ideal = x(event.published);
+      const placed = Math.max(ideal, previous + MIN_TICK_GAP);
+      positions.push(placed);
+      previous = placed;
     }
-    const sameDateSeen = new Map();
-    for (const event of events) {
-      const total = sameDateCounts.get(event.published);
-      const index = sameDateSeen.get(event.published) || 0;
-      sameDateSeen.set(event.published, index + 1);
-      // Centred on the true date so the group still reads at the right position:
-      // two cards straddle it rather than one hiding the other. The offset exceeds
-      // the tick's own stroke width, or the pair would abut into what looks like a
-      // single thick tick and defeat the point.
-      const spread = 4.5;
-      const tickX = x(event.published) + (total > 1 ? (index - (total - 1) / 2) * spread : 0);
+    const drift = positions.length ? positions[positions.length - 1] - x(events[events.length - 1].published) : 0;
+    const shift = drift / 2;
+    for (const [index, event] of events.entries()) {
+      const tickX = positions[index] - shift;
       const group = svgElement("g", {
         class: `card-rug-tick${event.advances ? " card-rug-tick-first" : " card-rug-tick-repeat"}`,
         tabindex: "0",

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -2029,17 +2029,34 @@ function renderScoreReadout(entry) {
 // the two for equivalent kinds of point. Each entry names the mark AND what it
 // does to the count, because "new organization" alone does not say that the other
 // kind leaves the staircase flat.
-function renderFrontierLegend(entry, record) {
+// `sparse` suppresses the staircase and the rug in favour of the step list, so
+// their legend entries are suppressed with them: a key describing marks that are
+// not on screen is worse than no key, and many shipped benchmarks take that path.
+function renderFrontierLegend(entry, record, { sparse = false } = {}) {
   const host = byId("frontier-legend");
   if (!host) return;
   const swatch = (className) => element("span", { className: `legend-swatch ${className}` });
-  const items = [
-    ["legend-swatch-diamond", "New organization", "cumulative count increases"],
-    ["legend-swatch-tick-first", "First card from that organization", "the tick under the jump"],
-    ["legend-swatch-tick-repeat", "Later card, organization already counted", "count unchanged"],
-  ];
+  const items = sparse
+    ? []
+    : [
+        ["legend-swatch-diamond", "New organization", "cumulative count increases"],
+        [
+          "legend-swatch-tick-first",
+          "First card from that organization",
+          "the tick under the jump",
+        ],
+        [
+          "legend-swatch-tick-repeat",
+          "Later card, organization already counted",
+          "count unchanged",
+        ],
+      ];
   if (record) {
-    items.push(["legend-swatch-score", "Readable score", "connected only at one instrument and protocol"]);
+    items.push([
+      "legend-swatch-score",
+      "Readable score",
+      "connected only at one instrument and protocol",
+    ]);
   }
   replaceChildren(
     host,
@@ -2234,8 +2251,27 @@ function adoptionFrontierChart(entry, board, events, { sparse = false } = {}) {
         class: "card-rug-baseline",
       }),
     );
+    // Cards sharing a publication date are fanned apart by a fixed offset. Using
+    // x(date) alone gave them identical coordinates, so they overpainted: the
+    // visible tick count came out short and only the last one drawn was
+    // hoverable. Seven shipped benchmarks have a same-day pair (2026-02-11), so
+    // this is the common case, not an edge one -- and "cards on one date stay
+    // visible" is the rug's entire reason for existing.
+    const sameDateCounts = new Map();
     for (const event of events) {
-      const tickX = x(event.published);
+      sameDateCounts.set(event.published, (sameDateCounts.get(event.published) || 0) + 1);
+    }
+    const sameDateSeen = new Map();
+    for (const event of events) {
+      const total = sameDateCounts.get(event.published);
+      const index = sameDateSeen.get(event.published) || 0;
+      sameDateSeen.set(event.published, index + 1);
+      // Centred on the true date so the group still reads at the right position:
+      // two cards straddle it rather than one hiding the other. The offset exceeds
+      // the tick's own stroke width, or the pair would abut into what looks like a
+      // single thick tick and defeat the point.
+      const spread = 4.5;
+      const tickX = x(event.published) + (total > 1 ? (index - (total - 1) / 2) * spread : 0);
       const group = svgElement("g", {
         class: `card-rug-tick${event.advances ? " card-rug-tick-first" : " card-rug-tick-repeat"}`,
         tabindex: "0",
@@ -2453,10 +2489,13 @@ function adoptionFrontierChart(entry, board, events, { sparse = false } = {}) {
           "text-anchor": "middle",
           class: "frontier-axis-label",
         },
-        // The band is only 132 units tall, so the "(zoomed)" qualifier is dropped
-        // on a narrow viewport where the rotated text would overrun it. The
-        // readout below the chart still states the band bounds either way.
-        narrow ? record.metric : `${record.metric} (zoomed)`,
+        // The zoom marker is never dropped. An earlier version omitted it on
+        // narrow viewports and justified that by saying the readout states the
+        // band bounds -- it does not; the bounds appear only as the two axis
+        // ticks. Removing it left small screens with no indication that the axis
+        // is magnified, which is the one thing about this band a reader must not
+        // misjudge. Abbreviated instead, so it still fits the rotated label.
+        narrow ? `${record.metric} (zoom)` : `${record.metric} (zoomed)`,
       ),
     );
   }
@@ -2601,11 +2640,16 @@ function renderAdoptionFrontier(board) {
     element("strong", { text: entry.name }),
     // "23 cards · 10 of 10 dated organizations" read as one ratio about a single
     // quantity. They are two different counts, so they are now named separately.
+    //
+    // The organization count is qualified as "dated" when some card carries no
+    // publication date: `card_count` includes those cards but `frontier` cannot,
+    // so an unqualified "distinct organizations" beside the card total would imply
+    // the two were counted over the same set of documents.
     element("span", {
-      text: `${metricLabel(entry.card_count, "model card")} · ${metricLabel(
-        frontier.length,
-        "distinct organization",
-      )}`,
+      text:
+        `${metricLabel(entry.card_count, "model card")} · ` +
+        `${metricLabel(frontier.length, "distinct organization")}` +
+        ((entry.adopters || []).some((adopter) => !adopter.published) ? " with a dated card" : ""),
     }),
     element("span", {
       text: `last new organization ${formatDate(lastAdvance.published, { dateStyle: "medium" })}`,
@@ -2618,7 +2662,7 @@ function renderAdoptionFrontier(board) {
   // *different* layer was thin.
   const sparse = frontier.length < 2;
   const scored = Boolean(scoreRecord(entry.benchmark_id));
-  renderFrontierLegend(entry, scoreRecord(entry.benchmark_id));
+  renderFrontierLegend(entry, scoreRecord(entry.benchmark_id), { sparse });
   replaceChildren(byId("frontier-chart"), [
     sparse ? sparseFrontier(entry, events) : null,
     sparse && !scored ? null : adoptionFrontierChart(entry, board, events, { sparse }),
@@ -3322,6 +3366,20 @@ function bindEvents() {
     passive: true,
   });
   window.addEventListener("resize", repositionDayTooltip);
+  // The frontier chart picks its viewBox width from the viewport, so crossing the
+  // 760px breakpoint has to redraw it. Without this a page loaded wide and then
+  // narrowed (or a rotated phone) keeps the 920-unit box until some unrelated
+  // rerender, and the CSS min-height only letterboxes the collapsed chart rather
+  // than fixing it. Re-rendered only on an actual crossing, not on every resize
+  // event, since redrawing every SVG mid-drag would be wasteful.
+  let wasNarrow = window.innerWidth <= 760;
+  window.addEventListener("resize", () => {
+    const isNarrow = window.innerWidth <= 760;
+    if (isNarrow === wasNarrow) return;
+    wasNarrow = isNarrow;
+    const board = state.data?.model_card_leaderboard;
+    if (board) renderAdoptionFrontier(board);
+  });
   document.addEventListener("keydown", (event) => {
     // Do not swallow Escape unless a card is actually open to close.
     if (event.key === "Escape" && dismissDayTooltip()) event.preventDefault();

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -1995,10 +1995,11 @@ function scoreReadout(entry, record) {
     record.third_party_count
       ? element("p", {
           className: "score-readout-note",
-          text: `${metricLabel(
-            record.third_party_count,
-            "value",
-          )} here is a third party quoting another vendor's figure, marked with a ring on the chart.`,
+          // The verb has to agree with the count, not stay singular beside a
+          // pluralized noun ("4 values here is a third party...").
+          text: `${metricLabel(record.third_party_count, "value")} here ${
+            record.third_party_count === 1 ? "is a third party" : "are third parties"
+          } quoting another vendor's figure, marked with a ring on the chart.`,
         })
       : null,
   ]);
@@ -2020,6 +2021,36 @@ function renderScoreReadout(entry) {
     return;
   }
   replaceChildren(host, [scoreReadout(entry, record)]);
+}
+
+// A legend keyed to the marks actually on the chart. The panel previously relied
+// on the prose explainer to say what orange versus gray meant, which put the key
+// several lines away from the thing it explains; issue #91 reports readers taking
+// the two for equivalent kinds of point. Each entry names the mark AND what it
+// does to the count, because "new organization" alone does not say that the other
+// kind leaves the staircase flat.
+function renderFrontierLegend(entry, record) {
+  const host = byId("frontier-legend");
+  if (!host) return;
+  const swatch = (className) => element("span", { className: `legend-swatch ${className}` });
+  const items = [
+    ["legend-swatch-diamond", "New organization", "cumulative count increases"],
+    ["legend-swatch-tick-first", "First card from that organization", "the tick under the jump"],
+    ["legend-swatch-tick-repeat", "Later card, organization already counted", "count unchanged"],
+  ];
+  if (record) {
+    items.push(["legend-swatch-score", "Readable score", "connected only at one instrument and protocol"]);
+  }
+  replaceChildren(
+    host,
+    items.map(([className, label, effect]) =>
+      element("span", { className: "frontier-legend-item" }, [
+        swatch(className),
+        element("strong", { text: label }),
+        element("span", { text: effect }),
+      ]),
+    ),
+  );
 }
 
 // `sparse` means the adoption stepper is being rendered separately because it has
@@ -2048,7 +2079,13 @@ function adoptionFrontierChart(entry, board, events, { sparse = false } = {}) {
   const start = new Date(`${startText}T00:00:00Z`).getTime();
   const rawEnd = new Date(`${endText}T00:00:00Z`).getTime();
   const end = Math.max(rawEnd, start + 86_400_000);
-  const width = 920;
+  // A narrower viewBox on a narrow viewport. `width: 100%` scales height with
+  // width, so a 920-unit box at 390px CSS pixels rendered the whole chart about
+  // 90px tall and the staircase became unreadable. Halving the coordinate width
+  // lets the same content scale up rather than being squashed; distorting the
+  // aspect ratio instead would stretch the axis text illegibly.
+  const narrow = typeof window !== "undefined" && window.innerWidth <= 760;
+  const width = narrow ? 520 : 920;
   // The score band is only reserved when there is a score to draw. A benchmark
   // with no readable value gets the original single-plot height rather than an
   // empty lower half, which would read as "scores went to zero here".
@@ -2063,7 +2100,18 @@ function adoptionFrontierChart(entry, board, events, { sparse = false } = {}) {
   // The adoption plot collapses to nothing when its stepper is drawn separately,
   // so the SVG carries no empty region where the step line would have been.
   const plotHeight = sparse ? 0 : 370 - margin.top - margin.bottom;
-  const height = margin.top + plotHeight + bandGap + scoreHeight + margin.bottom;
+  // The card rug: one tick per model card, on its own band under the staircase.
+  // Repeat cards used to be plotted *on* the count axis at the running total,
+  // which put a marker at a height the card did not cause -- a card that changed
+  // nothing sat at the same y as the advance that did. Worse, several cards
+  // sharing a date stacked into each other and occluded the numbers. Giving card
+  // events their own band separates "how many organizations by this date" from
+  // "when were the cards published", which is the whole confusion in issue #91.
+  const rugHeight = sparse || !events.length ? 0 : 26;
+  const rugGap = rugHeight ? 12 : 0;
+  const height =
+    margin.top + plotHeight + rugGap + rugHeight + bandGap + scoreHeight + margin.bottom;
+  const rugTop = margin.top + plotHeight + rugGap;
   const maxOrganizations = Math.max(1, Number(board.organization_count || 0));
   const x = (date) =>
     margin.left +
@@ -2072,7 +2120,7 @@ function adoptionFrontierChart(entry, board, events, { sparse = false } = {}) {
   // The score plot sits below the adoption plot and shares its x scale, which is
   // the whole point: the two readings are only comparable if a vertical line
   // through the chart means one date in both.
-  const scoreTop = margin.top + plotHeight + bandGap;
+  const scoreTop = margin.top + plotHeight + rugGap + rugHeight + bandGap;
   // Better is always up. `direction` exists in the schema precisely so a metric
   // where lower wins (an edit distance, an error rate) does not render its
   // improvements as a downward slope; consulting it here is what makes the axis
@@ -2139,36 +2187,102 @@ function adoptionFrontierChart(entry, board, events, { sparse = false } = {}) {
     path += ` H ${x(endText)}`;
     svg.append(svgElement("path", { d: path, class: "frontier-line" }));
 
-    for (const event of events) {
-      const advanceIndex = event.advances ? advances.indexOf(event) + 1 : null;
-      const group = svgElement("g", {
-        class: `frontier-point${event.advances ? " frontier-point-advance" : " frontier-point-repeat"}`,
-        tabindex: "0",
-        role: "img",
-        "aria-label": `${event.organization}, ${event.model}, ${formatDate(event.published, {
-          dateStyle: "medium",
-        })}${event.advances ? `, frontier step ${advanceIndex}` : ", repeat report"}`,
-      });
+    // Diamonds at the jumps, and only at the jumps. The marker number is gone: it
+    // restated the y-axis value the marker already sits at, and a digit inside a
+    // circle reads as a record id, so readers took the staircase for a numbered
+    // list of points rather than a cumulative count.
+    for (const event of advances) {
       const pointX = x(event.published);
       const pointY = y(event.organizationCount);
-      group.append(svgElement("circle", { cx: pointX, cy: pointY, r: event.advances ? 11 : 6 }));
-      if (advanceIndex) {
-        group.append(
-          svgElement(
-            "text",
-            {
-              x: pointX,
-              y: pointY + 4,
-              "text-anchor": "middle",
-              class: "frontier-point-number",
-            },
-            advanceIndex,
-          ),
-        );
-      }
-      group.append(svgElement("title", {}, `${event.organization} · ${event.model}`));
+      const group = svgElement("g", {
+        class: "frontier-point frontier-point-advance",
+        tabindex: "0",
+        role: "img",
+        "aria-label":
+          `${event.organization} first reported it ${formatDate(event.published, {
+            dateStyle: "medium",
+          })} with ${event.model}, taking the count to ${event.organizationCount}`,
+      });
+      const r = 7;
+      group.append(
+        svgElement("polygon", {
+          points: `${pointX},${pointY - r} ${pointX + r},${pointY} ${pointX},${pointY + r} ${pointX - r},${pointY}`,
+        }),
+      );
+      group.append(
+        svgElement(
+          "title",
+          {},
+          `${event.organization} · ${event.model} · first report · count ${event.organizationCount}`,
+        ),
+      );
       svg.append(group);
     }
+  }
+
+  // The card rug. Every card gets exactly one tick, so a date carrying several
+  // cards shows several ticks side by side instead of a pile of circles on the
+  // staircase. Orange marks a first report, gray a later card from an
+  // organization already counted.
+  if (rugHeight) {
+    svg.append(
+      svgElement("line", {
+        x1: margin.left,
+        y1: rugTop + rugHeight / 2,
+        x2: width - margin.right,
+        y2: rugTop + rugHeight / 2,
+        class: "card-rug-baseline",
+      }),
+    );
+    for (const event of events) {
+      const tickX = x(event.published);
+      const group = svgElement("g", {
+        class: `card-rug-tick${event.advances ? " card-rug-tick-first" : " card-rug-tick-repeat"}`,
+        tabindex: "0",
+        role: "img",
+        "aria-label":
+          `${event.organization}, ${event.model}, ${formatDate(event.published, {
+            dateStyle: "medium",
+          })}` +
+          (event.advances
+            ? ", first report from this organization"
+            : ", later card from an organization already counted"),
+      });
+      // A first report gets a full-height tick, a repeat a short one, so the two
+      // are distinguishable without relying on colour alone.
+      const halfHeight = event.advances ? rugHeight / 2 : rugHeight / 4;
+      group.append(
+        svgElement("line", {
+          x1: tickX,
+          y1: rugTop + rugHeight / 2 - halfHeight,
+          x2: tickX,
+          y2: rugTop + rugHeight / 2 + halfHeight,
+        }),
+      );
+      group.append(
+        svgElement(
+          "title",
+          {},
+          `${event.organization} · ${event.model} · ${
+            event.advances ? "first report" : "count unchanged"
+          }`,
+        ),
+      );
+      svg.append(group);
+    }
+    svg.append(
+      svgElement(
+        "text",
+        {
+          x: 17,
+          y: rugTop + rugHeight / 2,
+          transform: `rotate(-90 17 ${rugTop + rugHeight / 2})`,
+          "text-anchor": "middle",
+          class: "frontier-axis-label",
+        },
+        "cards",
+      ),
+    );
   }
 
   if (record) {
@@ -2339,7 +2453,10 @@ function adoptionFrontierChart(entry, board, events, { sparse = false } = {}) {
           "text-anchor": "middle",
           class: "frontier-axis-label",
         },
-        `${record.metric} (zoomed)`,
+        // The band is only 132 units tall, so the "(zoomed)" qualifier is dropped
+        // on a narrow viewport where the rotated text would overrun it. The
+        // readout below the chart still states the band bounds either way.
+        narrow ? record.metric : `${record.metric} (zoomed)`,
       ),
     );
   }
@@ -2352,7 +2469,7 @@ function adoptionFrontierChart(entry, board, events, { sparse = false } = {}) {
       // Spans both plots when a score band exists, so the release date reads as
       // one moment in the benchmark's life rather than as two unrelated marks.
       x2: releaseX,
-      y2: record ? scoreTop + scoreHeight : margin.top + plotHeight,
+      y2: record ? scoreTop + scoreHeight : rugTop + rugHeight,
       class: "frontier-release-line",
     }),
   );
@@ -2390,7 +2507,12 @@ function adoptionFrontierChart(entry, board, events, { sparse = false } = {}) {
           "text-anchor": "middle",
           class: "frontier-axis-label",
         },
-        "organizations reporting",
+        // Named for what the axis counts. "Organizations reporting" invited the
+        // reading that a repeat card adds to it; "cumulative distinct" says in the
+        // label itself that a second card from a counted vendor moves nothing.
+        // Shortened on a narrow viewport, where the rotated full text is longer
+        // than the plot is tall and would be clipped at the viewBox edge.
+        narrow ? "distinct orgs" : "cumulative distinct organizations",
       ),
     );
   }
@@ -2426,6 +2548,7 @@ function clearAdoptionFrontier(message) {
   replaceChildren(byId("frontier-milestones"), []);
   replaceChildren(byId("frontier-task-preview"), []);
   replaceChildren(byId("frontier-score-readout"), []);
+  replaceChildren(byId("frontier-legend"), []);
   replaceChildren(byId("frontier-chart"), [
     element("p", { className: "empty-state", text: message }),
   ]);
@@ -2476,11 +2599,16 @@ function renderAdoptionFrontier(board) {
   stageElement.textContent = `Reporting stage · ${stage.label}`;
   replaceChildren(byId("frontier-summary"), [
     element("strong", { text: entry.name }),
+    // "23 cards · 10 of 10 dated organizations" read as one ratio about a single
+    // quantity. They are two different counts, so they are now named separately.
     element("span", {
-      text: `${metricLabel(entry.card_count, "card")} · ${frontier.length} of ${board.organization_count} dated organizations`,
+      text: `${metricLabel(entry.card_count, "model card")} · ${metricLabel(
+        frontier.length,
+        "distinct organization",
+      )}`,
     }),
     element("span", {
-      text: `last frontier advance ${formatDate(lastAdvance.published, { dateStyle: "medium" })}`,
+      text: `last new organization ${formatDate(lastAdvance.published, { dateStyle: "medium" })}`,
     }),
     element("span", { className: "frontier-stage-description", text: stage.description }),
   ]);
@@ -2490,6 +2618,7 @@ function renderAdoptionFrontier(board) {
   // *different* layer was thin.
   const sparse = frontier.length < 2;
   const scored = Boolean(scoreRecord(entry.benchmark_id));
+  renderFrontierLegend(entry, scoreRecord(entry.benchmark_id));
   replaceChildren(byId("frontier-chart"), [
     sparse ? sparseFrontier(entry, events) : null,
     sparse && !scored ? null : adoptionFrontierChart(entry, board, events, { sparse }),

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -1666,25 +1666,46 @@ td a {
   stroke-width: 3;
 }
 
-.frontier-point circle {
-  transition: r 120ms ease, stroke-width 120ms ease;
-}
-
-.frontier-point-advance circle {
+/* A diamond, not a numbered circle. The shape carries the meaning "the count
+   stepped up here" on its own, so it reads without the digit that used to sit
+   inside it restating the y-axis (issue #91). */
+.frontier-point-advance polygon {
   fill: #f4b65e;
   stroke: #fff4dd;
   stroke-width: 2;
+  transition: stroke-width 120ms ease;
 }
 
-.frontier-point-repeat circle {
-  fill: #0d1519;
-  stroke: #91a0a7;
+.frontier-point:focus polygon,
+.frontier-point:hover polygon {
+  stroke-width: 4;
+}
+
+/* Card events live on their own band. A tick per card means several cards on one
+   date sit side by side instead of stacking into an unreadable pile on the
+   staircase, which is what made the old chart look like numbered records. */
+.card-rug-baseline {
+  stroke: #2c383e;
+  stroke-width: 1;
+}
+
+.card-rug-tick line {
+  stroke-linecap: butt;
+  transition: stroke-width 120ms ease;
+}
+
+.card-rug-tick-first line {
+  stroke: #f4b65e;
+  stroke-width: 2.5;
+}
+
+.card-rug-tick-repeat line {
+  stroke: #89969e;
   stroke-width: 2;
 }
 
-.frontier-point:focus circle,
-.frontier-point:hover circle {
-  r: 11px;
+.card-rug-tick:focus line,
+.card-rug-tick:hover line {
   stroke-width: 4;
 }
 
@@ -1713,12 +1734,65 @@ td a {
   font-size: 11px;
 }
 
-.frontier-point-number {
-  pointer-events: none;
-  fill: #162228;
-  font-family: var(--utility);
-  font-size: 10px;
-  font-weight: 800;
+/* Legend, keyed to the marks on the chart and sitting directly above it rather
+   than being described several lines away in the prose explainer. */
+.frontier-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1.4rem;
+  margin: 0.9rem 0 0.2rem;
+}
+
+.frontier-legend-item {
+  display: flex;
+  align-items: baseline;
+  gap: 0.45rem;
+  font-size: 0.78rem;
+  line-height: 1.4;
+}
+
+.frontier-legend-item strong {
+  color: #e8eef0;
+  font-weight: 600;
+}
+
+.frontier-legend-item > span:last-child {
+  color: #97a5ac;
+}
+
+.legend-swatch {
+  flex: 0 0 auto;
+  align-self: center;
+}
+
+.legend-swatch-diamond {
+  width: 11px;
+  height: 11px;
+  background: #f4b65e;
+  border: 1px solid #fff4dd;
+  transform: rotate(45deg);
+}
+
+.legend-swatch-tick-first,
+.legend-swatch-tick-repeat {
+  width: 3px;
+  background: #f4b65e;
+}
+
+.legend-swatch-tick-first {
+  height: 15px;
+}
+
+.legend-swatch-tick-repeat {
+  height: 8px;
+  background: #89969e;
+}
+
+.legend-swatch-score {
+  width: 11px;
+  height: 11px;
+  background: #6ea8dc;
+  border-radius: 50%;
 }
 
 /* Stated findings (issue #91). Sits above the workbench on the light canvas:
@@ -2684,6 +2758,15 @@ footer {
     width: min(100% - 28px, 1440px);
   }
 
+  /* `width: 100%` on a wide viewBox scales the height down with it, so at 390px
+     the chart collapsed to roughly 90px and the staircase became unreadable --
+     worse once the card rug was added. The fix is a narrower viewBox (set in
+     app.js from the viewport width), which scales the same content up instead of
+     squashing it; distorting the ratio here would stretch the axis text. */
+  .frontier-chart svg {
+    min-height: 300px;
+  }
+
   .masthead {
     min-height: 76px;
   }
@@ -2876,10 +2959,6 @@ footer {
   .score-best-label,
   .score-gap-label {
     font-size: 20px;
-  }
-
-  .frontier-point-number {
-    font-size: 16px;
   }
 
   .ledger-summary {

--- a/site/index.html
+++ b/site/index.html
@@ -245,8 +245,10 @@
             <p class="section-note" id="frontier-explainer">
               Three readings on one time axis. Each orange diamond marks an organization's first
               report of this benchmark, which is the only event that raises the cumulative count.
-              The rug beneath it puts one tick per model card, so later cards from an organization
-              already counted appear as gray ticks and leave the staircase flat. A long flat run is
+              The rug beneath it puts one tick per dated model card, so later cards from an
+              organization already counted appear as gray ticks and leave the staircase flat. A card
+              with no publication date cannot be placed on the timeline and is absent from both
+              bands, though it is still counted in the totals above. A long flat run is
               reporting saturation observed within this curated registry, not a claim about
               benchmark score saturation.
               The score track below it is a separate reading: every value that could be read

--- a/site/index.html
+++ b/site/index.html
@@ -243,16 +243,19 @@
               </div>
             </div>
             <p class="section-note" id="frontier-explainer">
-              Two readings on one time axis. The step line is adoption: it advances only when a
-              new organization reports the benchmark, and hollow dots are repeat reports from an
-              organization already on the frontier. A long flat run is reporting saturation
-              observed within this curated registry, not a claim about benchmark score saturation.
+              Three readings on one time axis. Each orange diamond marks an organization's first
+              report of this benchmark, which is the only event that raises the cumulative count.
+              The rug beneath it puts one tick per model card, so later cards from an organization
+              already counted appear as gray ticks and leave the staircase flat. A long flat run is
+              reporting saturation observed within this curated registry, not a claim about
+              benchmark score saturation.
               The score track below it is a separate reading: every value that could be read
               verbatim from a cited document, connected only where the instrument and protocol
               are identical. A flat score tail usually means no newer number could be read, which
               is why the gap is marked rather than drawn through.
             </p>
             <div class="frontier-summary" id="frontier-summary" aria-live="polite"></div>
+            <div class="frontier-legend" id="frontier-legend" aria-label="Chart legend"></div>
             <div class="frontier-chart" id="frontier-chart"></div>
             <div class="score-readout" id="frontier-score-readout"></div>
             <div class="frontier-evidence">

--- a/tests/test_leaderboard_workbench.py
+++ b/tests/test_leaderboard_workbench.py
@@ -47,7 +47,9 @@ def test_frontier_svg_fits_the_viewport_without_horizontal_scrolling():
     assert "width: 100%" in rule
     assert "height: auto" in rule
     assert "min-width" not in rule
-    assert ".frontier-point-number" in styles
+    # The marker styling this used to check (`.frontier-point-number`) is gone with
+    # the numbers themselves; the advance marker is now a diamond (issue #91).
+    assert ".frontier-point-advance polygon" in styles
 
 
 def test_task_preview_distinguishes_source_paraphrase_from_domain_fallback():

--- a/tests/test_saturation_view.py
+++ b/tests/test_saturation_view.py
@@ -26,8 +26,9 @@ def test_both_readings_share_one_time_axis():
         "\nfunction clearAdoptionFrontier", 1
     )[0]
 
-    # One x() for both plots, and a score y that offsets below the adoption plot.
-    assert "const scoreTop = margin.top + plotHeight + bandGap" in chart
+    # One x() for both plots, and a score y that offsets below the adoption plot
+    # and the card rug that now sits between them (issue #91 legibility pass).
+    assert "const scoreTop = margin.top + plotHeight + rugGap + rugHeight + bandGap" in chart
     assert "scoreY(observation.value)" in chart
     assert "x(observation.reported_at)" in chart
 
@@ -188,6 +189,79 @@ def test_the_reading_gap_ends_at_this_benchmarks_own_latest_mention():
 
     assert "lastMention > record.last_reported_at" in gap
     assert "x(endText)" not in gap, "the gap must not extend to the registry-wide end date"
+
+
+def test_card_events_live_on_their_own_band_not_the_count_axis():
+    # Issue #91 legibility pass. Repeat cards were plotted at `y(organizationCount)`,
+    # putting a marker at a height the card did not cause: a card that changed
+    # nothing sat at the same y as the advance that did, and several cards sharing
+    # a date stacked into each other. Card events now get their own rug band.
+    script = source("site/assets/app.js")
+    chart = script.split("function adoptionFrontierChart(", 1)[1].split(
+        "\nfunction clearAdoptionFrontier", 1
+    )[0]
+
+    assert "const rugTop = margin.top + plotHeight + rugGap" in chart
+    assert "card-rug-tick" in chart
+    # The staircase loop iterates advances only; nothing else may touch y().
+    staircase = chart.split("for (const event of advances) {", 1)[1].split("\n  }", 1)[0]
+    assert "for (const event of events)" not in staircase
+
+
+def test_the_advance_marker_carries_no_number():
+    # The digit inside the circle restated the y-axis value the marker already sat
+    # at, and a number in a circle reads as a record id, so readers took the
+    # staircase for a numbered list rather than a cumulative count.
+    script = source("site/assets/app.js")
+    styles = source("site/assets/styles.css")
+
+    assert "frontier-point-number" not in script
+    assert "frontier-point-number" not in styles
+    assert "advanceIndex" not in script
+    # A diamond, whose shape says "stepped up here" without a digit.
+    assert "frontier-point-advance" in script
+    assert ".frontier-point-advance polygon" in styles
+
+
+def test_a_legend_names_each_mark_and_its_effect_on_the_count():
+    # "New organization" alone does not say that the other kind leaves the
+    # staircase flat, so each entry states the mark AND what it does to the count.
+    html = source("site/index.html")
+    script = source("site/assets/app.js")
+
+    assert 'id="frontier-legend"' in html
+    assert "function renderFrontierLegend(entry, record)" in script
+    assert "cumulative count increases" in script
+    assert "count unchanged" in script
+
+
+def test_the_axis_and_header_name_distinct_organizations():
+    # "Organizations reporting" invited the reading that a repeat card adds to it,
+    # and "23 cards · 10 of 10 dated organizations" read as one ratio about a
+    # single quantity rather than two different counts.
+    script = source("site/assets/app.js")
+
+    assert "cumulative distinct organizations" in script
+    assert '"distinct organization"' in script
+    # Asserted on the template literal that actually renders, not on a source
+    # slice: "dated organizations" legitimately survives in comments (including the
+    # one documenting this very change) and in the navigator copy, so a
+    # substring-absence check over source text tests the wrong thing.
+    assert '"model card")} · ${metricLabel(' in script
+    assert '"distinct organization",' in script
+
+
+def test_the_chart_does_not_collapse_on_a_narrow_viewport():
+    # `width: 100%` scales height with width, so a 920-unit viewBox at 390px
+    # rendered the chart about 90px tall. A narrower viewBox scales the same
+    # content up; distorting the aspect ratio would stretch the axis text.
+    script = source("site/assets/app.js")
+    styles = source("site/assets/styles.css")
+
+    assert "window.innerWidth <= 760" in script
+    assert 'preserveAspectRatio: "none"' not in script
+    narrow_rule = styles.split("@media (max-width: 760px) {", 1)[1]
+    assert "min-height" in narrow_rule.split(".frontier-chart svg {", 1)[1].split("}", 1)[0]
 
 
 def test_the_score_axis_says_it_is_zoomed():

--- a/tests/test_saturation_view.py
+++ b/tests/test_saturation_view.py
@@ -230,7 +230,7 @@ def test_a_legend_names_each_mark_and_its_effect_on_the_count():
     script = source("site/assets/app.js")
 
     assert 'id="frontier-legend"' in html
-    assert "function renderFrontierLegend(entry, record)" in script
+    assert "function renderFrontierLegend(" in script
     assert "cumulative count increases" in script
     assert "count unchanged" in script
 
@@ -243,25 +243,67 @@ def test_the_axis_and_header_name_distinct_organizations():
 
     assert "cumulative distinct organizations" in script
     assert '"distinct organization"' in script
-    # Asserted on the template literal that actually renders, not on a source
-    # slice: "dated organizations" legitimately survives in comments (including the
-    # one documenting this very change) and in the navigator copy, so a
+    # Asserted on the strings that actually render, not on a source slice: "dated
+    # organizations" legitimately survives in comments (including the one
+    # documenting this very change) and in the navigator copy, so a
     # substring-absence check over source text tests the wrong thing.
-    assert '"model card")} · ${metricLabel(' in script
-    assert '"distinct organization",' in script
+    assert 'metricLabel(entry.card_count, "model card")' in script
+    assert 'metricLabel(frontier.length, "distinct organization")' in script
+    # And the organization count is qualified when some card carries no date, since
+    # card_count includes those while the plotted count cannot.
+    assert '" with a dated card"' in script
 
 
 def test_the_chart_does_not_collapse_on_a_narrow_viewport():
     # `width: 100%` scales height with width, so a 920-unit viewBox at 390px
     # rendered the chart about 90px tall. A narrower viewBox scales the same
     # content up; distorting the aspect ratio would stretch the axis text.
+    #
+    # The width selection itself is asserted, not just the breakpoint expression:
+    # an earlier version of this test passed even with `width` reverted to a
+    # constant 920, because `narrow` stayed in use for the axis labels.
     script = source("site/assets/app.js")
     styles = source("site/assets/styles.css")
 
-    assert "window.innerWidth <= 760" in script
+    assert 'const narrow = typeof window !== "undefined" && window.innerWidth <= 760' in script
+    assert "const width = narrow ? 520 : 920;" in script
     assert 'preserveAspectRatio: "none"' not in script
     narrow_rule = styles.split("@media (max-width: 760px) {", 1)[1]
     assert "min-height" in narrow_rule.split(".frontier-chart svg {", 1)[1].split("}", 1)[0]
+    # Crossing the breakpoint has to redraw, or a resized page keeps a stale box.
+    assert "if (isNarrow === wasNarrow) return;" in script
+
+
+def test_same_date_cards_do_not_overpaint_in_the_rug():
+    # Codex P1. x(date) alone gave every card on one date an identical coordinate,
+    # so they overpainted: the visible tick count came out short and only the last
+    # drawn was hoverable. Seven shipped benchmarks have a same-day pair, and
+    # "cards on one date stay visible" is the rug's whole reason for existing.
+    script = source("site/assets/app.js")
+    rug = script.split("const sameDateCounts = new Map();", 1)[1].split("\n  }", 1)[0]
+
+    assert "(index - (total - 1) / 2) * spread" in rug
+
+
+def test_the_zoom_marker_survives_a_narrow_viewport():
+    # Codex P2. Dropping it on small screens left no indication that the score axis
+    # is magnified, and the justification (that the readout states the band bounds)
+    # was false -- the bounds appear only as the two axis ticks.
+    script = source("site/assets/app.js")
+
+    assert "(zoom)" in script
+    assert "(zoomed)" in script
+
+
+def test_the_legend_omits_marks_that_sparse_mode_suppresses():
+    # Codex P2. `sparse` replaces the staircase and rug with the step list, so a
+    # key describing diamonds and ticks that are not on screen is worse than none.
+    script = source("site/assets/app.js")
+    legend = script.split("function renderFrontierLegend(", 1)[1].split("\n}", 1)[0]
+
+    assert "sparse" in legend
+    assert "const items = sparse" in legend
+    assert "renderFrontierLegend(entry, scoreRecord(entry.benchmark_id), { sparse })" in script
 
 
 def test_the_score_axis_says_it_is_zoomed():

--- a/tests/test_saturation_view.py
+++ b/tests/test_saturation_view.py
@@ -274,15 +274,22 @@ def test_the_chart_does_not_collapse_on_a_narrow_viewport():
     assert "if (isNarrow === wasNarrow) return;" in script
 
 
-def test_same_date_cards_do_not_overpaint_in_the_rug():
-    # Codex P1. x(date) alone gave every card on one date an identical coordinate,
-    # so they overpainted: the visible tick count came out short and only the last
-    # drawn was hoverable. Seven shipped benchmarks have a same-day pair, and
-    # "cards on one date stay visible" is the rug's whole reason for existing.
+def test_rug_ticks_never_overpaint_each_other():
+    # Codex P1, twice. Two earlier versions were wrong the same way at different
+    # scales: x(date) alone overpainted cards sharing a date, and fanning each date
+    # independently then pushed those ticks into a *neighbouring* date's -- 0.04
+    # units apart on shipped GPQA Diamond at the narrow viewBox, inside a 2.5-unit
+    # stroke. Positions are therefore allocated across every card at once.
     script = source("site/assets/app.js")
-    rug = script.split("const sameDateCounts = new Map();", 1)[1].split("\n  }", 1)[0]
+    rug = script.split("const MIN_TICK_GAP", 1)[1].split("\n  }", 1)[0]
 
-    assert "(index - (total - 1) / 2) * spread" in rug
+    # A single sweep enforcing a minimum gap, not a per-date fan.
+    assert "Math.max(ideal, previous + MIN_TICK_GAP)" in rug
+    # Recentred afterwards so the run still sits on the dates it represents.
+    assert "const shift = drift / 2;" in rug
+    # The gap has to exceed the widest tick stroke (2.5) or ticks still touch.
+    gap = float(script.split("const MIN_TICK_GAP = ", 1)[1].split(";", 1)[0])
+    assert gap > 2.5, "the minimum gap must exceed the tick stroke width"
 
 
 def test_the_zoom_marker_survives_a_narrow_viewport():

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -531,14 +531,17 @@ def test_a_zero_adoption_bar_has_no_visible_width():
 def test_leaderboard_has_an_honest_time_based_adoption_frontier():
     html = Path("site/index.html").read_text(encoding="utf-8")
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
+    # Whitespace-normalized: these are prose guarantees, and HTML collapses the
+    # line wrapping, so a reflowed paragraph must not read as a lost disclaimer.
+    prose = " ".join(html.split())
 
     assert 'id="adoption-frontier"' in html
     assert 'id="frontier-benchmark"' in html
     assert 'id="frontier-chart"' in html
     assert "function frontierEvents(entry)" in script
     assert "const advances = !seenOrganizations.has(adopter.organization)" in script
-    assert "A long flat run is reporting saturation" in html
-    assert "not a claim about benchmark score saturation" in html
+    assert "A long flat run is reporting saturation" in prose
+    assert "not a claim about benchmark score saturation" in prose
 
 
 def test_new_benchmarks_are_visually_prioritized_without_changing_the_rank():


### PR DESCRIPTION
Implements the `view=dashboard` legibility spec from [this comment](https://github.com/ktwu01/benchmark-radar/issues/91#issuecomment-5187397435).

## The problem was worse than reported

The critique said orange and gray markers "look like equivalent points". On shipped data they also **overlapped and occluded each other**: on GPQA Diamond the `10` marker was clipped off-canvas and three markers collided at counts 4, 6 and 9.

The root cause was an encoding error, not styling. Repeat cards were plotted at `y(event.organizationCount)` — putting a marker at a height that card did not cause, at the same y as the advance that did.

## All seven spec items

| Spec item | Change |
|---|---|
| Diamonds only at vertical jumps | Polygon marker, drawn from `advances` only |
| Gray ticks, not circles, for repeats | Own rug band: full-height orange for a first report, half-height gray for a repeat, so they differ in shape and not only colour |
| Remove marker numbers | Gone, with the `.frontier-point-number` rule and the `advanceIndex` computation |
| Direct legend | Above the chart; each entry names the mark **and** its effect on the count |
| Rewrite the subtitle | Describes the three bands instead of "hollow dots" |
| `CUMULATIVE DISTINCT ORGANIZATIONS` | Done |
| `23 MODEL CARDS · 10 DISTINCT ORGANIZATIONS` | Done, as two separately named counts |

I took the recommended two-panel split rather than the single-panel fallback, since it fixes the encoding rather than just the appearance.

## Found while verifying, not in the spec

**Mobile chart was collapsing to ~90px.** `width: 100%` scales height with width on a 920-unit viewBox, and the new band made it worse. Narrow viewports now use a 520-unit box so the same content scales up, with long rotated axis labels shortened to fit. `preserveAspectRatio: none` was tried first and rejected: it stretched the axis text illegibly.

**Grammar:** "4 values here is a third party" now agrees with its count.

## Review

Codex reviewed three times. 7 findings, all fixed; third pass returned "no blocking or materially wrong issues found".

Two were P1s, and both were the same bug at different scales:

1. Cards sharing a publication date got identical x coordinates and **overpainted** — the visible tick count came out short and only the last drawn was hoverable. Seven shipped benchmarks have a same-day pair on 2026-02-11.
2. Fanning each date independently then pushed those ticks into a *neighbouring* date's: 0.04 units apart on GPQA Diamond at the narrow viewBox, inside a 2.5-unit stroke. One-day-apart pairs collided at desktop width too.

Now a single left-to-right sweep enforcing a 3.5-unit minimum across all ticks, recentred by half its drift. A tick can sit a fraction of a unit off its exact date — the honest trade, since a hidden card is a lost observation and a 3px nudge is not.

Worth flagging: my own verification sweep asserted tick *count* but not *spacing*, which is exactly why it passed while both bugs were live. It now checks spacing, and that is a test.

The other five findings: the zoom marker was dropped on narrow screens (and my comment wrongly claimed the readout stated the band bounds — it does not, they appear only as axis ticks); crossing the 760px breakpoint never redrew, so a resized page kept a stale viewBox; sparse mode advertised legend marks it suppresses; and the explainer promised "one tick per model card" while `frontierEvents` filters undated cards.

## Verification

- 361 tests pass, ruff clean, rebased onto `8994d49`.
- Swept all 79 adopted benchmarks at 1440px and 390px: no marker numbers, tick counts equal dated card counts, tightest gap exactly 3.5 units, nothing outside the plot area, legend always consistent with the marks drawn.
- Resize verified in both directions (920 → 520 → 920).

Three existing test assertions were updated rather than deleted, each noted in its commit: the flat-run disclaimer check now normalizes whitespace (reflowing the paragraph split the phrase across lines and made an intact guarantee look lost), and two referenced markers that no longer exist.

Addresses the `view=dashboard` pass from #91. Items 4-5 (METR, Harbor) remain open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
