### PR TITLE
Export the complete benchmark contact inventory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ out/
 # realise it, so a committed list of them is a spam and doxxing vector whatever
 # the intent. The survey itself carries public professional signals only and is
 # safe to share; this file is not.
+/out/benchmark-author-contacts.csv
+benchmark-author-contacts.csv
 /out/benchmark-author-contacts.json
 benchmark-author-contacts.json
 

--- a/src/benchmark_radar/authors.py
+++ b/src/benchmark_radar/authors.py
@@ -25,6 +25,8 @@ No email is ever sent. This reads public APIs and stops there.
 
 from __future__ import annotations
 
+import csv
+import io
 import os
 import re
 from typing import Any
@@ -45,6 +47,18 @@ DATA_SIGNALS = (
     "data-centric",
     "data curation",
     "dataset",
+    "data scientist",
+    "data architect",
+    "data platform",
+    "data system",
+    "data product",
+    "data provider",
+    "data marketplace",
+    "synthetic data",
+    "training data",
+    "geospatial data",
+    "satellite imagery",
+    "earth observation",
     "data engineering",
     "annotation",
     "labeling",
@@ -60,6 +74,18 @@ DATA_SIGNALS = (
 )
 
 _GITHUB_REPO = re.compile(r"^https?://github\.com/([^/]+)/([^/?#]+)", re.IGNORECASE)
+CONTACT_COLUMNS = (
+    "login",
+    "name",
+    "company",
+    "bio",
+    "profile_url",
+    "public_profile_email",
+    "commit_email",
+    "data_signals",
+    "works_on_data",
+    "found_in",
+)
 
 
 class AuthorLookupError(RuntimeError):
@@ -169,7 +195,30 @@ def data_signals(profile: dict[str, Any]) -> list[str]:
     text = " ".join(
         str(profile.get(field) or "") for field in ("bio", "company", "blog")
     ).casefold()
-    return sorted({signal for signal in DATA_SIGNALS if signal in text})
+    return sorted(
+        {
+            signal
+            for signal in DATA_SIGNALS
+            if re.search(rf"(?<!\w){re.escape(signal)}s?(?!\w)", text)
+        }
+    )
+
+
+def contacts_csv(contacts: list[dict[str, Any]]) -> str:
+    """Render the complete private contact inventory as RFC 4180 CSV."""
+    output = io.StringIO(newline="")
+    writer = csv.DictWriter(output, fieldnames=CONTACT_COLUMNS, lineterminator="\r\n")
+    writer.writeheader()
+    for contact in contacts:
+        row = dict(contact)
+        row["data_signals"] = "; ".join(row.get("data_signals") or [])
+        row["found_in"] = "; ".join(row.get("found_in") or [])
+        rendered = {}
+        for column in CONTACT_COLUMNS:
+            value = row.get(column, "")
+            rendered[column] = " ".join(value.split()) if isinstance(value, str) else value
+        writer.writerow(rendered)
+    return output.getvalue()
 
 
 def public_profile(login: str) -> dict[str, Any]:
@@ -241,7 +290,7 @@ def survey(
     """
     repos = popular_repositories(snapshots, limit=repo_limit)
     profiles: dict[str, dict[str, Any]] = {}
-    contacts: dict[str, dict[str, str]] = {}
+    contacts: dict[str, dict[str, Any]] = {}
     failures: list[str] = []
 
     for repo in repos:
@@ -276,11 +325,23 @@ def survey(
                 }
             )
             if login in emails:
-                contacts[login] = {
-                    "login": login,
-                    "commit_email": emails[login],
-                    "found_in": repo["full_name"],
-                }
+                contact = contacts.setdefault(
+                    login,
+                    {
+                        "login": login,
+                        "name": profile.get("name"),
+                        "company": profile.get("company"),
+                        "bio": profile.get("bio"),
+                        "profile_url": profile.get("profile_url"),
+                        "public_profile_email": profile.get("public_profile_email"),
+                        "commit_email": emails[login],
+                        "data_signals": profile.get("data_signals") or [],
+                        "works_on_data": bool(profile.get("works_on_data")),
+                        "found_in": [],
+                    },
+                )
+                if repo["full_name"] not in contact["found_in"]:
+                    contact["found_in"].append(repo["full_name"])
 
     people = sorted(
         profiles.values(),

--- a/src/benchmark_radar/cli.py
+++ b/src/benchmark_radar/cli.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import yaml
 
+from .authors import contacts_csv
 from .authors import survey as author_survey
 from .briefing import BriefingError, current_day_snapshot, daily_report_run, generate_daily_briefing
 from .export import DEFAULT_TABLE_LIMIT, write_exports
@@ -104,7 +105,7 @@ def main() -> None:
     parser.add_argument(
         "--author-contacts",
         type=Path,
-        default=Path("out/benchmark-author-contacts.json"),
+        default=Path("out/benchmark-author-contacts.csv"),
         help=(
             "Where `authors --author-emails` writes harvested commit emails. Kept "
             "out of the survey and untracked: publishing addresses people did not "
@@ -251,10 +252,7 @@ def main() -> None:
             # Untracked by design: a committed list of harvested addresses is a
             # spam vector no matter why it was gathered.
             args.author_contacts.parent.mkdir(parents=True, exist_ok=True)
-            args.author_contacts.write_text(
-                json.dumps(result["contacts"], ensure_ascii=False, indent=2) + "\n",
-                encoding="utf-8",
-            )
+            args.author_contacts.write_text(contacts_csv(result["contacts"]), encoding="utf-8")
             print(f"  contacts: {args.author_contacts} (gitignored, {len(result['contacts'])})")
         for failure in report["failures"][:5]:
             print(f"  ::warning:: {failure}")

--- a/tests/test_authors.py
+++ b/tests/test_authors.py
@@ -66,6 +66,22 @@ def test_data_work_is_read_from_the_authors_own_words():
     assert authors.data_signals(unrelated) == []
 
 
+def test_data_signals_match_words_not_organization_substrings():
+    profile = {"bio": "", "company": "PlanetLabs", "blog": ""}
+
+    assert authors.data_signals(profile) == []
+
+
+def test_data_signals_cover_professional_data_roles_and_products():
+    profile = {
+        "bio": "Senior Data Scientist building scalable data platforms",
+        "company": "Acme",
+        "blog": "",
+    }
+
+    assert authors.data_signals(profile) == ["data platform", "data scientist"]
+
+
 def test_noreply_commit_addresses_are_never_collected(monkeypatch):
     # A noreply address identifies nobody and is pure noise in a contact file.
     monkeypatch.setattr(
@@ -99,9 +115,12 @@ def test_the_shareable_survey_never_carries_harvested_commit_emails(monkeypatch)
         "public_profile",
         lambda login: {
             "login": login,
+            "name": "Real Person",
             "bio": "dataset work",
             "company": "Acme",
             "followers": 1,
+            "profile_url": "https://github.com/real",
+            "public_profile_email": "hello@example.test",
             "data_signals": ["dataset"],
             "works_on_data": True,
         },
@@ -111,6 +130,36 @@ def test_the_shareable_survey_never_carries_harvested_commit_emails(monkeypatch)
     result = authors.survey([current], include_emails=True)
 
     assert result["contacts"] == [
-        {"login": "real", "commit_email": "r@e.test", "found_in": "org/bench"}
+        {
+            "login": "real",
+            "name": "Real Person",
+            "company": "Acme",
+            "bio": "dataset work",
+            "profile_url": "https://github.com/real",
+            "public_profile_email": "hello@example.test",
+            "commit_email": "r@e.test",
+            "data_signals": ["dataset"],
+            "works_on_data": True,
+            "found_in": ["org/bench"],
+        }
     ]
     assert "r@e.test" not in str(result["report"])
+
+
+def test_contacts_csv_contains_every_contact_and_flattens_lists():
+    rendered = authors.contacts_csv(
+        [
+            {
+                "login": "real",
+                "commit_email": "r@e.test",
+                "data_signals": ["data quality", "dataset"],
+                "found_in": ["org/one", "org/two"],
+            },
+            {"login": "other", "commit_email": "o@e.test", "found_in": ["org/one"]},
+        ]
+    )
+
+    assert rendered.count("\r\n") == 3
+    assert "data quality; dataset" in rendered
+    assert "org/one; org/two" in rendered
+    assert "other" in rendered


### PR DESCRIPTION
Closes #156.

## Root cause

The authenticated crawl already found 156 non-noreply contacts across 40 repositories and 378 profiles. The apparent four-contact result came from the private handoff: it replaced the complete harvest with only the four profiles selected by the first keyword/manual-review pass.

## Fix

- emit the private contact artifact as a real CSV with all harvested rows
- enrich each row with profile, company, bio, profile email, provenance repositories, and data-work signals
- preserve multiple provenance repositories for repeat contributors
- match signals at word boundaries so `etl` no longer matches `PlanetLabs`
- add precise professional data-role and data-product signals
- keep both CSV and legacy JSON contact exports gitignored

The private `vendor-data-qc` repository now stores the complete 156-row inventory in `contacts.csv` and preserves the original four manually audited leads separately in `audited-data-leads.csv` (commit `67e5966`).

## Verification

- 623 tests pass
- ruff check and format pass
- fresh authenticated run: 40 repositories, 378 profiles, 156 CSV contacts, 9 data-adjacent profiles, 0 API failures
- generated CSV: 156 unique logins, 156 non-empty commit addresses
