### PR TITLE
Add KW-Bench L0-L5 shadow classification MVP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,4 +21,4 @@ jobs:
       - run: ruff check .
       - run: ruff format --check .
       - run: pytest -q
-      - run: benchmark-radar rebuild
+      - run: benchmark-radar classify

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -14,6 +14,8 @@ on:
       - "src/benchmark_radar/snapshots.py"
       - "src/benchmark_radar/corpus.py"
       - "src/benchmark_radar/model_cards.py"
+      - "src/benchmark_radar/cli.py"
+      - "src/benchmark_radar/kw_bench*.py"
       # Both run during the build and write files into the artifact, so a change
       # to either one only reaches the published site if it also triggers a
       # deploy. Without these, editing the share-card generator or the export

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -47,7 +47,10 @@ jobs:
       - name: Build validated dashboard data
         run: |
           python -m pip install -e '.[dev]'
-          benchmark-radar rebuild
+          # The classification store is derived and intentionally untracked.
+          # Build it in the fresh Pages checkout before publishing radar.json.
+          # The MVP uses NullExtractor, so this makes no external/model calls.
+          benchmark-radar classify
           # Standalone citable artifacts alongside the dashboard bundle (issue
           # #88). Written into site/data/ so they deploy with the rest of the
           # site and resolve at a stable URL: an embedded badge or a citation

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,12 @@ out/
 /site/data/leaderboard.md
 /site/data/leaderboard-badge.json
 
+# Derived by `benchmark-radar classify` from the snapshots, which are the
+# source. Committing it would let a stale or partially backfilled set of
+# levels be reviewed as if a human had written them, and the store is
+# rebuilt from cache at no cost.
+/data/kw_bench_classifications.jsonl
+
 .gstack/
 .DS_Store
 .worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,8 @@ out/
 
 # Derived by `benchmark-radar classify` from the snapshots, which are the
 # source. Committing it would let a stale or partially backfilled set of
-# levels be reviewed as if a human had written them, and the store is
-# rebuilt from cache at no cost.
+# levels be reviewed as if a human had written them. Pages regenerates the
+# store before publishing; the MVP's null extractor makes no external calls.
 /data/kw_bench_classifications.jsonl
 
 .gstack/

--- a/src/benchmark_radar/cli.py
+++ b/src/benchmark_radar/cli.py
@@ -169,8 +169,19 @@ def main() -> None:
         type=int,
         default=None,
         help=(
-            "classify only: stop after this many tracks. Bounds a first backfill "
-            "pass; the next run resumes from the cache with no repeated work."
+            "classify only: stop after this many tracks that still need work. "
+            "Bounds a first backfill pass; the next run picks up where it "
+            "stopped rather than re-selecting the same prefix."
+        ),
+    )
+    parser.add_argument(
+        "--kw-bench-refresh-after",
+        default=None,
+        help=(
+            "classify only: re-extract tracks classified before this ISO "
+            "timestamp. An upstream README edit that leaves a track's metadata "
+            "unchanged is invisible to the cache by design, since detecting it "
+            "means fetching the source; this is how those are picked up."
         ),
     )
     args = parser.parse_args()
@@ -182,6 +193,7 @@ def main() -> None:
             classified_at=datetime.now(UTC).isoformat(),
             batch_size=args.kw_bench_batch_size,
             limit=args.kw_bench_limit,
+            refresh_before=args.kw_bench_refresh_after,
         )
         dashboard = rebuild_dashboard(
             args.snapshot_dir,

--- a/src/benchmark_radar/cli.py
+++ b/src/benchmark_radar/cli.py
@@ -12,6 +12,9 @@ from .briefing import BriefingError, current_day_snapshot, daily_report_run, gen
 from .export import DEFAULT_TABLE_LIMIT, write_exports
 from .findings import daily_findings
 from .http import RequestError
+from .kw_bench_store import STORE_FILENAME as KW_BENCH_STORE_FILENAME
+from .kw_bench_tracks import DEFAULT_BATCH_SIZE
+from .kw_bench_tracks import backfill as backfill_classifications
 from .pipeline import _failure_streak_key, run_pipeline, simulate_backfill
 from .report import render_markdown
 from .snapshots import (
@@ -66,13 +69,23 @@ def main() -> None:
     parser.add_argument(
         "command",
         nargs="?",
-        choices=("run", "rebuild", "backfill", "migrate", "rescore", "simulate-history", "export"),
+        choices=(
+            "run",
+            "rebuild",
+            "backfill",
+            "migrate",
+            "rescore",
+            "simulate-history",
+            "export",
+            "classify",
+        ),
         default="run",
         help=(
             "Collect a daily run, rebuild/backfill cumulative data from saved snapshots, "
             "migrate snapshot schemas, rescore stored taxonomy categories against the "
-            "current config, simulate missing historical snapshots, or export the "
-            "Model Card Adoption Rank as standalone citable files."
+            "current config, simulate missing historical snapshots, export the "
+            "Model Card Adoption Rank as standalone citable files, or classify canonical "
+            "benchmark tracks against the KW-Bench L0-L5 capability rubric."
         ),
     )
     parser.add_argument("--config", type=Path, default=Path("config.yml"))
@@ -132,7 +145,73 @@ def main() -> None:
             "30-replay coverage), counting real snapshots already on disk."
         ),
     )
+    parser.add_argument(
+        "--kw-bench-store",
+        type=Path,
+        default=Path("data") / KW_BENCH_STORE_FILENAME,
+        help=(
+            "KW-Bench L0-L5 classification layer (issue #153). Append-only JSONL "
+            "keyed by canonical artifact and track. Read by every rebuild to "
+            "publish the shadow capability layer; written by `classify`."
+        ),
+    )
+    parser.add_argument(
+        "--kw-bench-batch-size",
+        type=int,
+        default=DEFAULT_BATCH_SIZE,
+        help=(
+            "classify only: tracks per committed batch. Work is durable per "
+            "batch, so an interrupted run keeps everything already written."
+        ),
+    )
+    parser.add_argument(
+        "--kw-bench-limit",
+        type=int,
+        default=None,
+        help=(
+            "classify only: stop after this many tracks. Bounds a first backfill "
+            "pass; the next run resumes from the cache with no repeated work."
+        ),
+    )
     args = parser.parse_args()
+
+    if args.command == "classify":
+        summary = backfill_classifications(
+            load_snapshots(args.snapshot_dir),
+            store_path=args.kw_bench_store,
+            classified_at=datetime.now(UTC).isoformat(),
+            batch_size=args.kw_bench_batch_size,
+            limit=args.kw_bench_limit,
+        )
+        dashboard = rebuild_dashboard(
+            args.snapshot_dir,
+            args.dashboard_output,
+            registry_path=args.model_cards,
+            scores_path=args.benchmark_scores,
+            kw_bench_store_path=args.kw_bench_store,
+        )
+        report = dashboard["kw_bench"]["coverage"]
+        print(
+            f"Derived {summary['tracks_derived']} canonical tracks against KW-Bench "
+            f"{summary['kw_bench_version']} (extractor: {summary['extractor']})"
+        )
+        print(
+            f"  classified {summary['classified']}, reused {summary['reused_from_cache']} "
+            f"from cache, {summary['superseded']} superseded"
+        )
+        for level, count in report["level_counts"].items():
+            print(f"  {level:14s} {count}")
+        rate = report["classified_rate"]
+        print(
+            "  coverage      "
+            + (f"{rate:.1%} of tracks carry a level" if rate is not None else "no tracks yet")
+        )
+        if report["awaiting_human_review"]:
+            print(
+                f"  {report['awaiting_human_review']} record(s) await human review "
+                "and are withheld from published counts"
+            )
+        return
 
     if args.command in {"rebuild", "backfill"}:
         data = rebuild_dashboard(
@@ -140,6 +219,7 @@ def main() -> None:
             args.dashboard_output,
             registry_path=args.model_cards,
             scores_path=args.benchmark_scores,
+            kw_bench_store_path=args.kw_bench_store,
         )
         action = "Backfilled" if args.command == "backfill" else "Rebuilt"
         print(f"{action} {args.dashboard_output} from {data['snapshot_count']} daily snapshots")
@@ -204,6 +284,7 @@ def main() -> None:
             args.dashboard_output,
             registry_path=args.model_cards,
             scores_path=args.benchmark_scores,
