### PR TITLE
Fix overlapping category relationships in trends chart

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -710,10 +710,7 @@ function renderTrends() {
   const maxTotal = Math.max(
     1,
     ...state.data.days.map((day) =>
-      Math.max(
-        Object.values(countsFor(day)).reduce((sum, count) => sum + count, 0),
-        day.attention.active_count,
-      ),
+      Math.max(...Object.values(countsFor(day)), day.attention.active_count),
     ),
   );
   replaceChildren(
@@ -733,13 +730,10 @@ function renderTrends() {
         className: "day-column",
         attrs: {
           type: "button",
-          "aria-label": `${formatDate(day.date)}: ${total} evidence category matches across ${day.evidence_count} evidence records and ${day.attention.active_count} attention signals`,
+          "aria-label": `${formatDate(day.date)}: ${total} overlapping evidence category matches across ${day.evidence_count} evidence records and ${day.attention.active_count} attention signals`,
         },
       }, [
-        element("span", { className: "series-bars" }, [
-          element("span", { className: "bar-stack" }, segments),
-          attentionBar,
-        ]),
+        element("span", { className: "series-bars" }, [...segments, attentionBar]),
         element("span", { className: "day-label", text: day.date.slice(5) }),
       ]);
       const previous = state.data.days[dayIndex - 1];

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -1077,7 +1077,7 @@ input {
 
 .attention-swatch,
 .attention-volume {
-  background: #756aa8;
+  background: var(--ink);
 }
 
 .trend-filter {
@@ -1118,50 +1118,37 @@ input {
 
 .day-column {
   display: grid;
-  flex: 1 0 44px;
+  flex: 1 0 64px;
   gap: 0.6rem;
-  min-width: 44px;
+  min-width: 64px;
   border: 0;
   background: transparent;
   transition: opacity 180ms ease;
 }
 
-.bar-stack {
-  display: flex;
-  flex-direction: column-reverse;
-  justify-content: flex-start;
-  height: 260px;
-  border-bottom: 1px solid var(--ink);
-}
-
 .series-bars {
   display: flex;
-  gap: 5px;
+  gap: clamp(1px, 0.25vw, 4px);
   align-items: end;
   justify-content: center;
   height: 260px;
   border-bottom: 1px solid var(--ink);
 }
 
-.series-bars .bar-stack {
-  width: min(22px, 60%);
-  border-bottom: 0;
-}
-
-.attention-volume {
-  width: min(10px, 30%);
-  min-height: 2px;
+.attention-volume,
+.bar-segment {
+  width: min(10px, 13%);
   transition: filter 180ms ease;
 }
 
 .bar-segment {
-  min-height: 2px;
   background: var(--bar-color);
-  transition: filter 180ms ease;
 }
 
 .day-column:hover .bar-segment,
-.day-column:focus-visible .bar-segment {
+.day-column:hover .attention-volume,
+.day-column:focus-visible .bar-segment,
+.day-column:focus-visible .attention-volume {
   filter: saturate(1.35) brightness(0.93);
 }
 

--- a/site/index.html
+++ b/site/index.html
@@ -413,6 +413,9 @@
             <h2>Daily evidence and attention volume</h2>
             <div class="legend" id="trend-legend" aria-label="Category legend"></div>
           </div>
+          <p class="section-note">
+            Category tags overlap. Each bar is an independent count, not a part of a stacked total.
+          </p>
           <label class="trend-filter">
             <input type="checkbox" id="trend-released-only" />
             Releases only

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -286,6 +286,20 @@ def test_trend_chart_can_filter_to_releases_only():
     assert "also updated (not counted above)" in script
 
 
+def test_trend_chart_does_not_stack_overlapping_categories():
+    html = Path("site/index.html").read_text(encoding="utf-8")
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+    styles = Path("site/assets/styles.css").read_text(encoding="utf-8")
+
+    assert "Category tags overlap. Each bar is an independent count" in html
+    assert 'className: "series-bars" }, [...segments, attentionBar]' in script
+    assert 'className: "bar-stack"' not in script
+    assert "overlapping evidence category matches" in script
+    assert "Math.max(...Object.values(countsFor(day)), day.attention.active_count)" in script
+    assert ".bar-stack" not in styles
+    assert ".attention-volume {\n  background: var(--ink);" in styles
+
+
 def test_static_html_references_existing_local_assets():
     parser = SiteParser()
     parser.feed(Path("site/index.html").read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary
- render overlapping evidence categories as independent grouped bars instead of a stacked total
- scale the chart by the largest individual series and explain that category counts overlap
- distinguish attention from agentic evidence with a separate color

Closes #149

## Test plan
- `PYTHONPATH=src pytest -q`
- `ruff check .`
- `ruff format --check .`
- `git diff --check`
- rebuilt `site/data/radar.json` locally and inspected desktop/mobile headless Chrome renders of `?view=trends`
- `codex review --base main -c 'model_reasoning_effort="high"'`