### PR TITLE
Prevent truncated OpenAI briefing output

### DIFF
--- a/src/benchmark_radar/briefing.py
+++ b/src/benchmark_radar/briefing.py
@@ -30,7 +30,11 @@ DEFAULT_BRIEFING_MODEL = "gpt-5.6"
 # than dropped in silence.
 MAX_INPUT_CHARS = 260_000
 MAX_REQUEST_TOKENS = 60_000
-MAX_OUTPUT_TOKENS = 1_400
+# The structured response can contain three 800-character findings, three
+# 800-character explanations, a 1,000-character caveat, JSON framing, and
+# reasoning tokens. 1,400 tokens truncated valid responses mid-string in
+# production before the schema-sized answer could finish.
+MAX_OUTPUT_TOKENS = 4_000
 MAX_EVIDENCE_ITEMS = 120
 # Every attention observation the collector retains. The former cap of 8
 # discarded more than half of a typical day's 20 public-attention records

--- a/tests/test_briefing.py
+++ b/tests/test_briefing.py
@@ -323,6 +323,7 @@ def test_generate_daily_briefing_uses_real_responses_contract_and_records_usage(
     assert "identical collection_signature" in captured["payload"]["instructions"]
     assert "only when observed_today is true" in captured["payload"]["instructions"]
     assert captured["payload"]["text"]["format"]["strict"] is True
+    assert captured["payload"]["max_output_tokens"] == 4_000
     assert captured["payload"]["store"] is False
     assert captured["kwargs"]["headers"] == {"Authorization": "Bearer secret"}
     assert captured["kwargs"]["attempts"] == 5


### PR DESCRIPTION
## Summary
- raise the Responses output budget to fit the full strict-schema briefing plus reasoning
- lock the production request budget in the briefing contract test

## Test plan
- `python3.11 -m pytest -q` (641 passed)
- `python3.11 -m ruff check .`
- `python3.11 -m ruff format --check .`
- `python3.11 -m benchmark_radar.cli classify`
- `codex review --base main -c 'model_reasoning_effort="high"'`