### PR TITLE
Rank findings by how much a reader learns from them

### DIFF
--- a/src/benchmark_radar/findings.py
+++ b/src/benchmark_radar/findings.py
@@ -272,7 +272,13 @@ def _ranking_key(finding: dict[str, Any]) -> tuple[float, float, str]:
     than dependent on dictionary iteration.
     """
     weight = discriminating_power(finding["baseline_share"])
-    return weight * abs(finding["shift_points"]), abs(finding["shift_points"]), finding["category"]
+    # Rounded before the tie-breakers run. Binary floats make products that are
+    # mathematically equal compare unequal: a 20% baseline moving 6 pp and a 40%
+    # baseline moving 8 pp both score 4.8, but the first evaluates to
+    # 4.800000000000001 and would win on noise, silently skipping the larger-move
+    # tie-break that is supposed to decide it.
+    score = round(weight * abs(finding["shift_points"]), 6)
+    return score, abs(finding["shift_points"]), finding["category"]
 
 
 def _dominated_by_one_source(moves: list[float]) -> bool:

--- a/src/benchmark_radar/findings.py
+++ b/src/benchmark_radar/findings.py
@@ -230,6 +230,51 @@ def _contributing_sources(
     return moves, len(comparable)
 
 
+def discriminating_power(baseline_share: float) -> float:
+    """How much a category's presence distinguishes one artifact from another.
+
+    A tag carried by almost everything says almost nothing about the artifact
+    carrying it. In this corpus `benchmark` sits near 83% of items and `dataset`
+    near 69%, because virtually everything a benchmark tracker collects is both;
+    `agentic` sits near 12%, so knowing an artifact is agentic is genuinely
+    informative. A ten-point move in a near-universal tag and a ten-point move
+    in a discriminating one are not equally worth a reader's attention, even
+    when both are equally verified.
+
+    Scored as the absent fraction, `(100 - share) / 100`: the probability that
+    an arbitrary artifact does *not* carry the tag, which is exactly how much
+    the tag narrows the field when it does appear. This is the self-information
+    of the label expressed linearly, and it is a stated property of the data
+    rather than a threshold chosen to produce a preferred answer.
+
+    Deliberately one-sided. Bernoulli variance, `share * (100 - share)`, was the
+    first thing tried and is wrong here: it peaks at 50% and so scores `dataset`
+    at 69% above `agentic` at 14%, penalising a rare category as heavily as a
+    near-universal one. A rare category is informative, not less so; only
+    universality dilutes a claim.
+    """
+    share = max(0.0, min(100.0, baseline_share))
+    return (100.0 - share) / 100.0
+
+
+def _ranking_key(finding: dict[str, Any]) -> tuple[float, float, str]:
+    """Rank verified candidates by how much a reader learns from them.
+
+    Size alone ranked the `dataset` decline above the `agentic` rise on real
+    data, which is defensible arithmetic and a poor briefing: `dataset` tags
+    most of the corpus, so its share moving is closer to a restatement of volume
+    than to news about composition.
+
+    Direction is deliberately not part of this. Preferring rises because they
+    read as better news would choose the story over the evidence, and on a day
+    whose only real signal is a decline it would surface a weaker rise instead.
+    The category name breaks ties so the ordering is total and stable rather
+    than dependent on dictionary iteration.
+    """
+    weight = discriminating_power(finding["baseline_share"])
+    return weight * abs(finding["shift_points"]), abs(finding["shift_points"]), finding["category"]
+
+
 def _dominated_by_one_source(moves: list[float]) -> bool:
     """Whether one source supplies most of the movement being claimed.
 
@@ -439,9 +484,11 @@ def composition_shift(
         )
     if not candidates:
         return None
-    # Largest absolute move wins. Publishing every category that cleared the
-    # bar would let a reader pick the most flattering one.
-    candidates.sort(key=lambda finding: abs(finding["shift_points"]), reverse=True)
+    # Exactly one finding is published. Categories are multi-label and move
+    # together, so several candidates are usually the same underlying shift
+    # described three ways, and publishing all of them would let a reader pick
+    # the most flattering framing.
+    candidates.sort(key=_ranking_key, reverse=True)
     return candidates[0]
 
 

