### PR TITLE
docs: add copy-ready community launch posts

### DIFF
--- a/docs/launch-posts.md
+++ b/docs/launch-posts.md
@@ -325,7 +325,9 @@ Benchmark Radar 还会每日自动收集新的 benchmark、评测、数据集和
 
 ## 12. Dev.to / Hashnode
 
-*Format: article title, exactly three opening paragraphs, followed by a section outline.*
+*Format: complete Markdown article with exactly three opening paragraphs before the first subheading.*
+
+*Reuse decision: publish this article on DEV first. Paste it verbatim into Hashnode, then set the DEV article URL as the original or canonical URL in Hashnode. Do not reuse the LinkedIn post because it omits the method and data-access detail expected in a technical article.*
 
 **Title:** Which Benchmarks Do Frontier Model Reports Actually Use?
 
@@ -335,42 +337,66 @@ The first dataset covers 30 documents from 10 organizations and tracks 79 benchm
 
 This is a measure of vendor reporting convention, not benchmark quality. Saturated or contaminated benchmarks can rank highly precisely because reporting them has become conventional. I exclude scores because prompts, scaffolds, tool access, reasoning budgets, pass@k, and evaluators vary across vendors. A document-level mention is the unit that remains comparable across those differences.
 
-### Section outline
+### Adoption as an observable reporting choice
 
-1. **The question: adoption as an observable reporting choice**
-   - Why model-release documents are the source material
-   - What the dataset can and cannot establish
+A model-release document does not list every evaluation its authors ran. It presents a selected set of results to explain the model to readers. That selection reflects internal tooling, historical practice, the model's intended use, and the comparisons a lab expects readers to recognize.
 
-2. **Counting documents instead of result rows**
-   - One benchmark mention per document
-   - Why long appendices should not receive extra weight
+Benchmark Radar records that visible reporting choice. The source material is the released document itself, not a benchmark website or a third-party leaderboard. Each entry links back to the model card, system card, or technical report that supports it.
 
-3. **Card count and organization count**
-   - `card_count` as the headline measure
-   - `organization_count` as a tiebreak
-   - Shared convention versus organization-specific practice
+The dataset cannot establish that a benchmark is scientifically better, harder, or more predictive than another. It can show which evaluations have become common reporting conventions in the documents sampled.
 
-4. **What the first 30 documents show**
-   - The top 10 reported benchmarks
-   - The concentration among 21 recurring benchmarks
-   - The long tail of single-document and single-organization entries
+### Counting documents instead of result rows
 
-5. **Why scores are deliberately excluded**
-   - Prompt and scaffold differences
-   - Tool access and reasoning budgets
-   - pass@k and evaluator differences
+The counted unit is the document. A document contributes at most one adoption to a benchmark, even when it reports several prompts, scaffolds, tool settings, or pass@k variants.
 
-6. **The automated daily radar**
-   - Eight discovery sources
-   - Deduplication and transparent classification
-   - Explainable ranking components and daily GitHub Issues
+This rule prevents a long appendix from receiving more weight than a concise report. A model card with ten AIME result rows and a model card with one AIME result row each contribute one AIME adoption.
 
-7. **Using and citing the data**
-   - Dashboard and leaderboard
-   - JSON, CSV, Markdown, and Shields artifacts
-   - MIT-licensed repository
+### Separating document count from organization count
 
