### PR TITLE
Deploy when the share card or export generator changes

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -14,6 +14,12 @@ on:
       - "src/benchmark_radar/snapshots.py"
       - "src/benchmark_radar/corpus.py"
       - "src/benchmark_radar/model_cards.py"
+      # Both run during the build and write files into the artifact, so a change
+      # to either one only reaches the published site if it also triggers a
+      # deploy. Without these, editing the share-card generator or the export
+      # layer succeeds, merges, and changes nothing that anyone can see.
+      - "scripts/generate_og_image.py"
+      - "src/benchmark_radar/export.py"
       - ".github/workflows/pages.yml"
   workflow_dispatch:
 


### PR DESCRIPTION
`pages.yml` runs `python scripts/generate_og_image.py` and `benchmark-radar export` during
the build, and both write files into the deployed artifact. Neither was listed among the
paths that trigger the workflow.

The consequence showed up immediately: #117 fixed the share-card generator, merged green,
and published nothing. No path in its diff matched a trigger, so Pages never rebuilt and
the site kept serving the previously generated card. I only caught it by checking whether
the deployed image had actually changed rather than assuming the merge was sufficient.

This is the same argument the neighbouring comment already makes for `model_cards.yml`
("a maintenance commit that only adds a model card must rebuild the dashboard, or the
published ranking silently stays behind the registry"), applied to the two build inputs
that were missed. Anything that writes into the artifact during the build is a deploy
input, otherwise editing it is a silent no-op that still reports success.

Adds `scripts/generate_og_image.py` and `src/benchmark_radar/export.py`.

Part of #88.

## Verification

- Parsed the workflow YAML and confirmed both new paths register in `on.push.paths`
- Confirmed the failure was real: after #117 merged, the most recent Pages run predated it
- Triggered a manual `workflow_dispatch` to publish the corrected card in the meantime,
  which is the gap this PR closes for future changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
