### PR TITLE
Link homepage briefing to its cited evidence

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -273,6 +273,93 @@ function definition(label, value) {
   ]);
 }
 
+function safeHttpUrl(value) {
+  try {
+    const url = new URL(String(value));
+    return ["http:", "https:"].includes(url.protocol) ? url.href : "";
+  } catch {
+    return "";
+  }
+}
+
+function validBriefingCitations(citations) {
+  const seen = new Set();
+  return (Array.isArray(citations) ? citations : []).flatMap((citation) => {
+    const id = String(citation?.id || "");
+    const href = safeHttpUrl(citation?.url);
+    if (!/^E\d{3}$/.test(id) || !href || seen.has(id)) return [];
+    seen.add(id);
+    return [{
+      id,
+      href,
+      title: String(citation?.title || id),
+      source: String(citation?.source || "Primary source"),
+    }];
+  });
+}
+
+function briefingContent(line, citations) {
+  const links = new Map(citations.map((citation) => [citation.id, citation]));
+
+  const nodes = [];
+  let cursor = 0;
+  for (const match of String(line).matchAll(/\bE\d{3}\b/g)) {
+    const citation = links.get(match[0]);
+    if (!citation) continue;
+    nodes.push(document.createTextNode(line.slice(cursor, match.index)));
+    nodes.push(element("a", {
+      className: "briefing-evidence-link",
+      text: match[0],
+      attrs: {
+        href: citation.href,
+        target: "_blank",
+        rel: "noopener noreferrer",
+        title: `Open evidence: ${citation.title}`,
+        "aria-label": `${match[0]}: ${citation.title}`,
+      },
+    }));
+    cursor = match.index + match[0].length;
+  }
+  nodes.push(document.createTextNode(line.slice(cursor)));
+  return nodes;
+}
+
+function briefingProvenance(briefing) {
+  if (briefing.generator !== "openai-responses") return null;
+  const usage = briefing.usage || {};
+  const input = briefing.input || {};
+  return element("p", {
+    className: "daily-briefing-meta",
+    text: `GPT synthesis: ${briefing.model || "OpenAI model"} via OpenAI Responses API · ${Number(usage.input_tokens || 0).toLocaleString()} input / ${Number(usage.output_tokens || 0).toLocaleString()} output tokens · ${Number(input.evidence_items || 0).toLocaleString()} evidence records and ${Number(input.history_days || 0).toLocaleString()} history days injected.`,
+  });
+}
+
+function briefingEvidenceList(citations) {
+  if (!citations.length) return null;
+  return element("section", {
+    className: "daily-briefing-evidence",
+    attrs: { "aria-labelledby": "daily-briefing-evidence-heading" },
+  }, [
+    element("h3", {
+      className: "daily-briefing-evidence-title",
+      text: "Evidence cited by GPT",
+      attrs: { id: "daily-briefing-evidence-heading" },
+    }),
+    element("ul", {}, citations.map((citation) =>
+      element("li", {}, [
+        element("a", {
+          text: `${citation.id} — ${citation.title}`,
+          attrs: {
+            href: citation.href,
+            target: "_blank",
+            rel: "noopener noreferrer",
+          },
+        }),
+        element("span", { text: ` (${citation.source})` }),
+      ]))),
+  ]);
+}
+
 // The briefing is generated once per UTC day and stored in that day's snapshot,
 // so a day can legitimately have none: it predates the feature, no API key was
 // configured, or every pass over the day failed the call. Say which rather than