-Project: https://github.com/ktwu01/benchmark-radar
+The leaderboard publishes two values:
+
+- `card_count`: the number of documents that report the benchmark
+- `organization_count`: the number of organizations represented by those documents
+
+The values stay separate because repeated reporting within one organization differs from reporting across several organizations. `card_count` determines the headline order, while `organization_count` breaks ties.
+
+### What the first 30 documents show
+
+The current top five are:
+
+1. GPQA Diamond: 23 documents, 10 organizations
+2. SWE-bench Verified: 18 documents, 8 organizations
+3. LiveCodeBench: 15 documents, 7 organizations
+4. Humanity's Last Exam: 14 documents, 8 organizations
+5. AIME: 14 documents, 7 organizations
+
+The distribution also has a long tail. Of 79 tracked benchmarks, 21 appear in at least five documents, 24 appear in exactly one document, and 25 are reported by exactly one organization.
+
+The sample contains 30 documents from 10 organizations, so these figures describe the tracked registry rather than the full evaluation field.
+
+### Why the dataset excludes scores
+
+Two results with the same benchmark name may use different prompts, scaffolds, tools, reasoning budgets, pass@k settings, or evaluators. Placing those scores in one cross-vendor table would imply comparability that the source documents do not support.
+
+Benchmark Radar therefore records whether a document reports a benchmark, not which model received the highest number. A saturated or contaminated benchmark can still rank highly because reporting it remains conventional. The ranking measures reporting practice, not benchmark quality.
+
+### The automated daily radar
+
+The project also maintains a daily feed of new work on benchmarks, evaluations, datasets, and data quality. It collects records from arXiv, OpenReview, Hugging Face, GitHub, Semantic Scholar, OpenAlex, Brave Search, and Hacker News, then deduplicates and classifies them with published ranking components.
+
+The daily feed and the hand-curated adoption leaderboard serve different purposes. The feed tracks new work entering the field. The leaderboard tracks benchmarks appearing in model-release documents.
+
+### Using and citing the data
+
+The project is MIT licensed, and the leaderboard is available in several formats:
+
+- Dashboard: https://koutian.is-a.dev/benchmark-radar/?view=leaderboard
+- JSON: https://koutian.is-a.dev/benchmark-radar/data/leaderboard.json
+- CSV: https://koutian.is-a.dev/benchmark-radar/data/leaderboard.csv
+- Markdown: https://koutian.is-a.dev/benchmark-radar/data/leaderboard.md
+- Repository: https://github.com/ktwu01/benchmark-radar
+
+Corrections and additions can be submitted through the repository. The most useful additions are missing model documents and corrections to benchmark mentions already recorded.
 
 ## 13. Lobste.rs
 
@@ -419,3 +445,77 @@ v0.3.0 已经发布：https://github.com/ktwu01/benchmark-radar/releases/tag/v0.
 CSV：https://koutian.is-a.dev/benchmark-radar/data/leaderboard.csv
 
 希望请 V 友帮忙看两件事：统计口径是否合理；还有哪些重要的模型文档没有收录。