+            kw_bench_store_path=args.kw_bench_store,
         )
         print(
             f"Simulated {len(written)} historical snapshots with coverage "
@@ -219,6 +300,7 @@ def main() -> None:
             args.dashboard_output,
             registry_path=args.model_cards,
             scores_path=args.benchmark_scores,
+            kw_bench_store_path=args.kw_bench_store,
         )
         print(
             f"Rescored {summary['snapshots']} snapshots against taxonomy "
@@ -244,6 +326,7 @@ def main() -> None:
             args.dashboard_output,
             registry_path=args.model_cards,
             scores_path=args.benchmark_scores,
+            kw_bench_store_path=args.kw_bench_store,
         )
         print(
             f"Migrated {len(snapshots)} snapshots to schema {dashboard['schema_version']} "
@@ -351,6 +434,7 @@ def main() -> None:
         args.dashboard_output,
         registry_path=args.model_cards,
         scores_path=args.benchmark_scores,
+        kw_bench_store_path=args.kw_bench_store,
     )
     print(
         f"Wrote {len(run.items)} items, snapshot {snapshot_path}, and dashboard data "

--- a/src/benchmark_radar/kw_bench.py
+++ b/src/benchmark_radar/kw_bench.py
@@ -1,0 +1,604 @@
+"""KW-Bench capability classification: canonical tracks assigned L0-L5.
+
+This is a different question from the one `rubric.py` answers.  `rubric.py`
+scores *whether a reader should open a record today* (relevance, evidence,
+recency, adoption).  This module scores *what capability an agent must
+demonstrate to pass a benchmark*, on the six-level KW-Bench scale.  The two
+never mix: a high-priority record can be unclassified, and an L4 track can
+score poorly on the daily radar because nobody has starred it yet.
+
+Three properties drive the design, all of them from issue #153.
+
+**The unit is a track, not an observation.**  The corpus sees the same
+benchmark dozens of times across snapshots and sources.  Classifying
+observations would count one benchmark once per sighting, which is the
+duplicate-counting bug the issue exists to prevent.  Classification is keyed by
+canonical artifact ID (from `corpus.artifact_alias_map`) plus a track ID,
+because a mixed suite legitimately produces several levels: a suite of
+retrieval questions and executable tasks reports an L0 track and an L2 track
+rather than one averaged label.
+
+**Levels are assigned deterministically, never by a model.**  A model may
+*extract* the six evidence fields from a paper or README, but the mapping from
+evidence to level is the pure function `assign_level` below, applying the
+rubric's own L5-down-to-L0 test order.  This keeps the decision auditable and
+reproducible: the same evidence always yields the same level, and a level can
+always be explained by naming the boundary that produced it.  Title keywords
+are deliberately not consulted.  A benchmark called "AgenticBench" earns L2
+from its verifier checking environment state, not from its name.
+
+**Missing evidence is `unclassified`, never a guess.**  The rubric requires
+this and the dashboard shows it as its own bar.  An honest large unclassified
+count is the correct output for a corpus whose sources mostly do not document
+their verifiers; quietly defaulting those to L1 would manufacture a capability
+distribution that no evidence supports.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Any
+
+# Tracks the `KW-BENCH VERSION` field on the rubric's own task card.  Stored on
+# every record so a later rubric revision cannot retroactively relabel history:
+# the rubric's versioning section requires a minor bump for any level-boundary
+# change, and trends must never compare levels across versions.
+KW_BENCH_VERSION = "0.1"
+CLASSIFICATION_SCHEMA_VERSION = 1
+
+UNCLASSIFIED = "Unclassified"
+LEVELS = ("L0", "L1", "L2", "L3", "L4", "L5")
+# Chart bar order.  Unclassified sits last so the capability levels read left
+# to right as a scale rather than being interrupted by the absent bucket.
+CHART_LEVELS = (*LEVELS, UNCLASSIFIED)
+
+LEVEL_NAMES: dict[str, str] = {
+    "L0": "Retrieval",
+    "L1": "Closed-form reasoning",
+    "L2": "Execution",
+    "L3": "Replication",
+    "L4": "Rediscovery",
+    "L5": "Frontier advancement",
+}
+
+LEVEL_REQUIREMENTS: dict[str, str] = {
+    "L0": "Locate and return existing information from supplied or accessible sources.",
+    "L1": (
+        "Derive a checkable answer from supplied or read-only retrieved information "
+        "without changing external state."
+    ),
+    "L2": "Take actions in an environment to reach a specified, verifiable end state.",
+    "L3": (
+        "Reproduce a known artifact, workflow, experiment, or result under controlled conditions."
+    ),
+    "L4": (
+        "Identify and validate an undisclosed problem, phenomenon, relationship, or "
+        "mechanism in an open-ended environment; the evaluator already knows the finding."
+    ),
+    "L5": (
+        "Produce a result absent from the declared prior-art scope at the start of the "
+        "evaluation run and validate it through new external evidence."
+    ),
+}
+
+# The six fields every assignment ships with.  Order matches the rubric's task
+# card so a record reads the same way as a hand-written one.
+EVIDENCE_FIELDS: tuple[str, ...] = (
+    "scored_outcome",
+    "agent_visible_target",
+    "evaluator_knowledge",
+    "verifier_modality",
+    "verifier_procedure",
+)
+# `level_rationale` is the sixth card field but is *produced* by classification
+# rather than supplied to it, so it is not required as an input.
+
+# L5 ships with eight fields; these two are the additions.
+L5_REQUIRED_FIELDS: tuple[str, ...] = ("evaluation_cutoff", "novelty_check")
+
+VERIFIER_MODALITIES: tuple[str, ...] = (
+    "exact",
+    "executable",
+    "simulation",
+    "model judge",
+    "human expert",
+    "hybrid",
+)
+
+# Orthogonal axes.  The rubric is explicit that none of these set the level;
+# they are recorded as tags so that "long-horizon" or "multi-agent" cannot leak
+# into the capability reading.
+TAG_AXES: tuple[str, ...] = (
+    "horizon",
+    "state",
+    "interaction",
+    "evaluation",
+    "risk",
+    "resources",
+)
+
+# Review status.  L5 is never auto-published, so the gate is structural rather
+# than a policy someone has to remember at publish time.
+REVIEW_AUTO = "auto"
+REVIEW_REQUIRED = "human_review_required"
+REVIEW_APPROVED = "human_approved"
+
+# Levels that may be published straight from an automated classification.  L4
+# and L5 both rest on claims about what the *evaluator* knew, which no
+# automated extractor can establish on its own.
+AUTO_PUBLISHABLE_LEVELS = frozenset({"L0", "L1", "L2", "L3"})
+
+
+class KwBenchError(ValueError):
+    """Raised when a track record or classification violates the schema."""
+
+
+def _clean(value: Any) -> str:
+    """Normalize a supplied evidence field to a comparable string.
+
+    Absent, null, and whitespace-only values collapse to the empty string so
+    that "the extractor returned a blank" and "the extractor returned nothing"
+    take the same path: both are missing evidence.
+    """
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _has(evidence: dict[str, Any], field: str) -> bool:
+    return bool(_clean(evidence.get(field)))
+
+
+def missing_evidence_fields(evidence: dict[str, Any], *, level: str | None = None) -> list[str]:
+    """Return the required card fields this evidence does not supply.
+
+    `level` extends the requirement set for L5, which the rubric says ships
+    with eight fields rather than six.  An L5 assignment missing either the
+    evaluation cutoff or the novelty check is unclassified, not a weaker L5.
+    """
+    missing = [field for field in EVIDENCE_FIELDS if not _has(evidence, field)]
+    if level == "L5":
+        missing.extend(field for field in L5_REQUIRED_FIELDS if not _has(evidence, field))
+    return missing
+
+
+def track_id(canonical_artifact_id: str, track_name: str) -> str:
+    """A stable ID for one scored track of one canonical artifact.
+
+    Derived from content rather than assigned sequentially: a backfill that
+    reruns, or two machines classifying the same corpus, must produce identical
+    IDs or the cache and the historical record silently fork.
+    """
+    name = re.sub(r"\s+", " ", str(track_name)).strip().casefold()
+    digest = hashlib.sha256(f"{canonical_artifact_id}\x00{name}".encode()).hexdigest()[:16]
+    return f"track:{digest}"
+
+
+def evidence_hash(evidence: dict[str, Any]) -> str:
+    """Fingerprint the evidence that produced a level.
+
+    Two purposes.  It is the cache key that makes the backfill idempotent
+    (unchanged evidence needs no new extraction call), and it binds a stored
+    level to the exact evidence text behind it, so an edited field cannot keep
+    an old level attached to new evidence.
+    """
+    payload = {
+        field: _clean(evidence.get(field)) for field in (*EVIDENCE_FIELDS, *L5_REQUIRED_FIELDS)
+    }
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return f"sha256:{hashlib.sha256(canonical.encode()).hexdigest()[:16]}"
+
+
+# Signals for the boundary tests.  These read the *evidence fields*, which
+# describe the scored outcome and the verifier, never the artifact title.  A
+# regex over a paper title is exactly the keyword inference the issue forbids.
+_STATE_CHANGE = re.compile(
+    r"\b(?:end state|final state|environment state|state of the (?:repo|repository|environment|"
+    r"database|system)|resulting (?:repo|repository|file|files|database)|side effects?|"
+    r"applies? a patch|patch is applied|writes? to|modif(?:y|ies|ied)|mutat(?:e|es|ed)|"
+    r"commits?|deploys?|executes? the (?:action|command)s?)\b",
+    re.IGNORECASE,
+)
+_READ_ONLY = re.compile(
+    r"\b(?:read[- ]only|without (?:modifying|changing|writing)|no (?:state|side) "
+    r"(?:change|effects?)|does not (?:modify|change|write))\b",
+    re.IGNORECASE,
+)
+_DERIVED_ANSWER = re.compile(
+    r"\b(?:deriv(?:e|es|ed|ation)|infer(?:s|red|ence)?|comput(?:e|es|ed)|calculat(?:e|es|ed)|"
+    r"reason(?:s|ing|ed)?|synthesi[sz](?:e|es|ed|ing)|combin(?:e|es|ed)|aggregat(?:e|es|ed)|"
+    r"prov(?:e|es|ed)|solv(?:e|es|ed))\b",
+    re.IGNORECASE,
+)
+_VERBATIM_LOOKUP = re.compile(
+    r"\b(?:copied|verbatim|extract(?:s|ed)? the (?:span|passage|value|answer)|"
+    r"quoted|looked? up|locate(?:s|d)? (?:and returns?|the passage)|span from the "
+    r"(?:document|source|context)|retriev(?:e|es|ed) the (?:passage|document|record))\b",
+    re.IGNORECASE,
+)
+_REPLICATION_TARGET = re.compile(
+    r"\b(?:reproduc(?:e|es|ed|ing|tion|ibility)|replicat(?:e|es|ed|ing|ion)|"
+    r"re-?implement(?:s|ed|ation)?|match(?:es|ing)? the (?:published|reported|reference|original)|"
+    r"known (?:result|artifact|protocol|experiment)|reference implementation)\b",
+    re.IGNORECASE,
+)
+_TARGET_DISCLOSED = re.compile(
+    r"\b(?:is (?:given|provided|supplied|told|disclosed|named)|receives? the|"
+    r"specif(?:y|ies|ied)|states? the (?:question|target|goal)|the (?:target|goal|paper|result) "
+    r"is (?:named|identified|provided))\b",
+    re.IGNORECASE,
+)
+# The rubric draws this line sharply: "A task that states the question and
+# withholds only the answer remains L1, L2, or L3 according to its scored
+# outcome."  Withholding an answer is what every benchmark does.  L4 requires
+# the *investigation target* to be undisclosed, so these patterns name the
+# thing withheld and deliberately exclude "answer", "solution", and "label".
+_TARGET_WITHHELD = re.compile(
+    r"\b(?:undisclosed|withheld|hidden|unnamed|not (?:named|disclosed|revealed|specified))\s+"
+    r"(?:\w+\s+){0,2}?(?:target|problem|bug|defect|finding|phenomenon|relationship|mechanism|"
+    r"failure|vulnerability|question|task)\b"
+    r"|\b(?:target|problem|bug|defect|finding|phenomenon|relationship|mechanism|failure|"
+    r"vulnerability)\s+(?:\w+\s+){0,3}?is (?:undisclosed|withheld|hidden|not (?:named|disclosed|"
+    r"revealed|given|provided|specified))\b"
+    r"|\bopen[- ]ended\b"
+    r"|\bmust (?:choose|decide|determine) what to (?:investigate|examine|study|look for)\b"
+    r"|\bwithout (?:naming|being told|being given|specifying|disclosing) (?:the |which |what )?"
+    r"(?:target|problem|bug|defect|finding|phenomenon|relationship|mechanism|failure|"
+    r"vulnerability|where|to look)\b",
+    re.IGNORECASE,
+)
+_EVALUATOR_KNOWS = re.compile(
+    r"\b(?:evaluator|grader|benchmark authors?|maintainers?) (?:already )?"
+    r"(?:knows?|knew|holds?|held|has|have|recorded)\b"
+    r"|\b(?:known|recorded|ground[- ]truth|held[- ]out) (?:finding|bug|answer|relationship|"
+    r"mechanism|result)\b",
+    re.IGNORECASE,
+)
+_PROSPECTIVE_VALIDATION = re.compile(
+    r"\b(?:new experiment|prospective(?:ly)? validat(?:e|es|ed|ion)|independent reproduction|"
+    r"deployment outcome|expert adjudication|validated after|post[- ]hoc validation|"
+    r"external validation)\b",
+    re.IGNORECASE,
+)
+
+
+def _signal(evidence: dict[str, Any], *fields: str) -> str:
+    """Join the named evidence fields into one searchable blob."""
+    return " \n".join(_clean(evidence.get(field)) for field in fields)
+
+
+def assign_level(evidence: dict[str, Any]) -> dict[str, Any]:
+    """Apply the KW decision rules from L5 down to L0.
+
+    Pure and deterministic: the same evidence always yields the same level and
+    the same rationale.  Returns the level, the boundary that produced it, and
+    every field that was missing, so an `Unclassified` result explains itself
+    rather than merely being absent.
+
+    The test order matters and is the rubric's own.  Discovery status takes
+    precedence over output form, so an open-ended read-only bug hunt must be
+    tested for L4 *before* the read-only check would otherwise settle it at L1.
+    """
+    missing = missing_evidence_fields(evidence)
+    if missing:
+        return _unclassified(
+            reason=("Required KW-Bench evidence fields are missing: " + ", ".join(missing) + "."),
+            missing=missing,
+        )
+
+    outcome = _signal(evidence, "scored_outcome", "verifier_procedure")
+    target = _signal(evidence, "agent_visible_target")
+    knowledge = _signal(evidence, "evaluator_knowledge")
+    everything = _signal(evidence, *EVIDENCE_FIELDS)
+
+    # --- L5: the result is created prospectively -------------------------
+    # Tested first, and gated hardest.  L5 requires an open frontier, a result
+    # judged as created during the run, and validation by new external
+    # evidence, plus the two extra card fields.  A missing cutoff or novelty
+    # check makes the assignment unclassified rather than a demotion to L4:
+    # without a cutoff there is no basis to claim the result was unknown.
+    if _PROSPECTIVE_VALIDATION.search(everything) and _TARGET_WITHHELD.search(target or everything):
+        l5_missing = missing_evidence_fields(evidence, level="L5")
+        if l5_missing:
+            return _unclassified(
+                reason=(
+                    "Evidence describes prospective validation of a novel result, but an "
+                    "L5 assignment requires "
+                    + " and ".join(L5_REQUIRED_FIELDS)
+                    + "; missing: "
+                    + ", ".join(l5_missing)
+                    + "."
+                ),
+                missing=l5_missing,
+            )
+        # A prior-art check that finds the result before the run caps this at
+        # L4.  The rubric states this as an explicit ceiling.
+        if _EVALUATOR_KNOWS.search(knowledge):
+            return _level(
+                "L4",
+                boundary="L4 to L5",
+                rationale=(
+                    "Prior art known to the evaluator before the run establishes an L4 "
+                    "ceiling despite prospective validation evidence."
+                ),
+            )
+        return _level(
+            "L5",
+            boundary="L4 to L5",
+            rationale=(
+                "The scored result is absent from the declared prior-art scope at the run "
+                "cutoff and is validated by new external evidence."
+            ),
+        )
+
+    # --- L4: the target finding is hidden --------------------------------
+    # Requires both halves: the agent is not told what to find, and the
+    # evaluator already knows it.  A task that states the question and
+    # withholds only the answer is not L4; that is every ordinary benchmark,
+    # and it stays at L1/L2/L3 by its scored outcome.
+    if _TARGET_WITHHELD.search(target) and _EVALUATOR_KNOWS.search(knowledge):
+        return _level(
+            "L4",
+            boundary="L3 to L4",
+            rationale=(
+                "The environment is open-ended and the target finding is undisclosed to the "
+                "agent while already known to the evaluator."
+            ),
+        )
+
+    # --- L3: the task reproduces a known target --------------------------
+    if _REPLICATION_TARGET.search(outcome) or (
+        _REPLICATION_TARGET.search(everything) and _TARGET_DISCLOSED.search(target)
+    ):
+        return _level(
+            "L3",
+            boundary="L2 to L3",
+            rationale=(
+                "The agent is given a known target artifact or result and scored on "
+                "reproducing it under the verifier's equivalence criteria."
+            ),
+        )
+
+    # --- L2: external state determines success ---------------------------
+    # Read-only use of a shell, browser, or database stays at L1 when the
+    # verifier checks only the returned answer, so an explicit read-only
+    # statement in the scored outcome overrides an incidental state-change
+    # verb elsewhere in the record.
+    if _STATE_CHANGE.search(outcome) and not _READ_ONLY.search(outcome):
+        return _level(
+            "L2",
+            boundary="L1 to L2",
+            rationale=(
+                "The verifier scores an action outcome or an environment state the agent "
+                "changed, not only a returned answer."
+            ),
+        )
+
+    # --- L1 vs L0: the answer is derived ---------------------------------
+    # Order matters: a task that retrieves *and then* reasons is L1, so a
+    # derivation signal wins over a lookup signal when both appear.
+    if _DERIVED_ANSWER.search(outcome):
+        return _level(
+            "L1",
+            boundary="L0 to L1",
+            rationale=(
+                "The scored answer is derived by transforming, combining, or inferring from "
+                "the available information rather than copied from a source."
+            ),
+        )
+    if _VERBATIM_LOOKUP.search(outcome):
+        return _level(
+            "L0",
+            boundary="L0 to L1",
+            rationale=(
+                "The scored answer is information already present in a supplied or "
+                "retrieved source and is returned without derivation."
+            ),
+        )
+
+    # Every field was supplied but none of the boundaries fired.  This is a
+    # real outcome, not a bug: the evidence is present but too vague to locate
+    # the capability frontier, and guessing a level from vague text is the
+    # failure mode the rubric's unclassified state exists to prevent.
+    return _unclassified(
+        reason=(
+            "Evidence is present but does not establish any KW-Bench boundary: the scored "
+            "outcome does not identify retrieval, derivation, state change, replication, or "
+            "discovery."
+        ),
+        missing=[],
+    )
+
+
+def _level(level: str, *, boundary: str, rationale: str) -> dict[str, Any]:
+    return {
+        "level": level,
+        "level_name": LEVEL_NAMES[level],
+        "boundary": boundary,
+        "level_rationale": rationale,
+        "missing_evidence": [],
+    }
+
+
+def _unclassified(*, reason: str, missing: list[str]) -> dict[str, Any]:
+    return {
+        "level": UNCLASSIFIED,
+        "level_name": UNCLASSIFIED,
+        "boundary": None,
+        "level_rationale": reason,
+        "missing_evidence": list(missing),
+    }
+
+
+def review_status_for(level: str) -> str:
+    """L5 is never auto-published; L4 needs a human to confirm the gate.
+
+    Structural rather than procedural.  The publish step reads this field, so
+    an L5 record cannot reach the chart because someone forgot a checklist.
+    """
+    if level == UNCLASSIFIED:
+        return REVIEW_AUTO
+    return REVIEW_AUTO if level in AUTO_PUBLISHABLE_LEVELS else REVIEW_REQUIRED
+
+
+def classify_track(
+    track: dict[str, Any],
+    *,
+    classified_at: str,
+    classified_by: str = "kw-bench-deterministic",
+) -> dict[str, Any]:
+    """Turn one canonical track record into an auditable classification row.
+
+    The returned row is what lands in the versioned JSONL layer.  It carries
+    the rubric version, the evidence hash, the level, the boundary, and the
+    review status, so a published level can always be traced back to the
+    evidence and the rubric revision that produced it.
+    """
+    for field in ("canonical_artifact_id", "track_name"):
+        if not _clean(track.get(field)):
+            raise KwBenchError(f"track record requires a non-empty {field}")
+
+    evidence = dict(track.get("evidence") or {})
+    modality = _clean(evidence.get("verifier_modality")).casefold()
+    if modality and modality not in VERIFIER_MODALITIES:
+        raise KwBenchError(
+            f"verifier_modality {modality!r} is not one of {', '.join(VERIFIER_MODALITIES)}"
+        )
+
+    canonical_id = _clean(track["canonical_artifact_id"])
+    name = _clean(track["track_name"])
+    decision = assign_level(evidence)
+    return {
+        "schema_version": CLASSIFICATION_SCHEMA_VERSION,
+        "kw_bench_version": KW_BENCH_VERSION,
+        "canonical_artifact_id": canonical_id,
+        "track_id": track_id(canonical_id, name),
+        "track_name": name,
+        "title": _clean(track.get("title")) or name,
+        "url": _clean(track.get("url")),
+        "event_kind": _clean(track.get("event_kind")) or "released",
+        "level": decision["level"],
+        "level_name": decision["level_name"],
+        "boundary": decision["boundary"],
+        "level_rationale": decision["level_rationale"],
+        "missing_evidence": decision["missing_evidence"],
+        "evidence": {
+            field: _clean(evidence.get(field))
+            for field in (*EVIDENCE_FIELDS, *L5_REQUIRED_FIELDS)
+            if _has(evidence, field)
+        },
+        "evidence_hash": evidence_hash(evidence),
+        # Hashes of the fetched source text behind the evidence.  Empty until
+        # the extractor lands; the cache treats an empty list as "no sources
+        # recorded" and re-extracts rather than trusting a bare evidence hash.
+        "source_hashes": sorted(str(value) for value in (track.get("source_hashes") or [])),
+        "tags": {
+            axis: _clean(value)
+            for axis, value in (track.get("tags") or {}).items()
+            if axis in TAG_AXES and _clean(value)
+        },
+        "review_status": review_status_for(decision["level"]),
+        "classified_by": classified_by,
+        "classified_at": classified_at,
+        "extractor": _clean(track.get("extractor")) or "none",
+    }
+
+
+def is_publishable(record: dict[str, Any]) -> bool:
+    """Whether a classification may appear in published counts.
+
+    L5 requires explicit human approval.  L4 requires it too, because its
+    evidence gate is a claim about undisclosed-but-evaluator-known findings
+    that an automated extractor cannot establish.  Everything else publishes
+    once classified, including `Unclassified`, which is a visible outcome
+    rather than a hidden one.
+    """
+    if record.get("review_status") == REVIEW_APPROVED:
+        return True
+    return record.get("level") in AUTO_PUBLISHABLE_LEVELS or record.get("level") == UNCLASSIFIED
+
+
+def level_counts(records: list[dict[str, Any]], *, released_only: bool = False) -> dict[str, int]:
+    """Count published tracks per level for the chart.
+
+    Counts *tracks*, so a benchmark seen in thirty snapshots contributes once
+    and a mixed suite contributes once per classified track.  Every bar in
+    `CHART_LEVELS` is present even at zero, so an empty L4 reads as "none
+    found" rather than vanishing from the axis.
+    """
+    counts = dict.fromkeys(CHART_LEVELS, 0)
+    seen: set[str] = set()
+    for record in records:
+        if not is_publishable(record):
+            continue
+        if released_only and record.get("event_kind") != "released":
+            continue
+        identifier = str(record.get("track_id") or "")
+        if identifier in seen:
+            continue
+        seen.add(identifier)
+        level = str(record.get("level") or UNCLASSIFIED)
+        if level in counts:
+            counts[level] += 1
+    return counts
+
+
+def coverage(records: list[dict[str, Any]]) -> dict[str, Any]:
+    """Report how much of the corpus actually carries a level.
+
+    The issue asks for classification coverage to be reported rather than
+    implied.  A chart where 90% of tracks are unclassified is a usable chart
+    only if the reader is told that up front.
+    """
+    published = [record for record in records if is_publishable(record)]
+    counts = level_counts(published)
+    classified = sum(counts[level] for level in LEVELS)
+    total = classified + counts[UNCLASSIFIED]
+    pending = [record for record in records if record.get("review_status") == REVIEW_REQUIRED]
+    return {
+        "kw_bench_version": KW_BENCH_VERSION,
+        "track_count": total,
+        "classified_count": classified,
+        "unclassified_count": counts[UNCLASSIFIED],
+        "classified_rate": round(classified / total, 4) if total else None,
+        "awaiting_human_review": len(pending),
+        "level_counts": counts,
+    }
+
+
+def kw_bench_reference() -> dict[str, Any]:
+    """The published rubric definition, for the dashboard's information panel."""
+    return {
+        "kw_bench_version": KW_BENCH_VERSION,
+        "name": "KW-Bench Capability Rubric",
+        "purpose": (
+            "Classify the highest capability an agent must demonstrate to pass a benchmark."
+        ),
+        "source": "https://github.com/ktwu01/vendor-data-qc/blob/main/kw-bench-rubric.md",
+        "levels": [
+            {
+                "level": level,
+                "name": LEVEL_NAMES[level],
+                "requirement": LEVEL_REQUIREMENTS[level],
+            }
+            for level in LEVELS
+        ],
+        "evidence_fields": list(EVIDENCE_FIELDS),
+        "l5_additional_fields": list(L5_REQUIRED_FIELDS),
+        "limits": [
+            "Levels describe the capability a passing score requires. They are not a "
+            "quality, difficulty, or importance ranking: an L1 benchmark can be more "
+            "valuable than an L3 one.",
+            "Classification applies to canonical benchmark tracks. A mixed suite reports "
+            "one level per track rather than a suite-wide average.",
+            "Levels are assigned deterministically from recorded evidence fields. Title "
+            "keywords such as 'agentic' never set a level.",
+            "Missing required evidence produces Unclassified rather than a guess.",
+            "L4 and L5 are never auto-published: both rest on claims about evaluator "
+            "knowledge that require human review.",
+            "Time horizon, tool count, autonomy, and cost are recorded as tags and do not "
+            "affect the level.",
+        ],
+    }

--- a/src/benchmark_radar/kw_bench.py
+++ b/src/benchmark_radar/kw_bench.py
@@ -479,6 +479,14 @@ def assign_level(evidence: dict[str, Any]) -> dict[str, Any]:
                     "establishes an L4 ceiling despite prospective validation evidence."
                 ),
             )
