### PR TITLE
Expand first-party benchmark feed coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Default sources:
 | Hugging Face Hub | No | Dataset repository discovery |
 | GitHub | No in Actions | Code and artifact discovery |
 | GitHub Releases | No in Actions | Curated first-party release discovery |
+| First-party feeds | No | Curated official lab and engineering announcements |
 | Semantic Scholar | Optional `SEMANTIC_SCHOLAR_API_KEY` | Structured scholarly discovery |
 | OpenAlex | Free `OPENALEX_API_KEY` | Scholarly metadata enrichment |
 | Brave Search | `BRAVE_API_KEY` | Web and lab-blog discovery |

--- a/config.yml
+++ b/config.yml
@@ -230,19 +230,122 @@ sources:
       - stanford-crfm/helm
       - EleutherAI/lm-evaluation-harness
       - LiveBench/LiveBench
-      - princeton-nlp/SWE-bench
+      - SWE-bench/SWE-bench
       - evalplus/evalplus
       - openai/evals
       - mlcommons/inference
       - ARCPrize/ARC-AGI
+      - arcprize/ARC-AGI-3-Agents
+      # Curated first-party benchmark and evaluation repositories. Some
+      # projects release infrequently; an empty Releases response is healthy.
+      - openai/simple-evals
+      - openai/human-eval
+      - THUDM/AgentBench
+      - THUDM/LongBench
+      - modelscope/evalscope
+      - open-compass/opencompass
+      - huggingface/lighteval
+      - embeddings-benchmark/mteb
+      - EvolvingLMMs-Lab/lmms-eval
+      - LiveCodeBench/LiveCodeBench
+      - SWE-agent/SWE-agent
+      - lmarena/arena-hard-auto
+      - MMMU-Benchmark/MMMU
+      - MME-Benchmarks/Video-MME
+      - OpenGVLab/MMT-Bench
+      - AILab-CVC/SEED-Bench
+      - centerforaisafety/HarmBench
+      - centerforaisafety/wmdp
+      - NVIDIA/garak
+      - microsoft/BIPIA
+      - OSU-NLP-Group/Mind2Web
+      - OpenBMB/ToolBench
+      - ServiceNow/BrowserGym
+      - web-arena-x/webarena
+      - facebookresearch/CRAG
+      - confident-ai/deepeval
+      - vibrantlabsai/ragas
+      - UKGovernmentBEIS/inspect_ai
+      - OpenMOSS/VLABench
+      - EmbodiedBench/EmbodiedBench
+      - thu-coai/SafetyBench
+      # First-party model and agent repositories from Alina's feed audit.
+      # Their releases enter the radar only when the normal benchmark/data
+      # taxonomy finds relevant source text; ordinary model releases drop out.
+      - QwenLM/Qwen3
+      - QwenLM/Qwen-Agent
+      - deepseek-ai/DeepSeek-V3
+      - deepseek-ai/DeepSeek-R1
+      - PaddlePaddle/ERNIE
+      - PaddlePaddle/Paddle
+      - Tencent-Hunyuan/HunyuanVideo
+      - verl-project/verl
+      - zai-org/GLM-4
+      - zai-org/CogVideo
+      - MoonshotAI/Kimi-k1.5
+      - InternLM/InternLM
+      - meituan-longcat/LongCat-Next
+      - Kwai-Kolors/Kolors
+      - MiniMax-AI/MiniMax-01
+      - stepfun-ai/Step-Audio
+      - stepfun-ai/Step-Video-T2V
+      - bytedance/UI-TARS
+      - black-forest-labs/flux
+      - 01-ai/Yi
+      - meta-llama/llama-models
+      - openclaw/openclaw
+      - karpathy/autoresearch
+      - xai-org/grok-1
     page_size: 30
     max_pages_per_repository: 1
-    max_requests: 8
+    max_requests: 64
     # Invalid future-dated rows may consume a page slot. Replacement requests
     # use a separate cap so they cannot steal the first request from later repos.
     future_replacement_requests: 2
     attempts: 3
     timeout_seconds: 30