+
+## 17. Hugging Face Forums
+
+*Format: dataset announcement with a title, method summary, limitations, and direct data links.*
+
+**Title:** Benchmark Radar: benchmark adoption across 30 frontier model reports
+
+I built Benchmark Radar to track which benchmarks appear in model cards, system cards, and technical reports. The hand-curated dataset currently covers 30 documents from 10 organizations and records 79 benchmarks.
+
+The leading entries are GPQA Diamond at 23 documents from 10 organizations, SWE-bench Verified at 18/8, and LiveCodeBench at 15/7. Each document contributes at most one count per benchmark, regardless of how many prompts, scaffolds, tool settings, or pass@k variants it reports. Document count and organization count are published separately.
+
+This measures vendor reporting convention, not benchmark quality. Saturated or contaminated benchmarks may rank highly because reporting them remains conventional. Scores are excluded because prompts, tools, reasoning budgets, pass@k, and evaluators differ across vendors. The sample is small at 30 documents.
+
+Leaderboard: https://koutian.is-a.dev/benchmark-radar/?view=leaderboard
+CSV: https://koutian.is-a.dev/benchmark-radar/data/leaderboard.csv
+JSON: https://koutian.is-a.dev/benchmark-radar/data/leaderboard.json
+Repository: https://github.com/ktwu01/benchmark-radar
+
+Feedback on the counting method, incorrect entries, and missing model documents would be useful.
+
+## 18. AI community chat messages
+
+*Reuse decision: do not paste the X thread or LinkedIn post into Discord or Slack. The X copy depends on six separate posts, and the LinkedIn copy is too long for a community chat. Use the shorter messages below. The EleutherAI message may be reused verbatim in ML Collective and LAION.*
+
+### 18.1 EleutherAI Discord, ML Collective Discord, and LAION Discord
+
+*Paste this message verbatim in the server channel approved for project or research announcements.*
+
+Hi, I built a small open dataset on which benchmarks frontier labs report when releasing models. Benchmark Radar currently covers 30 model cards, system cards, and technical reports from 10 organizations, with 79 tracked benchmarks.
+
+GPQA Diamond appears in 23 documents from 10 organizations, SWE-bench Verified in 18/8, and LiveCodeBench in 15/7. Each document counts at most once per benchmark, and document count stays separate from organization count.
+
+This measures reporting convention, not benchmark quality. Scores are excluded because evaluation setups differ, and the sample is still small at n=30. I would appreciate feedback on the counting method or model documents I missed.
+
+Leaderboard: https://koutian.is-a.dev/benchmark-radar/?view=leaderboard
+Repository: https://github.com/ktwu01/benchmark-radar
+
+### 18.2 Hugging Face Discord
+
+*Paste this message verbatim in the server channel approved for community projects. Do not reuse the full LinkedIn post.*
+
+Hi, I published a small open dataset that counts benchmark mentions across 30 frontier model cards, system cards, and technical reports from 10 organizations. It tracks 79 benchmarks and publishes both document count and organization count.
+
+The top three are GPQA Diamond at 23 documents/10 organizations, SWE-bench Verified at 18/8, and LiveCodeBench at 15/7. This measures reporting convention, not benchmark quality. Scores are excluded because evaluation setups differ, and n=30 is a small sample.
+
+CSV: https://koutian.is-a.dev/benchmark-radar/data/leaderboard.csv
+JSON: https://koutian.is-a.dev/benchmark-radar/data/leaderboard.json
+Repository: https://github.com/ktwu01/benchmark-radar
+
+Corrections and missing model-report suggestions are welcome.
+
+### 18.3 MLOps Community Slack
+
+*Paste this message verbatim in the workspace channel approved for project announcements. Do not reuse the full LinkedIn post.*
+
+I built Benchmark Radar to make one part of model-release evaluation practice inspectable: which benchmarks vendors include in model cards, system cards, and technical reports.
+
+The current hand-curated dataset covers 30 documents from 10 organizations and 79 benchmarks. Each document counts once per benchmark, with document count and organization count published separately. GPQA Diamond currently leads at 23 documents from 10 organizations.
+
+This is a view of reporting convention, not benchmark quality. Cross-vendor scores are excluded because prompts, tools, reasoning budgets, pass@k, and evaluators differ. The sample is small at n=30.
+
+Leaderboard: https://koutian.is-a.dev/benchmark-radar/?view=leaderboard
+CSV: https://koutian.is-a.dev/benchmark-radar/data/leaderboard.csv
+Repository: https://github.com/ktwu01/benchmark-radar
+
+Feedback on the data model and counting rule would be useful.
+
+## 19. Substack Note
+
+*Reuse decision: do not paste the full X thread or LinkedIn post. This shorter note is copy-ready.*
+
+I reviewed 30 frontier model cards, system cards, and technical reports from 10 organizations to see which benchmarks they actually report. GPQA Diamond appears in 23 documents, while 24 of the 79 tracked benchmarks appear only once. Benchmark Radar counts each document once per benchmark and publishes document and organization counts separately. This measures reporting convention, not benchmark quality; scores are excluded because evaluation setups differ, and n=30 is a small sample.
+
+https://koutian.is-a.dev/benchmark-radar/?view=leaderboard

--- a/docs/launch-posts.md
+++ b/docs/launch-posts.md
@@ -30,7 +30,7 @@ Baseline before any of this ships: 8 stars, 6 forks.
 
 I built Benchmark Radar to answer a narrow question: which AI benchmarks do frontier labs actually report when they release a model?
 
-I manually reviewed 30 model cards, system cards, and technical reports from 10 organizations, recording the benchmarks mentioned in each document. The current leaderboard tracks 79 benchmarks. GPQA Diamond leads with 23 cards from 10 organizations, followed by SWE-bench Verified at 18/8 and LiveCodeBench at 15/7.
+I manually reviewed 30 model-release documents from 10 organizations, recording the benchmarks mentioned in each document. The current leaderboard tracks 79 benchmarks. GPQA Diamond leads with 23 documents from 10 organizations, followed by SWE-bench Verified at 18/8 and LiveCodeBench at 15/7.
 
 The unit is the document, not the result row. If one card reports AIME with several scaffolds or pass@k settings, that still counts as one adoption. I publish card count and organization count separately, with organization count used only as a tiebreak.
 
@@ -52,7 +52,7 @@ Of 79 tracked benchmarks, 21 appear in at least five model cards, while 24 appea
 
 I built an open-source project called Benchmark Radar around this question: which benchmarks do frontier labs actually report when releasing models?
 
-The ranking is hand-curated from 30 model cards, system cards, and technical reports. The counted unit is the document, not the result row. Reporting AIME at pass@1, consensus@64, and with tools in one card still contributes one adoption. The leaderboard publishes `card_count` and `organization_count` side by side rather than merging them.
+The ranking is hand-curated from 30 model-release documents. The counted unit is the document, not the result row. Reporting AIME at pass@1, consensus@64, and with tools in one document still contributes one adoption. The leaderboard publishes `card_count` and `organization_count` side by side rather than merging them.
 
 The sample is small, n=30 documents across 10 organizations, so I would not treat this as a full map of evaluation practice.
 