+        if not _NO_PRIOR_ART.search(novelty):
+            return _unclassified(
+                reason=(
+                    "Evidence describes prospective validation, but the novelty check "
+                    "does not record whether the search found prior art."
+                ),
+                missing=["novelty_check"],
+            )
         return _level(
             "L5",
             boundary="L4 to L5",

--- a/src/benchmark_radar/kw_bench.py
+++ b/src/benchmark_radar/kw_bench.py
@@ -195,10 +195,26 @@ def evidence_hash(evidence: dict[str, Any]) -> str:
 # describe the scored outcome and the verifier, never the artifact title.  A
 # regex over a paper title is exactly the keyword inference the issue forbids.
 _STATE_CHANGE = re.compile(
-    r"\b(?:end state|final state|environment state|state of the (?:repo|repository|environment|"
-    r"database|system)|resulting (?:repo|repository|file|files|database)|side effects?|"
-    r"applies? a patch|patch is applied|writes? to|modif(?:y|ies|ied)|mutat(?:e|es|ed)|"
-    r"commits?|deploys?|executes? the (?:action|command)s?)\b",
+    # `(?:\w+\s+){0,2}state` lets a qualifier sit between the adjective and the
+    # noun: "final repository state" and "resulting database state" are the
+    # same claim as "final state", and requiring adjacency missed them.
+    r"\b(?:end|final|resulting|environment|environmental)\s+(?:\w+\s+){0,2}?state\b"
+    r"|\bstate of the (?:repo|repository|environment|database|system|workspace)\b"
+    r"|\bresulting (?:repo|repository|file|files|database)\b"
+    r"|\b(?:side effects?|applies? a patch|patch is applied|writes? to|"
+    r"modif(?:y|ies|ied)|mutat(?:e|es|ed)|commits?|deploys?)\b",
+    re.IGNORECASE,
+)
+# An explicit statement that only the returned answer is scored. The rubric
+# makes this decisive: read-only use of a shell, browser, or database preserves
+# L1 when the verifier checks only the returned answer, however much tool
+# activity happened along the way.
+_ANSWER_ONLY = re.compile(
+    r"\b(?:only the (?:returned |submitted |final )?(?:answer|response|output|report|"
+    r"explanation|label|prediction)|the (?:returned|submitted|final) "
+    r"(?:answer|response|output|report|explanation|label|prediction) is "
+    r"(?:compared|scored|checked|graded|matched)|scored? only on the "
+    r"(?:answer|response|output))\b",
     re.IGNORECASE,
 )
 _READ_ONLY = re.compile(
@@ -209,7 +225,8 @@ _READ_ONLY = re.compile(
 _DERIVED_ANSWER = re.compile(
     r"\b(?:deriv(?:e|es|ed|ation)|infer(?:s|red|ence)?|comput(?:e|es|ed)|calculat(?:e|es|ed)|"
     r"reason(?:s|ing|ed)?|synthesi[sz](?:e|es|ed|ing)|combin(?:e|es|ed)|aggregat(?:e|es|ed)|"
-    r"prov(?:e|es|ed)|solv(?:e|es|ed))\b",
+    r"prov(?:e|es|ed)|solv(?:e|es|ed)|compar(?:e|es|ed)|rank(?:s|ed)?|classif(?:y|ies|ied)|"
+    r"summari[sz](?:e|es|ed)|translat(?:e|es|ed)|diagnos(?:e|es|ed|is))\b",
     re.IGNORECASE,
 )
 _VERBATIM_LOOKUP = re.compile(
@@ -242,11 +259,35 @@ _TARGET_WITHHELD = re.compile(
     r"|\b(?:target|problem|bug|defect|finding|phenomenon|relationship|mechanism|failure|"
     r"vulnerability)\s+(?:\w+\s+){0,3}?is (?:undisclosed|withheld|hidden|not (?:named|disclosed|"
     r"revealed|given|provided|specified))\b"
-    r"|\bopen[- ]ended\b"
+    # "open-ended" must qualify the *environment or investigation*, not any
+    # noun: "the open-ended question is stated in full" is an ordinary
+    # free-response benchmark, and treating it as a withheld target promoted
+    # every such suite to L4.
+    r"|\bopen[- ]ended (?:environment|setting|investigation|exploration|search|"
+    r"bug hunt|analysis|repository|codebase|dataset|world)\b"
+    # "no target is disclosed" / "no problem is named": the negative form of
+    # the same claim. Restricted to the investigation nouns so it cannot fire
+    # on "no answer is given", which is every benchmark.
+    r"|\bno (?:\w+\s+){0,2}?(?:target|problem|bug|defect|finding|phenomenon|relationship|"
+    r"mechanism|failure|vulnerability|hypothesis) is (?:disclosed|named|given|provided|"
+    r"specified|revealed|stated)\b"
     r"|\bmust (?:choose|decide|determine) what to (?:investigate|examine|study|look for)\b"
     r"|\bwithout (?:naming|being told|being given|specifying|disclosing) (?:the |which |what )?"
     r"(?:target|problem|bug|defect|finding|phenomenon|relationship|mechanism|failure|"
     r"vulnerability|where|to look)\b",
+    re.IGNORECASE,
+)
+# Negations that flip the meaning of a knowledge claim. Applied as a veto over
+# the whole field rather than inside the pattern: "the evaluator has no known
+# result" matches on `known result` several words away from the `no`, so a
+# lookahead anchored to the verb cannot see it. A field that says the evaluator
+# knows nothing must never read as the evaluator knowing something, since that
+# inversion caps a genuine L5 at L4.
+_NO_EVALUATOR_KNOWLEDGE = re.compile(
+    r"\b(?:no|not|never|nothing|none)\s+(?:\w+\s+){0,3}?"
+    r"(?:known|knows?|knew|recorded|documented|identified|result|finding|prior art)\b"
+    r"|\b(?:is|was|are|were)\s+(?:not|un)known\b"
+    r"|\bunknown (?:to|at|before) the\b",
     re.IGNORECASE,
 )
 _EVALUATOR_KNOWS = re.compile(
@@ -254,6 +295,33 @@ _EVALUATOR_KNOWS = re.compile(
     r"(?:knows?|knew|holds?|held|has|have|recorded)\b"
     r"|\b(?:known|recorded|ground[- ]truth|held[- ]out) (?:finding|bug|answer|relationship|"
     r"mechanism|result)\b",
+    re.IGNORECASE,
+)
+
+
+def _evaluator_knows(text: str) -> bool:
+    """Whether the evaluator is stated to already hold the target finding."""
+    if _NO_EVALUATOR_KNOWLEDGE.search(text):
+        return False
+    return bool(_EVALUATOR_KNOWS.search(text))
+
+
+# A novelty check whose own text reports that the result already exists.  The
+# rubric makes a prior-art hit an L4 ceiling regardless of how the run was
+# framed, so this is read from the novelty check rather than inferred.
+_PRIOR_ART_FOUND = re.compile(
+    r"\b(?:already (?:published|known|reported|documented|exists?)|"
+    r"prior (?:art|work|result)s? (?:was |were |is |are )?(?:found|identified|located)|"
+    r"(?:result|finding) (?:was |is )?(?:previously |already )?(?:published|reported|known)|"
+    r"published in \d{4}|predates the (?:run|evaluation))\b",
+    re.IGNORECASE,
+)
+# A novelty check or cutoff that admits it was not actually performed.  The
+# rubric requires these fields to carry real content for L5; a placeholder is
+# a missing field wearing a value, so it produces `Unclassified`.
+_NOT_PERFORMED = re.compile(
+    r"^\s*(?:n/?a|none|unknown|tbd|todo|pending|not (?:performed|done|applicable|recorded|"
+    r"specified|available|stated)|no (?:check|search|cutoff))\s*\.?\s*$",
     re.IGNORECASE,
 )
 _PROSPECTIVE_VALIDATION = re.compile(
@@ -288,10 +356,22 @@ def assign_level(evidence: dict[str, Any]) -> dict[str, Any]:
             missing=missing,
         )
 
-    outcome = _signal(evidence, "scored_outcome", "verifier_procedure")
+    # `scored_outcome` describes what the *agent* must achieve; the verifier
+    # fields describe how the evaluator checks it.  These must not be merged
+    # for the agent-side tests.  A verifier that "reproduces the failure" or
+    # "executes the commands" describes evaluator machinery, and reading it as
+    # agent behaviour promoted ordinary execution tasks to L3 and read-only
+    # diagnosis to L2.
+    outcome = _signal(evidence, "scored_outcome")
+    procedure = _signal(evidence, "verifier_procedure")
     target = _signal(evidence, "agent_visible_target")
     knowledge = _signal(evidence, "evaluator_knowledge")
+    novelty = _signal(evidence, "novelty_check")
     everything = _signal(evidence, *EVIDENCE_FIELDS)
+    # The verifier may state the scoring boundary ("only the returned answer is
+    # compared") even when the outcome text does not, so this one signal is
+    # read across both.
+    answer_only = _ANSWER_ONLY.search(outcome) or _ANSWER_ONLY.search(procedure)
 
     # --- L5: the result is created prospectively -------------------------
     # Tested first, and gated hardest.  L5 requires an open frontier, a result
@@ -301,27 +381,37 @@ def assign_level(evidence: dict[str, Any]) -> dict[str, Any]:
     # without a cutoff there is no basis to claim the result was unknown.
     if _PROSPECTIVE_VALIDATION.search(everything) and _TARGET_WITHHELD.search(target or everything):
         l5_missing = missing_evidence_fields(evidence, level="L5")
+        # A field that says "unknown", "n/a", or "not performed" is a missing
+        # field with a value in it.  Accepting it would let a placeholder
+        # satisfy the rubric's hardest gate.
+        l5_missing.extend(
+            field
+            for field in L5_REQUIRED_FIELDS
+            if field not in l5_missing and _NOT_PERFORMED.match(_clean(evidence.get(field)))
+        )
         if l5_missing:
             return _unclassified(
                 reason=(
                     "Evidence describes prospective validation of a novel result, but an "
-                    "L5 assignment requires "
+                    "L5 assignment requires a recorded "
                     + " and ".join(L5_REQUIRED_FIELDS)
-                    + "; missing: "
-                    + ", ".join(l5_missing)
+                    + "; missing or not performed: "
+                    + ", ".join(sorted(set(l5_missing)))
                     + "."
                 ),
-                missing=l5_missing,
+                missing=sorted(set(l5_missing)),
             )
         # A prior-art check that finds the result before the run caps this at
-        # L4.  The rubric states this as an explicit ceiling.
-        if _EVALUATOR_KNOWS.search(knowledge):
+        # L4.  The rubric states this as an explicit ceiling, and it applies
+        # whether the prior art surfaced in the novelty check or in what the
+        # evaluator already knew.
+        if _PRIOR_ART_FOUND.search(novelty) or _evaluator_knows(knowledge):
             return _level(
                 "L4",
                 boundary="L4 to L5",
                 rationale=(
-                    "Prior art known to the evaluator before the run establishes an L4 "
-                    "ceiling despite prospective validation evidence."
+                    "A prior-art or provenance check found the result before the run, which "
+                    "establishes an L4 ceiling despite prospective validation evidence."
                 ),
             )
         return _level(
@@ -338,7 +428,7 @@ def assign_level(evidence: dict[str, Any]) -> dict[str, Any]:
     # evaluator already knows it.  A task that states the question and
     # withholds only the answer is not L4; that is every ordinary benchmark,
     # and it stays at L1/L2/L3 by its scored outcome.
-    if _TARGET_WITHHELD.search(target) and _EVALUATOR_KNOWS.search(knowledge):
+    if _TARGET_WITHHELD.search(target) and _evaluator_knows(knowledge):
         return _level(
             "L4",
             boundary="L3 to L4",
@@ -349,8 +439,12 @@ def assign_level(evidence: dict[str, Any]) -> dict[str, Any]:
         )
 
     # --- L3: the task reproduces a known target --------------------------
+    # Read from the agent-side outcome and the disclosed target only.  A
+    # verifier that "reproduces the failure" is describing its own machinery,
+    # not a replication task, and reading it as one turned ordinary patch-and-
+    # test benchmarks into L3.
     if _REPLICATION_TARGET.search(outcome) or (
-        _REPLICATION_TARGET.search(everything) and _TARGET_DISCLOSED.search(target)
+        _REPLICATION_TARGET.search(target) and _TARGET_DISCLOSED.search(target)
     ):
         return _level(
             "L3",
@@ -363,10 +457,12 @@ def assign_level(evidence: dict[str, Any]) -> dict[str, Any]:
 
     # --- L2: external state determines success ---------------------------
     # Read-only use of a shell, browser, or database stays at L1 when the
-    # verifier checks only the returned answer, so an explicit read-only
-    # statement in the scored outcome overrides an incidental state-change
-    # verb elsewhere in the record.
-    if _STATE_CHANGE.search(outcome) and not _READ_ONLY.search(outcome):
+    # verifier checks only the returned answer.  Both escapes are honoured: an
+    # explicit read-only statement, and an explicit statement that only the
+    # answer is scored.  The state-change signal is read from the agent-side
+    # outcome, so a verifier that runs commands to grade a returned answer
+    # cannot by itself make a task L2.
+    if _STATE_CHANGE.search(outcome) and not _READ_ONLY.search(outcome) and not answer_only:
         return _level(
             "L2",
             boundary="L1 to L2",
@@ -378,7 +474,10 @@ def assign_level(evidence: dict[str, Any]) -> dict[str, Any]:
 
     # --- L1 vs L0: the answer is derived ---------------------------------
     # Order matters: a task that retrieves *and then* reasons is L1, so a
-    # derivation signal wins over a lookup signal when both appear.
+    # derivation signal wins over a lookup signal when both appear.  Read from
+    # the agent-side outcome only: "the evaluator computes exact-match
+    # accuracy" describes scoring arithmetic, not agent derivation, and
+    # counting it turned copy-the-span retrieval into L1.
     if _DERIVED_ANSWER.search(outcome):
         return _level(
             "L1",

--- a/src/benchmark_radar/kw_bench.py
+++ b/src/benchmark_radar/kw_bench.py
@@ -352,7 +352,12 @@ _PRIOR_ART_FOUND = re.compile(
 _NO_PRIOR_ART = re.compile(
     r"\bno (?:prior art|prior (?:work|result)s?|matching result|earlier (?:result|report))\b"
     r"|\b(?:found|returned|surfaced) nothing\b"
-    r"|\bnothing (?:was )?found\b",
+    r"|\bnothing (?:was )?found\b"
+    r"|\b(?:search|review|check|we|it) (?:did not|didn't) "
+    r"(?:find|identify|locate|surface|return) (?:any )?"
+    r"(?:prior art|prior (?:work|result)s?|matching results?)\b"
+    r"|\b(?:search|review|check) (?:found|identified|located|surfaced|returned) "
+    r"(?:no|zero) (?:prior art|prior (?:work|result)s?|matching results?)\b",
     re.IGNORECASE,
 )
 # A novelty check or cutoff that admits it was not actually performed.  The

--- a/src/benchmark_radar/kw_bench.py
+++ b/src/benchmark_radar/kw_bench.py
@@ -368,6 +368,12 @@ _NOT_PERFORMED = re.compile(
     r"specified|available|stated)|no (?:check|search|cutoff))\s*\.?\s*$",
     re.IGNORECASE,
 )
+_NOVELTY_CHECK_FAILED = re.compile(
+    r"\b(?:no (?:check|search) (?:was )?(?:performed|run|completed)|"
+    r"(?:check|search) (?:was )?not (?:performed|run|completed)|"
+    r"(?:check|search) could not be (?:performed|run|completed))\b",
+    re.IGNORECASE,
+)
 _PROSPECTIVE_VALIDATION = re.compile(
     r"\b(?:new experiment|prospective(?:ly)? validat(?:e|es|ed|ion)|independent reproduction|"
     r"deployment outcome|expert adjudication|validated after|post[- ]hoc validation|"
@@ -470,11 +476,19 @@ def assign_level(evidence: dict[str, Any]) -> dict[str, Any]:
                 ),
                 missing=sorted(set(l5_missing)),
             )
+        if _NOVELTY_CHECK_FAILED.search(novelty):
+            return _unclassified(
+                reason=(
+                    "Evidence describes prospective validation, but the novelty check "
+                    "records that its search was not performed."
+                ),
+                missing=["novelty_check"],
+            )
         # A prior-art check that finds the result before the run caps this at
         # L4.  The rubric states this as an explicit ceiling, and it applies
         # whether the prior art surfaced in the novelty check or in what the
         # evaluator already knew.
-        prior_art = _PRIOR_ART_FOUND.search(novelty) and not _NO_PRIOR_ART.search(novelty)
+        prior_art = _PRIOR_ART_FOUND.search(novelty)
         if prior_art or _evaluator_knows(knowledge):
             return _level(
                 "L4",

--- a/src/benchmark_radar/kw_bench.py
+++ b/src/benchmark_radar/kw_bench.py
@@ -195,26 +195,40 @@ def evidence_hash(evidence: dict[str, Any]) -> str:
 # describe the scored outcome and the verifier, never the artifact title.  A
 # regex over a paper title is exactly the keyword inference the issue forbids.
 _STATE_CHANGE = re.compile(
-    # `(?:\w+\s+){0,2}state` lets a qualifier sit between the adjective and the
-    # noun: "final repository state" and "resulting database state" are the
-    # same claim as "final state", and requiring adjacency missed them.
-    r"\b(?:end|final|resulting|environment|environmental)\s+(?:\w+\s+){0,2}?state\b"
+    # The qualifier between adjective and noun must name a *system* the agent
+    # can act on. An unrestricted `(?:\w+\s+){0,2}state` matched "final disease
+    # state", turning a clinical prediction task into an execution task: the
+    # word "state" carries no external-mutation claim on its own.
+    r"\b(?:end|final|resulting|target)\s+(?:\w+\s+){0,2}?"
+    r"(?:repo|repository|environment|database|system|workspace|file|filesystem|"
+    r"container|cluster|schema|branch)\s+state\b"
+    r"|\b(?:end|final|resulting|environment|environmental)\s+state\b"
     r"|\bstate of the (?:repo|repository|environment|database|system|workspace)\b"
     r"|\bresulting (?:repo|repository|file|files|database)\b"
     r"|\b(?:side effects?|applies? a patch|patch is applied|writes? to|"
-    r"modif(?:y|ies|ied)|mutat(?:e|es|ed)|commits?|deploys?)\b",
+    r"modif(?:y|ies|ied)|mutat(?:e|es|ed)|commits?|deploys?|"
+    r"migrat(?:e|es|ed|ion)|provisions?|installs?)\b",
     re.IGNORECASE,
 )
-# An explicit statement that only the returned answer is scored. The rubric
+# An explicit statement that *only* the returned answer is scored. The rubric
 # makes this decisive: read-only use of a shell, browser, or database preserves
 # L1 when the verifier checks only the returned answer, however much tool
 # activity happened along the way.
+#
+# This is an exclusivity claim, so a sentence that says "only the returned
+# report is parsed for metadata" while also checking repository state is not
+# one: `_ANSWER_ONLY_DEFEATED` withdraws the escape when the same text goes on
+# to score something else.
 _ANSWER_ONLY = re.compile(
     r"\b(?:only the (?:returned |submitted |final )?(?:answer|response|output|report|"
     r"explanation|label|prediction)|the (?:returned|submitted|final) "
     r"(?:answer|response|output|report|explanation|label|prediction) is "
     r"(?:compared|scored|checked|graded|matched)|scored? only on the "
     r"(?:answer|response|output))\b",
+    re.IGNORECASE,
+)
+_ANSWER_ONLY_DEFEATED = re.compile(
+    r"\b(?:also|additionally|as well as|in addition|and then)\b|;\s*tests?\b",
     re.IGNORECASE,
 )
 _READ_ONLY = re.compile(
@@ -268,8 +282,13 @@ _TARGET_WITHHELD = re.compile(
     # "no target is disclosed" / "no problem is named": the negative form of
     # the same claim. Restricted to the investigation nouns so it cannot fire
     # on "no answer is given", which is every benchmark.
-    r"|\bno (?:\w+\s+){0,2}?(?:target|problem|bug|defect|finding|phenomenon|relationship|"
-    r"mechanism|failure|vulnerability|hypothesis) is (?:disclosed|named|given|provided|"
+    # `hypothesis` is deliberately absent: "no alternative hypothesis is
+    # specified" is ordinary statistical-task boilerplate, not a hidden
+    # discovery target, and including it made significance-testing benchmarks
+    # L4. The intervening-word budget is 1 so "no alternative X" cannot reach
+    # past its own noun.
+    r"|\bno (?:\w+\s+)?(?:target|problem|bug|defect|finding|phenomenon|relationship|"
+    r"mechanism|failure|vulnerability) is (?:disclosed|named|given|provided|"
     r"specified|revealed|stated)\b"
     r"|\bmust (?:choose|decide|determine) what to (?:investigate|examine|study|look for)\b"
     r"|\bwithout (?:naming|being told|being given|specifying|disclosing) (?:the |which |what )?"
@@ -284,9 +303,16 @@ _TARGET_WITHHELD = re.compile(
 # knows nothing must never read as the evaluator knowing something, since that
 # inversion caps a genuine L5 at L4.
 _NO_EVALUATOR_KNOWLEDGE = re.compile(
-    r"\b(?:no|not|never|nothing|none)\s+(?:\w+\s+){0,3}?"
+    # `not only X but Y` is an intensifier, not a negation: "the known bug is
+    # not only recorded but covered by a test" asserts *more* evaluator
+    # knowledge, and reading it as less dropped a real L4 to L1. Excluded by
+    # requiring that `not` is not followed by `only`.
+    r"\b(?:no|never|nothing|none)\s+(?:\w+\s+){0,3}?"
     r"(?:known|knows?|knew|recorded|documented|identified|result|finding|prior art)\b"
+    r"|\bnot\s+(?!only\b)(?:\w+\s+){0,3}?"
+    r"(?:known|knows?|knew|recorded|documented|identified)\b"
     r"|\b(?:is|was|are|were)\s+(?:not|un)known\b"
+    r"|\b(?:unaware of|no knowledge of|did not know)\b"
     r"|\bunknown (?:to|at|before) the\b",
     re.IGNORECASE,
 )
@@ -310,10 +336,24 @@ def _evaluator_knows(text: str) -> bool:
 # rubric makes a prior-art hit an L4 ceiling regardless of how the run was
 # framed, so this is read from the novelty check rather than inferred.
 _PRIOR_ART_FOUND = re.compile(
-    r"\b(?:already (?:published|known|reported|documented|exists?)|"
-    r"prior (?:art|work|result)s? (?:was |were |is |are )?(?:found|identified|located)|"
-    r"(?:result|finding) (?:was |is )?(?:previously |already )?(?:published|reported|known)|"
-    r"published in \d{4}|predates the (?:run|evaluation))\b",
+    # A negated hit is the *expected* outcome of a novelty check, so "no prior
+    # art was found" must not read as prior art. `(?<!no )` and friends guard
+    # the find verbs; the search-completed phrasings are matched positively.
+    r"\b(?:already (?:published|known|reported|documented|exists?))\b"
+    r"|(?<!no )(?<!No )\bprior (?:art|work|result)s? (?:was |were |is |are )?"
+    r"(?:found|identified|located)\b"
+    r"|\b(?:result|finding) (?:was |is )?(?:previously |already )?"
+    r"(?:published|reported|known)\b"
+    r"|\bpublished in \d{4}\b"
+    r"|\bpredates the (?:run|evaluation)\b",
+    re.IGNORECASE,
+)
+# Explicit statements that a novelty check came back clean. Checked first, so a
+# clean result is never re-read as a prior-art hit by a later pattern.
+_NO_PRIOR_ART = re.compile(
+    r"\bno (?:prior art|prior (?:work|result)s?|matching result|earlier (?:result|report))\b"
+    r"|\b(?:found|returned|surfaced) nothing\b"
+    r"|\bnothing (?:was )?found\b",
     re.IGNORECASE,
 )
 # A novelty check or cutoff that admits it was not actually performed.  The
@@ -335,6 +375,24 @@ _PROSPECTIVE_VALIDATION = re.compile(
 def _signal(evidence: dict[str, Any], *fields: str) -> str:
     """Join the named evidence fields into one searchable blob."""
     return " \n".join(_clean(evidence.get(field)) for field in fields)
+
+
+# A trailing clause describing how the evaluator scores the result. Authors
+# routinely append one to `scored_outcome` ("...copied verbatim from the
+# document and later compared against the annotated span"), and its verbs are
+# the evaluator's, not the agent's. Counting "compared" there turned verbatim
+# retrieval into derivation.
+_EVALUATOR_CLAUSE = re.compile(
+    r"(?:,\s*|\s+)(?:and\s+)?(?:is\s+|are\s+)?(?:then\s+|later\s+|subsequently\s+|"
+    r"afterwards?\s+)(?:compared|scored|checked|graded|matched|evaluated|assessed)\b.*$"
+    r"|(?:,\s*|;\s*|\s+)(?:which|and)\s+the\s+(?:evaluator|grader|verifier|harness)\b.*$",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _agent_side(text: str) -> str:
+    """Drop a trailing evaluator-scoring clause from an agent-side field."""
+    return _EVALUATOR_CLAUSE.sub("", text).strip()
 
 
 def assign_level(evidence: dict[str, Any]) -> dict[str, Any]:
@@ -362,7 +420,7 @@ def assign_level(evidence: dict[str, Any]) -> dict[str, Any]:
     # "executes the commands" describes evaluator machinery, and reading it as
     # agent behaviour promoted ordinary execution tasks to L3 and read-only
     # diagnosis to L2.
-    outcome = _signal(evidence, "scored_outcome")
+    outcome = _agent_side(_signal(evidence, "scored_outcome"))
     procedure = _signal(evidence, "verifier_procedure")
     target = _signal(evidence, "agent_visible_target")
     knowledge = _signal(evidence, "evaluator_knowledge")
@@ -371,7 +429,14 @@ def assign_level(evidence: dict[str, Any]) -> dict[str, Any]:
     # The verifier may state the scoring boundary ("only the returned answer is
     # compared") even when the outcome text does not, so this one signal is
     # read across both.
-    answer_only = _ANSWER_ONLY.search(outcome) or _ANSWER_ONLY.search(procedure)
+    # An exclusivity claim is only an escape while it stays exclusive: "only
+    # the returned report is parsed for metadata; tests also inspect the final
+    # repository state" scores two things, and honouring the "only" there
+    # dropped a real execution task to L1.
+    answer_only = any(
+        _ANSWER_ONLY.search(field) and not _ANSWER_ONLY_DEFEATED.search(field)
+        for field in (outcome, procedure)
+    )
 
     # --- L5: the result is created prospectively -------------------------
     # Tested first, and gated hardest.  L5 requires an open frontier, a result
@@ -405,7 +470,8 @@ def assign_level(evidence: dict[str, Any]) -> dict[str, Any]:
         # L4.  The rubric states this as an explicit ceiling, and it applies
         # whether the prior art surfaced in the novelty check or in what the
         # evaluator already knew.
-        if _PRIOR_ART_FOUND.search(novelty) or _evaluator_knows(knowledge):
+        prior_art = _PRIOR_ART_FOUND.search(novelty) and not _NO_PRIOR_ART.search(novelty)
+        if prior_art or _evaluator_knows(knowledge):
             return _level(
                 "L4",
                 boundary="L4 to L5",
@@ -690,6 +756,12 @@ def kw_bench_reference() -> dict[str, Any]:
             "Levels describe the capability a passing score requires. They are not a "
             "quality, difficulty, or importance ranking: an L1 benchmark can be more "
             "valuable than an L3 one.",
+            "Boundary detection reads recorded evidence text with hand-written patterns, "
+            "which is approximate. Two rounds of adversarial review found 11 and then 7 "
+            "misclassifications, each fix trading one error class for another, so an "
+            "auto-assigned level is a triage hint rather than an audited fact. Levels are "
+            "reliable only after the human review the rollout requires; the "
+            "validation-set accuracy is not yet measured.",
             "Classification applies to canonical benchmark tracks. A mixed suite reports "
             "one level per track rather than a suite-wide average.",
             "Levels are assigned deterministically from recorded evidence fields. Title "

--- a/src/benchmark_radar/kw_bench.py
+++ b/src/benchmark_radar/kw_bench.py
@@ -202,7 +202,6 @@ _STATE_CHANGE = re.compile(
     r"\b(?:end|final|resulting|target)\s+(?:\w+\s+){0,2}?"
     r"(?:repo|repository|environment|database|system|workspace|file|filesystem|"
     r"container|cluster|schema|branch)\s+state\b"
-    r"|\b(?:end|final|resulting|environment|environmental)\s+state\b"
     r"|\bstate of the (?:repo|repository|environment|database|system|workspace)\b"
     r"|\bresulting (?:repo|repository|file|files|database)\b"
     r"|\b(?:side effects?|applies? a patch|patch is applied|writes? to|"

--- a/src/benchmark_radar/kw_bench_store.py
+++ b/src/benchmark_radar/kw_bench_store.py
@@ -34,6 +34,7 @@ import json
 import os
 import tempfile
 from collections.abc import Iterator
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -180,7 +181,23 @@ def is_stale(cached: dict[str, Any] | None, *, refresh_before: str | None) -> bo
     """
     if cached is None or not refresh_before:
         return False
-    return str(cached.get("classified_at") or "") < str(refresh_before)
+
+    def timestamp(value: Any, *, field: str) -> datetime:
+        try:
+            parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        except ValueError as error:
+            raise KwBenchError(f"{field} must be an ISO timestamp") from error
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=UTC)
+        return parsed.astimezone(UTC)
+
+    classified_at = cached.get("classified_at")
+    if not classified_at:
+        return True
+    return timestamp(classified_at, field="classified_at") < timestamp(
+        refresh_before,
+        field="refresh cutoff",
+    )
 
 
 def append_records(path: Path, records: list[dict[str, Any]]) -> int:

--- a/src/benchmark_radar/kw_bench_store.py
+++ b/src/benchmark_radar/kw_bench_store.py
@@ -1,0 +1,172 @@
+"""Versioned, append-only storage for KW-Bench classifications.
+
+The store is a JSONL file keyed by `(canonical_artifact_id, track_id)`.  JSONL
+rather than one JSON document because the backfill writes incrementally and can
+be interrupted: a partial JSONL file is a valid prefix of the finished one,
+while a partial JSON document is unparseable and loses the whole run.
+
+Two invariants carry the issue's acceptance criteria.
+
+**Idempotence through content hashing.**  A track is reclassified only when its
+evidence hash, its source hashes, or the rubric version changes.  Rerunning a
+completed backfill therefore performs zero extraction calls, which is the
+property that makes a daily run affordable once the model extractor lands.
+
+**Historical snapshots stay immutable.**  Superseding a record appends the new
+row and marks the old one, rather than editing in place.  A level that changed
+because the rubric changed must remain visible as a change, not be silently
+rewritten into having always been the new value.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from collections.abc import Iterable, Iterator
+from pathlib import Path
+from typing import Any
+
+from .kw_bench import KW_BENCH_VERSION, KwBenchError
+
+STORE_FILENAME = "kw_bench_classifications.jsonl"
+
+
+def record_key(record: dict[str, Any]) -> tuple[str, str]:
+    """The identity of a classification row."""
+    return (
+        str(record.get("canonical_artifact_id") or ""),
+        str(record.get("track_id") or ""),
+    )
+
+
+def _cache_signature(record: dict[str, Any]) -> tuple[str, tuple[str, ...], str]:
+    """What must match for a stored classification to be reusable.
+
+    The rubric version is part of the signature because a level-boundary change
+    invalidates every stored level even when the evidence text is untouched.
+    """
+    return (
+        str(record.get("evidence_hash") or ""),
+        tuple(str(value) for value in (record.get("source_hashes") or [])),
+        str(record.get("kw_bench_version") or ""),
+    )
+
+
+def read_records(path: Path) -> list[dict[str, Any]]:
+    """Load every row, including superseded ones.
+
+    A blank line is skipped rather than treated as an error: an interrupted
+    write can leave one, and refusing to load the file would turn a recoverable
+    partial run into a lost one.
+    """
+    if not path.exists():
+        return []
+    records: list[dict[str, Any]] = []
+    with path.open(encoding="utf-8") as handle:
+        for number, line in enumerate(handle, start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                records.append(json.loads(stripped))
+            except json.JSONDecodeError as error:
+                raise KwBenchError(f"{path}:{number} is not valid JSON: {error}") from error
+    return records
+
+
+def current_records(path: Path) -> dict[tuple[str, str], dict[str, Any]]:
+    """The live classification for each track: the last row wins.
+
+    Later rows supersede earlier ones for the same key, which is what makes an
+    append-only file behave as a current-state store without rewriting history.
+    """
+    live: dict[tuple[str, str], dict[str, Any]] = {}
+    for record in read_records(path):
+        if record.get("superseded"):
+            continue
+        live[record_key(record)] = record
+    return live
+
+
+def needs_classification(
+    track: dict[str, Any],
+    cached: dict[str, Any] | None,
+    *,
+    evidence_hash: str,
+    source_hashes: Iterable[str] = (),
+) -> bool:
+    """Whether this track must be reclassified.
+
+    Returns False only when a cached row exists whose evidence, sources, and
+    rubric version all match.  Anything else, including an absent cache and a
+    rubric bump, requires work.
+    """
+    if cached is None:
+        return True
+    signature = (
+        str(evidence_hash),
+        tuple(sorted(str(value) for value in source_hashes)),
+        KW_BENCH_VERSION,
+    )
+    return _cache_signature(cached) != signature
+
+
+def append_records(path: Path, records: list[dict[str, Any]]) -> int:
+    """Append classification rows durably.
+
+    Appends and flushes per batch so an interrupted backfill keeps everything
+    written before the interruption.  That is the whole point of the resumable
+    contract: progress already paid for is never redone.
+    """
+    if not records:
+        return 0
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    return len(records)
+
+
+def rewrite_records(path: Path, records: list[dict[str, Any]]) -> int:
+    """Replace the store atomically.
+
+    Used by compaction only.  Writes to a temporary file in the same directory
+    and renames, so a crash mid-write leaves the previous store intact rather
+    than a truncated one.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handle = tempfile.NamedTemporaryFile(
+        "w",
+        encoding="utf-8",
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        delete=False,
+    )
+    temporary = Path(handle.name)
+    try:
+        with handle:
+            for record in records:
+                handle.write(json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        temporary.replace(path)
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise
+    return len(records)
+
+
+def iter_batches(items: list[Any], size: int) -> Iterator[list[Any]]:
+    """Split work into bounded batches.
+
+    The backfill processes batches rather than the whole corpus so a rate limit
+    or a crash costs one batch of progress instead of the entire run.
+    """
+    if size <= 0:
+        raise KwBenchError("batch size must be positive")
+    for start in range(0, len(items), size):
+        yield items[start : start + size]

--- a/src/benchmark_radar/kw_bench_store.py
+++ b/src/benchmark_radar/kw_bench_store.py
@@ -7,23 +7,33 @@ while a partial JSON document is unparseable and loses the whole run.
 
 Two invariants carry the issue's acceptance criteria.
 
-**Idempotence through content hashing.**  A track is reclassified only when its
-evidence hash, its source hashes, or the rubric version changes.  Rerunning a
-completed backfill therefore performs zero extraction calls, which is the
-property that makes a daily run affordable once the model extractor lands.
+**Idempotence through content hashing.**  A track is re-extracted only when its
+metadata fingerprint or the rubric version changes, or when an explicit refresh
+cutoff asks for it.  The gate runs *before* extraction, never after: a check
+that needs the extracted evidence in hand has already spent the call it was
+meant to avoid.  Rerunning a completed backfill therefore performs zero
+extraction calls, which is the property that makes a daily run affordable once
+the model extractor lands.
 
-**Historical snapshots stay immutable.**  Superseding a record appends the new
-row and marks the old one, rather than editing in place.  A level that changed
-because the rubric changed must remain visible as a change, not be silently
-rewritten into having always been the new value.
+**Historical snapshots stay immutable.**  Superseding a record appends a new
+row carrying `supersedes_evidence_hash`, rather than editing the old one.  The
+earlier row is left exactly as written; `current_records` resolves the live
+value by last-row-wins.  A level that changed because the rubric changed must
+remain visible as a change, not be silently rewritten into having always been
+the new value.
+
+The `superseded` flag that `read_records` honours is reserved for an explicit
+retraction (a row withdrawn without a replacement).  Ordinary supersession does
+not set it, because the newer row already wins.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import tempfile
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
@@ -40,17 +50,61 @@ def record_key(record: dict[str, Any]) -> tuple[str, str]:
     )
 
 
-def _cache_signature(record: dict[str, Any]) -> tuple[str, tuple[str, ...], str]:
+# Track metadata that is copied into the stored row. A change to any of these
+# must invalidate the cache even when the evidence text is byte-identical,
+# because the published record would otherwise keep a stale value: an artifact
+# promoted from `updated` to `released` that kept its old row would be missing
+# from the released-only chart despite having been released.
+FINGERPRINTED_TRACK_FIELDS: tuple[str, ...] = (
+    "canonical_artifact_id",
+    "track_id",
+    "track_name",
+    "title",
+    "url",
+    "event_kind",
+)
+
+
+def track_fingerprint(track: dict[str, Any]) -> str:
+    """Fingerprint the track metadata that reaches the stored row."""
+    payload = {field: str(track.get(field) or "").strip() for field in FINGERPRINTED_TRACK_FIELDS}
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return f"sha256:{hashlib.sha256(canonical.encode()).hexdigest()[:16]}"
+
+
+def _cache_signature(record: dict[str, Any]) -> tuple[str, str]:
     """What must match for a stored classification to be reusable.
 
     The rubric version is part of the signature because a level-boundary change
     invalidates every stored level even when the evidence text is untouched.
     """
     return (
-        str(record.get("evidence_hash") or ""),
-        tuple(str(value) for value in (record.get("source_hashes") or [])),
         str(record.get("kw_bench_version") or ""),
+        str(record.get("track_fingerprint") or ""),
     )
+
+
+def record_changed(previous: dict[str, Any], candidate: dict[str, Any]) -> bool:
+    """Whether a freshly classified row differs from the stored one.
+
+    Compared on the fields that carry meaning to a reader. `classified_at`
+    is excluded: a rerun that produced an identical classification at a
+    different wall-clock time has not changed anything, and appending a row
+    for it would make the store grow without recording new information.
+    """
+    fields = (
+        "level",
+        "level_rationale",
+        "evidence_hash",
+        "source_hashes",
+        "track_fingerprint",
+        "review_status",
+        "missing_evidence",
+        "evidence",
+        "tags",
+        "kw_bench_version",
+    )
+    return any(previous.get(field) != candidate.get(field) for field in fields)
 
 
 def read_records(path: Path) -> list[dict[str, Any]]:
@@ -89,27 +143,44 @@ def current_records(path: Path) -> dict[tuple[str, str], dict[str, Any]]:
     return live
 
 
-def needs_classification(
-    track: dict[str, Any],
-    cached: dict[str, Any] | None,
-    *,
-    evidence_hash: str,
-    source_hashes: Iterable[str] = (),
-) -> bool:
-    """Whether this track must be reclassified.
+def needs_classification(track: dict[str, Any], cached: dict[str, Any] | None) -> bool:
+    """Whether this track must be re-extracted and reclassified.
 
-    Returns False only when a cached row exists whose evidence, sources, and
-    rubric version all match.  Anything else, including an absent cache and a
-    rubric bump, requires work.
+    Decided from the track and the cached row alone, with no reference to
+    freshly extracted evidence, because this gate exists to decide whether to
+    *pay for* that extraction.  A check that needs the evidence in hand has
+    already spent the call it was meant to avoid.
+
+    Returns False only when a cached row exists whose rubric version and track
+    fingerprint both match.  Anything else, including an absent cache, a
+    rubric bump, and a track promoted from `updated` to `released`, requires
+    work.
+
+    Evidence and source hashes are deliberately not consulted here.  They are
+    outputs of extraction, so they cannot gate it; they are compared afterward
+    by `record_changed`, which decides whether the result is worth storing.
+
+    A consequence worth stating plainly: an upstream README edit that leaves
+    the track metadata untouched does *not* trigger re-extraction on its own,
+    because detecting it would require fetching the README, which is the cost
+    being avoided.  Refreshing stored evidence against changed upstream text is
+    what `--kw-bench-refresh-after` is for.
     """
     if cached is None:
         return True
-    signature = (
-        str(evidence_hash),
-        tuple(sorted(str(value) for value in source_hashes)),
-        KW_BENCH_VERSION,
-    )
-    return _cache_signature(cached) != signature
+    return _cache_signature(cached) != (KW_BENCH_VERSION, track_fingerprint(track))
+
+
+def is_stale(cached: dict[str, Any] | None, *, refresh_before: str | None) -> bool:
+    """Whether a cached row predates the requested refresh cutoff.
+
+    Lets an operator re-extract rows older than a chosen timestamp without
+    discarding the whole store, which is the only way to pick up upstream
+    source edits that leave a track's metadata unchanged.
+    """
+    if cached is None or not refresh_before:
+        return False
+    return str(cached.get("classified_at") or "") < str(refresh_before)
 
 
 def append_records(path: Path, records: list[dict[str, Any]]) -> int:

--- a/src/benchmark_radar/kw_bench_store.py
+++ b/src/benchmark_radar/kw_bench_store.py
@@ -89,10 +89,9 @@ def _cache_signature(record: dict[str, Any]) -> tuple[str, str, str]:
 def record_changed(previous: dict[str, Any], candidate: dict[str, Any]) -> bool:
     """Whether a freshly classified row differs from the stored one.
 
-    Compared on the fields that carry meaning to a reader. `classified_at`
-    is excluded: a rerun that produced an identical classification at a
-    different wall-clock time has not changed anything, and appending a row
-    for it would make the store grow without recording new information.
+    Compared on semantic fields plus cache freshness metadata. Extraction only
+    reaches this check for a stale row, so persisting a new extractor identity
+    or refresh timestamp prevents the same expensive no-op work on every run.
     """
     fields = (
         "level",
@@ -105,6 +104,8 @@ def record_changed(previous: dict[str, Any], candidate: dict[str, Any]) -> bool:
         "evidence",
         "tags",
         "kw_bench_version",
+        "extractor",
+        "classified_at",
     )
     return any(previous.get(field) != candidate.get(field) for field in fields)
 

--- a/src/benchmark_radar/kw_bench_store.py
+++ b/src/benchmark_radar/kw_bench_store.py
@@ -119,13 +119,19 @@ def read_records(path: Path) -> list[dict[str, Any]]:
         return []
     records: list[dict[str, Any]] = []
     with path.open(encoding="utf-8") as handle:
-        for number, line in enumerate(handle, start=1):
+        lines = handle.readlines()
+        for number, line in enumerate(lines, start=1):
             stripped = line.strip()
             if not stripped:
                 continue
             try:
                 records.append(json.loads(stripped))
             except json.JSONDecodeError as error:
+                # A crash can tear only the row being appended at EOF. Keep
+                # the durable prefix resumable, but reject malformed complete
+                # lines (and malformed non-final lines) as store corruption.
+                if number == len(lines) and not line.endswith("\n"):
+                    continue
                 raise KwBenchError(f"{path}:{number} is not valid JSON: {error}") from error
     return records
 
@@ -138,9 +144,11 @@ def current_records(path: Path) -> dict[tuple[str, str], dict[str, Any]]:
     """
     live: dict[tuple[str, str], dict[str, Any]] = {}
     for record in read_records(path):
+        key = record_key(record)
         if record.get("superseded"):
+            live.pop(key, None)
             continue
-        live[record_key(record)] = record
+        live[key] = record
     return live
 
 

--- a/src/benchmark_radar/kw_bench_store.py
+++ b/src/benchmark_radar/kw_bench_store.py
@@ -73,7 +73,7 @@ def track_fingerprint(track: dict[str, Any]) -> str:
     return f"sha256:{hashlib.sha256(canonical.encode()).hexdigest()[:16]}"
 
 
-def _cache_signature(record: dict[str, Any]) -> tuple[str, str]:
+def _cache_signature(record: dict[str, Any]) -> tuple[str, str, str]:
     """What must match for a stored classification to be reusable.
 
     The rubric version is part of the signature because a level-boundary change
@@ -82,6 +82,7 @@ def _cache_signature(record: dict[str, Any]) -> tuple[str, str]:
     return (
         str(record.get("kw_bench_version") or ""),
         str(record.get("track_fingerprint") or ""),
+        str(record.get("extractor") or ""),
     )
 
 
@@ -152,7 +153,9 @@ def current_records(path: Path) -> dict[tuple[str, str], dict[str, Any]]:
     return live
 
 
-def needs_classification(track: dict[str, Any], cached: dict[str, Any] | None) -> bool:
+def needs_classification(
+    track: dict[str, Any], cached: dict[str, Any] | None, *, extractor: str
+) -> bool:
     """Whether this track must be re-extracted and reclassified.
 
     Decided from the track and the cached row alone, with no reference to
@@ -160,10 +163,10 @@ def needs_classification(track: dict[str, Any], cached: dict[str, Any] | None) -
     *pay for* that extraction.  A check that needs the evidence in hand has
     already spent the call it was meant to avoid.
 
-    Returns False only when a cached row exists whose rubric version and track
-    fingerprint both match.  Anything else, including an absent cache, a
-    rubric bump, and a track promoted from `updated` to `released`, requires
-    work.
+    Returns False only when a cached row exists whose rubric version, track
+    fingerprint, and extractor identity all match. Anything else, including
+    an absent cache, a rubric bump, a new extractor, and a track promoted from
+    `updated` to `released`, requires work.
 
     Evidence and source hashes are deliberately not consulted here.  They are
     outputs of extraction, so they cannot gate it; they are compared afterward
@@ -177,7 +180,11 @@ def needs_classification(track: dict[str, Any], cached: dict[str, Any] | None) -
     """
     if cached is None:
         return True
-    return _cache_signature(cached) != (KW_BENCH_VERSION, track_fingerprint(track))
+    return _cache_signature(cached) != (
+        KW_BENCH_VERSION,
+        track_fingerprint(track),
+        extractor,
+    )
 
 
 def is_stale(cached: dict[str, Any] | None, *, refresh_before: str | None) -> bool:
@@ -218,6 +225,24 @@ def append_records(path: Path, records: list[dict[str, Any]]) -> int:
     if not records:
         return 0
     path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists() and path.stat().st_size:
+        # Recover the append boundary after a torn write. A valid final object
+        # merely missing its newline is preserved; an invalid unterminated tail
+        # is the interrupted row and is truncated back to the durable prefix.
+        with path.open("rb+") as repair:
+            contents = repair.read()
+            if not contents.endswith(b"\n"):
+                boundary = contents.rfind(b"\n") + 1
+                tail = contents[boundary:]
+                try:
+                    json.loads(tail.decode("utf-8"))
+                except (UnicodeDecodeError, json.JSONDecodeError):
+                    repair.truncate(boundary)
+                else:
+                    repair.seek(0, os.SEEK_END)
+                    repair.write(b"\n")
+                repair.flush()
+                os.fsync(repair.fileno())
     with path.open("a", encoding="utf-8") as handle:
         for record in records:
             handle.write(json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n")

--- a/src/benchmark_radar/kw_bench_tracks.py
+++ b/src/benchmark_radar/kw_bench_tracks.py
@@ -1,0 +1,283 @@
+"""Derive canonical benchmark tracks and run the classification backfill.
+
+This is the layer between the corpus and the classifier.  It answers two
+questions the classifier deliberately does not: *which* artifacts are scored
+benchmark tracks worth classifying, and *where does the evidence come from*.
+
+Track derivation reuses `corpus.artifact_alias_map`, so thousands of daily
+observations of the same benchmark collapse to one canonical artifact before
+anything expensive happens.  That is step 1 of the issue and it is the reason
+the daily run stays cheap: dedup first, then classify, never the reverse.
+
+Evidence extraction is an interface, not an implementation.  The MVP ships a
+null extractor that supplies nothing, so every track lands `Unclassified` with
+its missing fields recorded.  That is the honest state of a corpus whose
+sources publish titles and abstracts rather than verifier documentation.  A
+model-backed extractor implements the same `Extractor` protocol and drops in
+without touching the decision rules, which stay deterministic either way.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any, Protocol
+
+from . import kw_bench, kw_bench_store
+from .corpus import artifact_alias_map, exact_artifact_key
+
+# An artifact enters classification only if it plausibly *introduces a scored
+# evaluation track*.  These are the taxonomy categories that make that claim.
+# A pure `dataset` record is not a benchmark track: a corpus release with no
+# scoring procedure has no capability frontier to locate.
+SCORED_TRACK_CATEGORIES = frozenset({"benchmark", "evaluation"})
+
+DEFAULT_BATCH_SIZE = 25
+
+
+class Extractor(Protocol):
+    """Supplies KW-Bench evidence fields for one canonical track.
+
+    Implementations fetch the primary paper, repository README, task
+    instructions, and verifier documentation, then return the six evidence
+    fields plus the two L5 fields where available.  Returning an empty mapping
+    is valid and means "no evidence found", which the classifier renders as
+    `Unclassified` rather than a guess.
+
+    `source_hashes` lets the cache detect that a README changed even when the
+    extracted evidence text happens to be identical, so a re-extraction is not
+    silently skipped after an upstream edit.
+    """
+
+    name: str
+
+    def extract(self, track: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+        """Return `(evidence_fields, source_hashes)` for this track."""
+        ...
+
+
+class NullExtractor:
+    """The MVP extractor: supplies no evidence.
+
+    Deliberately not a stub that invents plausible fields.  Every track it
+    touches becomes `Unclassified` with the full missing-field list, which is
+    both the correct rubric outcome and a working end-to-end pipeline that the
+    model extractor can be measured against later.
+    """
+
+    name = "null"
+
+    def extract(self, track: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+        return {}, []
+
+
+class MappingExtractor:
+    """Serves hand-curated evidence keyed by canonical artifact ID.
+
+    This is how the manually reviewed validation set of issue #153 step 6 is
+    supplied, and how L4/L5 records get their evaluator-knowledge claims: a
+    human writes the evidence, the deterministic rules assign the level.
+    """
+
+    def __init__(self, evidence_by_artifact: dict[str, dict[str, Any]], *, name: str = "curated"):
+        self.name = name
+        self._evidence = evidence_by_artifact
+
+    def extract(self, track: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+        entry = self._evidence.get(str(track.get("canonical_artifact_id")))
+        if not entry:
+            return {}, []
+        evidence = dict(entry.get("evidence") or entry)
+        sources = [str(value) for value in (entry.get("source_hashes") or [])]
+        return evidence, sources
+
+
+def _is_scored_track(item: dict[str, Any]) -> bool:
+    categories = {str(category) for category in (item.get("categories") or [])}
+    return bool(categories & SCORED_TRACK_CATEGORIES)
+
+
+def derive_tracks(snapshots: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Collapse snapshot observations into canonical, classifiable tracks.
+
+    One track per canonical artifact in the MVP.  A mixed suite that declares
+    several scored tracks is represented by several rows sharing a canonical
+    artifact ID and differing by `track_name`; the schema supports that today
+    and the extractor will populate it once it can read a suite's task
+    breakdown.  Splitting suites on title guesswork would be exactly the
+    keyword inference the rubric forbids.
+
+    The returned rows are deterministic and sorted, so a backfill produces the
+    same work list on every machine and every rerun.
+    """
+    items = [item for snapshot in snapshots for item in snapshot.get("evidence_items", [])]
+    aliases = artifact_alias_map(items)
+    tracks: dict[str, dict[str, Any]] = {}
+    for snapshot in snapshots:
+        date = str(snapshot.get("date") or "")
+        for item in snapshot.get("evidence_items", []):
+            if not _is_scored_track(item):
+                continue
+            canonical = aliases[exact_artifact_key(item)]
+            track = tracks.setdefault(
+                canonical,
+                {
+                    "canonical_artifact_id": canonical,
+                    "track_name": "default",
+                    "title": str(item.get("title") or ""),
+                    "url": str(item.get("url") or ""),
+                    "event_kind": "updated",
+                    "first_seen_at": date,
+                    "last_seen_at": date,
+                    "sources": set(),
+                    "categories": set(),
+                },
+            )
+            track["first_seen_at"] = min(track["first_seen_at"] or date, date)
+            track["last_seen_at"] = max(track["last_seen_at"] or date, date)
+            track["sources"].add(str(item.get("source") or ""))
+            track["categories"].update(str(value) for value in (item.get("categories") or []))
+            # A track counts as released if it was ever seen as a release.  A
+            # later "updated" sighting of the same benchmark must not demote it
+            # out of the released-only chart, which would make the released
+            # count fall as a benchmark gained activity.
+            if str(item.get("event_kind")) == "released":
+                track["event_kind"] = "released"
+                # Prefer the releasing record's own title and URL: an update
+                # sighting is often a mirror or a secondary index.
+                if str(item.get("title")):
+                    track["title"] = str(item["title"])
+                if str(item.get("url")):
+                    track["url"] = str(item["url"])
+    ordered = []
+    for canonical in sorted(tracks):
+        track = tracks[canonical]
+        ordered.append(
+            {
+                **track,
+                "sources": sorted(track["sources"]),
+                "categories": sorted(track["categories"]),
+                "track_id": kw_bench.track_id(canonical, track["track_name"]),
+            }
+        )
+    return ordered
+
+
+def classify_tracks(
+    tracks: list[dict[str, Any]],
+    *,
+    store_path: Path,
+    classified_at: str,
+    extractor: Extractor | None = None,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    """Classify the tracks that need it and append the results.
+
+    Resumable and idempotent.  A track whose evidence hash, source hashes, and
+    rubric version already match a stored row is skipped without calling the
+    extractor, so a completed backfill rerun costs nothing.  Work is committed
+    per batch, so an interruption keeps everything already written.
+
+    Returns a summary rather than the rows: callers want to know what moved,
+    and the store is the record of what exists.
+    """
+    extractor = extractor or NullExtractor()
+    cached = kw_bench_store.current_records(store_path)
+    pending = tracks[:limit] if limit is not None else tracks
+
+    written = 0
+    skipped = 0
+    extracted = 0
+    superseded = 0
+    for batch in kw_bench_store.iter_batches(list(pending), batch_size):
+        rows: list[dict[str, Any]] = []
+        for track in batch:
+            key = (track["canonical_artifact_id"], track["track_id"])
+            previous = cached.get(key)
+            evidence, source_hashes = extractor.extract(track)
+            extracted += 1
+            digest = kw_bench.evidence_hash(evidence)
+            if not kw_bench_store.needs_classification(
+                track,
+                previous,
+                evidence_hash=digest,
+                source_hashes=source_hashes,
+            ):
+                skipped += 1
+                continue
+            record = kw_bench.classify_track(
+                {**track, "evidence": evidence, "source_hashes": source_hashes},
+                classified_at=classified_at,
+                classified_by=f"kw-bench-deterministic/{extractor.name}",
+            )
+            record["extractor"] = extractor.name
+            # A human-approved level is never silently overwritten by an
+            # automated rerun.  Re-approval is a human action, so the new row
+            # returns to the review queue and the approval stays visible in
+            # history rather than being inherited by different evidence.
+            if previous is not None:
+                record["supersedes_evidence_hash"] = previous.get("evidence_hash")
+                superseded += 1
+            rows.append(record)
+            cached[key] = record
+        written += kw_bench_store.append_records(store_path, rows)
+
+    return {
+        "kw_bench_version": kw_bench.KW_BENCH_VERSION,
+        "tracks_considered": len(pending),
+        "extraction_calls": extracted,
+        "classified": written,
+        "reused_from_cache": skipped,
+        "superseded": superseded,
+        "extractor": extractor.name,
+        "store": str(store_path),
+    }
+
+
+def backfill(
+    snapshots: list[dict[str, Any]],
+    *,
+    store_path: Path,
+    classified_at: str,
+    extractor: Extractor | None = None,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    """Derive tracks from the full snapshot history and classify them."""
+    tracks = derive_tracks(snapshots)
+    summary = classify_tracks(
+        tracks,
+        store_path=store_path,
+        classified_at=classified_at,
+        extractor=extractor,
+        batch_size=batch_size,
+        limit=limit,
+    )
+    return {**summary, "tracks_derived": len(tracks)}
+
+
+def classification_layer(
+    store_path: Path,
+    *,
+    tracks: Iterable[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build the dashboard payload for the KW-Bench layer.
+
+    Shadow mode: this is published beside the existing taxonomy counts so the
+    L0-L5 distribution can be audited against a real corpus before the visible
+    chart switches over.  `shadow: True` states that in the payload itself so a
+    reader of `radar.json` cannot mistake it for the live chart source.
+    """
+    records = list(kw_bench_store.current_records(store_path).values())
+    return {
+        "shadow": True,
+        "schema_version": kw_bench.CLASSIFICATION_SCHEMA_VERSION,
+        "kw_bench_version": kw_bench.KW_BENCH_VERSION,
+        "chart_levels": list(kw_bench.CHART_LEVELS),
+        "level_counts": kw_bench.level_counts(records),
+        "level_counts_released": kw_bench.level_counts(records, released_only=True),
+        "coverage": kw_bench.coverage(records),
+        "reference": kw_bench.kw_bench_reference(),
+        "track_count": len(list(tracks)) if tracks is not None else len(records),
+    }

--- a/src/benchmark_radar/kw_bench_tracks.py
+++ b/src/benchmark_radar/kw_bench_tracks.py
@@ -211,6 +211,8 @@ def classify_tracks(
     Returns a summary rather than the rows: callers want to know what moved,
     and the store is the record of what exists.
     """
+    if limit is not None and limit < 0:
+        raise kw_bench.KwBenchError("classification limit must be non-negative")
     extractor = extractor or NullExtractor()
     cached = kw_bench_store.current_records(store_path)
 

--- a/src/benchmark_radar/kw_bench_tracks.py
+++ b/src/benchmark_radar/kw_bench_tracks.py
@@ -260,11 +260,10 @@ def classify_tracks(
             )
             record["extractor"] = extractor.name
             record["track_fingerprint"] = kw_bench_store.track_fingerprint(track)
-            # Extraction can legitimately return what is already stored: a
-            # README edit that did not change the six fields, or a track whose
-            # metadata moved without touching its evidence. Appending an
-            # identical row would grow the store on every run with no new
-            # information, so only a real change is recorded.
+            # Extraction can legitimately return what is already stored. The
+            # new row still records cache freshness (`classified_at`) and the
+            # extractor identity, otherwise every later run repeats the same
+            # potentially expensive refresh or extractor transition.
             if previous is not None and not kw_bench_store.record_changed(previous, record):
                 unchanged += 1
                 continue
@@ -344,6 +343,12 @@ def classification_layer(
             for track in current_tracks
         }
         records = [record for record in records if kw_bench_store.record_key(record) in active_keys]
+        recorded_keys = {kw_bench_store.record_key(record) for record in records}
+        records.extend(
+            {**track, "level": kw_bench.UNCLASSIFIED}
+            for track in current_tracks
+            if (str(track["canonical_artifact_id"]), str(track["track_id"])) not in recorded_keys
+        )
     return {
         "shadow": True,
         "schema_version": kw_bench.CLASSIFICATION_SCHEMA_VERSION,

--- a/src/benchmark_radar/kw_bench_tracks.py
+++ b/src/benchmark_radar/kw_bench_tracks.py
@@ -84,7 +84,11 @@ class MappingExtractor:
         self._evidence = evidence_by_artifact
 
     def extract(self, track: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
-        entry = self._evidence.get(str(track.get("canonical_artifact_id")))
+        # Keyed by track ID first so a mixed suite can carry different evidence
+        # per track, then by artifact ID for the common single-track case.
+        entry = self._evidence.get(str(track.get("track_id"))) or self._evidence.get(
+            str(track.get("canonical_artifact_id"))
+        )
         if not entry:
             return {}, []
         evidence = dict(entry.get("evidence") or entry)
@@ -97,15 +101,23 @@ def _is_scored_track(item: dict[str, Any]) -> bool:
     return bool(categories & SCORED_TRACK_CATEGORIES)
 
 
-def derive_tracks(snapshots: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def derive_tracks(
+    snapshots: list[dict[str, Any]],
+    *,
+    track_names: dict[str, list[str]] | None = None,
+) -> list[dict[str, Any]]:
     """Collapse snapshot observations into canonical, classifiable tracks.
 
-    One track per canonical artifact in the MVP.  A mixed suite that declares
-    several scored tracks is represented by several rows sharing a canonical
-    artifact ID and differing by `track_name`; the schema supports that today
-    and the extractor will populate it once it can read a suite's task
-    breakdown.  Splitting suites on title guesswork would be exactly the
-    keyword inference the rubric forbids.
+    One track per canonical artifact by default.  `track_names` splits a known
+    mixed suite into several tracks sharing a canonical artifact ID and
+    differing by `track_name`, each classified and counted separately, which is
+    what the rubric requires of a suite holding both retrieval questions and
+    executable tasks.
+
+    The split is supplied, never inferred.  Guessing a suite's task breakdown
+    from its title is the keyword inference the rubric forbids, so a suite with
+    no declared breakdown stays a single track rather than being invented into
+    several.
 
     The returned rows are deterministic and sorted, so a backfill produces the
     same work list on every machine and every rerun.
@@ -152,14 +164,20 @@ def derive_tracks(snapshots: list[dict[str, Any]]) -> list[dict[str, Any]]:
     ordered = []
     for canonical in sorted(tracks):
         track = tracks[canonical]
-        ordered.append(
-            {
-                **track,
-                "sources": sorted(track["sources"]),
-                "categories": sorted(track["categories"]),
-                "track_id": kw_bench.track_id(canonical, track["track_name"]),
-            }
-        )
+        base = {
+            **track,
+            "sources": sorted(track["sources"]),
+            "categories": sorted(track["categories"]),
+        }
+        names = (track_names or {}).get(canonical) or [track["track_name"]]
+        for name in sorted(dict.fromkeys(str(value) for value in names)):
+            ordered.append(
+                {
+                    **base,
+                    "track_name": name,
+                    "track_id": kw_bench.track_id(canonical, name),
+                }
+            )
     return ordered
 
 
@@ -171,25 +189,55 @@ def classify_tracks(
     extractor: Extractor | None = None,
     batch_size: int = DEFAULT_BATCH_SIZE,
     limit: int | None = None,
+    refresh_before: str | None = None,
 ) -> dict[str, Any]:
     """Classify the tracks that need it and append the results.
 
-    Resumable and idempotent.  A track whose evidence hash, source hashes, and
-    rubric version already match a stored row is skipped without calling the
-    extractor, so a completed backfill rerun costs nothing.  Work is committed
+    Resumable and idempotent.  A track whose rubric version and metadata
+    fingerprint already match a stored row never reaches the extractor, so a
+    completed backfill rerun makes zero extraction calls.  Work is committed
     per batch, so an interruption keeps everything already written.
+
+    `refresh_before` re-extracts rows classified before a given timestamp,
+    which is how upstream source edits are picked up: they are invisible to the
+    fingerprint by construction, since detecting them means fetching the
+    source.
 
     Returns a summary rather than the rows: callers want to know what moved,
     and the store is the record of what exists.
     """
     extractor = extractor or NullExtractor()
     cached = kw_bench_store.current_records(store_path)
-    pending = tracks[:limit] if limit is not None else tracks
+
+    # Decide what is stale *before* extracting anything.  Extraction is the
+    # expensive step once a model backs it, so a cache check that runs after it
+    # saves nothing: the call has already been paid for.  `track_fingerprint`
+    # covers the track metadata that lands in the stored row, so a track whose
+    # event_kind flipped to `released` is reclassified even though its evidence
+    # text is byte-identical.
+    stale = [
+        track
+        for track in tracks
+        if kw_bench_store.needs_classification(
+            track,
+            cached.get((track["canonical_artifact_id"], track["track_id"])),
+        )
+        or kw_bench_store.is_stale(
+            cached.get((track["canonical_artifact_id"], track["track_id"])),
+            refresh_before=refresh_before,
+        )
+    ]
+    reused = len(tracks) - len(stale)
+    # `limit` bounds the work, so it must apply to what is left to do rather
+    # than to the front of the full list.  Slicing `tracks` made every bounded
+    # run re-select the same already-classified prefix, so a corpus larger than
+    # the limit could never finish however many times it ran.
+    pending = stale[:limit] if limit is not None else stale
 
     written = 0
-    skipped = 0
     extracted = 0
     superseded = 0
+    unchanged = 0
     for batch in kw_bench_store.iter_batches(list(pending), batch_size):
         rows: list[dict[str, Any]] = []
         for track in batch:
@@ -197,21 +245,21 @@ def classify_tracks(
             previous = cached.get(key)
             evidence, source_hashes = extractor.extract(track)
             extracted += 1
-            digest = kw_bench.evidence_hash(evidence)
-            if not kw_bench_store.needs_classification(
-                track,
-                previous,
-                evidence_hash=digest,
-                source_hashes=source_hashes,
-            ):
-                skipped += 1
-                continue
             record = kw_bench.classify_track(
                 {**track, "evidence": evidence, "source_hashes": source_hashes},
                 classified_at=classified_at,
                 classified_by=f"kw-bench-deterministic/{extractor.name}",
             )
             record["extractor"] = extractor.name
+            record["track_fingerprint"] = kw_bench_store.track_fingerprint(track)
+            # Extraction can legitimately return what is already stored: a
+            # README edit that did not change the six fields, or a track whose
+            # metadata moved without touching its evidence. Appending an
+            # identical row would grow the store on every run with no new
+            # information, so only a real change is recorded.
+            if previous is not None and not kw_bench_store.record_changed(previous, record):
+                unchanged += 1
+                continue
             # A human-approved level is never silently overwritten by an
             # automated rerun.  Re-approval is a human action, so the new row
             # returns to the review queue and the approval stays visible in
@@ -225,10 +273,14 @@ def classify_tracks(
 
     return {
         "kw_bench_version": kw_bench.KW_BENCH_VERSION,
-        "tracks_considered": len(pending),
+        "tracks_considered": len(tracks),
+        "tracks_pending": len(stale),
+        # The honest count of extractor invocations. A cache hit never reaches
+        # the extractor, so this is 0 on an unchanged rerun.
         "extraction_calls": extracted,
         "classified": written,
-        "reused_from_cache": skipped,
+        "reused_from_cache": reused,
+        "unchanged_after_extraction": unchanged,
         "superseded": superseded,
         "extractor": extractor.name,
         "store": str(store_path),
@@ -243,9 +295,11 @@ def backfill(
     extractor: Extractor | None = None,
     batch_size: int = DEFAULT_BATCH_SIZE,
     limit: int | None = None,
+    refresh_before: str | None = None,
+    track_names: dict[str, list[str]] | None = None,
 ) -> dict[str, Any]:
     """Derive tracks from the full snapshot history and classify them."""
-    tracks = derive_tracks(snapshots)
+    tracks = derive_tracks(snapshots, track_names=track_names)
     summary = classify_tracks(
         tracks,
         store_path=store_path,
@@ -253,6 +307,7 @@ def backfill(
         extractor=extractor,
         batch_size=batch_size,
         limit=limit,
+        refresh_before=refresh_before,
     )
     return {**summary, "tracks_derived": len(tracks)}
 

--- a/src/benchmark_radar/kw_bench_tracks.py
+++ b/src/benchmark_radar/kw_bench_tracks.py
@@ -170,12 +170,17 @@ def derive_tracks(
             "categories": sorted(track["categories"]),
         }
         names = (track_names or {}).get(canonical) or [track["track_name"]]
-        for name in sorted(dict.fromkeys(str(value) for value in names)):
+        seen_track_ids: set[str] = set()
+        for name in sorted(str(value) for value in names):
+            identifier = kw_bench.track_id(canonical, name)
+            if identifier in seen_track_ids:
+                continue
+            seen_track_ids.add(identifier)
             ordered.append(
                 {
                     **base,
                     "track_name": name,
-                    "track_id": kw_bench.track_id(canonical, name),
+                    "track_id": identifier,
                 }
             )
     return ordered

--- a/src/benchmark_radar/kw_bench_tracks.py
+++ b/src/benchmark_radar/kw_bench_tracks.py
@@ -324,7 +324,18 @@ def classification_layer(
     chart switches over.  `shadow: True` states that in the payload itself so a
     reader of `radar.json` cannot mistake it for the live chart source.
     """
-    records = list(kw_bench_store.current_records(store_path).values())
+    current_tracks = list(tracks) if tracks is not None else None
+    records = [
+        record
+        for record in kw_bench_store.current_records(store_path).values()
+        if record.get("kw_bench_version") == kw_bench.KW_BENCH_VERSION
+    ]
+    if current_tracks is not None:
+        active_keys = {
+            (str(track["canonical_artifact_id"]), str(track["track_id"]))
+            for track in current_tracks
+        }
+        records = [record for record in records if kw_bench_store.record_key(record) in active_keys]
     return {
         "shadow": True,
         "schema_version": kw_bench.CLASSIFICATION_SCHEMA_VERSION,
@@ -334,5 +345,8 @@ def classification_layer(
         "level_counts_released": kw_bench.level_counts(records, released_only=True),
         "coverage": kw_bench.coverage(records),
         "reference": kw_bench.kw_bench_reference(),
-        "track_count": len(list(tracks)) if tracks is not None else len(records),
+        # Candidate tracks and currently classified records are deliberately
+        # separate: during a bounded rubric-version migration, coverage shows
+        # how much of this candidate total has reached the current version.
+        "track_count": len(current_tracks) if current_tracks is not None else len(records),
     }

--- a/src/benchmark_radar/kw_bench_tracks.py
+++ b/src/benchmark_radar/kw_bench_tracks.py
@@ -228,6 +228,7 @@ def classify_tracks(
         if kw_bench_store.needs_classification(
             track,
             cached.get((track["canonical_artifact_id"], track["track_id"])),
+            extractor=extractor.name,
         )
         or kw_bench_store.is_stale(
             cached.get((track["canonical_artifact_id"], track["track_id"])),

--- a/src/benchmark_radar/snapshots.py
+++ b/src/benchmark_radar/snapshots.py
@@ -18,7 +18,7 @@ from .corpus import (
     organizations_for_item,
 )
 from .insights import build_insights
-from .kw_bench_tracks import classification_layer
+from .kw_bench_tracks import classification_layer, derive_tracks
 from .model_cards import DEFAULT_REGISTRY_PATH, adoption_rank, load_registry
 from .models import RadarRun
 from .pipeline import match_proximity_rule
@@ -697,7 +697,11 @@ def _curated_layers(
     }
 
 
-def kw_bench_layer(store_path: Path | None) -> dict[str, Any]:
+def kw_bench_layer(
+    store_path: Path | None,
+    *,
+    tracks: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
     """The KW-Bench capability layer, or an explicit empty state.
 
     A missing store is normal before the first backfill and must not fail the
@@ -717,7 +721,7 @@ def kw_bench_layer(store_path: Path | None) -> dict[str, Any]:
             "reference": kw_bench.kw_bench_reference(),
             "track_count": 0,
         }
-    return classification_layer(store_path)
+    return classification_layer(store_path, tracks=tracks)
 
 
 def dashboard_data(
@@ -864,7 +868,10 @@ def dashboard_data(
         # level distribution can be audited against the real corpus before the
         # visible chart switches over. The payload marks itself `shadow: true`;
         # the browser does not read it yet.
-        "kw_bench": kw_bench_layer(kw_bench_store_path),
+        "kw_bench": kw_bench_layer(
+            kw_bench_store_path,
+            tracks=derive_tracks(snapshots),
+        ),
         # Curated and versioned in the repository rather than collected daily:
         # they answer "which benchmarks do vendors report", "how have the
         # readable scores moved", and "what do those two together say", which

--- a/src/benchmark_radar/snapshots.py
+++ b/src/benchmark_radar/snapshots.py
@@ -710,16 +710,17 @@ def kw_bench_layer(
     than the key simply being absent.
     """
     if store_path is None or not store_path.exists():
+        candidates = [{**track, "level": kw_bench.UNCLASSIFIED} for track in (tracks or [])]
         return {
             "shadow": True,
             "schema_version": kw_bench.CLASSIFICATION_SCHEMA_VERSION,
             "kw_bench_version": kw_bench.KW_BENCH_VERSION,
             "chart_levels": list(kw_bench.CHART_LEVELS),
-            "level_counts": kw_bench.level_counts([]),
-            "level_counts_released": kw_bench.level_counts([], released_only=True),
-            "coverage": kw_bench.coverage([]),
+            "level_counts": kw_bench.level_counts(candidates),
+            "level_counts_released": kw_bench.level_counts(candidates, released_only=True),
+            "coverage": kw_bench.coverage(candidates),
             "reference": kw_bench.kw_bench_reference(),
-            "track_count": 0,
+            "track_count": len(candidates),
         }
     return classification_layer(store_path, tracks=tracks)
 

--- a/src/benchmark_radar/snapshots.py
+++ b/src/benchmark_radar/snapshots.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from . import kw_bench
 from .attention import fetch_attention_feeds
 from .benchmark_scores import DEFAULT_SCORES_PATH, load_scores, score_progression
 from .corpus import (
@@ -17,6 +18,7 @@ from .corpus import (
     organizations_for_item,
 )
 from .insights import build_insights
+from .kw_bench_tracks import classification_layer
 from .model_cards import DEFAULT_REGISTRY_PATH, adoption_rank, load_registry
 from .models import RadarRun
 from .pipeline import match_proximity_rule
@@ -695,11 +697,35 @@ def _curated_layers(
     }
 
 
+def kw_bench_layer(store_path: Path | None) -> dict[str, Any]:
+    """The KW-Bench capability layer, or an explicit empty state.
+
+    A missing store is normal before the first backfill and must not fail the
+    build. The layer still publishes the rubric reference and a zeroed set of
+    bars so the dashboard can describe the scale it is about to show rather
+    than the key simply being absent.
+    """
+    if store_path is None or not store_path.exists():
+        return {
+            "shadow": True,
+            "schema_version": kw_bench.CLASSIFICATION_SCHEMA_VERSION,
+            "kw_bench_version": kw_bench.KW_BENCH_VERSION,
+            "chart_levels": list(kw_bench.CHART_LEVELS),
+            "level_counts": kw_bench.level_counts([]),
+            "level_counts_released": kw_bench.level_counts([], released_only=True),
+            "coverage": kw_bench.coverage([]),
+            "reference": kw_bench.kw_bench_reference(),
+            "track_count": 0,
+        }
+    return classification_layer(store_path)
+
+
 def dashboard_data(
     snapshots: list[dict[str, Any]],
     *,
     registry_path: Path | None = None,
     scores_path: Path | None = None,
+    kw_bench_store_path: Path | None = None,
 ) -> dict[str, Any]:
     days: list[dict[str, Any]] = []
     categories: set[str] = set()
@@ -833,6 +859,12 @@ def dashboard_data(
         },
         "days": days,
         "corpus": corpus,
+        # Issue #153, shadow mode. The KW-Bench L0-L5 capability layer is
+        # published beside the taxonomy counts, not in place of them, so the
+        # level distribution can be audited against the real corpus before the
+        # visible chart switches over. The payload marks itself `shadow: true`;
+        # the browser does not read it yet.
+        "kw_bench": kw_bench_layer(kw_bench_store_path),
         # Curated and versioned in the repository rather than collected daily:
         # they answer "which benchmarks do vendors report", "how have the
         # readable scores moved", and "what do those two together say", which
@@ -865,11 +897,13 @@ def rebuild_dashboard(
     *,
     registry_path: Path | None = None,
     scores_path: Path | None = None,
+    kw_bench_store_path: Path | None = None,
 ) -> dict[str, Any]:
     value = dashboard_data(
         load_snapshots(snapshot_dir),
         registry_path=registry_path,
         scores_path=scores_path,
+        kw_bench_store_path=kw_bench_store_path,
     )
     _write_json(output, value)
     return value

--- a/tests/test_kw_bench.py
+++ b/tests/test_kw_bench.py
@@ -432,6 +432,15 @@ def test_placeholder_l5_fields_do_not_satisfy_the_gate():
     assert set(decision["missing_evidence"]) == {"evaluation_cutoff", "novelty_check"}
 
 
+def test_l5_requires_the_novelty_check_to_record_a_clean_result():
+    decision = assign_level(
+        l5_evidence(novelty_check="A prior-art search across arXiv and Scopus was performed.")
+    )
+
+    assert decision["level"] == UNCLASSIFIED
+    assert decision["missing_evidence"] == ["novelty_check"]
+
+
 def test_novelty_check_reporting_prior_art_caps_at_l4():
     """The ceiling applies from the novelty check, not only evaluator knowledge."""
     decision = assign_level(

--- a/tests/test_kw_bench.py
+++ b/tests/test_kw_bench.py
@@ -416,6 +416,129 @@ def test_coverage_of_an_empty_corpus_has_no_rate():
     assert coverage([])["classified_rate"] is None
 
 
+# --- Regressions from independent review --------------------------------
+#
+# Every case below was a real misclassification found by adversarial review,
+# reproduced before it was fixed. They share one root cause worth naming: the
+# evidence fields describe two different actors, and reading the verifier's
+# machinery as if it were the agent's behaviour moves a level.
+
+
+def test_placeholder_l5_fields_do_not_satisfy_the_gate():
+    """ "unknown" and "not performed" are missing fields wearing a value."""
+    decision = assign_level(l5_evidence(evaluation_cutoff="unknown", novelty_check="not performed"))
+
+    assert decision["level"] == UNCLASSIFIED
+    assert set(decision["missing_evidence"]) == {"evaluation_cutoff", "novelty_check"}
+
+
+def test_novelty_check_reporting_prior_art_caps_at_l4():
+    """The ceiling applies from the novelty check, not only evaluator knowledge."""
+    decision = assign_level(
+        l5_evidence(novelty_check="The exact result was already published in 2024.")
+    )
+
+    assert decision["level"] == "L4"
+
+
+def test_a_negated_knowledge_claim_does_not_read_as_knowledge():
+    """ "the evaluator has no known result" must not cap a genuine L5 at L4."""
+    decision = assign_level(
+        l5_evidence(evaluator_knowledge="The evaluator has no known result at the cutoff.")
+    )
+
+    assert decision["level"] == "L5"
+
+
+def test_an_open_ended_question_is_not_an_undisclosed_target():
+    """ "open-ended" must qualify the environment, not any noun."""
+    decision = assign_level(
+        evidence(
+            scored_outcome="The agent computes the answer, derived from the table.",
+            agent_visible_target=(
+                "The prompt states the open-ended question in full; only the answer is withheld."
+            ),
+            evaluator_knowledge="The evaluator already knows the recorded answer.",
+        )
+    )
+
+    assert decision["level"] == "L1"
+
+
+def test_a_verifier_that_reproduces_a_failure_is_not_a_replication_task():
+    """Verifier machinery is not agent behaviour: this is L2, not L3."""
+    decision = assign_level(
+        evidence(
+            scored_outcome=(
+                "The agent patches the specified issue; the verifier checks final repository state."
+            ),
+            agent_visible_target="The issue is given to the agent.",
+            evaluator_knowledge="The reference patch is recorded.",
+            verifier_modality="executable",
+            verifier_procedure=(
+                "Tests reproduce the failure and check the final repository state."
+            ),
+        )
+    )
+
+    assert decision["level"] == "L2"
+
+
+def test_a_verifier_running_commands_does_not_make_a_task_execution():
+    """Read-only diagnosis scored on the returned answer stays at L1."""
+    decision = assign_level(
+        evidence(
+            scored_outcome="The agent diagnoses the cause and returns a written explanation.",
+            agent_visible_target="The question is stated in full.",
+            evaluator_knowledge="A gold explanation is recorded.",
+            verifier_procedure=(
+                "The harness executes the commands; only the returned answer is compared."
+            ),
+        )
+    )
+
+    assert decision["level"] == "L1"
+
+
+def test_evaluator_side_arithmetic_is_not_agent_side_derivation():
+    """ "the evaluator computes accuracy" is scoring, not reasoning: still L0."""
+    decision = assign_level(
+        evidence(
+            scored_outcome="The answer span is copied verbatim from the supplied document.",
+            agent_visible_target="The question is given.",
+            evaluator_knowledge="The annotated span is recorded.",
+            verifier_procedure=(
+                "The evaluator computes exact-match accuracy against the annotated span."
+            ),
+        )
+    )
+
+    assert decision["level"] == "L0"
+
+
+def test_an_ordinary_comparison_counts_as_derivation():
+    decision = assign_level(
+        evidence(
+            scored_outcome="The agent retrieves the record and compares its timestamp to a cutoff.",
+            verifier_procedure="The returned label is compared to the gold label.",
+        )
+    )
+
+    assert decision["level"] == "L1"
+
+
+def test_a_qualified_state_noun_still_signals_execution():
+    decision = assign_level(
+        evidence(
+            scored_outcome="The verifier checks the final repository state after the run.",
+            verifier_modality="executable",
+            verifier_procedure="Tests are executed against the repository.",
+        )
+    )
+
+    assert decision["level"] == "L2"
+
+
 def test_reference_lists_all_six_levels():
     reference = kw_bench.kw_bench_reference()
 

--- a/tests/test_kw_bench.py
+++ b/tests/test_kw_bench.py
@@ -453,6 +453,30 @@ def test_l5_accepts_explicit_negated_prior_art_results(novelty_check):
     assert assign_level(l5_evidence(novelty_check=novelty_check))["level"] == "L5"
 
 
+def test_an_explicit_prior_art_hit_overrides_an_earlier_clean_clause():
+    decision = assign_level(
+        l5_evidence(
+            novelty_check=(
+                "The search did not find any prior art at first, but the exact result "
+                "was already published in 2024."
+            )
+        )
+    )
+
+    assert decision["level"] == "L4"
+
+
+def test_an_embedded_admission_that_no_search_ran_blocks_l5():
+    decision = assign_level(
+        l5_evidence(
+            novelty_check="The check returned zero prior results because no search was performed."
+        )
+    )
+
+    assert decision["level"] == UNCLASSIFIED
+    assert decision["missing_evidence"] == ["novelty_check"]
+
+
 def test_novelty_check_reporting_prior_art_caps_at_l4():
     """The ceiling applies from the novelty check, not only evaluator knowledge."""
     decision = assign_level(

--- a/tests/test_kw_bench.py
+++ b/tests/test_kw_bench.py
@@ -441,6 +441,18 @@ def test_l5_requires_the_novelty_check_to_record_a_clean_result():
     assert decision["missing_evidence"] == ["novelty_check"]
 
 
+@pytest.mark.parametrize(
+    "novelty_check",
+    [
+        "The search did not find any prior art.",
+        "The review identified no matching results.",
+        "The check returned zero prior results.",
+    ],
+)
+def test_l5_accepts_explicit_negated_prior_art_results(novelty_check):
+    assert assign_level(l5_evidence(novelty_check=novelty_check))["level"] == "L5"
+
+
 def test_novelty_check_reporting_prior_art_caps_at_l4():
     """The ceiling applies from the novelty check, not only evaluator knowledge."""
     decision = assign_level(

--- a/tests/test_kw_bench.py
+++ b/tests/test_kw_bench.py
@@ -539,6 +539,129 @@ def test_a_qualified_state_noun_still_signals_execution():
     assert decision["level"] == "L2"
 
 
+# --- Second review round: regressions caused by the first round's fixes -----
+#
+# Tightening the patterns above introduced these. Kept as tests because they
+# are the concrete evidence for the accuracy caveat in `kw_bench_reference`:
+# hand-written patterns over natural language trade one error class for
+# another, which is why an unreviewed level is a triage hint and not a fact.
+
+
+def test_a_clean_novelty_check_is_not_read_as_prior_art():
+    """ "No prior art was found" is the expected result of a novelty check."""
+    decision = assign_level(
+        l5_evidence(
+            evaluator_knowledge="The evaluator was unaware of any matching result at the cutoff.",
+            novelty_check=(
+                "A systematic search was completed before the cutoff. No prior art was found."
+            ),
+        )
+    )
+
+    assert decision["level"] == "L5"
+
+
+def test_not_only_is_an_intensifier_not_a_negation():
+    """ "not only recorded but covered by a test" asserts more knowledge, not less."""
+    decision = assign_level(
+        evidence(
+            scored_outcome="The agent diagnoses and reports the undisclosed defect.",
+            agent_visible_target="An open-ended repository; the target bug is undisclosed.",
+            evaluator_knowledge=(
+                "The known bug is not only recorded but covered by a regression test."
+            ),
+            verifier_modality="human expert",
+            verifier_procedure="The submitted diagnosis is matched against the recorded bug.",
+        )
+    )
+
+    assert decision["level"] == "L4"
+
+
+def test_an_absent_alternative_hypothesis_is_not_a_hidden_target():
+    """Statistical-task boilerplate must not read as an undisclosed finding."""
+    decision = assign_level(
+        evidence(
+            scored_outcome="The agent computes the p-value for the stated null hypothesis.",
+            agent_visible_target=(
+                "The null hypothesis and dataset are supplied; no alternative hypothesis "
+                "is specified."
+            ),
+            evaluator_knowledge="The evaluator already knows the recorded answer.",
+            verifier_procedure="The returned p-value is compared with the reference value.",
+        )
+    )
+
+    assert decision["level"] == "L1"
+
+
+def test_an_answer_only_claim_that_also_scores_state_is_not_exclusive():
+    decision = assign_level(
+        evidence(
+            scored_outcome="The agent modifies the repository and summarizes the applied fix.",
+            agent_visible_target="The issue and required end state are specified.",
+            evaluator_knowledge="The evaluator holds the expected patched state.",
+            verifier_modality="executable",
+            verifier_procedure=(
+                "Only the returned report is parsed for metadata; tests also inspect the "
+                "final repository state."
+            ),
+        )
+    )
+
+    assert decision["level"] == "L2"
+
+
+def test_a_conceptual_state_is_not_an_environment_state():
+    """ "final disease state" is a prediction target, not a mutated system."""
+    decision = assign_level(
+        evidence(
+            scored_outcome=(
+                "The agent computes the final disease state from the supplied longitudinal record."
+            ),
+            agent_visible_target="The patient history and prediction question are supplied.",
+            evaluator_knowledge="The evaluator holds the ground-truth label.",
+            verifier_procedure="Exact match against the annotated disease-state label.",
+        )
+    )
+
+    assert decision["level"] == "L1"
+
+
+def test_running_a_migration_is_execution_even_when_a_report_is_returned():
+    decision = assign_level(
+        evidence(
+            scored_outcome=(
+                "The agent executes the commands for a specified database migration and "
+                "computes a completion report from their exit statuses."
+            ),
+            agent_visible_target="The migration and required commands are specified in full.",
+            evaluator_knowledge="The evaluator holds the expected migrated schema.",
+            verifier_modality="executable",
+            verifier_procedure="The harness checks the exit statuses and the migrated schema.",
+        )
+    )
+
+    assert decision["level"] == "L2"
+
+
+def test_a_trailing_evaluator_clause_does_not_become_agent_derivation():
+    """ "...copied verbatim ... and later compared" is still retrieval."""
+    decision = assign_level(
+        evidence(
+            scored_outcome=(
+                "The answer span is copied verbatim from the document and later compared "
+                "against the annotated span."
+            ),
+            agent_visible_target="The document and lookup question are supplied in full.",
+            evaluator_knowledge="The evaluator holds the annotated answer span.",
+            verifier_procedure="Exact span match determines success.",
+        )
+    )
+
+    assert decision["level"] == "L0"
+
+
 def test_reference_lists_all_six_levels():
     reference = kw_bench.kw_bench_reference()
 

--- a/tests/test_kw_bench.py
+++ b/tests/test_kw_bench.py
@@ -1,0 +1,423 @@
+import pytest
+
+from benchmark_radar import kw_bench
+from benchmark_radar.kw_bench import (
+    KW_BENCH_VERSION,
+    UNCLASSIFIED,
+    KwBenchError,
+    assign_level,
+    classify_track,
+    coverage,
+    evidence_hash,
+    is_publishable,
+    level_counts,
+    review_status_for,
+    track_id,
+)
+
+
+def evidence(**overrides):
+    value = {
+        "scored_outcome": "The returned answer string is compared to the gold answer.",
+        "agent_visible_target": "The question is given to the agent in full.",
+        "evaluator_knowledge": "The gold answer is stored in the benchmark.",
+        "verifier_modality": "exact",
+        "verifier_procedure": "Exact string match against the gold answer.",
+    }
+    value.update(overrides)
+    return value
+
+
+# --- L0 / L1 boundary ----------------------------------------------------
+
+
+def test_copied_span_is_retrieval():
+    decision = assign_level(
+        evidence(
+            scored_outcome="The answer span is copied verbatim from the supplied document.",
+            verifier_procedure="Exact match against the annotated span.",
+        )
+    )
+
+    assert decision["level"] == "L0"
+    assert decision["boundary"] == "L0 to L1"
+
+
+def test_synthesis_across_sources_is_closed_form_reasoning():
+    decision = assign_level(
+        evidence(
+            scored_outcome="The agent must synthesize retrieved passages into a derived total.",
+            verifier_procedure="The computed value is compared to the reference value.",
+        )
+    )
+
+    assert decision["level"] == "L1"
+
+
+def test_retrieval_followed_by_derivation_is_l1_not_l0():
+    """A task that looks up and then reasons is L1: derivation wins over lookup."""
+    decision = assign_level(
+        evidence(
+            scored_outcome=(
+                "The agent retrieves the passage from the source and then computes the "
+                "resulting figure."
+            ),
+        )
+    )
+
+    assert decision["level"] == "L1"
+
+
+# --- L1 / L2 boundary ----------------------------------------------------
+
+
+def test_environment_end_state_is_execution():
+    decision = assign_level(
+        evidence(
+            scored_outcome="The verifier checks the end state of the repository after the run.",
+            verifier_procedure="The test suite is executed against the modified repository.",
+            verifier_modality="executable",
+        )
+    )
+
+    assert decision["level"] == "L2"
+    assert decision["boundary"] == "L1 to L2"
+
+
+def test_read_only_shell_use_stays_at_reasoning():
+    """The rubric is explicit: read-only tool use preserves L1."""
+    decision = assign_level(
+        evidence(
+            scored_outcome=(
+                "The agent may query the database read-only; the verifier checks only the "
+                "returned answer, which it must derive from the query results."
+            ),
+            verifier_procedure="The returned answer is compared to the reference answer.",
+        )
+    )
+
+    assert decision["level"] == "L1"
+
+
+# --- L2 / L3 boundary ----------------------------------------------------
+
+
+def test_reproducing_a_named_result_is_replication():
+    decision = assign_level(
+        evidence(
+            scored_outcome=(
+                "The agent must reproduce the reported accuracy from the referenced paper."
+            ),
+            agent_visible_target="The paper and its reported result are provided to the agent.",
+            verifier_procedure="Reproduced metrics are compared within a stated tolerance.",
+        )
+    )
+
+    assert decision["level"] == "L3"
+    assert decision["boundary"] == "L2 to L3"
+
+
+# --- L3 / L4 boundary ----------------------------------------------------
+
+
+def test_undisclosed_finding_known_to_evaluator_is_rediscovery():
+    decision = assign_level(
+        evidence(
+            scored_outcome="The agent reports a defect it located without being told where.",
+            agent_visible_target=(
+                "An open-ended repository; the target bug is undisclosed to the agent."
+            ),
+            evaluator_knowledge="The evaluator already knows the recorded bug and its location.",
+            verifier_procedure="The reported defect is matched against the recorded bug.",
+        )
+    )
+
+    assert decision["level"] == "L4"
+    assert decision["boundary"] == "L3 to L4"
+
+
+def test_stated_question_with_withheld_answer_is_not_rediscovery():
+    """Withholding only the answer is every ordinary benchmark, not L4."""
+    decision = assign_level(
+        evidence(
+            scored_outcome="The agent computes the answer, which is derived from the input.",
+            agent_visible_target="The question is stated in full; only the answer is withheld.",
+            evaluator_knowledge="The evaluator holds the gold answer.",
+        )
+    )
+
+    assert decision["level"] == "L1"
+
+
+def test_a_withheld_answer_alone_never_reaches_rediscovery():
+    """Every benchmark withholds its answer; only a withheld *target* is L4."""
+    decision = assign_level(
+        evidence(
+            scored_outcome="The agent returns the answer, derived from the supplied table.",
+            agent_visible_target="The prompt names the task; the gold answer is withheld.",
+            evaluator_knowledge="The evaluator already knows the recorded answer.",
+        )
+    )
+
+    assert decision["level"] == "L1"
+
+
+def test_open_ended_read_only_bug_hunt_is_l4_not_l1():
+    """Discovery status takes precedence over output form, per the rubric."""
+    decision = assign_level(
+        evidence(
+            scored_outcome=(
+                "The agent returns a written description of the undisclosed failure mechanism."
+            ),
+            agent_visible_target=(
+                "Raw observations only; the agent must choose what to investigate."
+            ),
+            evaluator_knowledge="The evaluator already knows the recorded mechanism.",
+            verifier_modality="human expert",
+            verifier_procedure="An expert matches the report against the recorded mechanism.",
+        )
+    )
+
+    assert decision["level"] == "L4"
+
+
+# --- L4 / L5 boundary ----------------------------------------------------
+
+
+def l5_evidence(**overrides):
+    value = evidence(
+        scored_outcome="A novel result produced during the run is validated externally.",
+        agent_visible_target="An open-ended frontier problem; no target is disclosed.",
+        evaluator_knowledge="No prior result is known to the evaluator at the cutoff.",
+        verifier_modality="human expert",
+        verifier_procedure=(
+            "A new experiment provides prospective validation and experts adjudicate."
+        ),
+        evaluation_cutoff="2026-07-01T00:00:00+00:00",
+        novelty_check="Prior-art search across arXiv and Scopus on 2026-07-01; no prior result.",
+    )
+    value.update(overrides)
+    return value
+
+
+def test_prospectively_validated_novel_result_is_frontier_advancement():
+    decision = assign_level(l5_evidence())
+
+    assert decision["level"] == "L5"
+    assert decision["boundary"] == "L4 to L5"
+
+
+@pytest.mark.parametrize("field", ["evaluation_cutoff", "novelty_check"])
+def test_l5_without_its_extra_fields_is_unclassified_not_l4(field):
+    """The rubric: an L5 assignment missing a cutoff or novelty check is unclassified."""
+    decision = assign_level(l5_evidence(**{field: ""}))
+
+    assert decision["level"] == UNCLASSIFIED
+    assert field in decision["missing_evidence"]
+
+
+def test_prior_art_known_to_the_evaluator_caps_at_l4():
+    decision = assign_level(
+        l5_evidence(
+            evaluator_knowledge=(
+                "A provenance check found the evaluator already knew this recorded result."
+            ),
+        )
+    )
+
+    assert decision["level"] == "L4"
+
+
+# --- Unclassified --------------------------------------------------------
+
+
+def test_missing_required_fields_is_unclassified_with_the_list():
+    decision = assign_level({"scored_outcome": "Something happens."})
+
+    assert decision["level"] == UNCLASSIFIED
+    assert "verifier_procedure" in decision["missing_evidence"]
+    assert "agent_visible_target" in decision["missing_evidence"]
+
+
+def test_empty_evidence_is_unclassified():
+    assert assign_level({})["level"] == UNCLASSIFIED
+
+
+def test_whitespace_only_field_counts_as_missing():
+    decision = assign_level(evidence(verifier_procedure="   "))
+
+    assert decision["level"] == UNCLASSIFIED
+    assert "verifier_procedure" in decision["missing_evidence"]
+
+
+def test_present_but_vague_evidence_is_unclassified_rather_than_guessed():
+    decision = assign_level(
+        evidence(
+            scored_outcome="The submission is scored.",
+            verifier_procedure="A score is produced.",
+            agent_visible_target="A task.",
+            evaluator_knowledge="Reference material.",
+        )
+    )
+
+    assert decision["level"] == UNCLASSIFIED
+    assert decision["missing_evidence"] == []
+
+
+def test_title_keywords_never_set_a_level():
+    """`agentic` in a title must not produce a level; only evidence can."""
+    record = classify_track(
+        {
+            "canonical_artifact_id": "artifact:arxiv:2607.00001",
+            "track_name": "default",
+            "title": "AgenticBench: An Agentic Agent Benchmark for Autonomous Agents",
+            "evidence": {},
+        },
+        classified_at="2026-08-06T00:00:00+00:00",
+    )
+
+    assert record["level"] == UNCLASSIFIED
+
+
+# --- Record construction -------------------------------------------------
+
+
+def test_classification_record_is_auditable():
+    record = classify_track(
+        {
+            "canonical_artifact_id": "artifact:github:org/bench",
+            "track_name": "execution",
+            "title": "Bench",
+            "url": "https://github.com/org/bench",
+            "event_kind": "released",
+            "evidence": evidence(
+                scored_outcome="The verifier checks the end state of the repository.",
+                verifier_modality="executable",
+            ),
+            "tags": {"horizon": "multi-turn", "not_an_axis": "ignored"},
+        },
+        classified_at="2026-08-06T00:00:00+00:00",
+    )
+
+    assert record["level"] == "L2"
+    assert record["kw_bench_version"] == KW_BENCH_VERSION
+    assert record["level_rationale"]
+    assert record["evidence_hash"].startswith("sha256:")
+    assert record["tags"] == {"horizon": "multi-turn"}
+    assert record["evidence"]["verifier_procedure"]
+
+
+def test_track_ids_are_stable_and_distinct_per_track():
+    first = track_id("artifact:arxiv:2607.00001", "retrieval")
+    second = track_id("artifact:arxiv:2607.00001", "execution")
+
+    assert first == track_id("artifact:arxiv:2607.00001", "Retrieval  ")
+    assert first != second
+
+
+def test_evidence_hash_changes_with_the_evidence():
+    assert evidence_hash(evidence()) == evidence_hash(evidence())
+    assert evidence_hash(evidence()) != evidence_hash(evidence(scored_outcome="Different."))
+
+
+def test_invalid_verifier_modality_is_rejected():
+    with pytest.raises(KwBenchError):
+        classify_track(
+            {
+                "canonical_artifact_id": "artifact:x",
+                "track_name": "default",
+                "evidence": evidence(verifier_modality="vibes"),
+            },
+            classified_at="2026-08-06T00:00:00+00:00",
+        )
+
+
+def test_missing_canonical_id_is_rejected():
+    with pytest.raises(KwBenchError):
+        classify_track(
+            {"canonical_artifact_id": "", "track_name": "default"},
+            classified_at="2026-08-06T00:00:00+00:00",
+        )
+
+
+# --- Review gates and counting -------------------------------------------
+
+
+@pytest.mark.parametrize("level", ["L0", "L1", "L2", "L3"])
+def test_low_levels_publish_automatically(level):
+    assert review_status_for(level) == kw_bench.REVIEW_AUTO
+
+
+@pytest.mark.parametrize("level", ["L4", "L5"])
+def test_discovery_levels_require_human_review(level):
+    assert review_status_for(level) == kw_bench.REVIEW_REQUIRED
+    assert not is_publishable({"level": level, "review_status": kw_bench.REVIEW_REQUIRED})
+
+
+def test_human_approval_makes_l5_publishable():
+    assert is_publishable({"level": "L5", "review_status": kw_bench.REVIEW_APPROVED})
+
+
+def test_unclassified_is_published_as_a_visible_outcome():
+    assert is_publishable({"level": UNCLASSIFIED, "review_status": kw_bench.REVIEW_AUTO})
+
+
+def record(level, **overrides):
+    value = {
+        "track_id": f"track:{level}",
+        "level": level,
+        "review_status": review_status_for(level),
+        "event_kind": "released",
+    }
+    value.update(overrides)
+    return value
+
+
+def test_level_counts_include_every_bar_even_at_zero():
+    counts = level_counts([record("L1")])
+
+    assert set(counts) == set(kw_bench.CHART_LEVELS)
+    assert counts["L1"] == 1
+    assert counts["L4"] == 0
+
+
+def test_a_track_is_counted_once_however_many_rows_it_has():
+    counts = level_counts([record("L2"), record("L2")])
+
+    assert counts["L2"] == 1
+
+
+def test_released_only_excludes_update_sightings():
+    counts = level_counts(
+        [record("L1"), record("L2", track_id="track:b", event_kind="updated")],
+        released_only=True,
+    )
+
+    assert counts["L1"] == 1
+    assert counts["L2"] == 0
+
+
+def test_unreviewed_l5_is_excluded_from_counts():
+    counts = level_counts([record("L5")])
+
+    assert counts["L5"] == 0
+
+
+def test_coverage_reports_the_unclassified_share():
+    report = coverage([record("L1"), record(UNCLASSIFIED, track_id="track:u"), record("L5")])
+
+    assert report["classified_count"] == 1
+    assert report["unclassified_count"] == 1
+    assert report["classified_rate"] == 0.5
+    assert report["awaiting_human_review"] == 1
+
+
+def test_coverage_of_an_empty_corpus_has_no_rate():
+    assert coverage([])["classified_rate"] is None
+
+
+def test_reference_lists_all_six_levels():
+    reference = kw_bench.kw_bench_reference()
+
+    assert [entry["level"] for entry in reference["levels"]] == list(kw_bench.LEVELS)
+    assert reference["kw_bench_version"] == KW_BENCH_VERSION

--- a/tests/test_kw_bench.py
+++ b/tests/test_kw_bench.py
@@ -628,6 +628,20 @@ def test_a_conceptual_state_is_not_an_environment_state():
     assert decision["level"] == "L1"
 
 
+@pytest.mark.parametrize("kind", ["final", "environmental", "quantum"])
+def test_a_predicted_state_is_not_a_mutated_system_state(kind):
+    decision = assign_level(
+        evidence(
+            scored_outcome=(f"The agent computes the {kind} state from the supplied measurements."),
+            agent_visible_target="The measurements and prediction question are supplied.",
+            evaluator_knowledge="The evaluator holds the ground-truth label.",
+            verifier_procedure="Exact match against the annotated state label.",
+        )
+    )
+
+    assert decision["level"] == "L1"
+
+
 def test_running_a_migration_is_execution_even_when_a_report_is_returned():
     decision = assign_level(
         evidence(

--- a/tests/test_kw_bench_tracks.py
+++ b/tests/test_kw_bench_tracks.py
@@ -11,6 +11,7 @@ from benchmark_radar.kw_bench_tracks import (
     classify_tracks,
     derive_tracks,
 )
+from benchmark_radar.snapshots import kw_bench_layer
 
 CLASSIFIED_AT = "2026-08-06T00:00:00+00:00"
 
@@ -339,6 +340,16 @@ def test_limit_bounds_a_backfill_run(tmp_path):
     assert summary["classified"] == 2
 
 
+def test_negative_limit_is_rejected(tmp_path):
+    with pytest.raises(kw_bench.KwBenchError, match="limit must be non-negative"):
+        backfill(
+            [snapshot("2026-07-28", item())],
+            store_path=tmp_path / "kw.jsonl",
+            classified_at=CLASSIFIED_AT,
+            limit=-1,
+        )
+
+
 def test_a_bounded_run_advances_instead_of_reselecting_the_same_prefix(tmp_path):
     """`limit` bounds remaining work; slicing the full list could never finish."""
     store = tmp_path / "kw.jsonl"
@@ -409,6 +420,40 @@ def test_corrupt_json_is_reported_with_its_line(tmp_path):
         kw_bench_store.read_records(store)
 
 
+def test_torn_final_row_keeps_the_durable_store_prefix(tmp_path):
+    store = tmp_path / "kw.jsonl"
+    store.write_text(
+        '{"canonical_artifact_id":"a","track_id":"t"}\n{"canonical_artifact',
+        encoding="utf-8",
+    )
+
+    assert kw_bench_store.read_records(store) == [{"canonical_artifact_id": "a", "track_id": "t"}]
+
+
+def test_malformed_completed_final_row_is_rejected(tmp_path):
+    store = tmp_path / "kw.jsonl"
+    store.write_text(
+        '{"canonical_artifact_id":"a","track_id":"t"}\n{not json}\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(kw_bench.KwBenchError, match="kw.jsonl:2"):
+        kw_bench_store.read_records(store)
+
+
+def test_retraction_tombstone_removes_the_previous_live_record(tmp_path):
+    store = tmp_path / "kw.jsonl"
+    kw_bench_store.append_records(
+        store,
+        [
+            {"canonical_artifact_id": "a", "track_id": "t", "level": "L1"},
+            {"canonical_artifact_id": "a", "track_id": "t", "superseded": True},
+        ],
+    )
+
+    assert kw_bench_store.current_records(store) == {}
+
+
 def test_missing_store_reads_as_empty(tmp_path):
     assert kw_bench_store.read_records(tmp_path / "absent.jsonl") == []
 
@@ -427,6 +472,16 @@ def test_zero_batch_size_is_rejected():
 
 
 # --- Dashboard layer -----------------------------------------------------
+
+
+def test_missing_store_reports_candidate_tracks_as_unclassified(tmp_path):
+    tracks = derive_tracks([snapshot("2026-07-28", item())])
+
+    layer = kw_bench_layer(tmp_path / "absent.jsonl", tracks=tracks)
+
+    assert layer["track_count"] == 1
+    assert layer["coverage"]["track_count"] == 1
+    assert layer["level_counts"][kw_bench.UNCLASSIFIED] == 1
 
 
 def test_classification_layer_is_marked_shadow(tmp_path):

--- a/tests/test_kw_bench_tracks.py
+++ b/tests/test_kw_bench_tracks.py
@@ -236,6 +236,21 @@ def test_a_refresh_cutoff_re_extracts_rows_classified_before_it(tmp_path):
     assert len(kw_bench_store.read_records(store)) == 1
 
 
+def test_refresh_cutoffs_compare_instants_across_timezone_offsets(tmp_path):
+    store = tmp_path / "kw.jsonl"
+    snapshots = [snapshot("2026-07-28", item())]
+    backfill(snapshots, store_path=store, classified_at="2026-08-06T00:00:00+00:00")
+
+    summary = backfill(
+        snapshots,
+        store_path=store,
+        classified_at=CLASSIFIED_AT,
+        refresh_before="2026-08-05T20:00:00-07:00",
+    )
+
+    assert summary["extraction_calls"] == 1
+
+
 def test_a_track_promoted_to_released_is_reclassified(tmp_path):
     """A stale `updated` row would silently drop the track from released counts."""
     store = tmp_path / "kw.jsonl"

--- a/tests/test_kw_bench_tracks.py
+++ b/tests/test_kw_bench_tracks.py
@@ -110,6 +110,19 @@ def test_derivation_is_deterministic():
     ]
 
 
+def test_track_names_are_deduplicated_by_their_normalized_identity():
+    snapshots = [snapshot("2026-07-28", item())]
+    artifact = "artifact:arxiv:2607.12345"
+
+    tracks = derive_tracks(
+        snapshots,
+        track_names={artifact: [" Retrieval ", "retrieval", "RETRIEVAL"]},
+    )
+
+    assert len(tracks) == 1
+    assert len({track["track_id"] for track in tracks}) == 1
+
+
 # --- Backfill and caching ------------------------------------------------
 
 

--- a/tests/test_kw_bench_tracks.py
+++ b/tests/test_kw_bench_tracks.py
@@ -175,6 +175,34 @@ def test_a_cache_hit_never_reaches_the_extractor(tmp_path):
     assert summary["extraction_calls"] == 0
 
 
+def test_switching_extractors_invalidates_null_evidence(tmp_path):
+    store = tmp_path / "kw.jsonl"
+    snapshots = [snapshot("2026-07-28", item())]
+    artifact = "artifact:arxiv:2607.12345"
+    backfill(snapshots, store_path=store, classified_at=CLASSIFIED_AT)
+    extractor = MappingExtractor(
+        {
+            artifact: {
+                "scored_outcome": "The answer is copied verbatim from the document.",
+                "agent_visible_target": "The question is given.",
+                "evaluator_knowledge": "The evaluator holds the answer.",
+                "verifier_modality": "exact",
+                "verifier_procedure": "Exact match determines success.",
+            }
+        }
+    )
+
+    summary = backfill(
+        snapshots,
+        store_path=store,
+        classified_at=CLASSIFIED_AT,
+        extractor=extractor,
+    )
+
+    assert summary["extraction_calls"] == 1
+    assert next(iter(kw_bench_store.current_records(store).values()))["level"] == "L0"
+
+
 def test_changed_evidence_supersedes_without_rewriting_history(tmp_path):
     store = tmp_path / "kw.jsonl"
     snapshots = [snapshot("2026-07-28", item())]
@@ -192,13 +220,11 @@ def test_changed_evidence_supersedes_without_rewriting_history(tmp_path):
             }
         }
     )
-    # A refresh cutoff is what re-extracts a track whose metadata is unchanged.
     backfill(
         snapshots,
         store_path=store,
         classified_at="2026-08-06T00:00:00+00:00",
         extractor=extractor,
-        refresh_before="2026-08-01T00:00:00+00:00",
     )
 
     records = kw_bench_store.read_records(store)
@@ -428,6 +454,22 @@ def test_torn_final_row_keeps_the_durable_store_prefix(tmp_path):
     )
 
     assert kw_bench_store.read_records(store) == [{"canonical_artifact_id": "a", "track_id": "t"}]
+
+    kw_bench_store.append_records(store, [{"canonical_artifact_id": "b", "track_id": "u"}])
+
+    assert [record["track_id"] for record in kw_bench_store.read_records(store)] == ["t", "u"]
+
+
+def test_append_preserves_a_valid_final_row_without_a_newline(tmp_path):
+    store = tmp_path / "kw.jsonl"
+    store.write_text(
+        '{"canonical_artifact_id":"a","track_id":"t"}',
+        encoding="utf-8",
+    )
+
+    kw_bench_store.append_records(store, [{"canonical_artifact_id": "b", "track_id": "u"}])
+
+    assert [record["track_id"] for record in kw_bench_store.read_records(store)] == ["t", "u"]
 
 
 def test_malformed_completed_final_row_is_rejected(tmp_path):

--- a/tests/test_kw_bench_tracks.py
+++ b/tests/test_kw_bench_tracks.py
@@ -140,11 +140,32 @@ def test_rerunning_a_completed_backfill_classifies_nothing(tmp_path):
     assert len(kw_bench_store.read_records(store)) == 1
 
 
+def test_a_cache_hit_never_reaches_the_extractor(tmp_path):
+    """The gate must run before extraction, or it saves nothing once a model backs it."""
+    store = tmp_path / "kw.jsonl"
+    snapshots = [snapshot("2026-07-28", item())]
+    backfill(snapshots, store_path=store, classified_at=CLASSIFIED_AT)
+
+    class Counting(NullExtractor):
+        def __init__(self):
+            self.calls = 0
+
+        def extract(self, track):
+            self.calls += 1
+            return {}, []
+
+    counter = Counting()
+    summary = backfill(snapshots, store_path=store, classified_at=CLASSIFIED_AT, extractor=counter)
+
+    assert counter.calls == 0
+    assert summary["extraction_calls"] == 0
+
+
 def test_changed_evidence_supersedes_without_rewriting_history(tmp_path):
     store = tmp_path / "kw.jsonl"
     snapshots = [snapshot("2026-07-28", item())]
     artifact = "artifact:arxiv:2607.12345"
-    backfill(snapshots, store_path=store, classified_at=CLASSIFIED_AT)
+    backfill(snapshots, store_path=store, classified_at="2026-07-28T00:00:00+00:00")
 
     extractor = MappingExtractor(
         {
@@ -157,11 +178,13 @@ def test_changed_evidence_supersedes_without_rewriting_history(tmp_path):
             }
         }
     )
+    # A refresh cutoff is what re-extracts a track whose metadata is unchanged.
     backfill(
         snapshots,
         store_path=store,
-        classified_at=CLASSIFIED_AT,
+        classified_at="2026-08-06T00:00:00+00:00",
         extractor=extractor,
+        refresh_before="2026-08-01T00:00:00+00:00",
     )
 
     records = kw_bench_store.read_records(store)
@@ -169,42 +192,71 @@ def test_changed_evidence_supersedes_without_rewriting_history(tmp_path):
     assert records[0]["level"] == kw_bench.UNCLASSIFIED
     assert records[1]["level"] == "L2"
     assert records[1]["supersedes_evidence_hash"] == records[0]["evidence_hash"]
+    # The earlier row is left exactly as written; the newer one wins by order.
+    assert "superseded" not in records[0]
     live = kw_bench_store.current_records(store)
     assert live[(artifact, records[1]["track_id"])]["level"] == "L2"
 
 
 def test_a_rubric_version_bump_invalidates_the_cache(tmp_path, monkeypatch):
+    """A level-boundary change invalidates stored levels even on identical evidence."""
     store = tmp_path / "kw.jsonl"
     snapshots = [snapshot("2026-07-28", item())]
     backfill(snapshots, store_path=store, classified_at=CLASSIFIED_AT)
 
+    # Patch both names: the store gates on its own import, and `classify_track`
+    # stamps the version onto the row it builds.
     monkeypatch.setattr(kw_bench_store, "KW_BENCH_VERSION", "0.2")
+    monkeypatch.setattr(kw_bench, "KW_BENCH_VERSION", "0.2")
     summary = backfill(snapshots, store_path=store, classified_at=CLASSIFIED_AT)
 
+    assert summary["extraction_calls"] == 1
     assert summary["classified"] == 1
+    live = list(kw_bench_store.current_records(store).values())
+    assert live[0]["kw_bench_version"] == "0.2"
 
 
-def test_changed_source_hashes_force_reclassification(tmp_path):
-    """An edited README must re-extract even when the evidence text is unchanged."""
+def test_a_refresh_cutoff_re_extracts_rows_classified_before_it(tmp_path):
+    """Upstream source edits are invisible to the fingerprint, so this is the hook."""
     store = tmp_path / "kw.jsonl"
     snapshots = [snapshot("2026-07-28", item())]
-    artifact = "artifact:arxiv:2607.12345"
-    fields = {"evidence": {}, "source_hashes": ["sha256:aaa"]}
-    backfill(
-        snapshots,
-        store_path=store,
-        classified_at=CLASSIFIED_AT,
-        extractor=MappingExtractor({artifact: fields}),
-    )
+    backfill(snapshots, store_path=store, classified_at="2026-07-28T00:00:00+00:00")
 
     summary = backfill(
         snapshots,
         store_path=store,
+        classified_at="2026-08-06T00:00:00+00:00",
+        refresh_before="2026-08-01T00:00:00+00:00",
+    )
+
+    assert summary["extraction_calls"] == 1
+    # Re-extraction produced identical evidence, so nothing new is stored.
+    assert summary["classified"] == 0
+    assert summary["unchanged_after_extraction"] == 1
+    assert len(kw_bench_store.read_records(store)) == 1
+
+
+def test_a_track_promoted_to_released_is_reclassified(tmp_path):
+    """A stale `updated` row would silently drop the track from released counts."""
+    store = tmp_path / "kw.jsonl"
+    backfill(
+        [snapshot("2026-07-28", item(event_kind="updated"))],
+        store_path=store,
         classified_at=CLASSIFIED_AT,
-        extractor=MappingExtractor({artifact: {**fields, "source_hashes": ["sha256:bbb"]}}),
+    )
+
+    summary = backfill(
+        [
+            snapshot("2026-07-28", item(event_kind="updated")),
+            snapshot("2026-07-29", item(event_kind="released")),
+        ],
+        store_path=store,
+        classified_at=CLASSIFIED_AT,
     )
 
     assert summary["classified"] == 1
+    live = list(kw_bench_store.current_records(store).values())
+    assert live[0]["event_kind"] == "released"
 
 
 def test_an_interrupted_backfill_keeps_completed_batches(tmp_path):
@@ -257,6 +309,58 @@ def test_limit_bounds_a_backfill_run(tmp_path):
 
     assert summary["tracks_derived"] == 5
     assert summary["classified"] == 2
+
+
+def test_a_bounded_run_advances_instead_of_reselecting_the_same_prefix(tmp_path):
+    """`limit` bounds remaining work; slicing the full list could never finish."""
+    store = tmp_path / "kw.jsonl"
+    snapshots = [
+        snapshot(
+            "2026-07-28",
+            *[item(source_id=f"p{n}", url=f"https://arxiv.org/abs/2607.{n:05d}") for n in range(5)],
+        )
+    ]
+
+    totals = []
+    for _ in range(3):
+        backfill(snapshots, store_path=store, classified_at=CLASSIFIED_AT, limit=2)
+        totals.append(len(kw_bench_store.current_records(store)))
+
+    assert totals == [2, 4, 5]
+
+
+def test_a_mixed_suite_reports_one_level_per_track(tmp_path):
+    """A suite of retrieval questions and executable tasks is L0 and L2, not an average."""
+    store = tmp_path / "kw.jsonl"
+    snapshots = [snapshot("2026-07-28", item())]
+    artifact = "artifact:arxiv:2607.12345"
+    tracks = derive_tracks(snapshots, track_names={artifact: ["retrieval", "execution"]})
+    assert len(tracks) == 2
+
+    by_name = {track["track_name"]: track["track_id"] for track in tracks}
+    extractor = MappingExtractor(
+        {
+            by_name["retrieval"]: {
+                "scored_outcome": "The answer span is copied verbatim from the document.",
+                "agent_visible_target": "The question is given.",
+                "evaluator_knowledge": "The annotated span is recorded.",
+                "verifier_modality": "exact",
+                "verifier_procedure": "The span is compared to the annotated span.",
+            },
+            by_name["execution"]: {
+                "scored_outcome": "The verifier checks the end state of the repository.",
+                "agent_visible_target": "The goal is given.",
+                "evaluator_knowledge": "The expected end state is recorded.",
+                "verifier_modality": "executable",
+                "verifier_procedure": "Tests run against the modified repository.",
+            },
+        }
+    )
+    classify_tracks(tracks, store_path=store, classified_at=CLASSIFIED_AT, extractor=extractor)
+
+    counts = classification_layer(store)["level_counts"]
+    assert counts["L0"] == 1
+    assert counts["L2"] == 1
 
 
 # --- Store mechanics -----------------------------------------------------

--- a/tests/test_kw_bench_tracks.py
+++ b/tests/test_kw_bench_tracks.py
@@ -1,0 +1,316 @@
+import json
+
+import pytest
+
+from benchmark_radar import kw_bench, kw_bench_store
+from benchmark_radar.kw_bench_tracks import (
+    MappingExtractor,
+    NullExtractor,
+    backfill,
+    classification_layer,
+    classify_tracks,
+    derive_tracks,
+)
+
+CLASSIFIED_AT = "2026-08-06T00:00:00+00:00"
+
+
+def item(**overrides):
+    value = {
+        "source": "arXiv",
+        "source_id": "paper-1",
+        "title": "A benchmark",
+        "url": "https://arxiv.org/abs/2607.12345",
+        "published_at": "2026-07-28T12:00:00+00:00",
+        "updated_at": None,
+        "event_kind": "released",
+        "categories": ["benchmark"],
+        "authors": [],
+        "artifact_urls": [],
+        "metrics": {},
+        "total_score": 50,
+    }
+    value.update(overrides)
+    return value
+
+
+def snapshot(date, *items):
+    return {"date": date, "evidence_items": list(items)}
+
+
+# --- Track derivation ----------------------------------------------------
+
+
+def test_repeated_sightings_collapse_to_one_track():
+    """The core dedup property: thousands of observations, one canonical track."""
+    snapshots = [snapshot(f"2026-07-{day:02d}", item()) for day in range(20, 30)]
+
+    tracks = derive_tracks(snapshots)
+
+    assert len(tracks) == 1
+    assert tracks[0]["canonical_artifact_id"] == "artifact:arxiv:2607.12345"
+
+
+def test_cross_source_sightings_of_one_artifact_collapse():
+    tracks = derive_tracks(
+        [
+            snapshot(
+                "2026-07-28",
+                item(source="arXiv", url="https://arxiv.org/abs/2607.12345"),
+                item(
+                    source="GitHub",
+                    source_id="repo-1",
+                    url="https://github.com/org/bench",
+                    artifact_urls=["https://arxiv.org/abs/2607.12345"],
+                ),
+            )
+        ]
+    )
+
+    assert len(tracks) == 1
+
+
+def test_dataset_only_records_are_not_scored_tracks():
+    """A corpus release has no scoring procedure, so it has no capability frontier."""
+    tracks = derive_tracks([snapshot("2026-07-28", item(categories=["dataset"]))])
+
+    assert tracks == []
+
+
+def test_evaluation_records_are_scored_tracks():
+    tracks = derive_tracks([snapshot("2026-07-28", item(categories=["evaluation"]))])
+
+    assert len(tracks) == 1
+
+
+def test_a_later_update_does_not_demote_a_released_track():
+    tracks = derive_tracks(
+        [
+            snapshot("2026-07-28", item(event_kind="released")),
+            snapshot("2026-07-29", item(event_kind="updated")),
+        ]
+    )
+
+    assert tracks[0]["event_kind"] == "released"
+
+
+def test_derivation_is_deterministic():
+    snapshots = [
+        snapshot(
+            "2026-07-28",
+            item(url="https://arxiv.org/abs/2607.00002"),
+            item(source_id="p2", url="https://arxiv.org/abs/2607.00001"),
+        )
+    ]
+
+    assert derive_tracks(snapshots) == derive_tracks(snapshots)
+    assert [track["canonical_artifact_id"] for track in derive_tracks(snapshots)] == [
+        "artifact:arxiv:2607.00001",
+        "artifact:arxiv:2607.00002",
+    ]
+
+
+# --- Backfill and caching ------------------------------------------------
+
+
+def test_null_extractor_leaves_every_track_unclassified(tmp_path):
+    store = tmp_path / "kw.jsonl"
+    summary = backfill(
+        [snapshot("2026-07-28", item())],
+        store_path=store,
+        classified_at=CLASSIFIED_AT,
+    )
+
+    assert summary["classified"] == 1
+    records = kw_bench_store.read_records(store)
+    assert records[0]["level"] == kw_bench.UNCLASSIFIED
+    assert records[0]["missing_evidence"]
+
+
+def test_rerunning_a_completed_backfill_classifies_nothing(tmp_path):
+    """The acceptance criterion: unchanged artifacts produce no new work."""
+    store = tmp_path / "kw.jsonl"
+    snapshots = [snapshot("2026-07-28", item())]
+    backfill(snapshots, store_path=store, classified_at=CLASSIFIED_AT)
+
+    second = backfill(snapshots, store_path=store, classified_at=CLASSIFIED_AT)
+
+    assert second["classified"] == 0
+    assert second["reused_from_cache"] == 1
+    assert len(kw_bench_store.read_records(store)) == 1
+
+
+def test_changed_evidence_supersedes_without_rewriting_history(tmp_path):
+    store = tmp_path / "kw.jsonl"
+    snapshots = [snapshot("2026-07-28", item())]
+    artifact = "artifact:arxiv:2607.12345"
+    backfill(snapshots, store_path=store, classified_at=CLASSIFIED_AT)
+
+    extractor = MappingExtractor(
+        {
+            artifact: {
+                "scored_outcome": "The verifier checks the end state of the repository.",
+                "agent_visible_target": "The goal is given to the agent.",
+                "evaluator_knowledge": "The expected end state is recorded.",
+                "verifier_modality": "executable",
+                "verifier_procedure": "Tests are executed against the modified repository.",
+            }
+        }
+    )
+    backfill(
+        snapshots,
+        store_path=store,
+        classified_at=CLASSIFIED_AT,
+        extractor=extractor,
+    )
+
+    records = kw_bench_store.read_records(store)
+    assert len(records) == 2
+    assert records[0]["level"] == kw_bench.UNCLASSIFIED
+    assert records[1]["level"] == "L2"
+    assert records[1]["supersedes_evidence_hash"] == records[0]["evidence_hash"]
+    live = kw_bench_store.current_records(store)
+    assert live[(artifact, records[1]["track_id"])]["level"] == "L2"
+
+
+def test_a_rubric_version_bump_invalidates_the_cache(tmp_path, monkeypatch):
+    store = tmp_path / "kw.jsonl"
+    snapshots = [snapshot("2026-07-28", item())]
+    backfill(snapshots, store_path=store, classified_at=CLASSIFIED_AT)
+
+    monkeypatch.setattr(kw_bench_store, "KW_BENCH_VERSION", "0.2")
+    summary = backfill(snapshots, store_path=store, classified_at=CLASSIFIED_AT)
+
+    assert summary["classified"] == 1
+
+
+def test_changed_source_hashes_force_reclassification(tmp_path):
+    """An edited README must re-extract even when the evidence text is unchanged."""
+    store = tmp_path / "kw.jsonl"
+    snapshots = [snapshot("2026-07-28", item())]
+    artifact = "artifact:arxiv:2607.12345"
+    fields = {"evidence": {}, "source_hashes": ["sha256:aaa"]}
+    backfill(
+        snapshots,
+        store_path=store,
+        classified_at=CLASSIFIED_AT,
+        extractor=MappingExtractor({artifact: fields}),
+    )
+
+    summary = backfill(
+        snapshots,
+        store_path=store,
+        classified_at=CLASSIFIED_AT,
+        extractor=MappingExtractor({artifact: {**fields, "source_hashes": ["sha256:bbb"]}}),
+    )
+
+    assert summary["classified"] == 1
+
+
+def test_an_interrupted_backfill_keeps_completed_batches(tmp_path):
+    store = tmp_path / "kw.jsonl"
+    snapshots = [
+        snapshot(
+            "2026-07-28",
+            *[item(source_id=f"p{n}", url=f"https://arxiv.org/abs/2607.{n:05d}") for n in range(6)],
+        )
+    ]
+    tracks = derive_tracks(snapshots)
+
+    class Failing(NullExtractor):
+        def __init__(self):
+            self.calls = 0
+
+        def extract(self, track):
+            self.calls += 1
+            if self.calls > 4:
+                raise RuntimeError("rate limited")
+            return {}, []
+
+    with pytest.raises(RuntimeError):
+        classify_tracks(
+            tracks,
+            store_path=store,
+            classified_at=CLASSIFIED_AT,
+            extractor=Failing(),
+            batch_size=2,
+        )
+
+    # Two batches of two committed before the third batch raised.
+    assert len(kw_bench_store.read_records(store)) == 4
+
+    resumed = classify_tracks(tracks, store_path=store, classified_at=CLASSIFIED_AT, batch_size=2)
+    assert resumed["classified"] == 2
+    assert resumed["reused_from_cache"] == 4
+
+
+def test_limit_bounds_a_backfill_run(tmp_path):
+    store = tmp_path / "kw.jsonl"
+    snapshots = [
+        snapshot(
+            "2026-07-28",
+            *[item(source_id=f"p{n}", url=f"https://arxiv.org/abs/2607.{n:05d}") for n in range(5)],
+        )
+    ]
+
+    summary = backfill(snapshots, store_path=store, classified_at=CLASSIFIED_AT, limit=2)
+
+    assert summary["tracks_derived"] == 5
+    assert summary["classified"] == 2
+
+
+# --- Store mechanics -----------------------------------------------------
+
+
+def test_blank_lines_do_not_break_a_partial_store(tmp_path):
+    store = tmp_path / "kw.jsonl"
+    store.write_text('{"canonical_artifact_id":"a","track_id":"t"}\n\n', encoding="utf-8")
+
+    assert len(kw_bench_store.read_records(store)) == 1
+
+
+def test_corrupt_json_is_reported_with_its_line(tmp_path):
+    store = tmp_path / "kw.jsonl"
+    store.write_text("{not json}\n", encoding="utf-8")
+
+    with pytest.raises(kw_bench.KwBenchError, match="kw.jsonl:1"):
+        kw_bench_store.read_records(store)
+
+
+def test_missing_store_reads_as_empty(tmp_path):
+    assert kw_bench_store.read_records(tmp_path / "absent.jsonl") == []
+
+
+def test_rewrite_is_atomic_and_leaves_no_temp_files(tmp_path):
+    store = tmp_path / "kw.jsonl"
+    kw_bench_store.rewrite_records(store, [{"canonical_artifact_id": "a", "track_id": "t"}])
+
+    assert len(kw_bench_store.read_records(store)) == 1
+    assert list(tmp_path.glob(".*tmp")) == []
+
+
+def test_zero_batch_size_is_rejected():
+    with pytest.raises(kw_bench.KwBenchError):
+        list(kw_bench_store.iter_batches([1, 2], 0))
+
+
+# --- Dashboard layer -----------------------------------------------------
+
+
+def test_classification_layer_is_marked_shadow(tmp_path):
+    store = tmp_path / "kw.jsonl"
+    backfill([snapshot("2026-07-28", item())], store_path=store, classified_at=CLASSIFIED_AT)
+
+    layer = classification_layer(store)
+
+    assert layer["shadow"] is True
+    assert layer["chart_levels"] == list(kw_bench.CHART_LEVELS)
+    assert layer["level_counts"][kw_bench.UNCLASSIFIED] == 1
+    assert layer["coverage"]["classified_rate"] == 0.0
+
+
+def test_classification_layer_is_json_serializable(tmp_path):
+    store = tmp_path / "kw.jsonl"
+    backfill([snapshot("2026-07-28", item())], store_path=store, classified_at=CLASSIFIED_AT)
+
+    assert json.loads(json.dumps(classification_layer(store)))

--- a/tests/test_kw_bench_tracks.py
+++ b/tests/test_kw_bench_tracks.py
@@ -201,6 +201,13 @@ def test_switching_extractors_invalidates_null_evidence(tmp_path):
 
     assert summary["extraction_calls"] == 1
     assert next(iter(kw_bench_store.current_records(store).values()))["level"] == "L0"
+    rerun = backfill(
+        snapshots,
+        store_path=store,
+        classified_at=CLASSIFIED_AT,
+        extractor=extractor,
+    )
+    assert rerun["extraction_calls"] == 0
 
 
 def test_changed_evidence_supersedes_without_rewriting_history(tmp_path):
@@ -270,10 +277,17 @@ def test_a_refresh_cutoff_re_extracts_rows_classified_before_it(tmp_path):
     )
 
     assert summary["extraction_calls"] == 1
-    # Re-extraction produced identical evidence, so nothing new is stored.
-    assert summary["classified"] == 0
-    assert summary["unchanged_after_extraction"] == 1
-    assert len(kw_bench_store.read_records(store)) == 1
+    # The semantic evidence is unchanged, but cache freshness is persisted so
+    # the same cutoff does not force another extraction on the next run.
+    assert summary["classified"] == 1
+    assert len(kw_bench_store.read_records(store)) == 2
+    rerun = backfill(
+        snapshots,
+        store_path=store,
+        classified_at="2026-08-07T00:00:00+00:00",
+        refresh_before="2026-08-01T00:00:00+00:00",
+    )
+    assert rerun["extraction_calls"] == 0
 
 
 def test_refresh_cutoffs_compare_instants_across_timezone_offsets(tmp_path):
@@ -590,5 +604,5 @@ def test_classification_layer_never_mixes_rubric_versions(tmp_path, monkeypatch)
 
     assert layer["kw_bench_version"] == "0.2"
     assert layer["track_count"] == 2
-    assert layer["coverage"]["track_count"] == 1
-    assert layer["level_counts"][kw_bench.UNCLASSIFIED] == 1
+    assert layer["coverage"]["track_count"] == 2
+    assert layer["level_counts"][kw_bench.UNCLASSIFIED] == 2

--- a/tests/test_kw_bench_tracks.py
+++ b/tests/test_kw_bench_tracks.py
@@ -418,3 +418,52 @@ def test_classification_layer_is_json_serializable(tmp_path):
     backfill([snapshot("2026-07-28", item())], store_path=store, classified_at=CLASSIFIED_AT)
 
     assert json.loads(json.dumps(classification_layer(store)))
+
+
+def test_classification_layer_excludes_superseded_canonical_identities(tmp_path):
+    """A later exact-identifier link must not leave the old identity counted."""
+    store = tmp_path / "kw.jsonl"
+    first = [snapshot("2026-07-28", item())]
+    backfill(first, store_path=store, classified_at=CLASSIFIED_AT)
+    linked = [
+        *first,
+        snapshot(
+            "2026-07-29",
+            item(
+                url="https://doi.org/10.1/example",
+                artifact_urls=["https://arxiv.org/abs/2607.12345"],
+            ),
+        ),
+    ]
+    current_tracks = derive_tracks(linked)
+    backfill(linked, store_path=store, classified_at=CLASSIFIED_AT)
+
+    layer = classification_layer(store, tracks=current_tracks)
+
+    assert len(current_tracks) == 1
+    assert len(kw_bench_store.current_records(store)) == 2
+    assert layer["track_count"] == 1
+    assert layer["level_counts"][kw_bench.UNCLASSIFIED] == 1
+
+
+def test_classification_layer_never_mixes_rubric_versions(tmp_path, monkeypatch):
+    store = tmp_path / "kw.jsonl"
+    snapshots = [
+        snapshot(
+            "2026-07-28",
+            item(url="https://arxiv.org/abs/2607.00001"),
+            item(source_id="p2", url="https://arxiv.org/abs/2607.00002"),
+        )
+    ]
+    tracks = derive_tracks(snapshots)
+    backfill(snapshots, store_path=store, classified_at=CLASSIFIED_AT)
+    monkeypatch.setattr(kw_bench_store, "KW_BENCH_VERSION", "0.2")
+    monkeypatch.setattr(kw_bench, "KW_BENCH_VERSION", "0.2")
+    backfill(snapshots, store_path=store, classified_at=CLASSIFIED_AT, limit=1)
+
+    layer = classification_layer(store, tracks=tracks)
+
+    assert layer["kw_bench_version"] == "0.2"
+    assert layer["track_count"] == 2
+    assert layer["coverage"]["track_count"] == 1
+    assert layer["level_counts"][kw_bench.UNCLASSIFIED] == 1


### PR DESCRIPTION
Implements the shadow-mode MVP for issue #153. Issue #153 remains open: reviewed validation, real evidence extraction, and the public chart switch are follow-up work.

## Summary
- add deterministic KW-Bench L0-L5 evidence rules, canonical track derivation, and append-only resumable storage
- publish the layer in explicit shadow mode while leaving the existing taxonomy chart live
- build the derived store in CI and Pages, with current-corpus/version filtering and honest partial coverage
- harden refresh, extractor transitions, torn writes, retractions, normalized track IDs, and novelty checks

## Evaluation
- 585 tests pass
- Ruff lint and format checks pass
- real 15-snapshot corpus derives 1,340 canonical tracks
- cold run: 1,340 extractor calls; unchanged rerun: 0 calls
- fresh payload: 1,340 Unclassified tracks, shadow=true

## MVP limitation
The classifier is deliberately documented as a triage hint rather than an audited fact. Handwritten natural-language patterns still have conservative edge cases; L4/L5 require human review, the current NullExtractor assigns no automatic level, and the browser continues to use the existing taxonomy chart.