+
+  # Audited from data/feeds_curated_by_alina_allowed_to_go_public.yaml.
+  # Only live feeds hosted by the organization that authored the content are
+  # admitted here. Media, social proxies, community feeds, broad arXiv feeds,
+  # broken endpoints, and third-party Anthropic mirrors stay out of scored
+  # evidence. Entries are filtered locally for benchmark/data relevance.
+  first_party_feeds:
+    enabled: true
+    required: false
+    allow_empty: true
+    attempts: 3
+    timeout_seconds: 30
+    keywords:
+      - benchmark
+      - evaluation
+      - evals
+      - leaderboard
+      - dataset
+      - test set
+      - data contamination
+      - data quality
+    feeds:
+      - name: Meituan Engineering
+        url: https://tech.meituan.com/rss.xml
+      - name: OpenAI News
+        url: https://openai.com/news/rss.xml
+      - name: Google AI
+        url: https://blog.google/innovation-and-ai/technology/ai/rss/
+      - name: Google DeepMind
+        url: https://deepmind.google/blog/rss.xml
+      - name: Google Research
+        url: https://research.google/blog/rss/
+      - name: Apple Machine Learning Research
+        url: https://machinelearning.apple.com/rss.xml
+      - name: AWS Machine Learning
+        url: https://aws.amazon.com/blogs/machine-learning/feed/
+      - name: Hugging Face Blog
+        url: https://huggingface.co/blog/feed.xml
+      - name: Microsoft Research
+        url: https://www.microsoft.com/en-us/research/feed/
+      - name: NVIDIA AI Blog
+        url: https://blogs.nvidia.com/feed/
 
   openalex:
     enabled: true
@@ -259,6 +362,16 @@ sources:
       - new LLM benchmark leaderboard
       - AI dataset release data quality
       - new agentic AI benchmark leaderboard
+      # Official pages whose RSS endpoints in Alina's list are missing,
+      # unofficial, or broken. Search remains first-party-domain constrained.
+      - site:anthropic.com/news benchmark evaluation dataset
+      - site:anthropic.com/research benchmark evaluation dataset
+      - site:anthropic.com/engineering benchmark evaluation dataset
+      - site:ai.meta.com/blog benchmark evaluation dataset
+      - site:blogs.microsoft.com/ai benchmark evaluation dataset
+      - site:mistral.ai/news benchmark evaluation dataset
+      - site:stability.ai/news benchmark evaluation dataset
+      - site:01.ai/blog benchmark evaluation dataset
 
 attention:
   hacker_news:

--- a/data/feeds_curated_by_alina_allowed_to_go_public.yaml
+++ b/data/feeds_curated_by_alina_allowed_to_go_public.yaml
@@ -5,6 +5,12 @@ feeds:
   # LLM prompt 已优化，会自动过滤噪音（学术论文、非AI内容等）
   # ============================================================
 
+  # --- Benchmark Radar（聚合后的公开输出；只需订阅这一个 RSS）---
+  - name: "Benchmark Radar"
+    url: "https://ktwu01.github.io/benchmark-radar/feed.xml"
+    lang: "en"
+    category: "行业动态"
+
   # --- 橘鸦AI早报（核心参考源）---
   - name: "橘鸦AI早报"
     url: "https://imjuya.github.io/juya-ai-daily/rss.xml"
@@ -34,7 +40,7 @@ feeds:
 
   # --- 国内大模型厂商 ---
   - name: "美团技术博客"
-    url: "https://tech.meituan.com/feed/"
+    url: "https://tech.meituan.com/rss.xml"
     lang: "zh"
     category: "官方动态"
 