@@ -72,7 +72,7 @@ Feedback on the counting method and missing model documents would be especially 
 
 **Title:** I made a leaderboard of the benchmarks that model releases actually report
 
-When a new model drops, I often want to know whether its benchmark table uses broadly shared evaluations or a mostly vendor-specific set. So I read 30 model cards, system cards, and technical reports from 10 organizations and counted benchmark mentions by document.
+When a new model drops, I often want to know whether its benchmark table uses broadly shared evaluations or a mostly vendor-specific set. So I read 30 model-release documents from 10 organizations and counted benchmark mentions by document.
 
 The current top entries are GPQA Diamond at 23 cards/10 organizations, SWE-bench Verified at 18/8, LiveCodeBench at 15/7, Humanity's Last Exam at 14/8, and AIME at 14/7.
 
@@ -96,7 +96,7 @@ JSON: https://koutian.is-a.dev/benchmark-radar/data/leaderboard.json
 
 Which benchmarks do frontier labs actually report when they release a model?
 
-I reviewed 30 model cards, system cards, and technical reports from 10 organizations. Benchmark Radar now tracks 79 benchmarks.  
+I reviewed 30 model-release documents from 10 organizations. Benchmark Radar now tracks 79 benchmarks.
 https://koutian.is-a.dev/benchmark-radar/?view=leaderboard
 
 **2/6**
@@ -136,7 +136,7 @@ CSV: https://koutian.is-a.dev/benchmark-radar/data/leaderboard.csv
 
 Which AI benchmarks have become part of the standard model-release vocabulary?
 
-I have been working on Benchmark Radar, an open-source project built around that question. I manually reviewed 30 model cards, system cards, and technical reports from 10 organizations, then recorded which benchmarks each document reports. The current dataset contains 79 benchmarks.
+I have been working on Benchmark Radar, an open-source project built around that question. I manually reviewed 30 model-release documents from 10 organizations, then recorded which benchmarks each document reports. The current dataset contains 79 benchmarks.
 
 GPQA Diamond appears in 23 documents from all 10 organizations. SWE-bench Verified appears in 18 documents from 8 organizations, and LiveCodeBench in 15 from 7. At the other end, 24 benchmarks appear in exactly one document, and 25 are reported by only one organization.
 
@@ -209,7 +209,7 @@ Commit: `3b5524af003ce4b047036eb851dee66dac4b27b4`
 
 **Title:** Benchmark Radar v0.3.0: Model Card Adoption Rank
 
-This release adds the hand-curated Model Card Adoption Rank, which tracks which benchmarks appear in frontier model cards, system cards, and technical reports.
+This release adds the hand-curated Model Card Adoption Rank, which tracks which benchmarks appear in frontier model cards, system cards, technical reports, and release posts.
 
 > **Interpretation caveat:** This measures vendor reporting convention, not benchmark quality. A saturated or contaminated benchmark can rank highly because reporting it is conventional. Scores remain out of scope because prompts, scaffolds, tool access, reasoning budgets, pass@k, and evaluators differ across vendors. The current sample is small, with 30 documents.
 
@@ -331,7 +331,7 @@ Benchmark Radar 还会每日自动收集新的 benchmark、评测、数据集和
 
 **Title:** Which Benchmarks Do Frontier Model Reports Actually Use?
 
-When a lab releases a new model, its evaluation table reflects a mixture of scientific usefulness, historical convention, internal tooling, and what readers expect to see. I built Benchmark Radar to record one observable part of that process: which benchmarks are mentioned in actual model cards, system cards, and technical reports.
+When a lab releases a new model, its evaluation table reflects a mixture of scientific usefulness, historical convention, internal tooling, and what readers expect to see. I built Benchmark Radar to record one observable part of that process: which benchmarks are mentioned in actual model-release documents.
 
 The first dataset covers 30 documents from 10 organizations and tracks 79 benchmarks. It is a small sample. GPQA Diamond appears in 23 documents from all 10 organizations, while SWE-bench Verified appears in 18 from 8. The distribution also has a long tail: 24 benchmarks appear in exactly one document, and 25 are reported by only one organization.
 
