### PR TITLE
Give every Semantic Scholar search a request

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -215,7 +215,10 @@ sources:
       - data contamination benchmark
       - agentic benchmark evaluation
     page_size: 100
-    max_requests: 3
+    # The budget is shared across every search, not per search, so a value below
+    # the search count silently starves the trailing queries. Five covers all
+    # four searches plus one pagination follow-up.
+    max_requests: 5
     # A free individual API key starts at one request per second.
     request_delay_seconds: 1.1
     attempts: 3


### PR DESCRIPTION
## Summary

`max_requests` was 3 against four configured searches. The budget is checked in the pagination `while` loop at `sources.py:519`, outside the `for search in searches` loop, so it is shared across all searches rather than allocated per search.

Consequences:

- the fourth query, `agentic benchmark evaluation`, never issued a request
- a single search with deep pagination could consume the whole budget and starve the rest
- which queries actually ran depended on iteration order, with no signal in the output

Raised to 5: one request per search plus one pagination follow-up. At the configured 1.1s pacing that is about 5.5s of wall clock per run, and the per-run ceiling goes 3 to 5, so steady state across the two daily crons goes 6 to 10 requests per day.

## Verification

- `41 passed` (`tests/test_sources.py`)
- `ruff check .` clean

References #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)
