### PR TITLE
Fix GPT briefing sentence truncation

### DIFF
--- a/src/benchmark_radar/briefing.py
+++ b/src/benchmark_radar/briefing.py
@@ -104,9 +104,12 @@ def _plain(value: Any, limit: int) -> str:
     return " ".join(str(value or "").split())[:limit]
 
 
-def _output_text(value: Any) -> str:
-    """Normalize model prose without cutting a sentence after generation."""
-    return " ".join(str(value or "").split())
+def _output_text(value: Any, *, field: str, max_chars: int) -> str:
+    """Normalize model prose and reject oversize fields without cutting sentences."""
+    text = " ".join(str(value or "").split())
+    if len(text) > max_chars:
+        raise BriefingError(f"OpenAI returned an overlong {field}")
+    return text
 
 
 def _evidence_records(history: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -320,7 +323,8 @@ _INSTRUCTIONS = (
     "supports no material insight, return no_material_insight and say what is missing "
     "instead of forcing a story.\n\n"
     "Output: at most three non-overlapping insights. Keep each finding and why_it_matters "
-    "concrete, at most 80 words each, and end each with a complete sentence. Use the caveat "
+    "concrete, at most 80 words each, and end each with a complete sentence. Keep the caveat "
+    "at most 100 words and end it with a complete sentence. Use the caveat "
     "for the most material coverage or measurement limitation."
 )
 
@@ -460,8 +464,8 @@ def generate_daily_briefing(
         ):
             raise BriefingError("OpenAI cited evidence outside the injected packet")
         cited_ids.extend(value for value in ids if value not in cited_ids)
-        finding = _output_text(insight.get("finding"))
-        why = _output_text(insight.get("why_it_matters"))
+        finding = _output_text(insight.get("finding"), field="finding", max_chars=800)
+        why = _output_text(insight.get("why_it_matters"), field="why_it_matters", max_chars=800)
         confidence = str(insight.get("confidence") or "low").capitalize()
         if not finding or not why:
             raise BriefingError("OpenAI returned an empty finding")
@@ -469,7 +473,7 @@ def generate_daily_briefing(
             f"{finding} Why it matters: {why} Evidence: {', '.join(ids)}. {confidence} confidence."
         )
 
-    caveat = _output_text(parsed.get("caveat"))
+    caveat = _output_text(parsed.get("caveat"), field="caveat", max_chars=1_000)
     if not bullets:
         if not caveat:
             raise BriefingError("OpenAI returned neither an insight nor a caveat")

--- a/src/benchmark_radar/briefing.py
+++ b/src/benchmark_radar/briefing.py
@@ -104,6 +104,11 @@ def _plain(value: Any, limit: int) -> str:
     return " ".join(str(value or "").split())[:limit]
 
 
+def _output_text(value: Any) -> str:
+    """Normalize model prose without cutting a sentence after generation."""
+    return " ".join(str(value or "").split())
+
+
 def _evidence_records(history: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Select a broad but bounded set of artifacts that are genuinely new today."""
     selected: list[dict[str, Any]] = []
@@ -315,7 +320,8 @@ _INSTRUCTIONS = (
     "supports no material insight, return no_material_insight and say what is missing "
     "instead of forcing a story.\n\n"
     "Output: at most three non-overlapping insights. Keep each finding and why_it_matters "
-    "concrete. Use the caveat for the most material coverage or measurement limitation."
+    "concrete, at most 80 words each, and end each with a complete sentence. Use the caveat "
+    "for the most material coverage or measurement limitation."
 )
 
 
@@ -454,8 +460,8 @@ def generate_daily_briefing(
         ):
             raise BriefingError("OpenAI cited evidence outside the injected packet")
         cited_ids.extend(value for value in ids if value not in cited_ids)
-        finding = _plain(insight.get("finding"), 420)
-        why = _plain(insight.get("why_it_matters"), 420)
+        finding = _output_text(insight.get("finding"))
+        why = _output_text(insight.get("why_it_matters"))
         confidence = str(insight.get("confidence") or "low").capitalize()
         if not finding or not why:
             raise BriefingError("OpenAI returned an empty finding")
@@ -463,7 +469,7 @@ def generate_daily_briefing(
             f"{finding} Why it matters: {why} Evidence: {', '.join(ids)}. {confidence} confidence."
         )
 
-    caveat = _plain(parsed.get("caveat"), 500)
+    caveat = _output_text(parsed.get("caveat"))
     if not bullets:
         if not caveat:
             raise BriefingError("OpenAI returned neither an insight nor a caveat")

--- a/tests/test_briefing.py
+++ b/tests/test_briefing.py
@@ -238,7 +238,12 @@ def test_request_budget_has_an_offline_multibyte_fallback(monkeypatch):
 def test_model_output_is_not_cut_mid_sentence_after_generation():
     complete = "A" * 420 + " complete ending."
 
-    assert _output_text(complete) == complete
+    assert _output_text(complete, field="finding", max_chars=800) == complete
+
+
+def test_output_text_rejects_oversize_prose_instead_of_cutting_it() -> None:
+    with pytest.raises(BriefingError, match="overlong finding"):
+        _output_text("A" * 801, field="finding", max_chars=800)
 
 
 def test_generate_daily_briefing_uses_real_responses_contract_and_records_usage(monkeypatch):

--- a/tests/test_briefing.py
+++ b/tests/test_briefing.py
@@ -7,6 +7,7 @@ from benchmark_radar.briefing import (
     MAX_INPUT_CHARS,
     MAX_REQUEST_TOKENS,
     BriefingError,
+    _output_text,
     _payload,
     _request_token_estimate,
     briefing_input,
@@ -232,6 +233,12 @@ def test_request_budget_has_an_offline_multibyte_fallback(monkeypatch):
     estimate = _request_token_estimate(_payload("gpt-5.6", "界" * 12_000), "gpt-5.6")
 
     assert estimate > MAX_REQUEST_TOKENS
+
+
+def test_model_output_is_not_cut_mid_sentence_after_generation():
+    complete = "A" * 420 + " complete ending."
+
+    assert _output_text(complete) == complete
 
 
 def test_generate_daily_briefing_uses_real_responses_contract_and_records_usage(monkeypatch):


### PR DESCRIPTION
## Summary
- preserve complete GPT findings instead of clipping them at an arbitrary character boundary
- reject overlong model fields so reports remain bounded without publishing fragments
- instruct GPT to return bounded, complete findings, implications, and caveats

## Verification
- `PYTHONPATH=src pytest -q` (482 passed)
- `ruff check .`
- `ruff format --check .`
- clean Codex review against `origin/main`