@@ -414,7 +414,7 @@ Corrections and additions can be submitted through the repository. The most usef
 
 **Description:**
 
-Benchmark Radar tracks which AI benchmarks appear in model cards, system cards, and technical reports. The hand-curated leaderboard covers 30 documents, 10 organizations, and 79 benchmarks, counting each document once per benchmark and publishing document and organization counts separately.
+Benchmark Radar tracks which AI benchmarks appear in model cards, system cards, technical reports, and release posts. The hand-curated leaderboard covers 30 documents, 10 organizations, and 79 benchmarks, counting each document once per benchmark and publishing document and organization counts separately.
 
 It also runs a daily automated radar for new benchmarks, evals, datasets, and data-quality work.
 
@@ -426,7 +426,7 @@ https://koutian.is-a.dev/benchmark-radar/
 
 *Format: 3-sentence pitch to an AI evaluation newsletter writer.*
 
-I built a small open-source dataset that counts which benchmarks appear across 30 frontier model cards, system cards, and technical reports from 10 organizations. The main finding is concentration plus a long tail: GPQA Diamond appears in 23 documents, while 24 of the 79 tracked benchmarks appear in exactly one. It measures reporting convention, not benchmark quality, so saturated or contaminated benchmarks may rank highly; scores are excluded as evaluation setups differ, and the n=30 sample is explicitly limited: https://github.com/ktwu01/benchmark-radar
+I built a small open-source dataset that counts which benchmarks appear across 30 frontier model-release documents from 10 organizations. The main finding is concentration plus a long tail: GPQA Diamond appears in 23 documents, while 24 of the 79 tracked benchmarks appear in exactly one. It measures reporting convention, not benchmark quality, so saturated or contaminated benchmarks may rank highly; scores are excluded as evaluation setups differ, and the n=30 sample is explicitly limited: https://github.com/ktwu01/benchmark-radar
 
 ## 16. V2EX（分享创造）
 
@@ -452,7 +452,7 @@ CSV：https://koutian.is-a.dev/benchmark-radar/data/leaderboard.csv
 
 **Title:** Benchmark Radar: benchmark adoption across 30 frontier model reports
 
-I built Benchmark Radar to track which benchmarks appear in model cards, system cards, and technical reports. The hand-curated dataset currently covers 30 documents from 10 organizations and records 79 benchmarks.
+I built Benchmark Radar to track which benchmarks appear in model cards, system cards, technical reports, and release posts. The hand-curated dataset currently covers 30 documents from 10 organizations and records 79 benchmarks.
 
 The leading entries are GPQA Diamond at 23 documents from 10 organizations, SWE-bench Verified at 18/8, and LiveCodeBench at 15/7. Each document contributes at most one count per benchmark, regardless of how many prompts, scaffolds, tool settings, or pass@k variants it reports. Document count and organization count are published separately.
 
@@ -473,7 +473,7 @@ Feedback on the counting method, incorrect entries, and missing model documents 
 
 *Paste this message verbatim in the server channel approved for project or research announcements.*
 
-Hi, I built a small open dataset on which benchmarks frontier labs report when releasing models. Benchmark Radar currently covers 30 model cards, system cards, and technical reports from 10 organizations, with 79 tracked benchmarks.
+Hi, I built a small open dataset on which benchmarks frontier labs report when releasing models. Benchmark Radar currently covers 30 model-release documents from 10 organizations, with 79 tracked benchmarks.
 
 GPQA Diamond appears in 23 documents from 10 organizations, SWE-bench Verified in 18/8, and LiveCodeBench in 15/7. Each document counts at most once per benchmark, and document count stays separate from organization count.
 
@@ -486,7 +486,7 @@ Repository: https://github.com/ktwu01/benchmark-radar
 
 *Paste this message verbatim in the server channel approved for community projects. Do not reuse the full LinkedIn post.*
 
-Hi, I published a small open dataset that counts benchmark mentions across 30 frontier model cards, system cards, and technical reports from 10 organizations. It tracks 79 benchmarks and publishes both document count and organization count.
+Hi, I published a small open dataset that counts benchmark mentions across 30 frontier model-release documents from 10 organizations. It tracks 79 benchmarks and publishes both document count and organization count.
 
 The top three are GPQA Diamond at 23 documents/10 organizations, SWE-bench Verified at 18/8, and LiveCodeBench at 15/7. This measures reporting convention, not benchmark quality. Scores are excluded because evaluation setups differ, and n=30 is a small sample.
 
