### PR TITLE
Survey who builds the popular benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,14 @@ out/
 # store before publishing; the MVP's null extractor makes no external calls.
 /data/kw_bench_classifications.jsonl
 
+# Commit emails harvested by `benchmark-radar authors --author-emails` (issue
+# #156). `git log` publishes an author's address and most contributors do not
+# realise it, so a committed list of them is a spam and doxxing vector whatever
+# the intent. The survey itself carries public professional signals only and is
+# safe to share; this file is not.
+/out/benchmark-author-contacts.json
+benchmark-author-contacts.json
+
 .gstack/
 .DS_Store
 .worktrees/

--- a/src/benchmark_radar/authors.py
+++ b/src/benchmark_radar/authors.py
@@ -1,0 +1,319 @@
+"""Who builds the popular benchmarks, and which of them work on data.
+
+Issue #156 asks which authors behind popular benchmarks are doing data work.
+This answers it from public professional signals only: the GitHub repositories
+the radar already tracks, their contributor lists, and the profile fields those
+contributors chose to publish (name, company, bio, blog, location).
+
+Two deliberate limits.
+
+**Popularity is derived, not asserted.** The issue leaves "popular" to us, so it
+is defined here as a repository the radar's own corpus ranks: stars, how many
+days the radar has tracked it, and how many connectors reported it. That keeps
+the seed list reproducible and auditable rather than a hand-picked list of
+famous names.
+
+**Commit emails are collected but never committed.** `git log` publishes an
+author email, and most contributors do not realise it. A committed file of
+harvested addresses is a spam and doxxing vector whatever the intent, so emails
+go to a separate gitignored artifact and the shareable profile records carry
+professional signals only. `noreply` addresses are dropped entirely; they
+identify nobody and are pure noise.
+
+No email is ever sent. This reads public APIs and stops there.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Any
+
+from .corpus import build_corpus
+from .http import RequestError, get_json
+
+AUTHORS_SCHEMA_VERSION = 1
+GITHUB_API = "https://api.github.com"
+DEFAULT_REPO_LIMIT = 40
+DEFAULT_CONTRIBUTORS_PER_REPO = 20
+
+# Substrings that mark a profile as data-adjacent work. Matched against the
+# self-written bio and company fields, never inferred from a repository name:
+# an author is credited with data work because they said so.
+DATA_SIGNALS = (
+    "data quality",
+    "data-centric",
+    "data curation",
+    "dataset",
+    "data engineering",
+    "annotation",
+    "labeling",
+    "labelling",
+    "evaluation",
+    "eval",
+    "benchmark",
+    "rlhf",
+    "human feedback",
+    "data pipeline",
+    "etl",
+    "data infrastructure",
+)
+
+_GITHUB_REPO = re.compile(r"^https?://github\.com/([^/]+)/([^/?#]+)", re.IGNORECASE)
+
+
+class AuthorLookupError(RuntimeError):
+    """A required GitHub call failed and the result would be misleading."""
+
+
+def _headers() -> dict[str, str]:
+    token = os.getenv("GITHUB_TOKEN", "").strip()
+    headers = {"Accept": "application/vnd.github+json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def popular_repositories(
+    snapshots: list[dict[str, Any]],
+    *,
+    limit: int = DEFAULT_REPO_LIMIT,
+) -> list[dict[str, Any]]:
+    """Rank the GitHub benchmark repositories the radar has actually seen.
+
+    "Popular" is defined from the corpus rather than asserted: stars first, then
+    how many days the radar tracked the artifact, then how many connectors
+    reported it. A repository nobody starred that three connectors reported for
+    a week is a real signal; so is a highly starred one seen once.
+    """
+    corpus = build_corpus(snapshots)
+    ranked = []
+    for entity in corpus["entities"]:
+        if entity["type"] != "artifact":
+            continue
+        match = _GITHUB_REPO.match(str(entity.get("url") or ""))
+        if not match:
+            continue
+        owner, name = match.group(1), match.group(2).removesuffix(".git")
+        if owner.lower() in {"apps", "marketplace", "sponsors", "topics"}:
+            continue
+        categories = set(entity.get("categories") or [])
+        # A lone `evaluation` tag is the repo-side version of the keyword false
+        # positive `_evidence_records` already guards against: it admitted a
+        # 63k-star careers repository as a benchmark. Require either an explicit
+        # benchmark/dataset category or a second corroborating tag.
+        if not (categories & {"benchmark", "dataset"}) and len(categories) < 2:
+            continue
+        metrics = entity.get("metrics") or {}
+        ranked.append(
+            {
+                "full_name": f"{owner}/{name}",
+                "owner": owner,
+                "name": name,
+                "url": entity.get("url"),
+                "title": entity.get("label"),
+                "stars": float(metrics.get("stars") or 0),
+                "seen_days": len(entity.get("seen_days") or []),
+                "sources": list(entity.get("sources") or []),
+                "categories": list(entity.get("categories") or []),
+            }
+        )
+    ranked.sort(
+        key=lambda repo: (repo["stars"], repo["seen_days"], len(repo["sources"])),
+        reverse=True,
+    )
+    # One owner should not consume the whole seed list: a single org publishing
+    # thirty datasets would otherwise crowd out every other team.
+    selected: list[dict[str, Any]] = []
+    per_owner: dict[str, int] = {}
+    for repo in ranked:
+        owner = repo["owner"].casefold()
+        if per_owner.get(owner, 0) >= 3:
+            continue
+        selected.append(repo)
+        per_owner[owner] = per_owner.get(owner, 0) + 1
+        if len(selected) >= limit:
+            break
+    return selected
+
+
+def repository_contributors(
+    full_name: str,
+    *,
+    per_repo: int = DEFAULT_CONTRIBUTORS_PER_REPO,
+) -> list[dict[str, Any]]:
+    """Public contributor logins and commit counts for one repository."""
+    try:
+        payload = get_json(
+            f"{GITHUB_API}/repos/{full_name}/contributors",
+            params={"per_page": min(per_repo, 100)},
+            headers=_headers(),
+        )
+    except RequestError as error:
+        raise AuthorLookupError(f"contributors for {full_name}: {error}") from error
+    if not isinstance(payload, list):
+        return []
+    return [
+        {
+            "login": str(entry.get("login") or ""),
+            "contributions": int(entry.get("contributions") or 0),
+            "type": str(entry.get("type") or "User"),
+        }
+        for entry in payload
+        if isinstance(entry, dict) and entry.get("login") and entry.get("type") == "User"
+    ][:per_repo]
+
+
+def data_signals(profile: dict[str, Any]) -> list[str]:
+    """Which data-work signals a profile's own words contain."""
+    text = " ".join(
+        str(profile.get(field) or "") for field in ("bio", "company", "blog")
+    ).casefold()
+    return sorted({signal for signal in DATA_SIGNALS if signal in text})
+
+
+def public_profile(login: str) -> dict[str, Any]:
+    """Fetch the professional fields a GitHub user chose to publish."""
+    try:
+        payload = get_json(f"{GITHUB_API}/users/{login}", headers=_headers())
+    except RequestError as error:
+        raise AuthorLookupError(f"profile for {login}: {error}") from error
+    profile = {
+        "login": str(payload.get("login") or login),
+        "name": payload.get("name"),
+        "company": payload.get("company"),
+        "blog": payload.get("blog"),
+        "bio": payload.get("bio"),
+        "location": payload.get("location"),
+        "public_repos": int(payload.get("public_repos") or 0),
+        "followers": int(payload.get("followers") or 0),
+        "profile_url": f"https://github.com/{payload.get('login') or login}",
+    }
+    profile["data_signals"] = data_signals(profile)
+    profile["works_on_data"] = bool(profile["data_signals"])
+    # Self-published on the profile, which is a different act from a commit
+    # email the author may not know is public. Kept separate for that reason.
+    profile["public_profile_email"] = payload.get("email")
+    return profile
+
+
+def commit_emails(full_name: str, *, per_page: int = 100) -> dict[str, str]:
+    """Map contributor login to the commit email visible in that repository.
+
+    Collected because the issue asks for it, and written only to the untracked
+    contact artifact. `noreply` addresses are dropped: they identify nobody.
+    """
+    try:
+        payload = get_json(
+            f"{GITHUB_API}/repos/{full_name}/commits",
+            params={"per_page": min(per_page, 100)},
+            headers=_headers(),
+        )
+    except RequestError as error:
+        raise AuthorLookupError(f"commits for {full_name}: {error}") from error
+    if not isinstance(payload, list):
+        return {}
+    emails: dict[str, str] = {}
+    for entry in payload:
+        if not isinstance(entry, dict):
+            continue
+        author = entry.get("author") or {}
+        login = str(author.get("login") or "").strip()
+        email = str(((entry.get("commit") or {}).get("author") or {}).get("email") or "").strip()
+        if not login or not email or "noreply" in email.casefold():
+            continue
+        emails.setdefault(login, email)
+    return emails
+
+
+def survey(
+    snapshots: list[dict[str, Any]],
+    *,
+    repo_limit: int = DEFAULT_REPO_LIMIT,
+    per_repo: int = DEFAULT_CONTRIBUTORS_PER_REPO,
+    include_emails: bool = False,
+) -> dict[str, Any]:
+    """Build the author survey issue #156 asks for.
+
+    Returns the shareable report plus, when `include_emails` is set, a separate
+    `contacts` block the caller must write to the untracked artifact. Keeping
+    them apart is the point: the report is safe to commit, the contacts are not.
+    """
+    repos = popular_repositories(snapshots, limit=repo_limit)
+    profiles: dict[str, dict[str, Any]] = {}
+    contacts: dict[str, dict[str, str]] = {}
+    failures: list[str] = []
+
+    for repo in repos:
+        try:
+            contributors = repository_contributors(repo["full_name"], per_repo=per_repo)
+        except AuthorLookupError as error:
+            failures.append(str(error))
+            continue
+        repo["contributor_count"] = len(contributors)
+        emails = {}
+        if include_emails:
+            try:
+                emails = commit_emails(repo["full_name"])
+            except AuthorLookupError as error:
+                failures.append(str(error))
+        for contributor in contributors:
+            login = contributor["login"]
+            profile = profiles.get(login)
+            if profile is None:
+                try:
+                    profile = public_profile(login)
+                except AuthorLookupError as error:
+                    failures.append(str(error))
+                    continue
+                profile["repositories"] = []
+                profiles[login] = profile
+            profile["repositories"].append(
+                {
+                    "full_name": repo["full_name"],
+                    "url": repo["url"],
+                    "contributions": contributor["contributions"],
+                }
+            )
+            if login in emails:
+                contacts[login] = {
+                    "login": login,
+                    "commit_email": emails[login],
+                    "found_in": repo["full_name"],
+                }
+
+    people = sorted(
+        profiles.values(),
+        key=lambda profile: (
+            profile["works_on_data"],
+            len(profile["repositories"]),
+            profile["followers"],
+        ),
+        reverse=True,
+    )
+    data_people = [profile for profile in people if profile["works_on_data"]]
+    report = {
+        "schema_version": AUTHORS_SCHEMA_VERSION,
+        "popularity_definition": (
+            "GitHub repositories in the radar corpus ranked by stars, then days "
+            "tracked, then connector breadth, capped at three per owner."
+        ),
+        "method": (
+            "Public GitHub APIs only: contributor lists and the profile fields each "
+            "author chose to publish. Data-work classification reads the author's own "
+            "bio and company text and is never inferred from a repository name. No "
+            "email is ever sent."
+        ),
+        "repository_count": len(repos),
+        "author_count": len(people),
+        "data_author_count": len(data_people),
+        "repositories": repos,
+        "authors": people,
+        "failures": failures,
+    }
+    if include_emails:
+        # Never merged into `report`: the caller writes this to the untracked
+        # contact artifact so a harvested address cannot reach a public commit.
+        report_contacts = sorted(contacts.values(), key=lambda entry: entry["login"])
+        return {"report": report, "contacts": report_contacts}
+    return {"report": report, "contacts": []}

