### PR TITLE
Show the daily Q&A on the dashboard

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -423,6 +423,170 @@ function renderDailyBriefing(day) {
   );
 }
 
+// Statistic values are printed from the registry the answer cites, never from
+// the model's prose, so a number reaches the page only if it was computed
+// before the call. This mirrors report.py's `_format_stat_value` exactly.
+function formatStatValue(stat) {
+  const value = stat?.value;
+  // `toLocaleString()` is not used: it rounds to three fraction digits, so a
+  // registry value of 1234.56789 would reach the page as 1,234.568. Grouping is
+  // applied to the integer part only, which matches Python's `f"{value:,}"` and
+  // keeps the printed figure identical to the Markdown report's.
+  let rendered;
+  if (typeof value === "number" && Number.isFinite(value)) {
+    const [whole, fraction] = String(value).split(".");
+    // \B keeps the separator out of a leading "-", so -1234 groups as -1,234.
+    const grouped = whole.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+    rendered = fraction ? `${grouped}.${fraction}` : grouped;
+  } else {
+    rendered = String(value ?? "");
+  }
+  const unit = String(stat?.unit || "").trim();
+  if (unit && unit !== "count") rendered = `${rendered} ${unit}`;
+  const window = String(stat?.window || "").trim();
+  if (window && window !== "today") {
+    // Spans already carry their own parentheses; do not nest another pair.
+    rendered = window.endsWith(")") ? `${rendered} ${window}` : `${rendered} (${window})`;
+  }
+  return rendered;
+}
+
+function answerCitations(answer) {
+  const stats = (Array.isArray(answer?.cited_stats) ? answer.cited_stats : []).map((stat) =>
+    element("li", {}, [
+      element("code", { className: "answer-stat-id", text: String(stat?.id || "") }),
+      document.createTextNode(` ${String(stat?.label || "")}: `),
+      element("strong", { text: formatStatValue(stat) }),
+    ]),
+  );
+  // Same rule as the briefing: only an exact evidence ID with a safe http(s)
+  // URL becomes a link, so a citation nobody can follow is not rendered as one.
+  const evidence = validBriefingCitations(answer?.cited_evidence).map((citation) =>
+    element("li", {}, [
+      element("code", { className: "answer-stat-id", text: citation.id }),
+      document.createTextNode(" "),
+      element("a", {
+        text: citation.title,
+        attrs: {
+          href: citation.href,
+          target: "_blank",
+          rel: "noopener noreferrer",
+        },
+      }),
+      element("span", { text: ` (${citation.source})` }),
+    ]),
+  );
+  if (!stats.length && !evidence.length) return null;
+  return element("ul", { className: "answer-citations" }, [...stats, ...evidence]);
+}
+
+function answerBlock(answer) {
+  const insufficient = answer?.sufficient_evidence === false;
+  const confidence = String(answer?.confidence || "").trim();
+  return element("article", { className: "answer" }, [
+    // The confidence sits on the question's own line: it qualifies the answer
+    // that follows, so a reader should meet it before reading the claim.
+    element("h4", { className: "answer-question" }, [
+      document.createTextNode(String(answer?.question || "")),
+      ...(confidence
+        ? [
+            element("span", {
+              className: `pill pill-confidence pill-confidence-${confidence}`,
+              text: `${confidence} confidence`,
+            }),
+          ]
+        : []),
+    ]),
+    element("p", { className: "answer-signal", text: String(answer?.signal || "") }),
+    element("p", { className: "answer-plain" }, [
+      element("em", { text: "In plain English: " }),
+      document.createTextNode(String(answer?.plain_english || "")),
+    ]),
+    answerCitations(answer),
+    // Stated on the answer rather than hidden in a tooltip: "the evidence does
+    // not support an answer today" is a result, not a rendering failure.
+    ...(insufficient
+      ? [
+          element("p", {
+            className: "answer-insufficient",
+            text: "Evidence is insufficient to answer this today.",
+          }),
+        ]
+      : []),
+    element("p", { className: "answer-takeaway" }, [
+      element("strong", { text: "Takeaway: " }),
+      document.createTextNode(String(answer?.takeaway || "")),
+    ]),
+    // The counter-view is the point of the format: an answer that only ever
+    // confirms itself teaches a reader nothing about how much to trust it.
+    element("p", { className: "answer-counter-view" }, [
+      element("strong", { text: "Counter-view: " }),
+      document.createTextNode(String(answer?.counter_view || "")),
+    ]),
+  ]);
+}
+
+function questionsProvenance(questions) {
+  if (questions.generator !== "openai-responses") return null;
+  const usage = questions.usage || {};
+  return element("p", {
+    className: "daily-questions-meta",
+    text: `Answered by ${questions.model || "OpenAI model"} in ${Number(questions.calls || 0).toLocaleString()} calls · ${Number(usage.input_tokens || 0).toLocaleString()} input / ${Number(usage.output_tokens || 0).toLocaleString()} output tokens · every figure computed before the call and cited by ID.`,
+  });
+}
+
+// The Q&A is opt-in and generated once per UTC day, so a day can legitimately
+// have none: it predates the feature, no API key was configured, or the calls
+// failed. Say which rather than leaving a heading above blank space.
+function renderDailyQuestions(day) {
+  const questions = day.questions || {};
+  const groups = Array.isArray(questions.groups) ? questions.groups : [];
+  // A Q&A carrying another day's date answers questions about the wrong day,
+  // so it is withheld rather than shown beside this date's listings.
+  const usable = questions.date === day.date ? groups : [];
+  const rendered = usable.flatMap((group) => {
+    const answers = (Array.isArray(group?.answers) ? group.answers : []).map(answerBlock);
+    if (!answers.length) return [];
+    return [
+      element("section", { className: "question-group" }, [
+        element("h3", {
+          className: "question-group-title",
+          text: String(group?.title || "Questions"),
+        }),
+        ...answers,
+      ]),
+    ];
+  });
+  replaceChildren(
+    byId("daily-questions-body"),
+    rendered.length
+      ? [
+          // Without a certified comparison window, day-over-day differences may
+          // be collection changes rather than field changes. Saying so up front
+          // stops the answers below from reading as a trend claim.
+          ...(questions.comparable === false
+            ? [
+                element("p", {
+                  className: "daily-questions-caveat",
+                  text: String(
+                    questions.comparability_note ||
+                      "No certified comparison window today, so these answers describe what was captured rather than how the field is trending.",
+                  ),
+                }),
+              ]
+            : []),
+          ...rendered,
+          questionsProvenance(questions),
+        ]
+      : [
+          element("p", {
+            className: "empty-state",
+            text: "No questions were answered for this day.",
+          }),
+        ],
+  );
+}
+
 function renderToday() {
   const showingAllDates = state.todayDate === "all";
   const day = dailySnapshot(showingAllDates ? state.data.latest_date : state.todayDate);
@@ -433,9 +597,11 @@ function renderToday() {
   // result set. Hiding them in All dates mode keeps latest-day context from
   // appearing to explain observations collected across the full history.
   byId("daily-briefing").hidden = showingAllDates;
+  byId("daily-questions").hidden = showingAllDates;
   byId("source-health-panel").hidden = showingAllDates;
 
   renderDailyBriefing(day);
+  renderDailyQuestions(day);
 
   syncFilters();
   const observations = filteredObservations();

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -461,6 +461,111 @@ input {
   margin-top: 0.22rem;
 }
 
+.daily-questions {
+  margin-bottom: 1.5rem;
+  padding: 0.9rem 1.4rem;
+  border: 1px solid var(--ink);
+  background: var(--panel);
+}
+
+.daily-questions-title {
+  margin-bottom: 0.6rem;
+  font-size: 1rem;
+}
+
+.daily-questions-caveat {
+  margin: 0 0 0.85rem;
+  padding-left: 0.8rem;
+  border-left: 3px solid var(--line);
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.question-group + .question-group {
+  margin-top: 1.1rem;
+  padding-top: 0.9rem;
+  border-top: 1px solid var(--line);
+}
+
+.question-group-title {
+  margin: 0 0 0.55rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.answer + .answer {
+  margin-top: 0.9rem;
+}
+
+.answer-question {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin: 0 0 0.3rem;
+  font-size: 0.95rem;
+}
+
+.answer-signal,
+.answer-plain,
+.answer-takeaway,
+.answer-counter-view {
+  margin: 0.35rem 0 0;
+  font-size: 0.9rem;
+}
+
+.answer-plain {
+  color: var(--muted);
+}
+
+.answer-citations {
+  margin: 0.45rem 0 0;
+  padding-left: 1.2rem;
+  font-size: 0.84rem;
+}
+
+.answer-citations li + li {
+  margin-top: 0.22rem;
+}
+
+.answer-stat-id {
+  color: var(--muted);
+  font-size: 0.94em;
+}
+
+/* An answer the evidence cannot support is flagged in the flow of the answer,
+   not tucked away: withholding it is a result the reader needs to see. */
+.answer-insufficient {
+  margin: 0.4rem 0 0;
+  padding-left: 0.8rem;
+  border-left: 3px solid var(--line);
+  color: var(--muted);
+  font-size: 0.86rem;
+  font-style: italic;
+}
+
+.answer-counter-view {
+  padding-left: 0.8rem;
+  border-left: 3px solid var(--line);
+}
+
+.pill-confidence {
+  flex: none;
+  font-weight: 600;
+  text-transform: lowercase;
+}
+
+.daily-questions-meta {
+  margin: 0.9rem 0 0;
+  padding-top: 0.7rem;
+  border-top: 1px solid var(--line);
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
 .record-card {
   border-bottom: 1px solid var(--line);
 }

--- a/site/index.html
+++ b/site/index.html
@@ -127,6 +127,17 @@
           <h2 class="daily-briefing-title" id="daily-briefing-heading">Daily briefing</h2>
           <div id="daily-briefing-body"></div>
         </section>
+        <!-- The day's Q&A sits directly under the briefing: the briefing says
+             what changed, this answers what a reader would ask about it. Both
+             describe the whole scan date, so both stay above the filters. -->
+        <section
+          class="daily-questions"
+          id="daily-questions"
+          aria-labelledby="daily-questions-heading"
+        >
+          <h2 class="daily-questions-title" id="daily-questions-heading">Questions for today</h2>
+          <div id="daily-questions-body"></div>
+        </section>
         <form class="filter-panel today-filters" id="filters">
           <label class="search-field">
             Search

--- a/tests/fixtures/daily_questions.json
+++ b/tests/fixtures/daily_questions.json
@@ -1,0 +1,106 @@
+{
+  "date": "2026-08-08",
+  "questions": {
+    "schema_version": 1,
+    "date": "2026-08-08",
+    "generator": "openai-responses",
+    "model": "gpt-5",
+    "comparable": false,
+    "comparability_note": "No certified comparison window: collection changed on 2026-08-06.",
+    "calls": 3,
+    "usage": {
+      "input_tokens": 41234,
+      "output_tokens": 2810
+    },
+    "groups": [
+      {
+        "id": "arrivals",
+        "title": "What arrived",
+        "answers": [
+          {
+            "question": "What benchmarks, datasets, or evaluation methods did the radar first see today?",
+            "signal": "Most of today's first-observed records are agentic evaluation harnesses.",
+            "plain_english": "Most new items today test whether a model can carry out a task, not just answer a question.",
+            "takeaway": "Expect harness setup cost, not just a scoring script.",
+            "counter_view": "The feed is keyword-filtered, so agentic wording may be over-represented.",
+            "stat_ids": [
+              "S001"
+            ],
+            "evidence_ids": [
+              "E001"
+            ],
+            "confidence": "medium",
+            "sufficient_evidence": true,
+            "cited_stats": [
+              {
+                "id": "S001",
+                "label": "First-observed records today",
+                "value": 40,
+                "unit": "count",
+                "window": "today"
+              }
+            ],
+            "cited_evidence": [
+              {
+                "id": "E001",
+                "title": "A harness for long-horizon agent tasks",
+                "url": "https://arxiv.org/abs/2608.00001",
+                "source": "arxiv"
+              }
+            ]
+          },
+          {
+            "question": "Which of today's arrivals document how they score an answer?",
+            "signal": "Scoring documentation is absent from the captured metadata for most arrivals.",
+            "plain_english": "For most new items we cannot tell how they decide an answer is correct.",
+            "takeaway": "Treat unscored arrivals as unverified until the repository is read.",
+            "counter_view": "No credible counter-view found.",
+            "stat_ids": [],
+            "evidence_ids": [],
+            "confidence": "low",
+            "sufficient_evidence": false,
+            "cited_stats": [],
+            "cited_evidence": []
+          }
+        ]
+      },
+      {
+        "id": "movement",
+        "title": "What is still moving",
+        "answers": [
+          {
+            "question": "Which artifacts the radar already tracked moved measurably, and over what span?",
+            "signal": "Tracked artifacts moved on cumulative download counts across their whole tracked span.",
+            "plain_english": "Some items the radar has followed for a while kept gaining downloads overall.",
+            "takeaway": "Read the movement as a total since first sighting, not as a one-day jump.",
+            "counter_view": "Only one connector reported the movement, so it is uncorroborated.",
+            "stat_ids": [
+              "S014",
+              "S021"
+            ],
+            "evidence_ids": [],
+            "confidence": "low",
+            "sufficient_evidence": true,
+            "cited_stats": [
+              {
+                "id": "S014",
+                "label": "Tracked artifacts with movement",
+                "value": 12,
+                "unit": "count",
+                "window": "since 2026-07-23 (17 days)"
+              },
+              {
+                "id": "S021",
+                "label": "Mean days between sightings",
+                "value": 1234.56789,
+                "unit": "days",
+                "window": "today"
+              }
+            ],
+            "cited_evidence": []
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/render_questions_harness.mjs
+++ b/tests/render_questions_harness.mjs
@@ -1,0 +1,111 @@
+// Executes the dashboard's daily Q&A renderer against a fixture shaped exactly
+// like `questions.py` writes into a snapshot, and prints the resulting text and
+// link targets as JSON for the Python test to assert on.
+//
+// Source assertions alone cannot tell "the function renders the answer" apart
+// from "the function mentions the word answer", and this Q&A is the one part of
+// the page whose whole value is that every number on it is traceable. So the
+// renderer is run for real against a minimal DOM rather than grepped.
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(here, "..", "site", "assets", "app.js"), "utf8");
+
+class StubNode {
+  constructor(tag) {
+    this.tag = tag;
+    this.className = "";
+    this.children = [];
+    this.attributes = {};
+    this._text = "";
+    this.hidden = false;
+  }
+  set textContent(value) {
+    this._text = String(value);
+    this.children = [];
+  }
+  get textContent() {
+    return this.children.length
+      ? this.children.map((child) => child.textContent).join("")
+      : this._text;
+  }
+  setAttribute(key, value) {
+    this.attributes[key] = String(value);
+  }
+  append(child) {
+    this.children.push(child);
+  }
+  replaceChildren(...children) {
+    this.children = children;
+  }
+  addEventListener() {}
+  querySelectorAll() {
+    return [];
+  }
+  querySelector() {
+    return null;
+  }
+  getContext() {
+    return null;
+  }
+}
+
+class StubText {
+  constructor(value) {
+    this.tag = "#text";
+    this.children = [];
+    this.attributes = {};
+    this._text = String(value);
+  }
+  get textContent() {
+    return this._text;
+  }
+}
+
+const registry = new Map();
+globalThis.document = {
+  createElement: (tag) => new StubNode(tag),
+  createElementNS: (_ns, tag) => new StubNode(tag),
+  createTextNode: (value) => new StubText(value),
+  getElementById: (id) => {
+    if (!registry.has(id)) registry.set(id, new StubNode("div"));
+    return registry.get(id);
+  },
+  addEventListener: () => {},
+  querySelectorAll: () => [],
+  querySelector: () => null,
+};
+globalThis.window = { addEventListener: () => {}, location: { search: "", hash: "" } };
+// Bootstrap fetches radar.json on load. This harness renders a fixture instead,
+// so the request is stubbed to a never-settling promise: letting it reject would
+// print an unhandled rejection that has nothing to do with what is under test.
+globalThis.fetch = () => new Promise(() => {});
+
+// The module runs bootstrapping code on load. Function declarations hoist, so
+// the export is placed at the TOP of the harness: it then captures the render
+// helpers before any bootstrap statement can throw on a browser-only API.
+const harness =
+  `globalThis.__render = { renderDailyQuestions, formatStatValue };\n${source}`;
+// A bootstrap failure is NOT swallowed. The stubs above cover every browser API
+// app.js touches on load, so a throw here means the real script would break in a
+// browser too, and a renderer test that still passed would be hiding it.
+new Function(harness)();
+
+// A caller may pass a different fixture to exercise an absent or stale Q&A.
+const fixturePath = process.argv[2] || join(here, "fixtures", "daily_questions.json");
+const day = JSON.parse(readFileSync(fixturePath, "utf8"));
+globalThis.__render.renderDailyQuestions(day);
+
+function walk(node) {
+  return {
+    tag: node.tag,
+    className: node.className || "",
+    href: node.attributes?.href || "",
+    text: node.textContent,
+    children: (node.children || []).map(walk),
+  };
+}
+
+console.log(JSON.stringify(walk(document.getElementById("daily-questions-body")), null, 2));

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -748,3 +748,232 @@ def test_daily_briefing_collapses_verbose_evidence_details_by_default():
     assert "Evidence & briefing details · ${citations.length.toLocaleString()} sources" in script
     assert "briefingDetails(briefing, citations)" in script
     assert 'attrs: { open: "" }' not in script
+
+
+def test_today_view_renders_the_daily_questions_under_the_briefing():
+    html = Path("site/index.html").read_text(encoding="utf-8")
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    assert 'id="daily-questions"' in html
+    assert 'id="daily-questions-body"' in html
+    # The briefing says what changed and the Q&A answers what a reader would ask
+    # about it, so the Q&A follows the briefing and both sit above the filters.
+    assert html.index('id="daily-briefing"') < html.index('id="daily-questions"')
+    assert html.index('id="daily-questions"') < html.index('id="filters"')
+    assert "renderDailyQuestions(day)" in script
+    # Both describe one scan date, so neither is shown over the whole archive.
+    assert 'byId("daily-questions").hidden = showingAllDates' in script
+
+
+def test_daily_questions_withhold_another_days_answers_and_name_an_absent_set():
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    assert "questions.date === day.date" in script
+    assert "No questions were answered for this day." in script
+
+
+def test_daily_questions_print_stat_values_from_the_registry_not_the_prose():
+    """The renderer must never take a number from the model's own sentences.
+
+    `questions.py` computes every figure before the call and has the model cite
+    S### ids; the page prints the cited statistic's own value. Rendering prose
+    numbers instead would reintroduce exactly the fabrication the registry
+    exists to prevent.
+    """
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    assert "formatStatValue(stat)" in script
+    assert "answer.cited_stats" in script
+    assert 'unit !== "count"' in script
+    assert 'window !== "today"' in script
+    # Spans already carry parentheses; the Markdown renderer avoids nesting a
+    # second pair and the dashboard has to agree with it.
+    assert 'window.endsWith(")")' in script
+
+
+def test_daily_questions_show_the_counter_view_and_admitted_insufficiency():
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    # A daily feed that only ever confirms itself teaches a reader nothing about
+    # how much to trust it, so the counter-view is rendered, never collapsed.
+    assert 'text: "Counter-view: "' in script
+    assert 'text: "Takeaway: "' in script
+    assert "Evidence is insufficient to answer this today." in script
+    assert "answer?.sufficient_evidence === false" in script
+
+
+def test_daily_questions_flag_an_uncertified_comparison_window():
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    # Without a certified window, day-over-day differences may be collection
+    # changes rather than field changes, so the answers must not read as trends.
+    assert "questions.comparable === false" in script
+    assert "questions.comparability_note" in script
+    assert 'questions.generator !== "openai-responses"' in script
+    assert "every figure computed before the call and cited by ID." in script
+
+
+def test_daily_questions_link_only_validated_http_evidence():
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    # Same gate as the briefing: an id-shaped string with an unsafe or missing
+    # URL is not turned into a link a reader can click.
+    assert "validBriefingCitations(answer?.cited_evidence)" in script
+
+
+def _rendered_questions(fixture: str | None = None):
+    """Run the real renderer over a fixture and return the resulting DOM tree.
+
+    Source assertions cannot distinguish "renders the answer" from "mentions the
+    word answer". The whole claim of this section is that every figure on it is
+    traceable to a statistic computed before the model ran, so it is executed.
+    """
+    import json
+    import shutil
+    import subprocess
+
+    node = shutil.which("node")
+    if not node:
+        import pytest
+
+        pytest.skip("node is not installed")
+    result = subprocess.run(
+        [node, "tests/render_questions_harness.mjs", *([fixture] if fixture else [])],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def _flatten(node):
+    yield node
+    for child in node.get("children") or []:
+        yield from _flatten(child)
+
+
+def test_rendered_questions_carry_every_answer_field_and_registry_value():
+    nodes = list(_flatten(_rendered_questions()))
+    classes = {node["className"] for node in nodes}
+    text = next(iter(nodes))["text"]
+
+    assert {"question-group", "answer", "answer-signal", "answer-takeaway"} <= classes
+    assert "answer-counter-view" in classes
+    # Both fixture groups and all three answers render, not just the first.
+    assert len([n for n in nodes if n["className"] == "question-group"]) == 2
+    assert len([n for n in nodes if n["className"] == "answer"]) == 3
+
+    # The statistic's value and span come from the registry entry, and the span
+    # is not wrapped in a second pair of parentheses.
+    assert "First-observed records today: 40" in text
+    assert "12 since 2026-07-23 (17 days)" in text
+    assert "12 (since 2026-07-23 (17 days))" not in text
+
+    # A registry value is printed at full precision. `toLocaleString()` would
+    # round this to 1,234.568, quietly altering a figure on the one page whose
+    # whole claim is that every number is the one that was computed.
+    assert "1,234.56789 days" in text
+    assert "1,234.568 days" not in text
+
+    # The model's own prose is reproduced verbatim, and the counter-view with it.
+    assert "No credible counter-view found." in text
+    assert "Evidence is insufficient to answer this today." in text
+    assert "No certified comparison window" in text
+    assert "Answered by gpt-5 in 3 calls" in text
+
+
+def test_dashboard_and_markdown_format_statistics_identically():
+    """The two renderers must print the same figure for the same statistic.
+
+    The Markdown report and the dashboard are both published from one registry,
+    so a reader comparing them must not see two different numbers. This runs the
+    JS formatter against `report._format_stat_value` over the same inputs.
+    """
+    import json
+    import re
+    import shutil
+    import subprocess
+    from pathlib import Path as _Path
+
+    import pytest
+
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is not installed")
+
+    from benchmark_radar.report import _format_stat_value
+
+    cases = [1234.56789, 12.5, 40.0, 0.125, 1234567.0, -1234.5, -1234567, 0, 100, 999, 1000]
+    source = _Path("site/assets/app.js").read_text(encoding="utf-8")
+    match = re.search(r"function formatStatValue[\s\S]*?\n}\n", source)
+    assert match, "formatStatValue not found in app.js"
+    program = (
+        f"{match.group(0)}\n"
+        f"const cases = {json.dumps(cases)};\n"
+        "console.log(JSON.stringify(cases.map((value) => "
+        'formatStatValue({ value, unit: "count", window: "today" }))));'
+    )
+    result = subprocess.run(
+        [node, "-e", program], capture_output=True, text=True, timeout=60, check=True
+    )
+
+    expected = [
+        _format_stat_value({"value": value, "unit": "count", "window": "today"}) for value in cases
+    ]
+    assert json.loads(result.stdout) == expected
+
+
+def test_rendered_questions_link_cited_evidence_to_its_source():
+    nodes = list(_flatten(_rendered_questions()))
+    links = [node for node in nodes if node["href"]]
+
+    assert [node["href"] for node in links] == ["https://arxiv.org/abs/2608.00001"]
+    assert links[0]["text"] == "A harness for long-horizon agent tasks"
+
+
+def _render_with(mutate, tmp_path):
+    """Render the fixture after applying `mutate` to it."""
+    import json
+    from pathlib import Path as _Path
+
+    fixture = json.loads(_Path("tests/fixtures/daily_questions.json").read_text(encoding="utf-8"))
+    mutate(fixture)
+    path = tmp_path / "daily_questions.json"
+    path.write_text(json.dumps(fixture), encoding="utf-8")
+    return _rendered_questions(str(path))
+
+
+def test_rendered_questions_withhold_a_stale_day_rather_than_mislabel_it(tmp_path):
+    """A Q&A stamped with another date answers questions about the wrong day."""
+
+    def restamp(fixture):
+        fixture["questions"]["date"] = "2026-08-07"
+
+    rendered = _render_with(restamp, tmp_path)
+    assert "No questions were answered for this day." in rendered["text"]
+    assert not any(node["className"] == "answer" for node in _flatten(rendered))
+
+
+def test_rendered_questions_report_an_absent_set_rather_than_blank_space(tmp_path):
+    """The Q&A is opt-in, so a day with none must say so under its heading."""
+
+    def clear(fixture):
+        fixture["questions"] = {}
+
+    rendered = _render_with(clear, tmp_path)
+    assert "No questions were answered for this day." in rendered["text"]
+    assert not any(node["className"] == "question-group" for node in _flatten(rendered))
+
+
+def test_rendered_questions_drop_an_evidence_citation_with_an_unsafe_url(tmp_path):
+    """An id-shaped citation without a safe URL must not become a link."""
+
+    def poison(fixture):
+        citation = fixture["questions"]["groups"][0]["answers"][0]["cited_evidence"][0]
+        citation["url"] = "javascript:alert(1)"
+
+    rendered = _render_with(poison, tmp_path)
+    assert not [node for node in _flatten(rendered) if node["href"]]
+    # The answer itself still renders; only the unfollowable citation is dropped.
+    assert any(node["className"] == "answer" for node in _flatten(rendered))


### PR DESCRIPTION
Closes the UI half of #159. PR #162 got the answers into `radar.json`; only the Markdown report rendered them, so a reader on the dashboard saw the daily briefing and then nothing. This adds the section the data was already waiting for.

## What the renderer does

It follows the same grounding contract as `report.py` rather than reimplementing a looser one:

| Rule | Why it exists |
| --- | --- |
| Stat values printed from the cited registry entry | A number reaches the page only if it was computed before the model ran |
| Only `E###` with a safe http(s) URL becomes a link | Reuses the briefing's citation gate; a citation nobody can follow is not a link |
| Counter-view always rendered, never collapsed | A feed that only confirms itself teaches a reader nothing about how much to trust it |
| Insufficient evidence stated in the flow of the answer | "The evidence does not support an answer" is a result, not a rendering failure |
| Uncertified comparison window flagged above the answers | Without it, day-over-day differences read as trends when they may be collection changes |
| A Q&A stamped with another date is withheld | Same rule the briefing already applies |

## One real bug caught in review

`toLocaleString()` rounds to three fraction digits. A registry value of `1234.56789` would have reached the dashboard as `1,234.568` while the Markdown report printed `1,234.56789`: two different numbers for one statistic, on the one panel whose entire claim is that every figure is traceable. Grouping now matches Python's `f"{value:,}"` digit for digit.

Registry values are currently rounded to 1-2 decimals upstream, so this was latent rather than firing today. `test_dashboard_and_markdown_format_statistics_identically` runs both formatters over the same 11 inputs (floats, negatives, integral floats) so the two published surfaces cannot drift apart.

## Testing

Tests execute the real renderer against a fixture shaped like `questions.py`'s output, under a stubbed DOM (`tests/render_questions_harness.mjs`). Asserting on source text alone cannot tell "renders the answer" from "mentions the word answer", which is too weak here. Covered: full answer structure, registry values and spans, evidence links, a stale day, an absent Q&A, and a citation with a `javascript:` URL.

632 tests pass; ruff check and format clean. Verified in a browser at desktop and mobile widths.

## Reviewed, and one thing deliberately left out

An independent Codex review found no DOM-XSS path: untrusted text goes through `textContent`/text nodes and links are restricted to http(s). It raised three findings. Two are fixed here (the rounding bug above; the test harness no longer swallows bootstrap exceptions, so a real startup break fails the suite).

The third is real but **not** fixed here: `_ALLOWED_BARE_NUMBERS` in `questions.py` includes `100`, so an answer can write "100 benchmarks arrived today" while citing a statistic valued 2, and pass validation. That is a server-side validation gap affecting the Markdown report equally, so it is filed as #165 rather than bundled into a frontend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
