### PR TITLE
Fix ambiguous "Radar ingest" source health label

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -7,6 +7,19 @@ const CATEGORY_COLORS = {
 };
 const FALLBACK_COLORS = ["#756aa8", "#397f9a", "#a4576d", "#70833d"];
 const ALL_DATES_PAGE_SIZE = 100;
+// Snapshots recorded before SourceHealth.method existed carry no method
+// field; this fills the gap for historical dates only (issue #174).
+const LEGACY_SOURCE_COLLECTION_METHODS = {
+  arxiv: "RSS",
+  huggingface: "API",
+  github: "API",
+  openreview: "API",
+  semantic_scholar: "API",
+  github_releases: "API",
+  first_party_feeds: "RSS/Atom",
+  openalex: "API",
+  brave: "API",
+};
 
 const byId = (id) => document.getElementById(id);
 const state = {
@@ -653,6 +666,7 @@ function renderToday() {
     ...day.ingest_health.map((entry) => ({
       ...entry,
       layer: entry.kind === "attention" ? "Attention ingest" : "Evidence ingest",
+      method: entry.method || LEGACY_SOURCE_COLLECTION_METHODS[entry.source] || "",
     })),
     ...day.producer_health.map((entry) => ({ ...entry, layer: "Producer report" })),
   ];

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -666,7 +666,10 @@ function renderToday() {
     ...day.ingest_health.map((entry) => ({
       ...entry,
       layer: entry.kind === "attention" ? "Attention ingest" : "Evidence ingest",
-      method: entry.method || LEGACY_SOURCE_COLLECTION_METHODS[entry.source] || "",
+      method:
+        entry.method ||
+        (entry.ok ? LEGACY_SOURCE_COLLECTION_METHODS[entry.source] : "") ||
+        "",
     })),
     ...day.producer_health.map((entry) => ({ ...entry, layer: "Producer report" })),
   ];

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -7,20 +7,6 @@ const CATEGORY_COLORS = {
 };
 const FALLBACK_COLORS = ["#756aa8", "#397f9a", "#a4576d", "#70833d"];
 const ALL_DATES_PAGE_SIZE = 100;
-// How each evidence connector actually collects records (issue #174: every
-// row read "Radar ingest" regardless of source, so a stalled RSS feed and a
-// broken API call looked identical at a glance).
-const SOURCE_COLLECTION_METHODS = {
-  arxiv: "RSS",
-  huggingface: "API",
-  github: "API",
-  openreview: "API",
-  semantic_scholar: "API",
-  github_releases: "API",
-  first_party_feeds: "RSS",
-  openalex: "API",
-  brave: "API",
-};
 
 const byId = (id) => document.getElementById(id);
 const state = {
@@ -667,7 +653,6 @@ function renderToday() {
     ...day.ingest_health.map((entry) => ({
       ...entry,
       layer: entry.kind === "attention" ? "Attention ingest" : "Evidence ingest",
-      method: SOURCE_COLLECTION_METHODS[entry.source] || "",
     })),
     ...day.producer_health.map((entry) => ({ ...entry, layer: "Producer report" })),
   ];

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -7,6 +7,20 @@ const CATEGORY_COLORS = {
 };
 const FALLBACK_COLORS = ["#756aa8", "#397f9a", "#a4576d", "#70833d"];
 const ALL_DATES_PAGE_SIZE = 100;
+// How each evidence connector actually collects records (issue #174: every
+// row read "Radar ingest" regardless of source, so a stalled RSS feed and a
+// broken API call looked identical at a glance).
+const SOURCE_COLLECTION_METHODS = {
+  arxiv: "RSS",
+  huggingface: "API",
+  github: "API",
+  openreview: "API",
+  semantic_scholar: "API",
+  github_releases: "API",
+  first_party_feeds: "RSS",
+  openalex: "API",
+  brave: "API",
+};
 
 const byId = (id) => document.getElementById(id);
 const state = {
@@ -650,7 +664,11 @@ function renderToday() {
   );
 
   const healthEntries = [
-    ...day.ingest_health.map((entry) => ({ ...entry, layer: "Radar ingest" })),
+    ...day.ingest_health.map((entry) => ({
+      ...entry,
+      layer: entry.kind === "attention" ? "Attention ingest" : "Evidence ingest",
+      method: SOURCE_COLLECTION_METHODS[entry.source] || "",
+    })),
     ...day.producer_health.map((entry) => ({ ...entry, layer: "Producer report" })),
   ];
   // Fetch plumbing is not what the reader came for, so the roster stays
@@ -673,7 +691,9 @@ function renderToday() {
         element("span", { className: `health-dot${entry.ok ? " ok" : ""}` }),
         element("span", {
           className: "health-name",
-          text: `${entry.source} · ${entry.layer}`,
+          text: entry.method
+            ? `${entry.source} · ${entry.method} · ${entry.layer}`
+            : `${entry.source} · ${entry.layer}`,
         }),
         element("span", {
           className: "health-count",

--- a/src/benchmark_radar/models.py
+++ b/src/benchmark_radar/models.py
@@ -90,6 +90,10 @@ class SourceHealth:
     item_count: int = 0
     error: str | None = None
     kind: str = "evidence"
+    # How this run actually collected records ("API", "RSS", ...). Derived
+    # from what ran, not a static per-source guess, since connectors like
+    # arXiv fall back from API to RSS mid-run (issue #174).
+    method: str = ""
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)

--- a/src/benchmark_radar/pipeline.py
+++ b/src/benchmark_radar/pipeline.py
@@ -601,7 +601,6 @@ def simulate_backfill(
                     source=source_name,
                     ok=False,
                     error=f"{type(error).__name__}: {error}",
-                    method=collection_method(source_name, []),
                 )
             )
 
@@ -712,7 +711,6 @@ def run_pipeline(
                     source=source_name,
                     ok=False,
                     error=f"{type(error).__name__}: {error}",
-                    method=collection_method(source_name, []),
                 )
             )
     required = {

--- a/src/benchmark_radar/pipeline.py
+++ b/src/benchmark_radar/pipeline.py
@@ -14,7 +14,7 @@ from . import rubric
 from .attention import fetch_attention_feeds
 from .corpus import exact_artifact_keys
 from .models import RadarItem, RadarRun, SourceHealth
-from .sources import FUTURE_TIMESTAMP_TOLERANCE, SOURCE_FETCHERS
+from .sources import FUTURE_TIMESTAMP_TOLERANCE, SOURCE_FETCHERS, collection_method
 
 TRACKING_PARAMETERS = {"ref", "source", "utm_campaign", "utm_content", "utm_medium", "utm_source"}
 
@@ -586,7 +586,14 @@ def simulate_backfill(
         fetcher = SOURCE_FETCHERS[source_name]
         try:
             fetched = fetcher(source_config, earliest_since, limit)
-            fetch_health.append(SourceHealth(source=source_name, ok=True, item_count=len(fetched)))
+            fetch_health.append(
+                SourceHealth(
+                    source=source_name,
+                    ok=True,
+                    item_count=len(fetched),
+                    method=collection_method(source_name, fetched),
+                )
+            )
             pool.extend(fetched)
         except Exception as error:  # a partial backfill is preferable; health exposes the gap
             fetch_health.append(
@@ -594,6 +601,7 @@ def simulate_backfill(
                     source=source_name,
                     ok=False,
                     error=f"{type(error).__name__}: {error}",
+                    method=collection_method(source_name, []),
                 )
             )
 
@@ -681,6 +689,7 @@ def run_pipeline(
                     ok=True,
                     item_count=len(fetched),
                     error="; ".join(source_notes) if source_notes else None,
+                    method=collection_method(source_name, fetched),
                 )
             )
             for item in fetched:
@@ -703,6 +712,7 @@ def run_pipeline(
                     source=source_name,
                     ok=False,
                     error=f"{type(error).__name__}: {error}",
+                    method=collection_method(source_name, []),
                 )
             )
     required = {

--- a/src/benchmark_radar/report.py
+++ b/src/benchmark_radar/report.py
@@ -8,25 +8,6 @@ from . import __version__
 from .briefing import markdown_bullet
 from .models import RadarItem, RadarRun
 
-# How each `## Source health` connector actually collects records (issue
-# #174: a bare source name told readers nothing about API vs RSS vs search,
-# so a stalled feed and a broken API call looked identical at a glance).
-SOURCE_COLLECTION_METHODS = {
-    "arxiv": "RSS",
-    "huggingface": "API",
-    "github": "API",
-    "openreview": "API",
-    "semantic_scholar": "API",
-    "github_releases": "API",
-    "first_party_feeds": "RSS",
-    "openalex": "API",
-    "brave": "API",
-}
-
-
-def _collection_method(source: str) -> str:
-    return SOURCE_COLLECTION_METHODS.get(source, "")
-
 
 def _escape(text: str) -> str:
     return text.replace("|", "\\|").replace("\n", " ").strip()
@@ -435,9 +416,8 @@ def render_markdown(
     )
     for health in run.health:
         detail = _escape(health.error or "")
-        method = _collection_method(health.source)
         lines.append(
-            f"| {health.source} | {method} | {'✅' if health.ok else '⚠️'} | "
+            f"| {health.source} | {health.method} | {'✅' if health.ok else '⚠️'} | "
             f"{health.item_count} | {detail} |"
         )
     if run.attention_ingest_health or run.producer_health:

--- a/src/benchmark_radar/report.py
+++ b/src/benchmark_radar/report.py
@@ -8,6 +8,25 @@ from . import __version__
 from .briefing import markdown_bullet
 from .models import RadarItem, RadarRun
 
+# How each `## Source health` connector actually collects records (issue
+# #174: a bare source name told readers nothing about API vs RSS vs search,
+# so a stalled feed and a broken API call looked identical at a glance).
+SOURCE_COLLECTION_METHODS = {
+    "arxiv": "RSS",
+    "huggingface": "API",
+    "github": "API",
+    "openreview": "API",
+    "semantic_scholar": "API",
+    "github_releases": "API",
+    "first_party_feeds": "RSS",
+    "openalex": "API",
+    "brave": "API",
+}
+
+
+def _collection_method(source: str) -> str:
+    return SOURCE_COLLECTION_METHODS.get(source, "")
+
 
 def _escape(text: str) -> str:
     return text.replace("|", "\\|").replace("\n", " ").strip()
@@ -410,14 +429,16 @@ def render_markdown(
         [
             "## Source health",
             "",
-            "| Source | Status | Records | Detail |",
-            "|---|---:|---:|---|",
+            "| Source | Method | Status | Records | Detail |",
+            "|---|---|---:|---:|---|",
         ]
     )
     for health in run.health:
         detail = _escape(health.error or "")
+        method = _collection_method(health.source)
         lines.append(
-            f"| {health.source} | {'✅' if health.ok else '⚠️'} | {health.item_count} | {detail} |"
+            f"| {health.source} | {method} | {'✅' if health.ok else '⚠️'} | "
+            f"{health.item_count} | {detail} |"
         )
     if run.attention_ingest_health or run.producer_health:
         lines.extend(
@@ -432,7 +453,7 @@ def render_markdown(
         for health in run.attention_ingest_health:
             detail = _escape(health.error or "")
             lines.append(
-                f"| Radar ingest | {health.source} | {'✅' if health.ok else '⚠️'} | "
+                f"| Attention ingest | {health.source} | {'✅' if health.ok else '⚠️'} | "
                 f"{health.item_count} | {detail} |"
             )
         for health in run.producer_health:

--- a/src/benchmark_radar/sources.py
+++ b/src/benchmark_radar/sources.py
@@ -1001,6 +1001,46 @@ SOURCE_FETCHERS = {
     "brave": fetch_brave,
 }
 
+# What each connector's `parser_version` prefix says about how a record was
+# actually collected. arXiv, for one, tries its Atom API and falls back to
+# RSS mid-run, so this cannot be a static per-source label (issue #174).
+_PARSER_VERSION_METHODS = {
+    "arxiv-rss": "RSS",
+    "arxiv-atom": "API",
+    "first-party-rss-atom": "RSS/Atom",
+    "huggingface-hub": "API",
+    "github-search": "API",
+    "openreview-api-v2": "API",
+    "semantic-scholar-graph": "API",
+    "github-releases": "API",
+    "openalex-works": "API",
+    "brave-web-search": "API",
+}
+
+# Fallback label when a connector run produced no items to inspect (an empty
+# but healthy fetch, or a failure before any record was parsed).
+SOURCE_DEFAULT_METHODS = {
+    "arxiv": "RSS",
+    "huggingface": "API",
+    "github": "API",
+    "openreview": "API",
+    "semantic_scholar": "API",
+    "github_releases": "API",
+    "first_party_feeds": "RSS/Atom",
+    "openalex": "API",
+    "brave": "API",
+}
+
+
+def collection_method(source_name: str, fetched: list[RadarItem]) -> str:
+    """The collection method actually used this run, derived from what ran."""
+    for item in fetched:
+        prefix = item.parser_version.rsplit("/", 1)[0]
+        method = _PARSER_VERSION_METHODS.get(prefix)
+        if method:
+            return method
+    return SOURCE_DEFAULT_METHODS.get(source_name, "")
+
 
 def default_since(hours: int) -> datetime:
     return datetime.now(UTC) - timedelta(hours=hours)

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -34,15 +34,19 @@ def test_report_contains_evidence_and_health():
 def test_source_health_names_each_connectors_collection_method():
     # Issue #174: every row of the Source health table looked the same at a
     # glance, so a stalled RSS feed and a broken search API read as identical
-    # failures. The Method column names how each connector actually collects.
+    # failures. The Method column (populated by the pipeline from what a run
+    # actually did, see sources.collection_method) surfaces the difference.
     run = RadarRun(
         generated_at=datetime(2026, 7, 27, tzinfo=UTC),
         since=datetime(2026, 7, 25, tzinfo=UTC),
         items=[],
         health=[
-            SourceHealth(source="arxiv", ok=True, item_count=0),
+            SourceHealth(source="arxiv", ok=True, item_count=0, method="RSS"),
             SourceHealth(
-                source="brave", ok=False, error="RuntimeError: BRAVE_API_KEY is not configured"
+                source="brave",
+                ok=False,
+                error="RuntimeError: BRAVE_API_KEY is not configured",
+                method="API",
             ),
         ],
     )

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -31,6 +31,48 @@ def test_report_contains_evidence_and_health():
     assert "Source health" in report
 
 
+def test_source_health_names_each_connectors_collection_method():
+    # Issue #174: every row of the Source health table looked the same at a
+    # glance, so a stalled RSS feed and a broken search API read as identical
+    # failures. The Method column names how each connector actually collects.
+    run = RadarRun(
+        generated_at=datetime(2026, 7, 27, tzinfo=UTC),
+        since=datetime(2026, 7, 25, tzinfo=UTC),
+        items=[],
+        health=[
+            SourceHealth(source="arxiv", ok=True, item_count=0),
+            SourceHealth(
+                source="brave", ok=False, error="RuntimeError: BRAVE_API_KEY is not configured"
+            ),
+        ],
+    )
+
+    report = render_markdown(run)
+
+    assert "| arxiv | RSS |" in report
+    assert "| brave | API |" in report
+
+
+def test_attention_feed_health_layer_is_not_the_ambiguous_radar_ingest_label():
+    # Issue #174: the Layer column read the literal string "Radar ingest" for
+    # every attention-layer row, which restates the project's own name and
+    # tells the reader nothing about what actually ran.
+    run = RadarRun(
+        generated_at=datetime(2026, 7, 27, tzinfo=UTC),
+        since=datetime(2026, 7, 25, tzinfo=UTC),
+        items=[],
+        health=[],
+        attention_ingest_health=[
+            SourceHealth(source="Hacker News collector", kind="attention", ok=True, item_count=18)
+        ],
+    )
+
+    report = render_markdown(run)
+
+    assert "Radar ingest" not in report
+    assert "| Attention ingest | Hacker News collector |" in report
+
+
 def test_empty_report_explains_eligibility_not_recommendation_threshold():
     report = render_markdown(
         RadarRun(

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -4,8 +4,10 @@ from urllib.error import HTTPError
 import pytest
 
 from benchmark_radar.http import RequestError
+from benchmark_radar.models import RadarItem
 from benchmark_radar.sources import (
     ConnectorPayloadError,
+    collection_method,
     fetch_arxiv,
     fetch_brave,
     fetch_first_party_feeds,
@@ -950,3 +952,29 @@ def test_huggingface_filters_future_rows_before_the_local_cap(monkeypatch):
     assert seen_limit == [51, 51]
     assert [item.source_id for item in items] == ["org/current"]
     assert config["_future_rejections"] == 1
+
+
+def _item(parser_version: str) -> RadarItem:
+    return RadarItem(
+        source="arXiv",
+        source_id="abs/1",
+        title="t",
+        url="https://example.test/1",
+        published_at=datetime(2026, 7, 27, tzinfo=UTC),
+        parser_version=parser_version,
+    )
+
+
+def test_collection_method_reflects_what_actually_ran_not_a_static_guess():
+    # Issue #174 follow-up: arXiv tries its Atom API and falls back to RSS
+    # mid-run, so a static "arxiv -> RSS" label would misreport a run that
+    # succeeded over Atom. The method must come from what the run did.
+    assert collection_method("arxiv", [_item("arxiv-atom/1")]) == "API"
+    assert collection_method("arxiv", [_item("arxiv-rss/1")]) == "RSS"
+
+
+def test_collection_method_falls_back_to_a_static_default_without_items():
+    # An empty-but-healthy fetch, or a failure before any item was parsed,
+    # leaves nothing to inspect; fall back to the connector's usual method.
+    assert collection_method("arxiv", []) == "RSS"
+    assert collection_method("brave", []) == "API"


### PR DESCRIPTION
## Summary
- The Source health table and dashboard health list labeled every row "Radar ingest" regardless of connector, so a stalled arXiv RSS feed and a broken Brave search API call looked identical (issue #174).
- Adds a `Method` column/label showing how each connector actually collected records this run (API vs RSS), derived from what ran rather than a static per-source guess (arXiv falls back from its Atom API to RSS mid-run).
- Renames the ambiguous attention-layer "Radar ingest" tag to "Attention ingest" to match its section heading, and "Producer report" stays distinct.
- Historical snapshots recorded before this field existed fall back to a source-keyed default, but only for rows that actually succeeded — a failed or explicitly-excluded row (e.g. arXiv in simulated backfill) isn't credited with a method it never ran.

Fixes #174

## Test plan
- [x] `pytest` (645 passed)
- [x] `ruff check .` (clean)
- [x] `node --check site/assets/app.js` (valid syntax)
- [x] `codex review --base main` (no findings)