### PR TITLE
Make daily findings name the evidence

### DIFF
--- a/.github/workflows/daily-radar.yml
+++ b/.github/workflows/daily-radar.yml
@@ -72,7 +72,6 @@ jobs:
           SEMANTIC_SCHOLAR_API_KEY: ${{ secrets.SEMANTIC_SCHOLAR_API_KEY }}
           OPENALEX_API_KEY: ${{ secrets.OPENALEX_API_KEY }}
           BRAVE_API_KEY: ${{ secrets.BRAVE_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: benchmark-radar
       - name: Upload evidence artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/data/snapshots/2026-08-05.json
+++ b/data/snapshots/2026-08-05.json
@@ -615,9 +615,9 @@
   },
   "briefing": {
     "bullets": [
-      "Agentic artifacts rose to 26.3% of our captured feed over the last 5 days, against a 13.6% baseline across the prior 4 days (+12.7 pp).",
-      "Today 80 of 272 items carry it, and the change appeared independently in 2 of 3 sources comparable across both windows.",
-      "Moderate confidence. Coverage: 5/8 connectors healthy; brave, openreview, semantic_scholar unavailable."
+      "Agentic artifacts rose to 26.3% of our captured feed over the last 5 days, against a 13.6% baseline across the prior 4 days (+12.7 percentage points).",
+      "Personalization and memory recurred in 2 of the 3 leading releases first observed today: When Agents Learn to Be You (privacy leakage, impersonation risk, and defenses in persona skills); MemArena (on-device agentic personal memory assistants at scale); and Measurement Without Validity (compounding reliability problem in agentic AI evaluation).",
+      "The change appeared independently in 2 of the 3 sources present in both windows. Moderate confidence. Coverage: 5/8 connectors healthy; brave, openreview, semantic scholar unavailable."
     ],
     "date": "2026-08-05"
   },

--- a/src/benchmark_radar/findings.py
+++ b/src/benchmark_radar/findings.py
@@ -38,10 +38,13 @@ shifting" is overclaiming on a keyword-filtered scrape of five sources.
 
 from __future__ import annotations
 
+import re
 import statistics
 from collections import Counter
 from datetime import date, timedelta
 from typing import Any
+
+from .corpus import artifact_alias_map, exact_artifact_key
 
 # A finding needs enough of the day to be about the day rather than about noise.
 MINIMUM_DAY_ITEMS = 25
@@ -78,6 +81,7 @@ MAX_SOURCE_CONTRIBUTION = 0.7
 # shift is published, which is the same discipline as reporting the gated cell
 # rather than the average.
 MAX_FINDINGS = 1
+MAX_EVIDENCE_EXAMPLES = 3
 
 
 class Coverage:
@@ -112,9 +116,11 @@ class Coverage:
     def caption(self) -> str:
         parts = [f"Coverage: {self.healthy}/{self.total} connectors healthy"]
         if self.failed_required:
-            parts.append(f"required source(s) {', '.join(self.failed_required)} unavailable")
+            required = ", ".join(source.replace("_", " ") for source in self.failed_required)
+            parts.append(f"required source(s) {required} unavailable")
         if self.failed_optional:
-            parts.append(f"{', '.join(self.failed_optional)} unavailable")
+            optional = ", ".join(source.replace("_", " ") for source in self.failed_optional)
+            parts.append(f"{optional} unavailable")
         return "; ".join(parts) + "."
 
 
@@ -515,7 +521,138 @@ def _confidence(finding: dict[str, Any], coverage: Coverage) -> str:
     return "High confidence" if not coverage.failed_optional else "Moderate confidence"
 
 
-def describe(finding: dict[str, Any], coverage: Coverage) -> list[str]:
+def _representative_key(item: dict[str, Any]) -> tuple[bool, float, bool]:
+    """Rank evidence for a reader, not merely for ingestion."""
+    return (
+        item.get("event_kind") == "released",
+        float(item.get("total_score") or 0),
+        bool(str(item.get("summary") or "").strip()),
+    )
+
+
+def first_seen_items(history: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return the best record for each artifact on the day it first appeared.
+
+    Daily snapshots overlap, and one artifact can arrive from several connectors.
+    Examples must therefore be new to the radar, not merely present in today's
+    rolling scan. Alias resolution also prevents a paper and its repository from
+    being presented as independent pieces of evidence.
+    """
+    all_items = [item for day in history for item in day.get("evidence_items") or []]
+    if not all_items:
+        return []
+    aliases = artifact_alias_map(all_items)
+    seen: set[str] = set()
+    today: list[dict[str, Any]] = []
+    for day in history:
+        first_on_day: dict[str, dict[str, Any]] = {}
+        for item in day.get("evidence_items") or []:
+            identity = aliases[exact_artifact_key(item)]
+            if identity in seen:
+                continue
+            existing = first_on_day.get(identity)
+            if existing is None or _representative_key(item) > _representative_key(existing):
+                first_on_day[identity] = item
+        seen.update(first_on_day)
+        today = list(first_on_day.values())
+    return sorted(today, key=_representative_key, reverse=True)
+
+
+_FOCUS_PREFIX = re.compile(
+    r"^(?:an?\s+)?(?:[\w-]+\s+){0,3}benchmark(?:ing)?\s*(?:for|of|on)?\s*",
+    flags=re.IGNORECASE,
+)
+_EVIDENCE_THEMES = (
+    ("personalization and memory", re.compile(r"\b(?:persona\w*|personali[sz]\w*|memor\w*)\b")),
+    (
+        "safety and evaluation integrity",
+        re.compile(
+            r"\b(?:privacy|secur\w*|safety|reliab\w*|validit\w*|adversarial|attack\w*|gaming)\b"
+        ),
+    ),
+    ("coding agents", re.compile(r"\b(?:coding|software|web agents?|web generation|frontend)\b")),
+    ("embodied systems", re.compile(r"\b(?:embodied|robot\w*|home safety|vision-language)\b")),
+    (
+        "evaluation infrastructure",
+        re.compile(r"\b(?:harness\w*|infrastructure|observability|protocol\w*|framework\w*)\b"),
+    ),
+)
+
+
+def _compact_evidence_label(item: dict[str, Any], *, focus_limit: int = 88) -> str:
+    """Turn a source title into a compact statement of what it measures."""
+    title = " ".join(str(item.get("title") or "").split())
+    if not title:
+        return "Untitled artifact"
+    if ":" not in title:
+        return title[:120].rstrip()
+    name, focus = (part.strip() for part in title.split(":", 1))
+    focus = re.sub(r"^(?:the|an?)\s+", "", focus, flags=re.IGNORECASE)
+    focus = _FOCUS_PREFIX.sub("", focus).strip()
+    if not focus:
+        return name[:120].rstrip()
+    if len(focus) > focus_limit:
+        focus = focus[: focus_limit + 1].rsplit(" ", 1)[0].rstrip() + "…"
+    # Source titles are usually title-cased. Preserve real acronyms such as LLM
+    # and AI, while rendering the explanatory phrase as prose rather than a
+    # headline pasted into parentheses.
+    focus = re.sub(
+        r"\b[A-Z][A-Za-z-]*\b",
+        lambda match: match.group(0) if match.group(0).isupper() else match.group(0).lower(),
+        focus,
+    )
+    return f"{name} ({focus})"
+
+
+def _representative_evidence(
+    items: list[dict[str, Any]], category: str, *, limit: int = MAX_EVIDENCE_EXAMPLES
+) -> list[dict[str, Any]]:
+    matching = [
+        item
+        for item in items
+        if category in (item.get("categories") or []) and str(item.get("title") or "").strip()
+    ]
+    released = [item for item in matching if item.get("event_kind") == "released"]
+    pool = released or matching
+    return pool[:limit]
+
+
+def evidence_examples(
+    items: list[dict[str, Any]], category: str, *, limit: int = MAX_EVIDENCE_EXAMPLES
+) -> list[str]:
+    """Name the strongest first-seen releases that make a finding concrete."""
+    return [
+        _compact_evidence_label(item)
+        for item in _representative_evidence(items, category, limit=limit)
+    ]
+
+
+def _evidence_theme(items: list[dict[str, Any]], category: str) -> tuple[str, int, int] | None:
+    """Name a shared topic only when most representative titles support it."""
+    representatives = _representative_evidence(items, category)
+    if len(representatives) < 2:
+        return None
+    scored = []
+    for position, (label, pattern) in enumerate(_EVIDENCE_THEMES):
+        matches = sum(
+            bool(pattern.search(str(item.get("title") or "").lower())) for item in representatives
+        )
+        scored.append((matches, -position, label))
+    matches, _, label = max(scored)
+    return (label, matches, len(representatives)) if matches >= 2 else None
+
+
+def _join_examples(examples: list[str]) -> str:
+    if len(examples) == 1:
+        return examples[0]
+    if len(examples) == 2:
+        return f"{examples[0]} and {examples[1]}"
+    return f"{'; '.join(examples[:-1])}; and {examples[-1]}"
+
+
+def describe(
+    finding: dict[str, Any], coverage: Coverage, *, first_seen: list[dict[str, Any]] | None = None
+) -> list[str]:
     """Render a verified finding as a BLUF-ordered card.
 
     Judgment first, then the evidence that supports it, then the confidence and
@@ -525,21 +662,31 @@ def describe(finding: dict[str, Any], coverage: Coverage) -> list[str]:
     """
     direction = "rose to" if finding["rising"] else "fell to"
     category = finding["category"].replace("_", " ")
-    return [
+    bullets = [
         (
             f"{category.capitalize()} artifacts {direction} "
             f"{finding['recent_share']}% of our captured feed over the last "
             f"{finding['recent_days']} days, against a {finding['baseline_share']}% baseline "
             f"across the prior {finding['baseline_days']} days "
-            f"({finding['shift_points']:+.1f} pp)."
+            f"({finding['shift_points']:+.1f} percentage points)."
         ),
-        (
-            f"Today {finding['count']} of {finding['total']} items carry it, and the change "
-            f"appeared independently in {finding['sources_moved']} of "
-            f"{finding['sources_comparable']} sources comparable across both windows."
-        ),
-        f"{_confidence(finding, coverage)}. {coverage.caption()}",
     ]
+    examples = evidence_examples(first_seen or [], finding["category"])
+    if examples:
+        theme = _evidence_theme(first_seen or [], finding["category"])
+        lead = (
+            f"{theme[0].capitalize()} recurred in {theme[1]} of the "
+            f"{theme[2]} leading releases first observed today:"
+            if theme
+            else "The leading releases in that category first observed today were"
+        )
+        bullets.append(f"{lead} {_join_examples(examples)}.")
+    bullets.append(
+        f"The change appeared independently in {finding['sources_moved']} of "
+        f"the {finding['sources_comparable']} sources present in both windows. "
+        f"{_confidence(finding, coverage)}. {coverage.caption()}"
+    )
+    return bullets
 
 
 def no_finding(
@@ -601,4 +748,4 @@ def daily_findings(
     finding = composition_shift(history, config) if coverage.complete else None
     if finding is None:
         return no_finding(history, coverage, config)
-    return describe(finding, coverage)
+    return describe(finding, coverage, first_seen=first_seen_items(history))

--- a/src/benchmark_radar/findings.py
+++ b/src/benchmark_radar/findings.py
@@ -620,7 +620,7 @@ def _representative_evidence(
 def evidence_examples(
     items: list[dict[str, Any]], category: str, *, limit: int = MAX_EVIDENCE_EXAMPLES
 ) -> list[str]:
-    """Name the strongest first-seen releases that make a finding concrete."""
+    """Name the strongest first-seen artifacts that make a finding concrete."""
     return [
         _compact_evidence_label(item)
         for item in _representative_evidence(items, category, limit=limit)
@@ -671,14 +671,20 @@ def describe(
             f"({finding['shift_points']:+.1f} percentage points)."
         ),
     ]
-    examples = evidence_examples(first_seen or [], finding["category"])
+    representatives = _representative_evidence(first_seen or [], finding["category"])
+    examples = [_compact_evidence_label(item) for item in representatives]
     if examples:
         theme = _evidence_theme(first_seen or [], finding["category"])
+        evidence_noun = (
+            "releases"
+            if all(item.get("event_kind") == "released" for item in representatives)
+            else "artifacts"
+        )
         lead = (
             f"{theme[0].capitalize()} recurred in {theme[1]} of the "
-            f"{theme[2]} leading releases first observed today:"
+            f"{theme[2]} leading {evidence_noun} first observed today:"
             if theme
-            else "The leading releases in that category first observed today were"
+            else f"The leading {evidence_noun} in that category first observed today were"
         )
         bullets.append(f"{lead} {_join_examples(examples)}.")
     bullets.append(

--- a/src/benchmark_radar/findings.py
+++ b/src/benchmark_radar/findings.py
@@ -551,8 +551,26 @@ def first_seen_items(history: list[dict[str, Any]]) -> list[dict[str, Any]]:
             if identity in seen:
                 continue
             existing = first_on_day.get(identity)
-            if existing is None or _representative_key(item) > _representative_key(existing):
-                first_on_day[identity] = item
+            if existing is None:
+                first_on_day[identity] = {
+                    **item,
+                    "categories": list(item.get("categories") or []),
+                }
+                continue
+            # Corroborating connectors can classify the same artifact
+            # differently. Keep the best display record, but preserve the
+            # union of what those observations say it is; otherwise alias
+            # collapse can erase the very category the finding is explaining.
+            categories = sorted(
+                {
+                    *(existing.get("categories") or []),
+                    *(item.get("categories") or []),
+                }
+            )
+            representative = (
+                item if _representative_key(item) > _representative_key(existing) else existing
+            )
+            first_on_day[identity] = {**representative, "categories": categories}
         seen.update(first_on_day)
         today = list(first_on_day.values())
     return sorted(today, key=_representative_key, reverse=True)
@@ -570,7 +588,7 @@ _EVIDENCE_THEMES = (
             r"\b(?:privacy|secur\w*|safety|reliab\w*|validit\w*|adversarial|attack\w*|gaming)\b"
         ),
     ),
-    ("coding agents", re.compile(r"\b(?:coding|software|web agents?|web generation|frontend)\b")),
+    ("coding agents", re.compile(r"\b(?:coding|software|web generation|frontend)\b")),
     ("embodied systems", re.compile(r"\b(?:embodied|robot\w*|home safety|vision-language)\b")),
     (
         "evaluation infrastructure",

--- a/tests/test_findings.py
+++ b/tests/test_findings.py
@@ -386,6 +386,22 @@ def test_evidence_prefers_releases_and_compacts_the_measurement_focus():
     assert evidence_examples(items, "agentic") == ["MemArena (on-device personal memory)"]
 
 
+def test_non_release_evidence_is_not_called_a_release():
+    history = _history(10, 30)
+    history[-1]["evidence_items"][0].update(
+        {
+            "title": "Agent Harness Refresh",
+            "event_kind": "updated",
+            "total_score": 99,
+        }
+    )
+
+    findings = daily_findings(history, CONFIG)
+
+    assert "leading artifacts" in findings[1]
+    assert "leading releases" not in findings[1]
+
+
 def test_evidence_theme_requires_a_recurrence_and_reports_its_denominator():
     items = [
         {

--- a/tests/test_findings.py
+++ b/tests/test_findings.py
@@ -3,11 +3,14 @@ from datetime import UTC, date, datetime, timedelta
 from benchmark_radar.findings import (
     MINIMUM_DAY_ITEMS,
     Coverage,
+    _evidence_theme,
     _ranking_key,
     composition_shift,
     coverage_for,
     daily_findings,
     discriminating_power,
+    evidence_examples,
+    first_seen_items,
 )
 
 CONFIG = {
@@ -72,8 +75,8 @@ def test_a_separated_persistent_shift_is_reported():
 
     assert "Agentic artifacts rose to 30.0% of our captured feed" in findings[0]
     assert "against a 10.0% baseline" in findings[0]
-    assert "+20.0 pp" in findings[0]
-    assert "30 of 100 items carry it" in findings[1]
+    assert "+20.0 percentage points" in findings[0]
+    assert "appeared independently in 4 of the 4 sources present in both windows" in findings[-1]
 
 
 def test_a_one_day_spike_is_not_reported():
@@ -289,8 +292,8 @@ def test_failed_optional_sources_do_not_suppress_a_claim():
 
     assert "Agentic artifacts rose" in findings[0]
     # The claim survives, but confidence is capped and the gap is disclosed.
-    assert "Moderate confidence" in findings[2]
-    assert "brave, openreview unavailable" in findings[2]
+    assert "Moderate confidence" in findings[-1]
+    assert "brave, openreview unavailable" in findings[-1]
 
 
 def test_a_thin_day_reports_insufficient_volume():
@@ -332,6 +335,75 @@ def test_only_the_largest_shift_is_published():
     assert len([line for line in findings if "of our captured feed" in line]) == 1
 
 
+def test_a_finding_names_first_seen_evidence_instead_of_repeating_the_counter():
+    history = _history(10, 30)
+    history[-1]["evidence_items"][0].update(
+        {
+            "title": "TrustBench: Benchmarking Privacy Failures in Tool-Using Agents",
+            "summary": "A substantive source description.",
+            "event_kind": "released",
+            "total_score": 99,
+        }
+    )
+
+    findings = daily_findings(history, CONFIG)
+
+    assert "TrustBench (privacy failures in tool-using agents)" in findings[1]
+    assert "Today 30 of 100 items" not in " ".join(findings)
+    assert "appeared independently" in findings[2]
+
+
+def test_first_seen_evidence_omits_an_artifact_repeated_from_yesterday():
+    history = _history(10, 30, days=9)
+    repeated = history[-2]["evidence_items"][0]
+    history[-1]["evidence_items"][0] = {
+        **repeated,
+        "title": "A later update to the same artifact",
+        "total_score": 100,
+    }
+
+    today = first_seen_items(history)
+
+    assert repeated["source_id"] not in {item["source_id"] for item in today}
+
+
+def test_evidence_prefers_releases_and_compacts_the_measurement_focus():
+    items = [
+        {
+            "title": "Old Harness",
+            "event_kind": "updated",
+            "total_score": 100,
+            "categories": ["agentic"],
+        },
+        {
+            "title": "MemArena: An Ego-Centric Benchmark for On-Device Personal Memory",
+            "event_kind": "released",
+            "total_score": 80,
+            "categories": ["agentic"],
+        },
+    ]
+
+    assert evidence_examples(items, "agentic") == ["MemArena (on-device personal memory)"]
+
+
+def test_evidence_theme_requires_a_recurrence_and_reports_its_denominator():
+    items = [
+        {
+            "title": title,
+            "event_kind": "released",
+            "total_score": score,
+            "categories": ["agentic"],
+        }
+        for score, title in [
+            (90, "PersonaBench: Personalized Agent Evaluation"),
+            (80, "MemArena: Long-Term Memory for Agents"),
+            (70, "CodeBench: Coding Agents in Real Repositories"),
+        ]
+    ]
+
+    assert _evidence_theme(items, "agentic") == ("personalization and memory", 2, 3)
+
+
 def test_claims_are_scoped_to_the_captured_feed():
     # The crawler is a keyword-filtered scrape of a handful of sources, not a
     # sample of the field, so no claim may generalize beyond it.
@@ -364,7 +436,7 @@ def test_a_falling_share_is_reported_with_its_direction():
     findings = daily_findings(_history(40, 10), CONFIG)
 
     assert "fell to 10.0%" in findings[0]
-    assert "-30.0 pp" in findings[0]
+    assert "-30.0 percentage points" in findings[0]
 
 
 def test_real_history_reports_the_verified_agentic_shift():

--- a/tests/test_findings.py
+++ b/tests/test_findings.py
@@ -367,6 +367,37 @@ def test_first_seen_evidence_omits_an_artifact_repeated_from_yesterday():
     assert repeated["source_id"] not in {item["source_id"] for item in today}
 
 
+def test_first_seen_aliases_preserve_categories_from_every_observation():
+    history = _history(10, 30)
+    history[-1]["evidence_items"] = [
+        {
+            "source": "arxiv",
+            "source_id": "2608.01234",
+            "title": "Shared Artifact",
+            "url": "https://arxiv.org/abs/2608.01234",
+            "artifact_urls": ["https://github.com/example/shared-artifact"],
+            "event_kind": "released",
+            "total_score": 80,
+            "categories": ["benchmark"],
+        },
+        {
+            "source": "github",
+            "source_id": "example/shared-artifact",
+            "title": "example/shared-artifact",
+            "url": "https://github.com/example/shared-artifact",
+            "event_kind": "updated",
+            "total_score": 90,
+            "categories": ["agentic"],
+        },
+    ]
+
+    today = first_seen_items(history)
+
+    assert len(today) == 1
+    assert today[0]["categories"] == ["agentic", "benchmark"]
+    assert evidence_examples(today, "agentic") == ["Shared Artifact"]
+
+
 def test_evidence_prefers_releases_and_compacts_the_measurement_focus():
     items = [
         {
@@ -418,6 +449,23 @@ def test_evidence_theme_requires_a_recurrence_and_reports_its_denominator():
     ]
 
     assert _evidence_theme(items, "agentic") == ("personalization and memory", 2, 3)
+
+
+def test_browser_agents_are_not_mislabeled_as_coding_agents():
+    items = [
+        {
+            "title": title,
+            "event_kind": "released",
+            "total_score": score,
+            "categories": ["agentic"],
+        }
+        for score, title in [
+            (90, "TrailBench: Personalized Web Agents through Browsing Trails"),
+            (80, "ShopBench: Web Agents for Product Research"),
+        ]
+    ]
+
+    assert _evidence_theme(items, "agentic") is None
 
 
 def test_claims_are_scoped_to_the_captured_feed():


### PR DESCRIPTION
Closes #39.
Addresses the TLDR quality failure analyzed in #127.

## What changed

- replace the redundant daily item counter with named, first-observed evidence
- report a recurring theme only when at least 2 of the 3 leading artifacts support it
- deduplicate overlapping snapshots and cross-source aliases while retaining corroborating categories
- scope claims to the captured feed and keep source breadth, confidence, and connector gaps explicit
- remove the unused OpenAI key from the daily workflow

## Real Aug 5 result

> Agentic artifacts rose to 26.3% of our captured feed over the last 5 days, against a 13.6% baseline across the prior 4 days (+12.7 percentage points).
>
> Personalization and memory recurred in 2 of the 3 leading releases first observed today: When Agents Learn to Be You (privacy leakage, impersonation risk, and defenses in persona skills); MemArena (on-device agentic personal memory assistants at scale); and Measurement Without Validity (compounding reliability problem in agentic AI evaluation).
>
> The change appeared independently in 2 of the 3 sources present in both windows. Moderate confidence. Coverage: 5/8 connectors healthy; brave, openreview, semantic scholar unavailable.

## Validation

- 465 tests pass
- Ruff lint and format checks pass
- snapshot validation passes
- headless Chrome preview verified the briefing card layout
- final Codex review: no actionable defects found