### PR TITLE
Suppress sponsor-bait resource-listing spam from GitHub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 .pytest_cache/
 .ruff_cache/
 .venv/
+node_modules/
 dist/
 build/
 *.egg-info/

--- a/src/benchmark_radar/rubric.py
+++ b/src/benchmark_radar/rubric.py
@@ -91,6 +91,14 @@ LOW_VALUE_SIGNALS: tuple[dict[str, Any], ...] = (
         "deduction": 25.0,
         "action": "suppress",
     },
+    {
+        "label": "sponsor-bait resource listing",
+        "pattern": (
+            r"\bsponsor\b.{0,40}\bobtain\b.{0,20}\b(?:full|complete)\b.{0,20}\b(?:data|dataset)\b"
+        ),
+        "deduction": 30.0,
+        "action": "suppress",
+    },
 )
 MAX_LOW_VALUE_DEDUCTION = 60.0
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -329,6 +329,23 @@ def test_low_value_follower_leaderboard_is_explicitly_demoted():
     assert any("Demoted: follower-count leaderboard" in reason for reason in low_value.rationale)
 
 
+def test_sponsor_bait_resource_listing_is_suppressed():
+    taxonomy = {"dataset": ["dataset"]}
+    spam = score_item(
+        item(
+            source="GitHub",
+            source_id="lonlonago/a-large-scale-fish-taxonomy-dataset",
+            title="lonlonago/a-large-scale-fish-taxonomy-dataset",
+            summary="Dataset / resource listing. Sponsor to obtain the full data files.",
+        ),
+        taxonomy,
+        datetime(2026, 7, 27, 1, tzinfo=UTC),
+    )
+
+    assert spam.relevance_score == 0
+    assert "sponsor-bait resource listing" in spam.suppression_reasons
+
+
 def test_recency_uses_the_configured_collection_window():
     taxonomy = {"benchmark": ["benchmark"]}
     published = datetime(2026, 7, 27, tzinfo=UTC)


### PR DESCRIPTION
## What changed

- adds a `LOW_VALUE_SIGNALS` pattern that suppresses GitHub repos whose description matches the "sponsor to obtain the full data files" resource-listing spam pattern

## Why

The Daily Benchmark Radar workflow (run 31343515670, triggered manually to verify) crashed with:

```
RuntimeError: Refusing to publish templated descriptions: 3 records share the summary
'dataset / resource listing. sponsor to obtain the full data files.'.
```

Three unrelated repos, all from the same GitHub account (`lonlonago`), reuse this literal description text as a GitHub Sponsors-bait tactic. `assert_no_boilerplate_summaries` correctly caught it as templated content, but the fix belongs upstream in the low-value-signal suppression list (same mechanism already used for "results dump" and "submission placeholder" spam) rather than leaving the run hard-failing every time this account's repos get discovered again.

## Validation

- `pytest -q` — 641 passed (640 + 1 new regression test)
- `ruff check .` / `ruff format --check .` — passed
- Reproduced the crash locally against live sources, confirmed the fix resolves it (131 items written successfully)