### PR TITLE
Fix shared URLs and all-date scan filtering

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -121,7 +121,9 @@ function readUrl() {
 function writeUrl() {
   const params = new URLSearchParams();
   if (state.view !== "today") params.set("view", state.view);
-  if (state.todayDate && state.todayDate !== state.data?.latest_date) {
+  if (state.todayDate === "all") {
+    params.set("date", "all");
+  } else if (state.todayDate && state.todayDate !== state.data?.latest_date) {
     params.set("date", state.todayDate);
   }
   if (state.q) params.set("q", state.q);
@@ -279,10 +281,9 @@ function renderDailyBriefing(day) {
 }
 
 function renderToday() {
-  const day = dailySnapshot();
+  const day = dailySnapshot(state.todayDate === "all" ? state.data.latest_date : state.todayDate);
   if (!day) return;
-  state.todayDate = day.date;
-  byId("today-date").value = day.date;
+  byId("today-date").value = state.todayDate;
 
   renderDailyBriefing(day);
 
@@ -964,7 +965,7 @@ function filteredObservations() {
   return allObservations().filter((item) => {
     const haystack = `${item.title} ${item.summary} ${item.source}`.toLowerCase();
     return (
-      item.snapshot_date === state.todayDate &&
+      (state.todayDate === "all" || item.snapshot_date === state.todayDate) &&
       (!state.kind || item.observation_kind === state.kind) &&
       (!state.category || (item.categories || []).includes(state.category)) &&
       (!state.source || item.source === state.source) &&
@@ -3454,6 +3455,7 @@ function bindEvents() {
     form.addEventListener("submit", (event) => event.preventDefault());
   });
   byId("clear-filters").addEventListener("click", () => {
+    state.todayDate = "all";
     state.q = "";
     state.kind = "";
     state.category = "";
@@ -3578,16 +3580,17 @@ async function initialize() {
     ) {
       throw new Error("No compatible snapshots");
     }
-    if (!state.data.facets.dates.includes(state.todayDate)) {
+    if (state.todayDate !== "all" && !state.data.facets.dates.includes(state.todayDate)) {
       state.todayDate = state.data.latest_date;
     }
     replaceChildren(
       byId("today-date"),
-      [...state.data.facets.dates]
-        .reverse()
-        .map((date) =>
+      [
+        option("all", "All dates", state.todayDate === "all"),
+        ...[...state.data.facets.dates].reverse().map((date) =>
           option(date, formatDate(date, { dateStyle: "medium" }), date === state.todayDate),
         ),
+      ],
     );
     renderToday();
     renderLeaderboard();

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -29,6 +29,7 @@ const state = {
   lorg: "",
   lera: "",
   lfrontier: "",
+  lfrontierExplicit: false,
   leaderboardShowAll: false,
 };
 
@@ -113,6 +114,7 @@ function readUrl() {
   state.lorg = params.get("lorg") || "";
   state.lera = params.get("lera") || "";
   state.lfrontier = params.get("lfrontier") || "";
+  state.lfrontierExplicit = Boolean(state.lfrontier);
   state.rubric = new URLSearchParams(window.location.hash.slice(1)).get("rubric") || "";
 }
 
@@ -133,7 +135,9 @@ function writeUrl() {
   if (state.ldomain) params.set("ldomain", state.ldomain);
   if (state.lorg) params.set("lorg", state.lorg);
   if (state.lera) params.set("lera", state.lera);
-  if (state.lfrontier) params.set("lfrontier", state.lfrontier);
+  if (state.lfrontierExplicit && state.lfrontier) {
+    params.set("lfrontier", state.lfrontier);
+  }
   const query = params.toString();
   // The rubric dialog is a hashtag, not a query param, so a shared link like
   // #rubric=2 reads as "jump to this section" rather than another filter.
@@ -160,6 +164,11 @@ function setView(view, update = true) {
     }
   });
   if (update) writeUrl();
+}
+
+function selectFrontier(benchmarkId) {
+  state.lfrontier = benchmarkId;
+  state.lfrontierExplicit = true;
 }
 
 function categoryColor(category, index = 0) {
@@ -1765,7 +1774,7 @@ function renderBenchmarkNavigator(board) {
               }),
             ]);
             button.addEventListener("click", () => {
-              state.lfrontier = entry.benchmark_id;
+              selectFrontier(entry.benchmark_id);
               renderAdoptionFrontier(board);
               writeUrl();
             });
@@ -2639,6 +2648,7 @@ function renderAdoptionFrontier(board) {
   }
   if (!adopted.some((entry) => entry.benchmark_id === state.lfrontier)) {
     state.lfrontier = defaultEntry.benchmark_id;
+    state.lfrontierExplicit = false;
   }
   replaceChildren(byId("frontier-benchmark"), [
     ...[...adopted]
@@ -2758,7 +2768,7 @@ function findingCard(finding, board) {
       attrs: { type: "button" },
     });
     jump.addEventListener("click", () => {
-      state.lfrontier = target.benchmark_id;
+      selectFrontier(target.benchmark_id);
       renderAdoptionFrontier(board);
       writeUrl();
       byId("adoption-frontier").scrollIntoView({ behavior: "smooth", block: "start" });
@@ -2894,7 +2904,7 @@ function leaderboardRow(entry) {
     attrs: { type: "button" },
   });
   frontierButton.addEventListener("click", () => {
-    state.lfrontier = entry.benchmark_id;
+    selectFrontier(entry.benchmark_id);
     renderAdoptionFrontier(board);
     writeUrl();
     byId("adoption-frontier").scrollIntoView({ behavior: "smooth", block: "start" });
@@ -3385,7 +3395,7 @@ function bindEvents() {
     byId("leaderboard-table-heading").scrollIntoView({ behavior: "smooth", block: "start" });
   });
   byId("frontier-benchmark").addEventListener("change", (event) => {
-    state.lfrontier = event.target.value;
+    selectFrontier(event.target.value);
     renderAdoptionFrontier(state.data.model_card_leaderboard);
     writeUrl();
   });

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -6,6 +6,7 @@ const CATEGORY_COLORS = {
   agentic: "#756aa8",
 };
 const FALLBACK_COLORS = ["#756aa8", "#397f9a", "#a4576d", "#70833d"];
+const ALL_DATES_PAGE_SIZE = 100;
 
 const byId = (id) => document.getElementById(id);
 const state = {
@@ -31,6 +32,8 @@ const state = {
   lfrontier: "",
   lfrontierExplicit: false,
   leaderboardShowAll: false,
+  todayResultsKey: "",
+  todayResultsLimit: ALL_DATES_PAGE_SIZE,
 };
 
 function element(tag, options = {}, children = []) {
@@ -281,14 +284,43 @@ function renderDailyBriefing(day) {
 }
 
 function renderToday() {
-  const day = dailySnapshot(state.todayDate === "all" ? state.data.latest_date : state.todayDate);
+  const showingAllDates = state.todayDate === "all";
+  const day = dailySnapshot(showingAllDates ? state.data.latest_date : state.todayDate);
   if (!day) return;
   byId("today-date").value = state.todayDate;
+
+  // The briefing and connector health describe one scan, not an archive-wide
+  // result set. Hiding them in All dates mode keeps latest-day context from
+  // appearing to explain observations collected across the full history.
+  byId("daily-briefing").hidden = showingAllDates;
+  byId("source-health-panel").hidden = showingAllDates;
 
   renderDailyBriefing(day);
 
   syncFilters();
   const observations = filteredObservations();
+  const resultsKey = [
+    state.todayDate,
+    state.q,
+    state.kind,
+    state.category,
+    state.source,
+    state.organization,
+    state.event,
+  ].join("\u0000");
+  if (resultsKey !== state.todayResultsKey) {
+    state.todayResultsKey = resultsKey;
+    state.todayResultsLimit = ALL_DATES_PAGE_SIZE;
+  }
+  const visibleObservations = showingAllDates
+    ? observations.slice(0, state.todayResultsLimit)
+    : observations;
+  const remainingResults = observations.length - visibleObservations.length;
+  const showMore = byId("today-show-more");
+  showMore.hidden = remainingResults <= 0;
+  showMore.textContent = remainingResults > 0
+    ? `Show ${Math.min(ALL_DATES_PAGE_SIZE, remainingResults)} more · ${remainingResults} remaining`
+    : "Show more results";
   const evidenceCount = observations.filter(
     (item) => item.observation_kind === "evidence",
   ).length;
@@ -298,8 +330,8 @@ function renderToday() {
     `${evidenceCount} evidence · ${attentionCount} attention`;
   replaceChildren(
     byId("today-list"),
-    observations.length
-      ? observations.map(observationCard)
+    visibleObservations.length
+      ? visibleObservations.map(observationCard)
       : [
           element("p", {
             className: "empty-state",
@@ -3402,6 +3434,10 @@ function bindEvents() {
   });
   byId("today-date").addEventListener("change", (event) => {
     state.todayDate = event.target.value;
+    renderToday();
+  });
+  byId("today-show-more").addEventListener("click", () => {
+    state.todayResultsLimit += ALL_DATES_PAGE_SIZE;
     renderToday();
   });
   byId("trend-released-only").addEventListener("change", (event) => {

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -2704,6 +2704,11 @@ dialog::backdrop {
   text-transform: uppercase;
 }
 
+.today-show-more {
+  margin-top: 1.5rem;
+  background: transparent;
+}
+
 .stale-banner {
   margin: 0;
   padding: 0.6rem 0;

--- a/site/index.html
+++ b/site/index.html
@@ -156,9 +156,12 @@
               <span id="today-count" aria-live="polite"></span>
             </div>
             <div class="signal-list" id="today-list"></div>
+            <button class="secondary-link today-show-more" id="today-show-more" type="button" hidden>
+              Show more results
+            </button>
           </div>
           <div>
-            <aside class="health-panel" aria-labelledby="health-heading">
+            <aside class="health-panel" id="source-health-panel" aria-labelledby="health-heading">
               <details id="health-panel-details">
                 <summary>
                   <span class="health-panel-title" id="health-heading">Sources</span>

--- a/tests/test_saturation_view.py
+++ b/tests/test_saturation_view.py
@@ -382,7 +382,7 @@ def test_a_finding_can_move_the_chart_to_the_benchmark_it_is_about():
         "\nfunction renderBenchmarkFindings", 1
     )[0]
 
-    assert "state.lfrontier = target.benchmark_id" in card
+    assert "selectFrontier(target.benchmark_id)" in card
     assert "renderAdoptionFrontier(board)" in card
     # Corpus-scope findings name no benchmark, so there is nothing to focus.
     assert "finding.benchmark_id" in card

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -65,6 +65,15 @@ def test_scan_date_select_is_not_reset_by_the_shared_filters_input_handler():
     assert "return" in handler_body
 
 
+def test_scan_date_can_be_reset_to_all_dates():
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    assert 'option("all", "All dates", state.todayDate === "all")' in script
+    assert 'state.todayDate === "all" || item.snapshot_date === state.todayDate' in script
+    assert 'state.todayDate = "all";' in script
+    assert 'params.set("date", "all")' in script
+
+
 def test_automatic_frontier_default_does_not_leak_into_unrelated_urls():
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
 

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -65,6 +65,16 @@ def test_scan_date_select_is_not_reset_by_the_shared_filters_input_handler():
     assert "return" in handler_body
 
 
+def test_automatic_frontier_default_does_not_leak_into_unrelated_urls():
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    assert "lfrontierExplicit: false" in script
+    assert "state.lfrontierExplicit = Boolean(state.lfrontier)" in script
+    assert "if (state.lfrontierExplicit && state.lfrontier)" in script
+    assert "state.lfrontierExplicit = false" in script
+    assert "function selectFrontier(benchmarkId)" in script
+
+
 def test_rubric_dialog_is_linkable_by_url_hash():
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
 

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -67,11 +67,18 @@ def test_scan_date_select_is_not_reset_by_the_shared_filters_input_handler():
 
 def test_scan_date_can_be_reset_to_all_dates():
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
+    html = Path("site/index.html").read_text(encoding="utf-8")
 
     assert 'option("all", "All dates", state.todayDate === "all")' in script
     assert 'state.todayDate === "all" || item.snapshot_date === state.todayDate' in script
     assert 'state.todayDate = "all";' in script
     assert 'params.set("date", "all")' in script
+    assert 'id="today-show-more"' in html
+    assert 'id="source-health-panel"' in html
+    assert "observations.slice(0, state.todayResultsLimit)" in script
+    assert "state.todayResultsLimit += ALL_DATES_PAGE_SIZE" in script
+    assert 'byId("daily-briefing").hidden = showingAllDates' in script
+    assert 'byId("source-health-panel").hidden = showingAllDates' in script
 
 
 def test_automatic_frontier_default_does_not_leak_into_unrelated_urls():
@@ -130,7 +137,7 @@ def test_today_view_has_one_filterable_observation_list_and_one_source_status():
     assert 'id="today-list"' in html
     assert 'id="filters"' in html
     assert 'id="kind-filter"' in html
-    assert "observations.map(observationCard)" in script
+    assert "visibleObservations.map(observationCard)" in script
     assert "Daily field note" not in html
     assert "What entered the field?" not in html
     assert "today-overview" not in html


### PR DESCRIPTION
## Summary

- keep the leaderboard’s automatic frontier default out of unrelated shared URLs while preserving explicit frontier selections
- add an `All dates` scan-date state, persist it as `date=all`, and make Clear filters restore it
- page archive-wide results in 100-card batches and hide day-specific briefing/source-health context in all-date mode

## Test plan

- `benchmark-radar rebuild`
- `python3.11 -m pytest -q` (435 passed)
- `python3.11 -m ruff check .`
- `node --check site/assets/app.js`
- Chrome smoke test for date-only URLs, `date=all` reload/paging, and explicit `lfrontier` navigation
- Codex review against `main` with high reasoning effort (clean)

Closes #123
Closes #129