### PR TITLE
Enable and require daily Q&A in production

### DIFF
--- a/.github/workflows/daily-radar.yml
+++ b/.github/workflows/daily-radar.yml
@@ -77,6 +77,14 @@ jobs:
           # violating the purpose of this production run: prove a real GPT
           # synthesis occurred and retain its model/usage metadata.
           OPENAI_BRIEFING_REQUIRED: "true"
+          # Issue #159: the Q&A implementation shipped opt-in behind this flag
+          # and production never set it, so every run silently skipped
+          # question generation despite a successful briefing. Enabling and
+          # requiring it here closes that gap the same way the briefing is
+          # required above: a green run must carry real answers, not a quiet
+          # absence.
+          OPENAI_QUESTIONS: "true"
+          OPENAI_QUESTIONS_REQUIRED: "true"
         run: benchmark-radar
       - name: Upload evidence artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -539,8 +539,20 @@ function questionsProvenance(questions) {
 }
 
 // The Q&A is opt-in and generated once per UTC day, so a day can legitimately
-// have none: it predates the feature, no API key was configured, or the calls
-// failed. Say which rather than leaving a heading above blank space.
+// have none: it predates the feature, was disabled, or the calls failed. The
+// snapshot's `questions.status` says which, so the empty state names the
+// actual reason instead of one generic message for all three.
+function absentQuestionsMessage(questions) {
+  const status = questions.status;
+  if (status === "disabled") {
+    return questions.reason || "Daily questions were not enabled for this run.";
+  }
+  if (status === "error") {
+    return `Daily questions failed to generate: ${questions.reason || "unknown error"}.`;
+  }
+  return "No questions were answered for this day.";
+}
+
 function renderDailyQuestions(day) {
   const questions = day.questions || {};
   const groups = Array.isArray(questions.groups) ? questions.groups : [];
@@ -584,7 +596,7 @@ function renderDailyQuestions(day) {
       : [
           element("p", {
             className: "empty-state",
-            text: "No questions were answered for this day.",
+            text: absentQuestionsMessage(questions),
           }),
         ],
   );

--- a/src/benchmark_radar/cli.py
+++ b/src/benchmark_radar/cli.py
@@ -18,7 +18,7 @@ from .kw_bench_store import STORE_FILENAME as KW_BENCH_STORE_FILENAME
 from .kw_bench_tracks import DEFAULT_BATCH_SIZE
 from .kw_bench_tracks import backfill as backfill_classifications
 from .pipeline import _failure_streak_key, run_pipeline, simulate_backfill
-from .questions import generate_daily_questions
+from .questions import QA_SCHEMA_VERSION, generate_daily_questions
 from .report import render_markdown
 from .snapshots import (
     load_snapshots,
@@ -468,10 +468,18 @@ def main() -> None:
     elif briefing_required:
         raise RuntimeError("OPENAI_BRIEFING_REQUIRED is true but OPENAI_API_KEY is missing")
 
-    # The daily Q&A is opt-in: it costs one API call per question group, and a
-    # failure here must never cost the run its briefing or its snapshot.
+    # The daily Q&A is opt-in: it costs one API call per question group. By
+    # default a failure here must never cost the run its briefing or its
+    # snapshot, but OPENAI_QUESTIONS_REQUIRED lets production demand it the
+    # same way OPENAI_BRIEFING_REQUIRED demands the briefing.
+    questions_enabled = os.getenv("OPENAI_QUESTIONS", "").lower() in {"1", "true", "yes"}
+    questions_required = os.getenv("OPENAI_QUESTIONS_REQUIRED", "").lower() in {
+        "1",
+        "true",
+        "yes",
+    }
     daily_questions: dict | None = None
-    if api_key and os.getenv("OPENAI_QUESTIONS", "").lower() in {"1", "true", "yes"}:
+    if questions_enabled and api_key:
         try:
             daily_questions = generate_daily_questions(
                 history,
@@ -482,7 +490,34 @@ def main() -> None:
                 config=config,
             )
         except (BriefingError, RequestError, ValueError) as error:
+            if questions_required:
+                raise RuntimeError(f"required daily questions failed: {error}") from error
             print(f"::warning title=Daily questions skipped::{error}")
+            daily_questions = {
+                "schema_version": QA_SCHEMA_VERSION,
+                "date": today,
+                "status": "error",
+                "reason": f"{type(error).__name__}: {error}",
+            }
+    elif questions_required:
+        raise RuntimeError(
+            "OPENAI_QUESTIONS_REQUIRED is true but OPENAI_QUESTIONS is not enabled "
+            "or OPENAI_API_KEY is missing"
+        )
+    elif not questions_enabled:
+        daily_questions = {
+            "schema_version": QA_SCHEMA_VERSION,
+            "date": today,
+            "status": "disabled",
+            "reason": "OPENAI_QUESTIONS is not enabled",
+        }
+    elif not api_key:
+        daily_questions = {
+            "schema_version": QA_SCHEMA_VERSION,
+            "date": today,
+            "status": "disabled",
+            "reason": "OPENAI_API_KEY is not configured",
+        }
 
     # Attach before writing so the snapshot, the dashboard payload, and the
     # Markdown report all describe the same briefing.

--- a/src/benchmark_radar/questions.py
+++ b/src/benchmark_radar/questions.py
@@ -398,6 +398,7 @@ def generate_daily_questions(
     return {
         "schema_version": QA_SCHEMA_VERSION,
         "date": current.get("date"),
+        "status": "generated",
         "generator": "openai-responses",
         "model": model,
         "comparable": registry["comparable"],

--- a/src/benchmark_radar/snapshots.py
+++ b/src/benchmark_radar/snapshots.py
@@ -72,7 +72,9 @@ def snapshot_for_run(run: RadarRun) -> dict[str, Any]:
         # Omitted entirely when the day has no briefing, so an absent key means
         # "not generated yet" and a later pass knows to retry.
         **({"briefing": briefing} if briefing else {}),
-        # Same contract for the opt-in daily Q&A.
+        # Q&A always carries a `status` (generated/disabled/error) so a
+        # skip or failure is distinguishable from "not attempted yet" instead
+        # of collapsing into one absent key.
         **({"questions": run.daily_questions} if run.daily_questions else {}),
         "evidence_items": [item.to_dict() for item in run.items],
         "attention": {
@@ -467,9 +469,19 @@ def merge_snapshots(existing: dict[str, Any], incoming: dict[str, Any]) -> dict[
     # that describes the merged day. Fall back to the existing briefing only
     # when the incoming pass has none, so a day never loses one it already had.
     briefing = incoming.get("briefing") or existing.get("briefing")
-    # The Q&A follows the same rule: the incoming pass answered from the union,
-    # so it wins, and a day never loses answers it already had.
-    day_questions = incoming.get("questions") or existing.get("questions")
+    # The Q&A mostly follows the same rule: the incoming pass answered from the
+    # union, so it wins. The exception is a day that already has real answers
+    # (status "generated") and the incoming pass only disabled/errored, e.g. a
+    # transient failure on the second scheduled run: keep the existing answers
+    # rather than overwriting them with a status object.
+    incoming_questions = incoming.get("questions")
+    existing_questions = existing.get("questions")
+    if incoming_questions and incoming_questions.get("status") == "generated":
+        day_questions = incoming_questions
+    elif existing_questions and existing_questions.get("status") == "generated":
+        day_questions = existing_questions
+    else:
+        day_questions = incoming_questions or existing_questions
 
     merged = {
         **incoming,

--- a/tests/test_briefing.py
+++ b/tests/test_briefing.py
@@ -454,6 +454,45 @@ def test_merge_snapshots_leaves_no_briefing_key_when_neither_pass_had_one():
     assert "briefing" not in merged
 
 
+def test_merge_snapshots_takes_the_recomputed_questions_of_the_day():
+    run = _run([_item(1)])
+    run.daily_questions = {"status": "generated", "groups": [{"id": "first"}]}
+    existing = snapshot_for_run(run)
+    later = _run([_item(2)])
+    later.daily_questions = {"status": "generated", "groups": [{"id": "second"}]}
+
+    merged = merge_snapshots(existing, snapshot_for_run(later))
+
+    assert merged["questions"]["groups"] == [{"id": "second"}]
+
+
+def test_merge_snapshots_keeps_real_answers_when_the_incoming_pass_only_errored():
+    # Issue #159: a day that already has real answers must not lose them to a
+    # later pass's transient failure or a disabled second run.
+    run = _run([_item(1)])
+    run.daily_questions = {"status": "generated", "groups": [{"id": "first"}]}
+    existing = snapshot_for_run(run)
+    later = _run([_item(2)])
+    later.daily_questions = {"status": "error", "reason": "boom"}
+
+    merged = merge_snapshots(existing, snapshot_for_run(later))
+
+    assert merged["questions"]["status"] == "generated"
+    assert merged["questions"]["groups"] == [{"id": "first"}]
+
+
+def test_merge_snapshots_keeps_the_incoming_status_when_neither_pass_generated():
+    run = _run([_item(1)])
+    run.daily_questions = {"status": "disabled", "reason": "OPENAI_QUESTIONS is not enabled"}
+    existing = snapshot_for_run(run)
+    later = _run([_item(2)])
+    later.daily_questions = {"status": "error", "reason": "boom"}
+
+    merged = merge_snapshots(existing, snapshot_for_run(later))
+
+    assert merged["questions"]["status"] == "error"
+
+
 def test_markdown_bullet_escapes_interpolated_values():
     # Both model prose and source-derived values are data at this boundary.
     assert markdown_bullet("data_quality rose 5%") == "data\\_quality rose 5%"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,6 +16,8 @@ from benchmark_radar.snapshots import write_snapshot
 def _isolate_openai_credentials(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("OPENAI_BRIEFING_REQUIRED", raising=False)
+    monkeypatch.delenv("OPENAI_QUESTIONS", raising=False)
+    monkeypatch.delenv("OPENAI_QUESTIONS_REQUIRED", raising=False)
 
 
 def _config_path(tmp_path: Path) -> Path:
@@ -339,6 +341,108 @@ def test_cli_persists_real_gpt_briefing_metadata(monkeypatch, tmp_path):
     assert stored["briefing"]["generator"] == "openai-responses"
     assert stored["briefing"]["response_id"] == "resp_real"
     assert stored["briefing"]["usage"]["total_tokens"] == 8200
+
+
+def test_questions_are_skipped_and_marked_disabled_without_the_flag(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "secret")
+    _stub_sources(monkeypatch, datetime.now(UTC))
+    monkeypatch.setattr("sys.argv", _briefing_argv(tmp_path))
+
+    cli.main()
+
+    stored = json.loads(next((tmp_path / "snapshots").glob("*.json")).read_text(encoding="utf-8"))
+    assert stored["questions"]["status"] == "disabled"
+    assert "OPENAI_QUESTIONS" in stored["questions"]["reason"]
+
+
+def test_daily_radar_yml_enables_and_requires_questions_in_production():
+    """Issue #159: production ran Q&A-eligible days with no Q&A because the
+    workflow set OPENAI_API_KEY and OPENAI_BRIEFING_REQUIRED but never set
+    OPENAI_QUESTIONS, so the CLI skipped question generation by design."""
+    workflow_path = Path(".github/workflows/daily-radar.yml")
+    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    collect_step = next(
+        step
+        for step in workflow["jobs"]["build-report"]["steps"]
+        if step.get("name") == "Collect evidence and public attention"
+    )
+    env = collect_step["env"]
+    assert str(env.get("OPENAI_QUESTIONS")).lower() == "true"
+    assert str(env.get("OPENAI_QUESTIONS_REQUIRED")).lower() == "true"
+
+
+def test_questions_required_raises_without_a_flag_or_key(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_QUESTIONS_REQUIRED", "true")
+    _stub_sources(monkeypatch, datetime.now(UTC))
+    monkeypatch.setattr("sys.argv", _briefing_argv(tmp_path))
+
+    with pytest.raises(RuntimeError, match="OPENAI_QUESTIONS_REQUIRED"):
+        cli.main()
+
+
+def test_questions_required_raises_when_generation_fails(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "secret")
+    monkeypatch.setenv("OPENAI_QUESTIONS", "true")
+    monkeypatch.setenv("OPENAI_QUESTIONS_REQUIRED", "true")
+    _stub_sources(monkeypatch, datetime.now(UTC))
+    monkeypatch.setattr("sys.argv", _briefing_argv(tmp_path))
+    monkeypatch.setattr(
+        cli,
+        "generate_daily_questions",
+        lambda *args, **kwargs: (_ for _ in ()).throw(cli.BriefingError("boom")),
+    )
+
+    with pytest.raises(RuntimeError, match="required daily questions failed"):
+        cli.main()
+
+
+def test_questions_best_effort_persists_error_status_without_failing_the_run(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "secret")
+    monkeypatch.setenv("OPENAI_QUESTIONS", "true")
+    _stub_sources(monkeypatch, datetime.now(UTC))
+    monkeypatch.setattr("sys.argv", _briefing_argv(tmp_path))
+    monkeypatch.setattr(
+        cli,
+        "generate_daily_questions",
+        lambda *args, **kwargs: (_ for _ in ()).throw(cli.BriefingError("boom")),
+    )
+
+    cli.main()
+
+    stored = json.loads(next((tmp_path / "snapshots").glob("*.json")).read_text(encoding="utf-8"))
+    assert stored["questions"]["status"] == "error"
+    assert "boom" in stored["questions"]["reason"]
+
+
+def test_questions_generated_status_is_persisted_when_enabled(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "secret")
+    monkeypatch.setenv("OPENAI_QUESTIONS", "true")
+    _stub_sources(monkeypatch, datetime.now(UTC))
+    monkeypatch.setattr("sys.argv", _briefing_argv(tmp_path))
+    monkeypatch.setattr(
+        cli,
+        "generate_daily_questions",
+        lambda *args, **kwargs: {
+            "schema_version": 1,
+            "date": datetime.now(UTC).date().isoformat(),
+            "status": "generated",
+            "generator": "openai-responses",
+            "model": "gpt-5.6",
+            "comparable": False,
+            "comparability_note": "no certified window",
+            "groups": [],
+            "stat_registry": [],
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+            "calls": 3,
+            "coverage": {},
+        },
+    )
+
+    cli.main()
+
+    stored = json.loads(next((tmp_path / "snapshots").glob("*.json")).read_text(encoding="utf-8"))
+    assert stored["questions"]["status"] == "generated"
+    assert stored["questions"]["calls"] == 3
 
 
 def test_a_thin_day_reports_insufficient_volume_rather_than_a_pattern(monkeypatch, tmp_path):

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -966,6 +966,37 @@ def test_rendered_questions_report_an_absent_set_rather_than_blank_space(tmp_pat
     assert not any(node["className"] == "question-group" for node in _flatten(rendered))
 
 
+def test_rendered_questions_name_a_disabled_run_rather_than_the_generic_message(tmp_path):
+    """Issue #159: a disabled run must say so, not collapse into the generic empty state."""
+
+    def disable(fixture):
+        fixture["questions"] = {
+            "status": "disabled",
+            "reason": "OPENAI_QUESTIONS is not enabled",
+        }
+
+    rendered = _render_with(disable, tmp_path)
+    assert "OPENAI_QUESTIONS is not enabled" in rendered["text"]
+    assert "No questions were answered for this day." not in rendered["text"]
+    assert not any(node["className"] == "question-group" for node in _flatten(rendered))
+
+
+def test_rendered_questions_name_a_failed_run_rather_than_the_generic_message(tmp_path):
+    """Issue #159: a failed generation must say so, not collapse into the generic empty state."""
+
+    def fail(fixture):
+        fixture["questions"] = {
+            "status": "error",
+            "reason": "BriefingError: OpenAI structured output is not valid JSON",
+        }
+
+    rendered = _render_with(fail, tmp_path)
+    assert "Daily questions failed to generate" in rendered["text"]
+    assert "OpenAI structured output is not valid JSON" in rendered["text"]
+    assert "No questions were answered for this day." not in rendered["text"]
+    assert not any(node["className"] == "question-group" for node in _flatten(rendered))
+
+
 def test_rendered_questions_drop_an_evidence_citation_with_an_unsafe_url(tmp_path):
     """An id-shaped citation without a safe URL must not become a link."""
 


### PR DESCRIPTION
## Summary

Fixes #159. Production never sets `OPENAI_QUESTIONS`, so the CLI skips question generation by design on every run while the GPT briefing succeeds — the resulting snapshot has no `questions` object, and the dashboard correctly shows "No questions were answered for this day." PR #162 implemented Q&A and PR #166 rendered it, but neither activated the production feature flag.

This also closes the reliability gap flagged in the issue's production audit: missing or failed Q&A did not fail the workflow, so a green run could publish a day with no Q&A, and absence, disable, and failure all collapsed into one indistinguishable UI message.

- `daily-radar.yml`: sets `OPENAI_QUESTIONS: "true"` and `OPENAI_QUESTIONS_REQUIRED: "true"`, mirroring the existing `OPENAI_BRIEFING_REQUIRED` guard.
- `cli.py`: enforces `OPENAI_QUESTIONS_REQUIRED` (raises if the flag/key is missing, or if generation fails) and always persists a structured `status` (`generated` / `disabled` / `error`) with a `reason`, instead of silently omitting the key.
- `snapshots.py`: the two-pass-per-day merge now keeps a day's real (`generated`) answers if a later pass only disabled or errored, instead of the previous `or` logic overwriting them with a status object.
- `app.js`: renders the actual disabled/error reason instead of one generic "No questions were answered" message for every absent case.

## Test plan

- [x] `pytest -q` — 652 passed
- [x] `ruff check` / `ruff format --check` — clean
- [x] New tests: `cli.py` required-mode enforcement (raises on missing flag/key, raises on generation failure, persists `error`/`disabled`/`generated` status), workflow YAML asserts `OPENAI_QUESTIONS`/`OPENAI_QUESTIONS_REQUIRED` are set, `snapshots.py` merge keeps real answers over a later error/disabled pass, `app.js` renders distinct disabled/error messages
- [ ] Verify a live production run publishes a snapshot with a real `questions.status == "generated"` and six answers across three groups

🤖 Generated with [Claude Code](https://claude.com/claude-code)