@@ -500,7 +500,7 @@ Corrections and missing model-report suggestions are welcome.
 
 *Paste this message verbatim in the workspace channel approved for project announcements. Do not reuse the full LinkedIn post.*
 
-I built Benchmark Radar to make one part of model-release evaluation practice inspectable: which benchmarks vendors include in model cards, system cards, and technical reports.
+I built Benchmark Radar to make one part of model-release evaluation practice inspectable: which benchmarks vendors include in model cards, system cards, technical reports, and release posts.
 
 The current hand-curated dataset covers 30 documents from 10 organizations and 79 benchmarks. Each document counts once per benchmark, with document count and organization count published separately. GPQA Diamond currently leads at 23 documents from 10 organizations.
 
@@ -516,6 +516,6 @@ Feedback on the data model and counting rule would be useful.
 
 *Reuse decision: do not paste the full X thread or LinkedIn post. This shorter note is copy-ready.*
 
-I reviewed 30 frontier model cards, system cards, and technical reports from 10 organizations to see which benchmarks they actually report. GPQA Diamond appears in 23 documents, while 24 of the 79 tracked benchmarks appear only once. Benchmark Radar counts each document once per benchmark and publishes document and organization counts separately. This measures reporting convention, not benchmark quality; scores are excluded because evaluation setups differ, and n=30 is a small sample.
+I reviewed 30 frontier model-release documents from 10 organizations to see which benchmarks they actually report. GPQA Diamond appears in 23 documents, while 24 of the 79 tracked benchmarks appear only once. Benchmark Radar counts each document once per benchmark and publishes document and organization counts separately. This measures reporting convention, not benchmark quality; scores are excluded because evaluation setups differ, and n=30 is a small sample.
 
 https://koutian.is-a.dev/benchmark-radar/?view=leaderboard

--- a/docs/launch-posts.md
+++ b/docs/launch-posts.md
@@ -382,7 +382,7 @@ Benchmark Radar therefore records whether a document reports a benchmark, not wh
 
 ### The automated daily radar
 
-The project also maintains a daily feed of new work on benchmarks, evaluations, datasets, and data quality. It collects records from arXiv, OpenReview, Hugging Face, GitHub, Semantic Scholar, OpenAlex, Brave Search, and Hacker News, then deduplicates and classifies them with published ranking components.
+The project also maintains a daily feed of new work on benchmarks, evaluations, datasets, and data quality. It collects records from arXiv, OpenReview, Hugging Face, GitHub, GitHub Releases, Semantic Scholar, OpenAlex, and Brave Search, then deduplicates and classifies them with published ranking components. Hacker News is tracked separately as an attention signal and does not affect evidence ranking.
 
 The daily feed and the hand-curated adoption leaderboard serve different purposes. The feed tracks new work entering the field. The leaderboard tracks benchmarks appearing in model-release documents.
 

--- a/docs/launch-posts.md
+++ b/docs/launch-posts.md
@@ -341,7 +341,7 @@ This is a measure of vendor reporting convention, not benchmark quality. Saturat
 
 A model-release document does not list every evaluation its authors ran. It presents a selected set of results to explain the model to readers. That selection reflects internal tooling, historical practice, the model's intended use, and the comparisons a lab expects readers to recognize.
 
-Benchmark Radar records that visible reporting choice. The source material is the released document itself, not a benchmark website or a third-party leaderboard. Each entry links back to the model card, system card, or technical report that supports it.
+Benchmark Radar records that visible reporting choice. The source material is the released document itself, not a benchmark website or a third-party leaderboard. Each entry links back to the model-release document that supports it.
 
 The dataset cannot establish that a benchmark is scientifically better, harder, or more predictive than another. It can show which evaluations have become common reporting conventions in the documents sampled.
 


### PR DESCRIPTION
## Summary

- replace the DEV/Hashnode outline with a complete copy-ready article
- add paste-ready drafts for Hugging Face Forums, EleutherAI, ML Collective, LAION, Hugging Face Discord, MLOps Community Slack, and Substack Notes
- document which drafts can be reused verbatim and why the X or LinkedIn copy should not be reused for the remaining channels
- correct launch copy to cover release posts and distinguish Hacker News attention from ranked discovery sources

## Verification

- `PYTHONPATH=src /usr/bin/python3.11 -m pytest -q` (485 passed)
- `git diff --check`
- Codex review: no actionable defects found

Closes no issue. Updates the publishing checklist maintained in issue #88.
