### PR TITLE
Diagnose and retry OpenAI rate limits

### DIFF
--- a/src/benchmark_radar/briefing.py
+++ b/src/benchmark_radar/briefing.py
@@ -375,7 +375,7 @@ def generate_daily_briefing(
         RESPONSES_URL,
         payload,
         headers={"Authorization": f"Bearer {api_key}"},
-        attempts=2,
+        attempts=4,
         timeout=90.0,
     )
     try:

--- a/src/benchmark_radar/http.py
+++ b/src/benchmark_radar/http.py
@@ -24,6 +24,25 @@ def _safe_url(url: str) -> str:
     return urllib.parse.urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
 
 
+def _safe_openai_error_detail(url: str, error: urllib.error.HTTPError) -> str:
+    """Expose only structured OpenAI error codes, never request or response prose."""
+    if urllib.parse.urlsplit(url).netloc != "api.openai.com":
+        return ""
+    try:
+        payload = json.loads(error.read(16_384).decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return ""
+    detail = payload.get("error") if isinstance(payload, dict) else None
+    if not isinstance(detail, dict):
+        return ""
+    fields = [
+        f"{key}={detail[key]}"
+        for key in ("type", "code", "param")
+        if isinstance(detail.get(key), (str, int, float)) and str(detail[key]).strip()
+    ]
+    return f" ({', '.join(fields)})" if fields else ""
+
+
 def get_json(
     url: str,
     *,
@@ -88,6 +107,7 @@ def _request(
     if timeout <= 0:
         raise ValueError("timeout must be positive")
     last_error: Exception | None = None
+    last_http_detail = ""
     for attempt in range(attempts):
         try:
             with urllib.request.urlopen(
@@ -99,11 +119,16 @@ def _request(
         except urllib.error.HTTPError as error:
             # Only rate limits and server failures are transient. Never expose
             # a query string: some APIs carry credentials there.
+            detail = _safe_openai_error_detail(url, error)
             if error.code != 429 and error.code < 500:
-                raise RequestError(f"HTTP {error.code} from {_safe_url(url)}") from None
+                raise RequestError(f"HTTP {error.code} from {_safe_url(url)}{detail}") from None
             last_error = error
+            last_http_detail = detail
             retry_after = error.headers.get("Retry-After") if error.headers else None
-            delay = float(retry_after) if retry_after and retry_after.isdigit() else 2**attempt
+            try:
+                delay = max(0.0, float(retry_after)) if retry_after else float(2**attempt)
+            except ValueError:
+                delay = float(2**attempt)
             if attempt + 1 < attempts:
                 time.sleep(min(delay, MAX_RETRY_DELAY_SECONDS))
         except (urllib.error.URLError, TimeoutError) as error:
@@ -114,6 +139,7 @@ def _request(
     if isinstance(last_error, urllib.error.HTTPError):
         raise RequestError(
             f"HTTP {last_error.code} from {_safe_url(url)} after {attempts} attempts"
+            f"{last_http_detail}"
         ) from None
     raise RequestError(
         f"{type(last_error).__name__} from {_safe_url(url)} after {attempts} attempts"

--- a/src/benchmark_radar/http.py
+++ b/src/benchmark_radar/http.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import http.client
 import json
 import ssl
 import time
@@ -30,7 +31,7 @@ def _safe_openai_error_detail(url: str, error: urllib.error.HTTPError) -> str:
         return ""
     try:
         payload = json.loads(error.read(16_384).decode("utf-8"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+    except (OSError, http.client.HTTPException, UnicodeDecodeError, json.JSONDecodeError):
         return ""
     detail = payload.get("error") if isinstance(payload, dict) else None
     if not isinstance(detail, dict):

--- a/tests/test_briefing.py
+++ b/tests/test_briefing.py
@@ -285,6 +285,7 @@ def test_generate_daily_briefing_uses_real_responses_contract_and_records_usage(
     assert captured["payload"]["text"]["format"]["strict"] is True
     assert captured["payload"]["store"] is False
     assert captured["kwargs"]["headers"] == {"Authorization": "Bearer secret"}
+    assert captured["kwargs"]["attempts"] == 4
     assert captured["kwargs"]["timeout"] == 90.0
 
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,3 +1,4 @@
+import http.client
 import io
 import urllib.error
 
@@ -18,6 +19,14 @@ class Response:
 
     def read(self):
         return self.body
+
+
+class TruncatedResponse:
+    def read(self, *args):
+        raise http.client.IncompleteRead(b'{"error":')
+
+    def close(self):
+        pass
 
 
 def test_http_retries_rate_limits_then_succeeds(monkeypatch):
@@ -89,6 +98,22 @@ def test_openai_failure_exposes_codes_without_error_prose(monkeypatch):
     assert "type=insufficient_quota" in str(captured.value)
     assert "code=insufficient_quota" in str(captured.value)
     assert "secret-looking prose" not in str(captured.value)
+
+
+def test_truncated_openai_error_body_stays_a_request_error(monkeypatch):
+    def fake_urlopen(request, **kwargs):
+        raise urllib.error.HTTPError(
+            request.full_url,
+            429,
+            "rate limited",
+            {},
+            TruncatedResponse(),
+        )
+
+    monkeypatch.setattr("benchmark_radar.http.urllib.request.urlopen", fake_urlopen)
+
+    with pytest.raises(RequestError, match="HTTP 429"):
+        post_json("https://api.openai.com/v1/responses", {"input": "private"}, attempts=1)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -44,6 +44,53 @@ def test_http_retries_rate_limits_then_succeeds(monkeypatch):
     assert sleeps == [0.0, 0.0]
 
 
+def test_http_honors_decimal_retry_after(monkeypatch):
+    sleeps = []
+    calls = 0
+
+    def fake_urlopen(request, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise urllib.error.HTTPError(
+                request.full_url,
+                429,
+                "rate limited",
+                {"Retry-After": "1.5"},
+                io.BytesIO(),
+            )
+        return Response(b'{"ok": true}')
+
+    monkeypatch.setattr("benchmark_radar.http.urllib.request.urlopen", fake_urlopen)
+    monkeypatch.setattr("benchmark_radar.http.time.sleep", sleeps.append)
+
+    assert get_json("https://example.test/data", attempts=2) == {"ok": True}
+    assert sleeps == [1.5]
+
+
+def test_openai_failure_exposes_codes_without_error_prose(monkeypatch):
+    def fake_urlopen(request, **kwargs):
+        raise urllib.error.HTTPError(
+            request.full_url,
+            429,
+            "rate limited",
+            {},
+            io.BytesIO(
+                b'{"error":{"message":"secret-looking prose","type":"insufficient_quota",'
+                b'"code":"insufficient_quota"}}'
+            ),
+        )
+
+    monkeypatch.setattr("benchmark_radar.http.urllib.request.urlopen", fake_urlopen)
+
+    with pytest.raises(RequestError) as captured:
+        post_json("https://api.openai.com/v1/responses", {"input": "private"}, attempts=1)
+
+    assert "type=insufficient_quota" in str(captured.value)
+    assert "code=insufficient_quota" in str(captured.value)
+    assert "secret-looking prose" not in str(captured.value)
+
+
 @pytest.mark.parametrize(
     ("error", "expected"),
     [


### PR DESCRIPTION
## Summary
- retry the required GPT briefing up to four times and honor decimal Retry-After values
- expose only safe structured OpenAI error type/code fields so production 429s can be distinguished from quota failures
- contain truncated error bodies inside RequestError

## Validation
- `PYTHONPATH=src pytest -q` (477 passed)
- `ruff check .`
- `ruff format --check .`
- independent Codex review clean