@@ -280,16 +367,27 @@ function definition(label, value) {
 function renderDailyBriefing(day) {
   const briefing = day.briefing || {};
   const bullets = Array.isArray(briefing.bullets) ? briefing.bullets : [];
+  const citations = validBriefingCitations(briefing.citations);
   // A briefing carrying another day's date describes the wrong day, so it is
   // withheld rather than shown beside this date's listings.
   const usable = briefing.date === day.date ? bullets.filter((line) => line.trim()) : [];
   replaceChildren(
     byId("daily-briefing-body"),
     usable.length
-      ? [element("ul", { className: "daily-briefing-list" },
-          // `text` assigns textContent, so the stored bullets render as the
-          // plain text they are. They are never inserted as HTML.
-          usable.map((line) => element("li", { text: line })))]
+      ? [
+          element("ul", { className: "daily-briefing-list" },
+          // Model prose remains text nodes. Only exact evidence IDs present in
+          // the snapshot's validated citation map become links.
+          usable.map((line) => element("li", {}, briefingContent(line, citations)))),
+          briefingProvenance(briefing),
+          briefing.caveat
+            ? element("p", { className: "daily-briefing-caveat" }, [
+                element("strong", { text: "Caveat: " }),
+                document.createTextNode(String(briefing.caveat)),
+              ])
+            : null,
+          briefingEvidenceList(citations),
+        ]
       : [
           element("p", {
             className: "empty-state",

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -383,6 +383,53 @@ input {
   margin-top: 0.4rem;
 }
 
+.briefing-evidence-link {
+  color: var(--blue-deep);
+  font-weight: 650;
+  text-decoration: underline;
+  text-decoration-thickness: 0.08em;
+  text-underline-offset: 0.14em;
+}
+
+.briefing-evidence-link:hover {
+  text-decoration-thickness: 0.14em;
+}
+
+.daily-briefing-meta {
+  margin: 0.85rem 0 0;
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+.daily-briefing-caveat {
+  margin: 0.85rem 0 0;
+  padding-left: 0.8rem;
+  border-left: 3px solid var(--line);
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.daily-briefing-evidence {
+  margin-top: 0.9rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--line);
+}
+
+.daily-briefing-evidence-title {
+  margin: 0 0 0.35rem;
+  font-size: 0.9rem;
+}
+
+.daily-briefing-evidence ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  font-size: 0.86rem;
+}
+
+.daily-briefing-evidence li + li {
+  margin-top: 0.22rem;
+}
+
 .record-card {
   border-bottom: 1px solid var(--line);
 }

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -661,3 +661,29 @@ def test_daily_briefing_withholds_another_days_text_and_names_an_absent_one():
     # listings.
     assert "briefing.date === day.date" in script
     assert "No briefing was recorded for this day." in script
+
+
+def test_daily_briefing_links_only_cited_http_evidence_ids():
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    assert "validBriefingCitations(briefing.citations)" in script
+    assert "briefingContent(line, citations)" in script
+    assert "String(line).matchAll(/\\bE\\d{3}\\b/g)" in script
+    assert '["http:", "https:"].includes(url.protocol)' in script
+    assert 'className: "briefing-evidence-link"' in script
+    assert 'target: "_blank"' in script
+    assert 'rel: "noopener noreferrer"' in script
+    assert "document.createTextNode(line.slice(cursor))" in script
+
+
+def test_daily_briefing_renders_its_provenance_caveat_and_evidence_ledger():
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    assert 'briefing.generator !== "openai-responses"' in script
+    assert "via OpenAI Responses API" in script
+    assert "input.evidence_items" in script
+    assert "input.history_days" in script
+    assert 'text: "Caveat: "' in script
+    assert 'text: "Evidence cited by GPT"' in script
+    assert "briefingEvidenceList(citations)" in script
+    assert "`${citation.id} — ${citation.title}`" in script


### PR DESCRIPTION
## Summary
- link every cited `E###` token in homepage briefing prose to its primary source
- render the GPT model/input provenance and caveat already stored in the daily snapshot
- add the complete linked “Evidence cited by GPT” ledger below the briefing
- keep model text as DOM text nodes and accept only HTTP(S) citation links

## Verification
- `PYTHONPATH=src pytest -q` — 484 passed
- `node --check site/assets/app.js`
- `ruff check .`
- `ruff format --check .`
- rebuilt the dashboard from all 15 snapshots
- rendered `?date=2026-08-06` in Chrome and verified all 8 evidence destinations
- clean Codex review against `origin/main`