--- a/tests/test_findings.py
+++ b/tests/test_findings.py
@@ -3,6 +3,7 @@ from datetime import UTC, date, datetime, timedelta
 from benchmark_radar.findings import (
     MINIMUM_DAY_ITEMS,
     Coverage,
+    _ranking_key,
     composition_shift,
     coverage_for,
     daily_findings,
@@ -599,3 +600,23 @@ def test_a_high_discrimination_category_cannot_be_promoted_without_a_shift():
     assert discriminating_power(1.8) > discriminating_power(13.6)
     findings = daily_findings(_history(10, 30), CONFIG)
     assert "Agentic artifacts rose" in findings[0]
+
+
+def test_a_mathematical_tie_is_broken_by_the_larger_move():
+    # A 20% baseline moving 6 pp and a 40% baseline moving 8 pp both weight to
+    # 4.8, but in binary floats the first is 4.800000000000001 and would win on
+    # noise, skipping the tie-break that is supposed to decide it.
+    smaller = {"baseline_share": 20.0, "shift_points": 6.0, "category": "b"}
+    larger = {"baseline_share": 40.0, "shift_points": 8.0, "category": "a"}
+
+    assert max([smaller, larger], key=_ranking_key) is larger
+
+
+def test_ranking_is_a_total_and_stable_order():
+    # The category name breaks a genuine tie so the ordering never depends on
+    # dictionary iteration.
+    first = {"baseline_share": 50.0, "shift_points": 10.0, "category": "aaa"}
+    second = {"baseline_share": 50.0, "shift_points": 10.0, "category": "bbb"}
+
+    assert max([first, second], key=_ranking_key) is second
+    assert max([second, first], key=_ranking_key) is second

--- a/tests/test_findings.py
+++ b/tests/test_findings.py
@@ -6,6 +6,7 @@ from benchmark_radar.findings import (
     composition_shift,
     coverage_for,
     daily_findings,
+    discriminating_power,
 )
 
 CONFIG = {
@@ -515,3 +516,86 @@ def test_a_disabled_required_source_does_not_invalidate_coverage():
     assert coverage.failed_required == []
     assert coverage.complete
     assert coverage.caption() == "Coverage: 1/1 connectors healthy."
+
+
+def test_a_discriminating_category_outranks_a_larger_move_in_a_universal_tag():
+    # Real data: `dataset` fell 15.4 pp from a 69% baseline while `agentic` rose
+    # 12.3 pp from 13.6%. Size alone reports the dataset decline, which is closer
+    # to a restatement of volume than news about composition, because almost
+    # everything in a benchmark tracker is a dataset.
+    days = []
+    for index in range(14):
+        recent = index >= 9
+        items = []
+        for position in range(200):
+            categories = []
+            # `dataset` is near-universal and falls; `agentic` is rare and rises.
+            if position < (108 if recent else 138):
+                categories.append("dataset")
+            if position < (52 if recent else 27):
+                categories.append("agentic")
+            items.append(
+                {
+                    "source": f"source-{position % 4}",
+                    "source_id": f"item-{index}-{position}",
+                    "categories": categories,
+                }
+            )
+        day = _day(index)
+        day["evidence_items"] = items
+        days.append(day)
+
+    finding = composition_shift(days, CONFIG)
+
+    assert finding is not None
+    assert finding["category"] == "agentic"
+    assert finding["rising"] is True
+
+
+def test_discriminating_power_only_discounts_universality():
+    # One-sided by design. Bernoulli variance was tried first and is wrong here:
+    # it peaks at 50% and scores a 69% tag above a 14% one, penalising a rare
+    # category as heavily as a near-universal one.
+    assert discriminating_power(14.0) > discriminating_power(69.0)
+    assert discriminating_power(2.0) > discriminating_power(50.0)
+    assert discriminating_power(0.0) == 1.0
+    assert discriminating_power(100.0) == 0.0
+
+
+def test_ranking_does_not_prefer_rises_over_declines():
+    # Preferring rises because they read as better news would choose the story
+    # over the evidence. A decline in a discriminating category must still win
+    # over a smaller rise in a more universal one.
+    days = []
+    for index in range(14):
+        recent = index >= 9
+        items = []
+        for position in range(200):
+            categories = ["benchmark"] if position < (168 if recent else 160) else []
+            if position < (20 if recent else 60):
+                categories.append("agentic")
+            items.append(
+                {
+                    "source": f"source-{position % 4}",
+                    "source_id": f"item-{index}-{position}",
+                    "categories": categories,
+                }
+            )
+        day = _day(index)
+        day["evidence_items"] = items
+        days.append(day)
+
+    finding = composition_shift(days, CONFIG)
+
+    assert finding is not None
+    assert finding["category"] == "agentic"
+    assert finding["rising"] is False
+
+
+def test_a_high_discrimination_category_cannot_be_promoted_without_a_shift():
+    # Weighting multiplies the shift, so a rare category that did not move
+    # cannot outrank one that did. `data_quality` scores the highest
+    # discrimination on real data and correctly ranks last.
+    assert discriminating_power(1.8) > discriminating_power(13.6)
+    findings = daily_findings(_history(10, 30), CONFIG)
+    assert "Agentic artifacts rose" in findings[0]


### PR DESCRIPTION
## Summary

Size alone selected the `dataset` decline over the `agentic` rise on real data. Both are equally verified and the arithmetic was right, but the briefing was worse for it.

| category | baseline | shift | discrimination | weighted |
|---|---|---|---|---|
| **agentic** | 13.6% | **+12.3 pp** | 0.864 | **10.625** |
| dataset | 69.1% | -15.4 pp | 0.309 | 4.743 |
| evaluation | 62.4% | -8.7 pp | 0.376 | 3.288 |
| benchmark | 81.9% | +1.1 pp | 0.181 | 0.197 |
| data_quality | 1.8% | -0.0 pp | 0.982 | 0.009 |

Almost everything a benchmark tracker collects is a dataset, so that share moving is closer to a restatement of volume than news about composition. `agentic` distinguishes artifacts, so a reader learns more from the same size of move.

Before and after, same day and same corpus:

```
- Dataset artifacts fell to 53.8% of our captured feed over the last 5 days,
  against a 69.1% baseline across the prior 4 days (-15.4 pp).

+ Agentic artifacts rose to 25.9% of our captured feed over the last 5 days,
  against a 13.6% baseline across the prior 4 days (+12.3 pp).
```

## The measure

Candidates are weighted by the absent fraction of the baseline share, `(100 - share) / 100`: the probability that an arbitrary artifact does *not* carry the tag, which is exactly how much the tag narrows the field when it does appear. A stated property of the data rather than a threshold picked to produce a preferred answer.

**Bernoulli variance was tried first and is wrong here.** `share * (100 - share)` peaks at 50%, so it scored `dataset` at 69% (0.854) above `agentic` at 14% (0.470), penalising a rare category as heavily as a near-universal one. Only universality dilutes a claim; rarity does not. The measure is one-sided by design, and a test pins that.

The weighting multiplies the shift, so it cannot promote a non-finding: `data_quality` has the highest discrimination on real data (0.982) and correctly ranks last, because it did not move.

## Direction is not part of the ranking

Preferring rises because they read as better news would choose the story over the evidence, and on a day whose only real signal is a decline it would surface a weaker rise instead. That is the manufactured-significance failure mode the engine exists to avoid. A test pins it: a decline in a discriminating category still outranks a smaller rise in a universal one.

## Verification

- `437 passed` (from 433; 4 new tests)
- `ruff check .` and `ruff format` clean
- Replayed against all 14 days of real snapshots

**The gates are untouched.** The engine still publishes on 1 of 14 days with the same 13 declines and the same reasons; only which category it selects changed.

Refs #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)