--- a/src/benchmark_radar/corpus.py
+++ b/src/benchmark_radar/corpus.py
@@ -17,6 +17,7 @@ CORPUS_SCHEMA_VERSION = 1
 AGGREGATE_WINDOW_DAYS = 7
 PRIMARY_SOURCE_RANK = {
     "arXiv": 1,
+    "First-party feed": 1,
     "OpenReview": 1,
     "GitHub Release": 1,
     "GitHub": 1,

--- a/src/benchmark_radar/pipeline.py
+++ b/src/benchmark_radar/pipeline.py
@@ -672,16 +672,15 @@ def run_pipeline(
             fetched, rejected_future = _drop_future_dated_items(fetched, now=now)
             rejected_future += connector_rejected
             future_dated_count += rejected_future
+            source_notes = [str(value) for value in fetch_config.get("_source_warnings", [])]
+            if rejected_future:
+                source_notes.insert(0, f"Discarded {rejected_future} future-dated record(s)")
             health.append(
                 SourceHealth(
                     source=source_name,
                     ok=True,
                     item_count=len(fetched),
-                    error=(
-                        f"Discarded {rejected_future} future-dated record(s)"
-                        if rejected_future
-                        else None
-                    ),
+                    error="; ".join(source_notes) if source_notes else None,
                 )
             )
             for item in fetched:

--- a/src/benchmark_radar/rubric.py
+++ b/src/benchmark_radar/rubric.py
@@ -12,7 +12,7 @@ import hashlib
 import json
 from typing import Any
 
-SCORING_VERSION = 2
+SCORING_VERSION = 3
 SCORE_MAX = 100.0
 DEFAULT_LOOKBACK_HOURS = 48.0
 
@@ -29,7 +29,13 @@ WEIGHTS: dict[str, float] = {
 
 # Evidence is explicit and additive on a 0-100 scale.
 EVIDENCE_BASE = 10.0
-EVIDENCE_PRIMARY_SOURCES = ("arXiv", "OpenAlex", "OpenReview", "Semantic Scholar")
+EVIDENCE_PRIMARY_SOURCES = (
+    "arXiv",
+    "First-party feed",
+    "OpenAlex",
+    "OpenReview",
+    "Semantic Scholar",
+)
 EVIDENCE_PRIMARY_CREDIT = 40.0
 EVIDENCE_ARTIFACT_SOURCES = ("GitHub", "GitHub Release", "Hugging Face")
 EVIDENCE_ARTIFACT_CREDIT = 30.0
@@ -170,7 +176,7 @@ def _components(*, lookback_hours: float) -> list[dict[str, Any]]:
             ),
             "bands": [
                 f"{EVIDENCE_BASE:.0f} baseline for any record that passed ingest",
-                f"+{EVIDENCE_PRIMARY_CREDIT:.0f} from a primary scholarly record "
+                f"+{EVIDENCE_PRIMARY_CREDIT:.0f} from a primary or structured record "
                 f"({', '.join(EVIDENCE_PRIMARY_SOURCES)})",
                 f"+{EVIDENCE_ARTIFACT_CREDIT:.0f} from a structured artifact registry "
                 f"({', '.join(EVIDENCE_ARTIFACT_SOURCES)})",
@@ -240,6 +246,21 @@ def rubric_reference(
         ],
         "lookback_hours": float(lookback_hours),
     }
+    return value
+
+
+def v2_rubric_reference(
+    *, lookback_hours: float = DEFAULT_LOOKBACK_HOURS
+) -> dict[str, Any]:
+    """Describe v2 without retroactively granting its records the v3 feed tier."""
+    value = rubric_reference(lookback_hours=lookback_hours)
+    value["scoring_version"] = 2
+    for component in value["components"]:
+        if component["key"] != "evidence":
+            continue
+        component["bands"] = [
+            band.replace(", First-party feed", "") for band in component["bands"]
+        ]
     return value
 
 

--- a/src/benchmark_radar/rubric.py
+++ b/src/benchmark_radar/rubric.py
@@ -249,18 +249,14 @@ def rubric_reference(
     return value
 
 
-def v2_rubric_reference(
-    *, lookback_hours: float = DEFAULT_LOOKBACK_HOURS
-) -> dict[str, Any]:
+def v2_rubric_reference(*, lookback_hours: float = DEFAULT_LOOKBACK_HOURS) -> dict[str, Any]:
     """Describe v2 without retroactively granting its records the v3 feed tier."""
     value = rubric_reference(lookback_hours=lookback_hours)
     value["scoring_version"] = 2
     for component in value["components"]:
         if component["key"] != "evidence":
             continue
-        component["bands"] = [
-            band.replace(", First-party feed", "") for band in component["bands"]
-        ]
+        component["bands"] = [band.replace(", First-party feed", "") for band in component["bands"]]
     return value
 
 

--- a/src/benchmark_radar/snapshots.py
+++ b/src/benchmark_radar/snapshots.py
@@ -28,6 +28,7 @@ from .rubric import (
     legacy_rubric_reference,
     rubric_reference,
     taxonomy_version,
+    v2_rubric_reference,
 )
 
 SCHEMA_VERSION = 2
@@ -898,6 +899,11 @@ def dashboard_data(
         # v2 arithmetic.
         "rubrics": {
             "1": legacy_rubric_reference(),
+            "2": v2_rubric_reference(
+                lookback_hours=(
+                    (days[-1].get("selection") or {}).get("lookback_hours") or 48 if days else 48
+                ),
+            ),
             str(SCORING_VERSION): rubric_reference(
                 lookback_hours=(
                     (days[-1].get("selection") or {}).get("lookback_hours") or 48 if days else 48

--- a/src/benchmark_radar/sources.py
+++ b/src/benchmark_radar/sources.py
@@ -62,9 +62,7 @@ def _feed_link(entry: ET.Element) -> str:
     return ""
 
 
-def fetch_first_party_feeds(
-    config: dict[str, Any], since: datetime, limit: int
-) -> list[RadarItem]:
+def fetch_first_party_feeds(config: dict[str, Any], since: datetime, limit: int) -> list[RadarItem]:
     """Collect relevant announcements from an explicit first-party RSS/Atom allowlist."""
     keywords = [
         str(value).casefold()
@@ -95,9 +93,11 @@ def fetch_first_party_feeds(
         root_name = _xml_local_name(root.tag)
         if root_name == "rss":
             channel = _feed_child(root, "channel")
-            entries = [] if channel is None else [
-                child for child in channel if _xml_local_name(child.tag) == "item"
-            ]
+            entries = (
+                []
+                if channel is None
+                else [child for child in channel if _xml_local_name(child.tag) == "item"]
+            )
         elif root_name == "feed":
             entries = [child for child in root if _xml_local_name(child.tag) == "entry"]
         else:

--- a/src/benchmark_radar/sources.py
+++ b/src/benchmark_radar/sources.py
@@ -20,6 +20,123 @@ class ConnectorPayloadError(ValueError):
 FUTURE_TIMESTAMP_TOLERANCE = timedelta(minutes=5)
 
 
+def _xml_local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def _feed_child(element: ET.Element, name: str) -> ET.Element | None:
+    return next((child for child in element if _xml_local_name(child.tag) == name), None)
+
+
+def _feed_text(element: ET.Element, *names: str) -> str:
+    for name in names:
+        child = _feed_child(element, name)
+        if child is not None:
+            text = " ".join("".join(child.itertext()).split())
+            if text:
+                return text
+    return ""
+
+
+def _feed_date(value: str) -> datetime | None:
+    if not value:
+        return None
+    parsed = _optional_date(value)
+    if parsed is not None:
+        return parsed
+    try:
+        return parsedate_to_datetime(value).astimezone(UTC)
+    except (TypeError, ValueError, OverflowError):
+        return None
+
+
+def _feed_link(entry: ET.Element) -> str:
+    # RSS puts the URL in the node text; Atom uses an href attribute and may
+    # include alternate, self, and enclosure links.
+    for child in entry:
+        if _xml_local_name(child.tag) != "link":
+            continue
+        href = str(child.get("href") or child.text or "").strip()
+        if href and child.get("rel", "alternate") == "alternate":
+            return href
+    return ""
+
+
+def fetch_first_party_feeds(
+    config: dict[str, Any], since: datetime, limit: int
+) -> list[RadarItem]:
+    """Collect relevant announcements from an explicit first-party RSS/Atom allowlist."""
+    keywords = [
+        str(value).casefold()
+        for value in config.get(
+            "keywords",
+            [
+                "benchmark",
+                "evaluation",
+                "evals",
+                "leaderboard",
+                "dataset",
+                "test set",
+                "data contamination",
+            ],
+        )
+        if str(value).strip()
+    ]
+    feeds = config.get("feeds") or []
+    if not isinstance(feeds, list):
+        raise ConnectorPayloadError("First-party feeds must be an array")
+    found: dict[str, RadarItem] = {}
+    for feed in feeds:
+        if not isinstance(feed, dict) or not feed.get("name") or not feed.get("url"):
+            raise ConnectorPayloadError("First-party feed is missing name or url")
+        name = str(feed["name"]).strip()
+        feed_url = str(feed["url"]).strip()
+        root = ET.fromstring(get_text(feed_url, **_request_options(config)))
+        root_name = _xml_local_name(root.tag)
+        if root_name == "rss":
+            channel = _feed_child(root, "channel")
+            entries = [] if channel is None else [
+                child for child in channel if _xml_local_name(child.tag) == "item"
+            ]
+        elif root_name == "feed":
+            entries = [child for child in root if _xml_local_name(child.tag) == "entry"]
+        else:
+            raise ConnectorPayloadError(f"{name} returned an incompatible feed document")
+        for entry in entries:
+            title = _feed_text(entry, "title")
+            summary = clean_card_text(_feed_text(entry, "description", "summary", "content"))
+            haystack = f"{title} {summary}".casefold()
+            if not title or (keywords and not any(keyword in haystack for keyword in keywords)):
+                continue
+            url = _feed_link(entry)
+            source_id = _feed_text(entry, "id", "guid") or url
+            published = _feed_date(_feed_text(entry, "published", "pubDate", "date"))
+            updated = _feed_date(_feed_text(entry, "updated")) or published
+            activity = updated or published
+            if not url or not source_id or published is None or activity is None:
+                raise ConnectorPayloadError(f"{name} feed item is missing required fields")
+            identity = f"{name}:{source_id}"
+            if activity < since or _reject_future(config, identity, published, updated):
+                continue
+            found[identity] = RadarItem(
+                source="First-party feed",
+                source_id=identity,
+                title=title,
+                url=url,
+                published_at=published,
+                updated_at=updated,
+                summary=summary,
+                event_kind="updated" if updated > published else "released",
+                raw={"xml": ET.tostring(entry, encoding="unicode")},
+                parser_version="first-party-rss-atom/1",
+            )
+    return sorted(
+        found.values(),
+        key=lambda item: (item.updated_at or item.published_at, item.source_id),
+        reverse=True,
+    )[:limit]
+
+
 def _latest_allowed(config: dict[str, Any]) -> datetime:
     collection_now = config.get("_collection_now")
     if not isinstance(collection_now, datetime):
@@ -625,6 +742,7 @@ def fetch_github_releases(
     regular_requests = 0
     replacement_requests = 0
     found: dict[str, RadarItem] = {}
+    failures: list[Exception] = []
     for repository in repositories:
         page = 1
         page_limit = max_pages
@@ -636,12 +754,20 @@ def fetch_github_releases(
                 or len(found) >= limit
             ):
                 break
-            payload = get_json(
-                f"https://api.github.com/repos/{repository}/releases",
-                params={"per_page": min(page_size, limit - len(found)), "page": page},
-                headers=headers,
-                **_request_options(config),
-            )
+            try:
+                payload = get_json(
+                    f"https://api.github.com/repos/{repository}/releases",
+                    params={"per_page": min(page_size, limit - len(found)), "page": page},
+                    headers=headers,
+                    **_request_options(config),
+                )
+            except Exception as error:
+                # Degrade per repository: one renamed, archived, or temporarily
+                # unavailable project must not erase every healthy release.
+                warnings = config.setdefault("_source_warnings", [])
+                warnings.append(f"{repository}: {type(error).__name__}: {error}")
+                failures.append(error)
+                break
             if is_replacement:
                 replacement_requests += 1
             else:
@@ -711,6 +837,9 @@ def fetch_github_releases(
             page += 1
         if regular_requests >= budget or len(found) >= limit:
             break
+    warnings = config.get("_source_warnings") or []
+    if repositories and len(warnings) == len(repositories):
+        raise failures[0]
     return sorted(found.values(), key=lambda item: item.published_at, reverse=True)[:limit]
 
 
@@ -867,6 +996,7 @@ SOURCE_FETCHERS = {
     "openreview": fetch_openreview,
     "semantic_scholar": fetch_semantic_scholar,
     "github_releases": fetch_github_releases,
+    "first_party_feeds": fetch_first_party_feeds,
     "openalex": fetch_openalex,
     "brave": fetch_brave,
 }

--- a/tests/test_rubric.py
+++ b/tests/test_rubric.py
@@ -37,7 +37,7 @@ def test_published_rubric_describes_every_scored_component():
 
     assert keys == list(rubric.WEIGHTS)
     assert reference["score_max"] == 100
-    assert reference["scoring_version"] == 2
+    assert reference["scoring_version"] == 3
     for component in reference["components"]:
         assert component["weight"] == rubric.WEIGHTS[component["key"]]
         assert component["summary"].strip()

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -94,6 +94,7 @@ def test_first_party_feeds_reject_non_feed_documents(monkeypatch):
             10,
         )
 
+
 ARXIV_XML = """\
 <feed xmlns="http://www.w3.org/2005/Atom">
   <entry>

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -8,6 +8,7 @@ from benchmark_radar.sources import (
     ConnectorPayloadError,
     fetch_arxiv,
     fetch_brave,
+    fetch_first_party_feeds,
     fetch_github,
     fetch_github_releases,
     fetch_huggingface,
@@ -15,6 +16,83 @@ from benchmark_radar.sources import (
     fetch_openreview,
     fetch_semantic_scholar,
 )
+
+FIRST_PARTY_RSS = """\
+<rss version="2.0"><channel>
+  <item>
+    <title>A new agent evaluation benchmark</title>
+    <link>https://lab.example/benchmark</link>
+    <guid>benchmark-one</guid>
+    <pubDate>Sat, 08 Aug 2026 12:00:00 GMT</pubDate>
+    <description>We release a dataset and evaluation suite.</description>
+  </item>
+  <item>
+    <title>Office update</title>
+    <link>https://lab.example/office</link>
+    <guid>office-one</guid>
+    <pubDate>Sat, 08 Aug 2026 13:00:00 GMT</pubDate>
+    <description>News about a new office.</description>
+  </item>
+</channel></rss>
+"""
+
+
+FIRST_PARTY_ATOM = """\
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <id>tag:lab.example,2026:leaderboard</id>
+    <title>Leaderboard evaluation update</title>
+    <link rel="alternate" href="https://lab.example/leaderboard"/>
+    <published>2026-08-08T14:00:00Z</published>
+    <updated>2026-08-08T15:00:00Z</updated>
+    <summary>Updated benchmark results.</summary>
+  </entry>
+</feed>
+"""
+
+
+def test_first_party_feeds_parse_rss_and_atom_and_filter_noise(monkeypatch):
+    payloads = {
+        "https://lab.example/rss": FIRST_PARTY_RSS,
+        "https://lab.example/atom": FIRST_PARTY_ATOM,
+    }
+    monkeypatch.setattr(
+        "benchmark_radar.sources.get_text",
+        lambda url, attempts=3, timeout=30: payloads[url],
+    )
+
+    items = fetch_first_party_feeds(
+        {
+            "feeds": [
+                {"name": "Lab RSS", "url": "https://lab.example/rss"},
+                {"name": "Lab Atom", "url": "https://lab.example/atom"},
+            ]
+        },
+        datetime(2026, 8, 8, 0, tzinfo=UTC),
+        10,
+    )
+
+    assert [item.title for item in items] == [
+        "Leaderboard evaluation update",
+        "A new agent evaluation benchmark",
+    ]
+    assert items[0].event_kind == "updated"
+    assert items[0].source == "First-party feed"
+    assert items[0].source_id == "Lab Atom:tag:lab.example,2026:leaderboard"
+
+
+def test_first_party_feeds_reject_non_feed_documents(monkeypatch):
+    monkeypatch.setattr(
+        "benchmark_radar.sources.get_text",
+        lambda url, attempts=3, timeout=30: "<html><body>Not a feed</body></html>",
+    )
+
+    with pytest.raises(ConnectorPayloadError, match="incompatible feed document"):
+        fetch_first_party_feeds(
+            {"feeds": [{"name": "Broken", "url": "https://lab.example/feed"}]},
+            datetime(2026, 8, 8, 0, tzinfo=UTC),
+            10,
+        )
 
 ARXIV_XML = """\
 <feed xmlns="http://www.w3.org/2005/Atom">
@@ -440,6 +518,25 @@ def test_github_releases_success_uses_release_notes(monkeypatch):
     assert items[0].summary == "The upstream release notes."
     assert items[0].metrics["downloads"] == 7
     assert items[0].parser_version == "github-releases/1"
+
+
+def test_github_releases_isolates_one_repository_failure(monkeypatch):
+    def fake_get_json(url, **kwargs):
+        if "/repos/broken/benchmark/" in url:
+            raise RequestError("HTTP 404 from https://api.github.com/repos/broken/benchmark")
+        return []
+
+    monkeypatch.setattr("benchmark_radar.sources.get_json", fake_get_json)
+    config = {
+        "repositories": ["broken/benchmark", "healthy/benchmark"],
+        "max_requests": 2,
+    }
+
+    assert fetch_github_releases(config, datetime(2026, 7, 26, tzinfo=UTC), 10) == []
+    assert config["_source_warnings"] == [
+        "broken/benchmark: RequestError: HTTP 404 from "
+        "https://api.github.com/repos/broken/benchmark"
+    ]
 
 
 def test_github_releases_replaces_a_page_consumed_by_future_rows(monkeypatch):


### PR DESCRIPTION
## What changed

- adds a scored first-party RSS/Atom connector and ten verified official feeds
- expands the GitHub Releases allowlist to 64 canonical, live repositories
- adds official-domain search coverage where Alina's RSS endpoints are unofficial or broken
- records Benchmark Radar's aggregate RSS in Alina's public feed list
- isolates per-repository GitHub failures and publishes partial-coverage warnings
- versions the scoring rubric after granting official feeds primary-source credit

## Why

Alina's feed list mixed first-party announcements, media, community attention, broken endpoints, and third-party mirrors. Benchmark Radar needs the useful coverage without treating second-hand or proxy content as primary evidence.

## Audit decisions

- all ten configured RSS feeds return HTTP 200 and parse as RSS
- all 64 configured GitHub repository URLs are live, canonical, and unique
- Reddit currently returns HTTP 403 and the listed RSSHub Twitter endpoints return HTTP 404, so they are not shipped as working sources
- Anthropic, Meta, Microsoft AI, Mistral, Stability, and 01.AI are covered through official-domain Brave queries where verified RSS is unavailable

## Validation

- `python -m pytest -q` — 640 passed
- `ruff check .` — passed
- `git diff --check` — passed
- YAML coverage invariants — passed
