### PR TITLE
Scope URL filters to their view, and give the site an icon

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -124,24 +124,35 @@ function readUrl() {
 function writeUrl() {
   const params = new URLSearchParams();
   if (state.view !== "today") params.set("view", state.view);
-  if (state.todayDate === "all") {
-    params.set("date", "all");
-  } else if (state.todayDate && state.todayDate !== state.data?.latest_date) {
-    params.set("date", state.todayDate);
+  // Every filter below belongs to exactly one view, so only that view may write
+  // it. Serializing all of them unconditionally is what leaked `lfrontier` onto
+  // Today/Trends/Map links and `date` onto Leaderboard links (issue #123): the
+  // reader would click "2026-07-31" and land on a URL carrying a leaderboard
+  // selection that nothing on the page reads back.
+  if (state.view === "today") {
+    if (state.todayDate === "all") {
+      params.set("date", "all");
+    } else if (state.todayDate && state.todayDate !== state.data?.latest_date) {
+      params.set("date", state.todayDate);
+    }
+    if (state.q) params.set("q", state.q);
+    if (state.kind) params.set("kind", state.kind);
+    if (state.category) params.set("category", state.category);
+    if (state.source) params.set("source", state.source);
+    if (state.organization) params.set("organization", state.organization);
+    if (state.event) params.set("event", state.event);
   }
-  if (state.q) params.set("q", state.q);
-  if (state.kind) params.set("kind", state.kind);
-  if (state.category) params.set("category", state.category);
-  if (state.source) params.set("source", state.source);
-  if (state.organization) params.set("organization", state.organization);
-  if (state.event) params.set("event", state.event);
   if (state.view === "map" && state.entity) params.set("entity", state.entity);
-  if (state.lq) params.set("lq", state.lq);
-  if (state.ldomain) params.set("ldomain", state.ldomain);
-  if (state.lorg) params.set("lorg", state.lorg);
-  if (state.lera) params.set("lera", state.lera);
-  if (state.lfrontierExplicit && state.lfrontier) {
-    params.set("lfrontier", state.lfrontier);
+  if (state.view === "leaderboard") {
+    if (state.lq) params.set("lq", state.lq);
+    if (state.ldomain) params.set("ldomain", state.ldomain);
+    if (state.lorg) params.set("lorg", state.lorg);
+    if (state.lera) params.set("lera", state.lera);
+    // A benchmark auto-picked as the default is not the reader's choice, so it
+    // stays out of the URL until they select one themselves.
+    if (state.lfrontierExplicit && state.lfrontier) {
+      params.set("lfrontier", state.lfrontier);
+    }
   }
   const query = params.toString();
   // The rubric dialog is a hashtag, not a query param, so a shared link like

--- a/site/icon.svg
+++ b/site/icon.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Benchmark Radar">
+  <!-- The masthead brand mark (.brand-mark in assets/styles.css) redrawn as a
+       real file, so tabs and bookmarks get the same radar glyph the header
+       shows instead of a 404 on /favicon.ico. Colors are the ink, line and
+       orange tokens; the site is color-scheme: light, so they are fixed. -->
+  <circle cx="32" cy="32" r="30" fill="#f7f9fa" stroke="#15242a" stroke-width="2"/>
+  <!-- Crosshairs, drawn edge to edge and trimmed by the dial. -->
+  <path d="M32 4v56M4 32h56" stroke="#bdc9ce" stroke-width="1.5"/>
+  <!-- The sweep: a quarter arc on the inset ring, rotated to match the 35deg
+       transform the CSS mark uses. -->
+  <path
+    d="M32 10a22 22 0 0 1 22 22"
+    fill="none"
+    stroke="#dc633f"
+    stroke-width="4"
+    stroke-linecap="round"
+    transform="rotate(35 32 32)"
+  />
+</svg>

--- a/site/index.html
+++ b/site/index.html
@@ -31,6 +31,7 @@
     >
     <meta name="twitter:card" content="summary_large_image">
 
+    <link rel="icon" href="icon.svg" type="image/svg+xml">
     <link rel="alternate" type="application/rss+xml" title="Benchmark Radar RSS" href="feed.xml">
     <link rel="stylesheet" href="assets/styles.css">
     <script src="assets/app.js" type="module"></script>

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -12,6 +12,7 @@ class SiteParser(HTMLParser):
         self.html_lang = ""
         self.viewport = False
         self.local_refs: list[str] = []
+        self.icon_hrefs: list[str] = []
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         values = dict(attrs)
@@ -22,6 +23,8 @@ class SiteParser(HTMLParser):
             self.html_lang = str(values.get("lang", ""))
         if tag == "meta" and values.get("name") == "viewport":
             self.viewport = True
+        if tag == "link" and "icon" in str(values.get("rel", "")).split():
+            self.icon_hrefs.append(str(values.get("href", "")))
         reference = values.get("href") or values.get("src")
         if reference and not urlsplit(reference).scheme and not reference.startswith(("#", "//")):
             self.local_refs.append(reference)
@@ -124,6 +127,16 @@ def test_each_view_serializes_only_the_filters_it_reads():
         assert f'params.set("{key}"' in leaderboard
 
     assert 'if (state.view === "map" && state.entity) params.set("entity"' in body
+
+
+def test_site_has_an_icon():
+    parser = SiteParser()
+    parser.feed(Path("site/index.html").read_text(encoding="utf-8"))
+
+    # Issue #152: without this the browser requests /favicon.ico and 404s, so
+    # tabs and bookmarks fall back to a blank page glyph. The referenced file
+    # is checked for existence by test_static_html_references_existing_local_assets.
+    assert parser.icon_hrefs, "index.html declares no icon"
 
 
 def test_rubric_dialog_is_linkable_by_url_hash():

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -105,6 +105,27 @@ def test_automatic_frontier_default_does_not_leak_into_unrelated_urls():
     assert "function selectFrontier(benchmarkId)" in script
 
 
+def test_each_view_serializes_only_the_filters_it_reads():
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+    body = script.split("function writeUrl()", 1)[1].split("\nfunction ", 1)[0]
+
+    # Issue #123: a reader clicking a trend date got
+    # ?date=...&lfrontier=apex_agents, and switching to the leaderboard carried
+    # ?date=... along, because writeUrl() wrote every filter on every view.
+    # Each param is read back by exactly one view, so only that view may write
+    # it. Guard the gate rather than the individual set() calls, which the
+    # previous fix already had and which still leaked.
+    today = body.split('if (state.view === "today")', 1)[1].split('if (state.view === "map"', 1)[0]
+    for key in ("date", "q", "kind", "category", "source", "organization", "event"):
+        assert f'params.set("{key}"' in today
+
+    leaderboard = body.split('if (state.view === "leaderboard")', 1)[1]
+    for key in ("lq", "ldomain", "lorg", "lera", "lfrontier"):
+        assert f'params.set("{key}"' in leaderboard
+
+    assert 'if (state.view === "map" && state.entity) params.set("entity"' in body
+
+
 def test_rubric_dialog_is_linkable_by_url_hash():
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
 


### PR DESCRIPTION
Two independent site fixes, one commit each.

## Fix #123: URL params leak across views

`writeUrl()` serialized every filter on every view, but each param is read back by exactly one view:

| Param | Read by |
|---|---|
| `date`, `q`, `kind`, `category`, `source`, `organization`, `event` | Today |
| `lq`, `ldomain`, `lorg`, `lera`, `lfrontier` | Leaderboard |
| `entity` | Map (already gated) |

So clicking a trend date produced `?date=2026-07-31&lfrontier=apex_agents`, and moving to the leaderboard from a dated Today view kept a `date=` the leaderboard ignores (the follow-up comment on the issue).

The earlier `lfrontierExplicit` flag only fixed the *default* case: once a reader clicked a benchmark, the flag stuck and leaked into every view. It is kept here because it answers a different question (reader-picked vs auto-defaulted), but it is no longer load-bearing for cross-view leakage.

Switching views now drops the previous view's params from the URL while in-memory state keeps them, so returning to a view restores its filters.

## Fix #152: site icon

`index.html` declared no icon at all, so browsers requested `/favicon.ico` and 404'd. The only image in the repo was the 1200x630 OG share card, which is the wrong shape and subject.

Added `site/icon.svg`, redrawing the existing masthead brand mark (`.brand-mark`: dial, crosshairs, orange sweep rotated 35deg) so the tab matches the header. Single fixed-color SVG, since the site is `color-scheme: light`. The Pages workflow uploads all of `site/`, so it deploys with no build change.

## Test plan

- `pytest -q`: **592 passed** (up from 540; the extra tests were previously blocked by a missing `tiktoken` dep, unrelated to this change).
- Both new tests were confirmed to **fail against `origin/main`** and pass here, so they are not vacuous.
- Drove the real page in headless Chrome through the exact steps in #123:
  - `?view=leaderboard&lfrontier=apex_agents`, then trends gives `?view=trends`, map gives `?view=map`, today gives a clean URL, and returning to leaderboard restores `?view=leaderboard&lfrontier=apex_agents`
  - clicking trend date `2026-07-23` gives `?date=2026-07-23` (no `lfrontier`), then leaderboard gives `?view=leaderboard&lfrontier=apex_agents` (no `date`), then back to Today restores `?date=2026-07-23`
  - `icon.svg` resolves `200 image/svg+xml`; rendered at 256px and downscaled to 16px to confirm it still reads
- `codex review --base main`: clean, no findings.

Note: `site/icon.svg` is referenced by the existing `test_static_html_references_existing_local_assets`, so a missing icon file would fail CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
