### PR TITLE
Collapse verbose briefing evidence by default

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -360,6 +360,28 @@ function briefingEvidenceList(citations) {
   ]);
 }
 
+function briefingDetails(briefing, citations) {
+  const provenance = briefingProvenance(briefing);
+  const caveat = briefing.caveat
+    ? element("p", { className: "daily-briefing-caveat" }, [
+        element("strong", { text: "Caveat: " }),
+        document.createTextNode(String(briefing.caveat)),
+      ])
+    : null;
+  const evidence = briefingEvidenceList(citations);
+  if (!provenance && !caveat && !evidence) return null;
+
+  const label = citations.length
+    ? `Evidence & briefing details · ${citations.length.toLocaleString()} sources`
+    : "Briefing details";
+  return element("details", { className: "daily-briefing-details" }, [
+    element("summary", { text: label }),
+    provenance,
+    caveat,
+    evidence,
+  ]);
+}
+
 // The briefing is generated once per UTC day and stored in that day's snapshot,
 // so a day can legitimately have none: it predates the feature, no API key was
 // configured, or every pass over the day failed the call. Say which rather than
@@ -379,14 +401,7 @@ function renderDailyBriefing(day) {
           // Model prose remains text nodes. Only exact evidence IDs present in
           // the snapshot's validated citation map become links.
           usable.map((line) => element("li", {}, briefingContent(line, citations)))),
-          briefingProvenance(briefing),
-          briefing.caveat
-            ? element("p", { className: "daily-briefing-caveat" }, [
-                element("strong", { text: "Caveat: " }),
-                document.createTextNode(String(briefing.caveat)),
-              ])
-            : null,
-          briefingEvidenceList(citations),
+          briefingDetails(briefing, citations),
         ]
       : [
           element("p", {

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -395,8 +395,27 @@ input {
   text-decoration-thickness: 0.14em;
 }
 
+.daily-briefing-details {
+  margin-top: 0.85rem;
+  padding-top: 0.7rem;
+  border-top: 1px solid var(--line);
+}
+
+.daily-briefing-details summary {
+  width: fit-content;
+  color: var(--blue-deep);
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.daily-briefing-details summary:hover {
+  text-decoration: underline;
+  text-underline-offset: 0.14em;
+}
+
 .daily-briefing-meta {
-  margin: 0.85rem 0 0;
+  margin: 0.7rem 0 0;
   color: var(--muted);
   font-size: 0.82rem;
 }
@@ -410,9 +429,7 @@ input {
 }
 
 .daily-briefing-evidence {
-  margin-top: 0.9rem;
-  padding-top: 0.75rem;
-  border-top: 1px solid var(--line);
+  margin-top: 0.75rem;
 }
 
 .daily-briefing-evidence-title {

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -687,3 +687,12 @@ def test_daily_briefing_renders_its_provenance_caveat_and_evidence_ledger():
     assert 'text: "Evidence cited by GPT"' in script
     assert "briefingEvidenceList(citations)" in script
     assert "`${citation.id} — ${citation.title}`" in script
+
+
+def test_daily_briefing_collapses_verbose_evidence_details_by_default():
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    assert 'element("details", { className: "daily-briefing-details" }' in script
+    assert "Evidence & briefing details · ${citations.length.toLocaleString()} sources" in script
+    assert "briefingDetails(briefing, citations)" in script
+    assert 'attrs: { open: "" }' not in script


### PR DESCRIPTION
## Summary
- keep daily insight bullets and inline evidence links visible
- collapse GPT provenance, caveat, and evidence ledger behind a native details control
- label the disclosure with the number of cited sources

## Verification
- `PYTHONPATH=src pytest -q` — 485 passed
- `node --check site/assets/app.js`
- `ruff check .`
- `ruff format --check .`
- Selenium: closed by default, opens on click, exposes 8 evidence links plus provenance and caveat
- clean Codex review against `origin/main`