--- a/src/benchmark_radar/cli.py
+++ b/src/benchmark_radar/cli.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import yaml
 
+from .authors import survey as author_survey
 from .briefing import BriefingError, current_day_snapshot, daily_report_run, generate_daily_briefing
 from .export import DEFAULT_TABLE_LIMIT, write_exports
 from .findings import daily_findings
@@ -81,15 +82,40 @@ def main() -> None:
             "simulate-history",
             "export",
             "classify",
+            "authors",
         ),
         default="run",
         help=(
             "Collect a daily run, rebuild/backfill cumulative data from saved snapshots, "
             "migrate snapshot schemas, rescore stored taxonomy categories against the "
             "current config, simulate missing historical snapshots, export the "
-            "Model Card Adoption Rank as standalone citable files, or classify canonical "
-            "benchmark tracks against the KW-Bench L0-L5 capability rubric."
+            "Model Card Adoption Rank as standalone citable files, classify canonical "
+            "benchmark tracks against the KW-Bench L0-L5 capability rubric, or survey "
+            "the public profiles of authors behind popular benchmark repositories."
         ),
+    )
+    parser.add_argument(
+        "--author-output",
+        type=Path,
+        default=Path("out/benchmark-authors.json"),
+        help="Where `authors` writes its shareable survey of public profiles.",
+    )
+    parser.add_argument(
+        "--author-contacts",
+        type=Path,
+        default=Path("out/benchmark-author-contacts.json"),
+        help=(
+            "Where `authors --author-emails` writes harvested commit emails. Kept "
+            "out of the survey and untracked: publishing addresses people did not "
+            "knowingly share invites spam regardless of intent."
+        ),
+    )
+    parser.add_argument("--author-repo-limit", type=int, default=40)
+    parser.add_argument("--author-contributors", type=int, default=20)
+    parser.add_argument(
+        "--author-emails",
+        action="store_true",
+        help="Also collect commit emails into the untracked contacts file (issue #156).",
     )
     parser.add_argument("--config", type=Path, default=Path("config.yml"))
     parser.add_argument("--output", type=Path, default=Path("out/report.md"))
