### PR TITLE
Give the OpenAI briefing call enough retry budget to outlast TPM limits

### DIFF
--- a/src/benchmark_radar/briefing.py
+++ b/src/benchmark_radar/briefing.py
@@ -557,7 +557,13 @@ def generate_daily_briefing(
         RESPONSES_URL,
         payload,
         headers={"Authorization": f"Bearer {api_key}"},
-        attempts=4,
+        # Token-bucket 429s (type=tokens) often carry no Retry-After header and
+        # need a full per-minute window to refill, not a fast exponential
+        # backoff meant for transient server errors. 5 attempts against a
+        # 60s-capped backoff (1+2+4+8+16=31s minimum, up to 4*60=240s worst
+        # case) gives a token-bucket limit real time to reset within the CI
+        # job's 20-minute budget.
+        attempts=5,
         timeout=90.0,
     )
     try:

--- a/src/benchmark_radar/http.py
+++ b/src/benchmark_radar/http.py
@@ -13,7 +13,7 @@ import certifi
 
 USER_AGENT = "benchmark-radar/0.1 (+https://github.com/ktwu01/benchmark-radar)"
 DEFAULT_TIMEOUT_SECONDS = 30.0
-MAX_RETRY_DELAY_SECONDS = 30.0
+MAX_RETRY_DELAY_SECONDS = 60.0
 
 
 class RequestError(RuntimeError):

--- a/tests/test_briefing.py
+++ b/tests/test_briefing.py
@@ -325,7 +325,7 @@ def test_generate_daily_briefing_uses_real_responses_contract_and_records_usage(
     assert captured["payload"]["text"]["format"]["strict"] is True
     assert captured["payload"]["store"] is False
     assert captured["kwargs"]["headers"] == {"Authorization": "Bearer secret"}
-    assert captured["kwargs"]["attempts"] == 4
+    assert captured["kwargs"]["attempts"] == 5
     assert captured["kwargs"]["timeout"] == 90.0
 
 


### PR DESCRIPTION
## What changed

- raises the shared HTTP retry delay cap (`MAX_RETRY_DELAY_SECONDS`) from 30s to 60s
- gives the OpenAI briefing call a 5th retry attempt (was 4)

## Why

The Daily Benchmark Radar workflow has been intermittently failing (most recently run 31344133782) with:

```
RequestError: HTTP 429 from https://api.openai.com/v1/responses after 4 attempts (type=tokens, code=rate_limit_exceeded)
```

Token-bucket rate limits (`type=tokens`) reset on a per-minute window and OpenAI typically does not send a `Retry-After` header for them, unlike request-count limits. The existing budget (4 attempts, exponential backoff capped at 30s) totals roughly 15s of waiting in the worst case, which is not enough to outlast a per-minute token bucket that's momentarily exhausted by this call's own ~60K-token request.

This does not fix an underlying account-tier constraint, but gives the retry loop a real chance to survive transient exhaustion instead of failing the required briefing step on the first unlucky minute.

## Validation

- `pytest -q` — 641 passed
- `ruff check .` / `ruff format --check .` — passed