@@ -201,6 +227,37 @@ def main() -> None:
     feed_output = args.feed_output
     if feed_output is None and args.dashboard_output == DEFAULT_DASHBOARD_OUTPUT:
         feed_output = DEFAULT_FEED_OUTPUT
+
+    if args.command == "authors":
+        result = author_survey(
+            load_snapshots(args.snapshot_dir),
+            repo_limit=args.author_repo_limit,
+            per_repo=args.author_contributors,
+            include_emails=args.author_emails,
+        )
+        report = result["report"]
+        args.author_output.parent.mkdir(parents=True, exist_ok=True)
+        args.author_output.write_text(
+            json.dumps(report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+        )
+        print(
+            f"Surveyed {report['repository_count']} popular repositories and "
+            f"{report['author_count']} contributors"
+        )
+        print(f"  {report['data_author_count']} describe data work in their own profile")
+        print(f"  report: {args.author_output}")
+        if result["contacts"]:
+            # Untracked by design: a committed list of harvested addresses is a
+            # spam vector no matter why it was gathered.
+            args.author_contacts.parent.mkdir(parents=True, exist_ok=True)
+            args.author_contacts.write_text(
+                json.dumps(result["contacts"], ensure_ascii=False, indent=2) + "\n",
+                encoding="utf-8",
+            )
+            print(f"  contacts: {args.author_contacts} (gitignored, {len(result['contacts'])})")
+        for failure in report["failures"][:5]:
+            print(f"  ::warning:: {failure}")
+        return
 
     if args.command == "classify":
         summary = backfill_classifications(

--- a/tests/test_authors.py
+++ b/tests/test_authors.py
@@ -1,0 +1,116 @@
+from datetime import UTC, datetime
+
+from benchmark_radar import authors
+from benchmark_radar.models import RadarItem, RadarRun
+from benchmark_radar.snapshots import snapshot_for_run
+
+
+def _repo(name: str, *, stars: float, categories: list[str], day: int = 4) -> RadarItem:
+    return RadarItem(
+        source="GitHub",
+        source_id=f"{name}",
+        title=name,
+        url=f"https://github.com/{name}",
+        published_at=datetime(2026, 8, day, tzinfo=UTC),
+        categories=categories,
+        summary="A repository the radar captured.",
+        event_kind="released",
+        metrics={"stars": stars},
+    )
+
+
+def _run(items, *, day: int = 4) -> RadarRun:
+    return RadarRun(
+        generated_at=datetime(2026, 8, day, 12, tzinfo=UTC),
+        since=datetime(2026, 8, day - 1, 12, tzinfo=UTC),
+        items=items,
+        health=[],
+        selection={"taxonomy_version": "taxonomy-v2"},
+    )
+
+
+def test_a_lone_evaluation_tag_does_not_make_a_repository_a_benchmark():
+    # A 63k-star careers repository entered the real survey on a single
+    # `evaluation` keyword match. Popularity must not launder a false positive.
+    careers = _repo("santifer/career-ops", stars=63136.0, categories=["evaluation"])
+    real = _repo("huggingface/datasets", stars=21821.0, categories=["dataset"])
+    current = snapshot_for_run(_run([careers, real]))
+
+    ranked = authors.popular_repositories([current])
+
+    assert [repo["full_name"] for repo in ranked] == ["huggingface/datasets"]
+
+
+def test_one_owner_cannot_crowd_out_the_seed_list():
+    items = [
+        _repo(f"bigorg/bench-{index}", stars=9000.0 - index, categories=["benchmark"])
+        for index in range(6)
+    ]
+    items.append(_repo("smallorg/bench", stars=10.0, categories=["benchmark"]))
+    current = snapshot_for_run(_run(items))
+
+    ranked = authors.popular_repositories([current])
+    owners = [repo["owner"] for repo in ranked]
+
+    assert owners.count("bigorg") == 3
+    assert "smallorg" in owners
+
+
+def test_data_work_is_read_from_the_authors_own_words():
+    # Never inferred from a repository name: an author is credited with data
+    # work because they described it themselves.
+    maintainer = {"bio": "Maintainer of Datasets", "company": "Hugging Face", "blog": ""}
+    unrelated = {"bio": "I like bicycles", "company": "Acme", "blog": ""}
+
+    assert authors.data_signals(maintainer) == ["dataset"]
+    assert authors.data_signals(unrelated) == []
+
+
+def test_noreply_commit_addresses_are_never_collected(monkeypatch):
+    # A noreply address identifies nobody and is pure noise in a contact file.
+    monkeypatch.setattr(
+        authors,
+        "get_json",
+        lambda *args, **kwargs: [
+            {
+                "author": {"login": "ghost"},
+                "commit": {"author": {"email": "1234+ghost@users.noreply.github.com"}},
+            },
+            {
+                "author": {"login": "real"},
+                "commit": {"author": {"email": "real@example.test"}},
+            },
+        ],
+    )
+
+    assert authors.commit_emails("org/repo") == {"real": "real@example.test"}
+
+
+def test_the_shareable_survey_never_carries_harvested_commit_emails(monkeypatch):
+    # The report is safe to commit; the contacts are not. They must not merge.
+    current = snapshot_for_run(_run([_repo("org/bench", stars=5.0, categories=["benchmark"])]))
+    monkeypatch.setattr(
+        authors,
+        "repository_contributors",
+        lambda *args, **kwargs: [{"login": "real", "contributions": 4, "type": "User"}],
+    )
+    monkeypatch.setattr(
+        authors,
+        "public_profile",
+        lambda login: {
+            "login": login,
+            "bio": "dataset work",
+            "company": "Acme",
+            "followers": 1,
+            "data_signals": ["dataset"],
+            "works_on_data": True,
+        },
+    )
+    monkeypatch.setattr(authors, "commit_emails", lambda *args, **kwargs: {"real": "r@e.test"})
+
+    result = authors.survey([current], include_emails=True)
+
+    assert result["contacts"] == [
+        {"login": "real", "commit_email": "r@e.test", "found_in": "org/bench"}
+    ]
+    assert "r@e.test" not in str(result["report"])


### PR DESCRIPTION
Closes #156.

## The seed list already existed

The corpus tracks **6,060 people and 741 organizations** through `AUTHORED_BY` edges, built by `build_corpus` and never used for anything. This puts it to work.

`benchmark-radar authors` ranks the GitHub benchmark repositories the radar has seen, reads their public contributor lists, and records the profile fields each contributor chose to publish (name, company, blog, bio, location, follower count).

## "Popular" is derived, not asserted

The issue leaves the definition to us, so it is computed from the corpus and is reproducible: **stars, then days tracked by the radar, then connector breadth**, capped at three repositories per owner so one prolific org cannot crowd out every other team.

Repository selection needed the same guard the briefing already has. A lone `evaluation` tag admitted `santifer/career-ops` (63k stars, a careers repository) as a benchmark, so a repository now needs an explicit `benchmark`/`dataset` category or a second corroborating tag. After the fix the seed list is `huggingface/datasets`, `NVIDIA/cosmos`, `yzhao062/pyod`, `torchgeo/torchgeo`, `modelscope/evalscope`, and similar.

## Data work is read from the author's own words

The classifier matches the self-written `bio` and `company` text against data-work signals and **never infers from a repository name**, so an author is credited because they described the work themselves. On a live run against the real API it found:

- `lhoestq` — "ML Engineer @huggingface | Maintainer of 🤗Datasets"
- `kritinv` — "Co-founder @ Confident AI (YC W25) | LLM Evals"

Both correct, both self-described.

## Emails: collected, deliberately not committed

The issue asks for contributor emails and specifies 纯爬虫，不要发邮件问. Nothing here sends mail.

On the addresses themselves I made a judgement call worth flagging: `git log` publishes an author's email and most contributors do not realise it, so a committed list of them is a spam and doxxing vector whatever the intent. So:

- emails are gathered only behind an explicit `--author-emails` flag
- they are written to a **gitignored** contacts file, never into the survey
- `noreply` addresses are dropped, since they identify nobody
- a test asserts no harvested address can reach the shareable report

The survey itself carries public professional signals only and is safe to commit or share. If you want the addresses committed too, that is a one-line change to `.gitignore`, but I would not do it by default.

## Verification

- 601 tests pass (596 on main + 5 new), `ruff check` and `ruff format --check` clean
- Ran live against the GitHub API; the 403s on unauthenticated runs surface as warnings rather than silently dropping repositories

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)
