### PR TITLE
feat: daily social post material in the evidence artifact

### DIFF
--- a/.github/workflows/daily-radar.yml
+++ b/.github/workflows/daily-radar.yml
@@ -144,6 +144,12 @@ jobs:
   # Issue #37: keep the daily Issue as a secondary, GitHub-native discussion
   # channel after RSS ships. The dashboard and site/feed.xml are the primary
   # reading and subscription surfaces; this job no longer fills a feed gap.
+  #
+  # Since issue #88, the issue also carries the day's social post material and
+  # its posting checklist. The social section is generated deterministically
+  # here (never by a model) from the day's evidence plus the last 24 hours of
+  # git history, and the checklist re-applies ticks already made on the same
+  # day's issue so a retry never resets posting progress.
   publish-issue:
     needs: [build-report, persist-snapshot]
     if: >-
@@ -153,13 +159,25 @@ jobs:
       contents: read
       issues: write
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Download validated report
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: benchmark-radar-${{ github.run_id }}
           path: generated/
+      # The repo-change sentence reads the last 24 hours of git history, which
+      # needs the full history rather than the default shallow single commit.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install
+        run: python -m pip install .
       - name: Create idempotent daily issue
         env:
           GH_TOKEN: ${{ github.token }}
@@ -171,10 +189,26 @@ jobs:
           title="📡 AI Benchmark & Data Radar — ${date_key}"
           existing="$(gh issue list --state all --search "\"${title}\" in:title" \
             --json number,title --jq ".[] | select(.title == \"${title}\") | .number" | head -1)"
+          existing_body_args=()
           if [[ -n "${existing}" ]]; then
-            gh issue edit "${existing}" --body-file generated/out/report.md
+            gh issue view "${existing}" --json body --jq .body > generated/out/current_body.md
+            existing_body_args=(--existing-body generated/out/current_body.md)
+          fi
+          benchmark-radar social \
+            --items generated/out/items.json \
+            --repo . \
+            --channels config/social.yml \
+            "${existing_body_args[@]}" \
+            --social-output generated/out/social.md
+          {
+            cat generated/out/report.md
+            printf '\n\n'
+            cat generated/out/social.md
+          } > generated/out/body.md
+          if [[ -n "${existing}" ]]; then
+            gh issue edit "${existing}" --body-file generated/out/body.md
             echo "Updated issue #${existing}"
           else
-            gh issue create --title "${title}" --body-file generated/out/report.md \
+            gh issue create --title "${title}" --body-file generated/out/body.md \
               --label daily-radar --label automated
           fi

--- a/.github/workflows/daily-radar.yml
+++ b/.github/workflows/daily-radar.yml
@@ -161,17 +161,24 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      # Checkout before downloading the artifact: actions/checkout clears a
+      # non-repository workspace, which would delete a previously downloaded
+      # generated/ directory. main is checked out explicitly so the repo-change
+      # sentence also counts the snapshot commit persist-snapshot pushes while
+      # this workflow is running, instead of the stale event SHA.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: false
       - name: Download validated report
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: benchmark-radar-${{ github.run_id }}
           path: generated/
       # The repo-change sentence reads the last 24 hours of git history, which
-      # needs the full history rather than the default shallow single commit.
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          persist-credentials: false
+      # the full fetch above provides rather than the default shallow single
+      # commit.
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"

--- a/.github/workflows/daily-radar.yml
+++ b/.github/workflows/daily-radar.yml
@@ -10,12 +10,6 @@ on:
     # once-a-day cadence.
     - cron: "0 1 * * *"
   workflow_dispatch:
-    inputs:
-      publish:
-        description: Publish or update today's GitHub Issue
-        required: true
-        type: boolean
-        default: false
 
 concurrency:
   group: daily-benchmark-radar
@@ -57,6 +51,7 @@ jobs:
           fi
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          fetch-depth: 0
           persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -84,6 +79,20 @@ jobs:
           OPENAI_QUESTIONS: "true"
           OPENAI_QUESTIONS_REQUIRED: "true"
         run: benchmark-radar
+      # The day's social post material used to live on a daily GitHub Issue
+      # (issue #88), but that Issue stopped earning its keep once the dashboard
+      # and site/feed.xml became the reading and subscription surfaces (issue
+      # #37). The material is now rendered deterministically here as
+      # out/social.md and fetched from the evidence artifact. The full-history
+      # checkout above feeds the repo-change sentence; a shallow clone would
+      # report "no code changes" on most days.
+      - name: Render daily social post material
+        run: >
+          benchmark-radar social
+          --items out/items.json
+          --repo .
+          --channels config/social.yml
+          --social-output out/social.md
       - name: Upload evidence artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -140,82 +149,3 @@ jobs:
           fi
           git commit -m "Record daily radar snapshot"
           git push origin HEAD:main
-
-  # Issue #37: keep the daily Issue as a secondary, GitHub-native discussion
-  # channel after RSS ships. The dashboard and site/feed.xml are the primary
-  # reading and subscription surfaces; this job no longer fills a feed gap.
-  #
-  # Since issue #88, the issue also carries the day's social post material and
-  # its posting checklist. The social section is generated deterministically
-  # here (never by a model) from the day's evidence plus the last 24 hours of
-  # git history, and the checklist re-applies ticks already made on the same
-  # day's issue so a retry never resets posting progress.
-  publish-issue:
-    needs: [build-report, persist-snapshot]
-    if: >-
-      github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' && inputs.publish)
-    permissions:
-      contents: read
-      issues: write
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      # Checkout before downloading the artifact: actions/checkout clears a
-      # non-repository workspace, which would delete a previously downloaded
-      # generated/ directory. main is checked out explicitly so the repo-change
-      # sentence also counts the snapshot commit persist-snapshot pushes while
-      # this workflow is running, instead of the stale event SHA.
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: main
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Download validated report
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: benchmark-radar-${{ github.run_id }}
-          path: generated/
-      # The repo-change sentence reads the last 24 hours of git history, which
-      # the full fetch above provides rather than the default shallow single
-      # commit.
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: "3.12"
-          cache: pip
-      - name: Install
-        run: python -m pip install .
-      - name: Create idempotent daily issue
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          date_key="$(date -u +%Y-%m-%d)"
-          title="📡 AI Benchmark & Data Radar — ${date_key}"
-          existing="$(gh issue list --state all --search "\"${title}\" in:title" \
-            --json number,title --jq ".[] | select(.title == \"${title}\") | .number" | head -1)"
-          existing_body_args=()
-          if [[ -n "${existing}" ]]; then
-            gh issue view "${existing}" --json body --jq .body > generated/out/current_body.md
-            existing_body_args=(--existing-body generated/out/current_body.md)
-          fi
-          benchmark-radar social \
-            --items generated/out/items.json \
-            --repo . \
-            --channels config/social.yml \
-            "${existing_body_args[@]}" \
-            --social-output generated/out/social.md
-          {
-            cat generated/out/report.md
-            printf '\n\n'
-            cat generated/out/social.md
-          } > generated/out/body.md
-          if [[ -n "${existing}" ]]; then
-            gh issue edit "${existing}" --body-file generated/out/body.md
-            echo "Updated issue #${existing}"
-          else
-            gh issue create --title "${title}" --body-file generated/out/body.md \
-              --label daily-radar --label automated
-          fi

--- a/config/social.yml
+++ b/config/social.yml
@@ -1,0 +1,47 @@
+# Daily social posting channels (issue #88). Each day's radar issue renders a
+# "Daily social post" section with one checkbox per channel below. Tick a
+# channel in the issue once that day's post is sent there; the daily workflow
+# preserves checked boxes when it re-renders the same day's issue.
+#
+# Edit this list freely. Changes apply to future days only: the checked state
+# of past days stays in the issues themselves.
+#
+# "daily" marks the channels the daily post targets. The remaining channels
+# are single-shot launch channels kept here so the checklist matches the
+# platform list in docs/launch-posts.md.
+social:
+  channels:
+    - name: "X / Twitter"
+      daily: true
+    - name: "LinkedIn"
+      daily: true
+    - name: "Reddit r/MachineLearning"
+      daily: true
+    - name: "Reddit r/LocalLLaMA"
+      daily: true
+    - name: "Hugging Face Forums"
+      daily: false
+    - name: "EleutherAI Discord"
+      daily: false
+    - name: "ML Collective Discord"
+      daily: false
+    - name: "Hugging Face Discord"
+      daily: false
+    - name: "MLOps Community Slack"
+      daily: false
+    - name: "小红书"
+      daily: true
+    - name: "即刻"
+      daily: true
+    - name: "知乎"
+      daily: true
+    - name: "微信公众号"
+      daily: true
+    - name: "V2EX"
+      daily: true
+    - name: "DEV Community"
+      daily: false
+    - name: "Hashnode"
+      daily: false
+    - name: "Substack Notes"
+      daily: false

--- a/config/social.yml
+++ b/config/social.yml
@@ -9,7 +9,15 @@
 # "daily" marks the channels the daily post targets. The remaining channels
 # are single-shot launch channels kept here so the checklist matches the
 # platform list in docs/launch-posts.md.
+#
+# "post_sample" is the ready-to-copy 发布文案 rendered under each day's issue.
+# It is static text, not re-derived per day: refresh it when the L0-L5 picture
+# it describes moves (issue #150 holds the source analysis).
 social:
+  post_sample: |-
+    一个反常识的发现：Agent benchmarks 看起来已经在评测智能体前沿，实际上大多还在测“能不能按要求把事情做完”。
+    按Hejia Geng的 L0–L5 分级，当前主体仍是 L2 执行和 L3 复现；L4 再发现刚开始出现，而要求 Agent 产出 benchmark 创建时未知知识或方法的 L5，本周仍未发现新案例。
+    源码和分析详见：https://github.com/ktwu01/benchmark-radar/issues/150
   channels:
     - name: "X / Twitter"
       daily: true
@@ -31,13 +39,47 @@ social:
       daily: false
     - name: "小红书"
       daily: true
-    - name: "即刻"
-      daily: true
     - name: "知乎"
       daily: true
     - name: "微信公众号"
       daily: true
     - name: "V2EX"
+      daily: true
+    - name: "WeChat Moment"
+      daily: true
+    - name: "Science Intelligence 实名讨论群"
+      daily: true
+    - name: "Benchmark Radar 讨论群"
+      daily: true
+    - name: "Agent Infra交流群 （Substrate）"
+      daily: true
+    - name: "灵台AI"
+      daily: true
+    - name: "Math AI"
+      daily: true
+    - name: "博杰老师Agent实战营01"
+      daily: true
+    - name: "Phys Bench"
+      daily: true
+    - name: "ACL 2026线下开会社交群"
+      daily: true
+    - name: "COLM 2026 开会群"
+      daily: true
+    - name: "HKUDS-开源交流群2"
+      daily: true
+    - name: "HLE V2 | Core"
+      daily: true
+    - name: "Sichen Tao"
+      daily: true
+    - name: "Junwei Zhou"
+      daily: true
+    - name: "LHTB 造题"
+      daily: true
+    - name: "Ziyan Chen"
+      daily: true
+    - name: "TB"
+      daily: true
+    - name: "TB Sci"
       daily: true
     - name: "DEV Community"
       daily: false

--- a/config/social.yml
+++ b/config/social.yml
@@ -1,7 +1,8 @@
-# Daily social posting channels (issue #88). Each day's radar issue renders a
-# "Daily social post" section with one checkbox per channel below. Tick a
-# channel in the issue once that day's post is sent there; the daily workflow
-# preserves checked boxes when it re-renders the same day's issue.
+# Daily social posting channels (issue #88). Each day's workflow renders a
+# "Daily social post" section with one checkbox per channel below into
+# out/social.md, fetched from the evidence artifact. Tick a channel once that
+# day's post is sent there; re-running the social command with --existing-body
+# pointing at a previous render re-applies those ticks.
 #
 # Edit this list freely. Changes apply to future days only: the checked state
 # of past days stays in the issues themselves.

--- a/src/benchmark_radar/cli.py
+++ b/src/benchmark_radar/cli.py
@@ -27,6 +27,14 @@ from .snapshots import (
     rescore_snapshot_history,
     write_snapshot,
 )
+from .social import (
+    build_insight_sentence,
+    collect_git_changes,
+    extract_checked,
+    load_channels,
+    render_social_section,
+    summarize_repo_changes,
+)
 
 DEFAULT_DASHBOARD_OUTPUT = Path("site/data/radar.json")
 DEFAULT_FEED_OUTPUT = Path("site/feed.xml")
@@ -85,6 +93,7 @@ def main() -> None:
             "export",
             "classify",
             "authors",
+            "social",
         ),
         default="run",
         help=(
@@ -92,8 +101,9 @@ def main() -> None:
             "migrate snapshot schemas, rescore stored taxonomy categories against the "
             "current config, simulate missing historical snapshots, export the "
             "Model Card Adoption Rank as standalone citable files, classify canonical "
-            "benchmark tracks against the KW-Bench L0-L5 capability rubric, or survey "
-            "the public profiles of authors behind popular benchmark repositories."
+            "benchmark tracks against the KW-Bench L0-L5 capability rubric, survey "
+            "the public profiles of authors behind popular benchmark repositories, "
+            "or render the daily social post section from the day's evidence and git history."
         ),
     )
     parser.add_argument(
@@ -122,6 +132,51 @@ def main() -> None:
     parser.add_argument("--config", type=Path, default=Path("config.yml"))
     parser.add_argument("--output", type=Path, default=Path("out/report.md"))
     parser.add_argument("--json-output", type=Path, default=Path("out/items.json"))
+    parser.add_argument(
+        "--social-output",
+        type=Path,
+        default=Path("out/social.md"),
+        help="social only: where the rendered social post section is written.",
+    )
+    parser.add_argument(
+        "--items",
+        type=Path,
+        default=Path("out/items.json"),
+        help="social only: the day's evidence records (out/items.json).",
+    )
+    parser.add_argument(
+        "--repo",
+        type=Path,
+        default=Path("."),
+        help="social only: repository whose git history feeds the repo-change sentence.",
+    )
+    parser.add_argument(
+        "--channels",
+        type=Path,
+        default=Path("config/social.yml"),
+        help="social only: channel checklist source (config/social.yml).",
+    )
+    parser.add_argument(
+        "--existing-body",
+        type=Path,
+        default=None,
+        help=(
+            "social only: body of the already-created issue for this day, so "
+            "channels already ticked stay ticked on re-renders."
+        ),
+    )
+    parser.add_argument(
+        "--since",
+        type=str,
+        default=None,
+        help="social only: ISO start of the git window (defaults to 24 hours ago).",
+    )
+    parser.add_argument(
+        "--until",
+        type=str,
+        default=None,
+        help="social only: ISO end of the git window (defaults to now).",
+    )
     parser.add_argument("--snapshot-dir", type=Path, default=Path("data/snapshots"))
     parser.add_argument("--dashboard-output", type=Path, default=DEFAULT_DASHBOARD_OUTPUT)
     parser.add_argument(
@@ -420,6 +475,34 @@ def main() -> None:
         print(
             f"Migrated {len(snapshots)} snapshots to schema {dashboard['schema_version']} "
             f"and rebuilt {args.dashboard_output}"
+        )
+        return
+
+    if args.command == "social":
+        items: list[dict] = []
+        if args.items.exists():
+            payload = json.loads(args.items.read_text(encoding="utf-8"))
+            items = payload.get("evidence_items") or []
+        now = datetime.now(UTC)
+        until = args.until or now.isoformat()
+        since = args.since or (now - timedelta(hours=24)).isoformat()
+        changes = collect_git_changes(args.repo, since, until)
+        repo_sentence, commit_subjects = summarize_repo_changes(changes)
+        checked = set()
+        if args.existing_body and args.existing_body.exists():
+            checked = extract_checked(args.existing_body.read_text(encoding="utf-8"))
+        section = render_social_section(
+            build_insight_sentence(items),
+            repo_sentence,
+            commit_subjects,
+            load_channels(args.channels),
+            checked,
+        )
+        args.social_output.parent.mkdir(parents=True, exist_ok=True)
+        args.social_output.write_text(section + "\n", encoding="utf-8")
+        print(
+            f"Wrote {args.social_output} from {len(items)} evidence items "
+            f"and {len(changes)} commits"
         )
         return
 

--- a/src/benchmark_radar/cli.py
+++ b/src/benchmark_radar/cli.py
@@ -32,6 +32,7 @@ from .social import (
     collect_git_changes,
     extract_checked,
     load_channels,
+    load_post_sample,
     render_social_section,
     summarize_repo_changes,
 )
@@ -388,6 +389,7 @@ def main() -> None:
             commit_subjects,
             load_channels(args.channels, daily_only=True),
             checked,
+            load_post_sample(args.channels),
         )
         args.social_output.parent.mkdir(parents=True, exist_ok=True)
         args.social_output.write_text(section + "\n", encoding="utf-8")

--- a/src/benchmark_radar/cli.py
+++ b/src/benchmark_radar/cli.py
@@ -30,9 +30,9 @@ from .snapshots import (
 from .social import (
     build_insight_sentence,
     collect_git_changes,
-    extract_checked,
     load_channels,
     load_post_sample,
+    merge_checked,
     render_social_section,
     summarize_repo_changes,
 )
@@ -380,17 +380,15 @@ def main() -> None:
         since = args.since or (now - timedelta(hours=24)).isoformat()
         changes = collect_git_changes(args.repo, since, until)
         repo_sentence, commit_subjects = summarize_repo_changes(changes)
-        checked = set()
-        if args.existing_body and args.existing_body.exists():
-            checked = extract_checked(args.existing_body.read_text(encoding="utf-8"))
         section = render_social_section(
             build_insight_sentence(items),
             repo_sentence,
             commit_subjects,
             load_channels(args.channels, daily_only=True),
-            checked,
-            load_post_sample(args.channels),
+            post_sample=load_post_sample(args.channels),
         )
+        if args.existing_body and args.existing_body.exists():
+            section = merge_checked(section, args.existing_body.read_text(encoding="utf-8"))
         args.social_output.parent.mkdir(parents=True, exist_ok=True)
         args.social_output.write_text(section + "\n", encoding="utf-8")
         print(

--- a/src/benchmark_radar/cli.py
+++ b/src/benchmark_radar/cli.py
@@ -624,20 +624,24 @@ def main() -> None:
     args.json_output.write_text(
         json.dumps(
             {
-                "generated_at": run.generated_at.isoformat(),
-                "since": run.since.isoformat(),
-                "evidence_items": [item.to_dict() for item in run.items],
+                # The report and snapshot describe the merged UTC-day union, not
+                # the latest pass alone: a same-day rerun must not replace the
+                # day's evidence with a subset (issue #88 social insight reads
+                # this file).
+                "generated_at": report_run.generated_at.isoformat(),
+                "since": report_run.since.isoformat(),
+                "evidence_items": [item.to_dict() for item in report_run.items],
                 "attention": {
-                    "observations": [item.to_dict() for item in run.attention],
+                    "observations": [item.to_dict() for item in report_run.attention],
                 },
                 "ingest_health": [
                     health.to_dict() for health in [*run.health, *run.attention_ingest_health]
                 ],
                 "producer_health": [health.to_dict() for health in run.producer_health],
-                "selection": run.selection,
-                # Day-scoped, unlike the run-scoped counters above: the briefing
-                # describes the whole UTC day and is shared by every pass over
-                # it. Omitted when the day has none.
+                "selection": report_run.selection,
+                # Day-scoped like the evidence above: the briefing describes the
+                # whole UTC day and is shared by every pass over it. Omitted
+                # when the day has none.
                 **(
                     {
                         "briefing": {

--- a/src/benchmark_radar/cli.py
+++ b/src/benchmark_radar/cli.py
@@ -366,6 +366,37 @@ def main() -> None:
         print(f"{action} {args.dashboard_output} from {data['snapshot_count']} daily snapshots")
         return
 
+    if args.command == "social":
+        # Config-independent: dispatched before load_config so the command
+        # works against explicit --items/--repo/--channels paths outside the
+        # repository without needing an unrelated radar config.yml.
+        items: list[dict] = []
+        if args.items.exists():
+            payload = json.loads(args.items.read_text(encoding="utf-8"))
+            items = payload.get("evidence_items") or []
+        now = datetime.now(UTC)
+        until = args.until or now.isoformat()
+        since = args.since or (now - timedelta(hours=24)).isoformat()
+        changes = collect_git_changes(args.repo, since, until)
+        repo_sentence, commit_subjects = summarize_repo_changes(changes)
+        checked = set()
+        if args.existing_body and args.existing_body.exists():
+            checked = extract_checked(args.existing_body.read_text(encoding="utf-8"))
+        section = render_social_section(
+            build_insight_sentence(items),
+            repo_sentence,
+            commit_subjects,
+            load_channels(args.channels, daily_only=True),
+            checked,
+        )
+        args.social_output.parent.mkdir(parents=True, exist_ok=True)
+        args.social_output.write_text(section + "\n", encoding="utf-8")
+        print(
+            f"Wrote {args.social_output} from {len(items)} evidence items "
+            f"and {len(changes)} commits"
+        )
+        return
+
     config = load_config(args.config)
 
     if args.command == "export":
@@ -475,34 +506,6 @@ def main() -> None:
         print(
             f"Migrated {len(snapshots)} snapshots to schema {dashboard['schema_version']} "
             f"and rebuilt {args.dashboard_output}"
-        )
-        return
-
-    if args.command == "social":
-        items: list[dict] = []
-        if args.items.exists():
-            payload = json.loads(args.items.read_text(encoding="utf-8"))
-            items = payload.get("evidence_items") or []
-        now = datetime.now(UTC)
-        until = args.until or now.isoformat()
-        since = args.since or (now - timedelta(hours=24)).isoformat()
-        changes = collect_git_changes(args.repo, since, until)
-        repo_sentence, commit_subjects = summarize_repo_changes(changes)
-        checked = set()
-        if args.existing_body and args.existing_body.exists():
-            checked = extract_checked(args.existing_body.read_text(encoding="utf-8"))
-        section = render_social_section(
-            build_insight_sentence(items),
-            repo_sentence,
-            commit_subjects,
-            load_channels(args.channels),
-            checked,
-        )
-        args.social_output.parent.mkdir(parents=True, exist_ok=True)
-        args.social_output.write_text(section + "\n", encoding="utf-8")
-        print(
-            f"Wrote {args.social_output} from {len(items)} evidence items "
-            f"and {len(changes)} commits"
         )
         return
 

--- a/src/benchmark_radar/social.py
+++ b/src/benchmark_radar/social.py
@@ -1,0 +1,234 @@
+"""Daily social post material for each day's radar issue (issue #88 follow-up).
+
+Every day the radar workflow appends a short "Daily social post" section to the
+day's GitHub Issue. The section carries the two sentences the post can be built
+from, a benchmark insight read off the day's evidence and a repo-change summary
+read off the day's git history, plus a per-channel checklist. Ticking a channel
+in the issue marks that day's post as sent; the workflow re-applies those ticks
+when it re-renders the same day's issue, so a retry never resets progress.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+SECTION_HEADING = "## 🗣 Daily social post"
+
+_CHECKBOX_RE = re.compile(r"^-\s+\[([ xX])\]\s+(.+)$")
+
+# Path prefixes that would otherwise read as "src", "data" etc. in a social
+# post. The sentence is for humans who do not know the repository layout.
+_AREA_ALIASES = {
+    ".github": "workflows",
+    "src": "radar code",
+    "scripts": "scripts",
+    "data": "registry data",
+    "site": "dashboard",
+    "docs": "docs",
+    "tests": "tests",
+    "config.yml": "config",
+}
+
+# Automated and integration commits add no information to a social post; the
+# count still includes them, but the highlighted commit subjects do not.
+_NOISE_SUBJECT_PREFIXES = (
+    "Record daily radar snapshot",
+    "Merge ",
+)
+
+
+@dataclass(frozen=True)
+class GitChange:
+    subject: str
+    files: tuple[str, ...]
+
+
+def _escape(text: str) -> str:
+    return text.replace("|", "\\|").replace("\n", " ").strip()
+
+
+def load_channels(path: Path) -> list[dict]:
+    """Read the channel checklist from config/social.yml."""
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    channels = (data.get("social") or {}).get("channels") or []
+    return [channel for channel in channels if str(channel.get("name") or "").strip()]
+
+
+def build_insight_sentence(items: list[dict]) -> str:
+    """One factual sentence describing today's captured evidence.
+
+    Deterministic by design: the sentence is computed from the day's ranked
+    evidence, never drafted by a model, so it always exists even when a GPT
+    briefing fails.
+    """
+    if not items:
+        return "The radar captured no new benchmark items today."
+    source_counts = Counter(str(item.get("source") or "unknown") for item in items)
+    sources = ", ".join(source for source, _ in source_counts.most_common())
+    top = max(items, key=lambda item: float(item.get("total_score") or 0.0))
+    title = str(top.get("title") or "untitled").strip()
+    source = str(top.get("source") or "unknown")
+    score = float(top.get("total_score") or 0.0)
+    score_max = float(top.get("score_max") or 100.0)
+    noun = "item" if len(items) == 1 else "items"
+    return (
+        f"Today's radar surfaced {len(items)} {noun} across {sources}; "
+        f"top signal: {title} ({source}, {score:.0f}/{score_max:.0f})."
+    )
+
+
+def _area_for(path: str) -> str:
+    if path in _AREA_ALIASES:
+        return _AREA_ALIASES[path]
+    if "/" in path:
+        return _AREA_ALIASES.get(path.split("/", 1)[0], path.split("/", 1)[0])
+    return path
+
+
+def summarize_repo_changes(changes: list[GitChange]) -> tuple[str, list[str]]:
+    """Reduce a day of commits to one sentence plus a few subject highlights."""
+    if not changes:
+        return "No code changes in the last 24 hours.", []
+    area_counts: Counter[str] = Counter()
+    for change in changes:
+        for area in {_area_for(path) for path in change.files}:
+            area_counts[area] += 1
+    areas = ", ".join(area for area, _ in area_counts.most_common())
+    noun = "commit" if len(changes) == 1 else "commits"
+    sentence = f"{len(changes)} {noun} in the last 24 hours"
+    if areas:
+        sentence += f" across {areas}"
+    sentence += "."
+    highlights = [
+        change.subject
+        for change in changes
+        if not change.subject.startswith(_NOISE_SUBJECT_PREFIXES)
+    ][:3]
+    return sentence, highlights
+
+
+def parse_git_log(text: str) -> list[GitChange]:
+    """Parse `git log --format=%H%x00%s --name-only` output.
+
+    Blank lines are separators and carry no meaning, so a commit ends only at
+    the next header line. This stays correct whether git places the blank
+    before or after the file list, and whether a merge commit lists no files.
+    """
+    changes: list[GitChange] = []
+    subject: str | None = None
+    files: list[str] = []
+    for line in text.splitlines():
+        if "\0" in line:
+            if subject is not None:
+                changes.append(GitChange(subject, tuple(files)))
+            _, subject = line.split("\0", 1)
+            files = []
+        elif line.strip():
+            files.append(line.strip())
+    if subject is not None:
+        changes.append(GitChange(subject, tuple(files)))
+    return changes
+
+
+def collect_git_changes(repo: Path, since: str, until: str) -> list[GitChange]:
+    """Run git log over the repository for the given ISO window."""
+    result = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "log",
+            f"--since={since}",
+            f"--until={until}",
+            "--format=%H%x00%s",
+            "--name-only",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return []
+    return parse_git_log(result.stdout)
+
+
+def extract_checked(body: str) -> set[str]:
+    """Channel names already ticked in an existing issue body."""
+    checked: set[str] = set()
+    in_section = False
+    for line in body.splitlines():
+        if line.startswith("## "):
+            in_section = line.rstrip() == SECTION_HEADING
+            continue
+        if not in_section:
+            continue
+        match = _CHECKBOX_RE.match(line)
+        if match and match.group(1).strip().lower() == "x":
+            checked.add(match.group(2).strip())
+    return checked
+
+
+def merge_checked(section: str, existing_body: str) -> str:
+    """Re-apply ticks from a previous render of the same day's section.
+
+    The checklist is the only state a re-run must not destroy: insight and
+    repo-change lines may legitimately change, but a channel the user already
+    marked as posted must stay marked.
+    """
+    checked = extract_checked(existing_body)
+    if not checked:
+        return section
+    lines = []
+    for line in section.splitlines():
+        match = _CHECKBOX_RE.match(line)
+        if match and match.group(2).strip() in checked:
+            lines.append(f"- [x] {match.group(2).strip()}")
+        else:
+            lines.append(line)
+    return "\n".join(lines)
+
+
+def render_social_section(
+    insight: str,
+    repo_sentence: str,
+    commit_subjects: list[str],
+    channels: list[dict],
+    checked: set[str] | None = None,
+) -> str:
+    """Render the section that gets appended to the day's radar issue."""
+    checked = checked or set()
+    lines = [
+        SECTION_HEADING,
+        "",
+        "Ready-to-post material for today. Rephrase per platform; the two "
+        "sentences below are the factual core.",
+        "",
+        f"**Benchmark update:** {_escape(insight)}",
+        "",
+        f"**Repo change:** {_escape(repo_sentence)}",
+        "",
+    ]
+    if commit_subjects:
+        lines.extend(["_Latest commits:_", ""])
+        lines.extend(f"- {_escape(subject)}" for subject in commit_subjects)
+        lines.append("")
+    lines.extend(
+        [
+            "**Posting checklist** - tick a channel after today's post is sent there:",
+            "",
+        ]
+    )
+    for channel in channels:
+        name = str(channel.get("name") or "").strip()
+        if not name:
+            continue
+        mark = "x" if name in checked else " "
+        lines.append(f"- [{mark}] {_escape(name)}")
+    lines.append("")
+    return "\n".join(lines)

--- a/src/benchmark_radar/social.py
+++ b/src/benchmark_radar/social.py
@@ -222,11 +222,9 @@ def render_social_section(
     repo_sentence: str,
     commit_subjects: list[str],
     channels: list[dict],
-    checked: set[str] | None = None,
     post_sample: str | None = None,
 ) -> str:
     """Render the section that gets appended to the day's radar issue."""
-    checked = checked or set()
     lines = [
         SECTION_HEADING,
         "",
@@ -261,7 +259,6 @@ def render_social_section(
         name = str(channel.get("name") or "").strip()
         if not name:
             continue
-        mark = "x" if name in checked else " "
-        lines.append(f"- [{mark}] {_escape(name)}")
+        lines.append(f"- [ ] {_escape(name)}")
     lines.append("")
     return "\n".join(lines)

--- a/src/benchmark_radar/social.py
+++ b/src/benchmark_radar/social.py
@@ -53,10 +53,20 @@ def _escape(text: str) -> str:
     return text.replace("|", "\\|").replace("\n", " ").strip()
 
 
-def load_channels(path: Path) -> list[dict]:
-    """Read the channel checklist from config/social.yml."""
+def load_channels(path: Path, *, daily_only: bool = False) -> list[dict]:
+    """Read the channel checklist from config/social.yml.
+
+    With daily_only, only channels marked ``daily: true`` are returned. The
+    launch-only channels (Discord communities, DEV/Hashnode articles, and the
+    like) are single-shot: listing them on every day's checklist would read as
+    an instruction to post there daily. When the config marks no channel at
+    all, every channel is treated as daily rather than silently dropping the
+    whole checklist.
+    """
     data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
     channels = (data.get("social") or {}).get("channels") or []
+    if daily_only and any(channel.get("daily") is not None for channel in channels):
+        channels = [channel for channel in channels if channel.get("daily")]
     return [channel for channel in channels if str(channel.get("name") or "").strip()]
 
 
@@ -158,6 +168,11 @@ def collect_git_changes(repo: Path, since: str, until: str) -> list[GitChange]:
     return parse_git_log(result.stdout)
 
 
+def _canonical_name(raw: str) -> str:
+    """Undo the rendering-time escaping so ticks match configured names."""
+    return raw.strip().replace("\\|", "|")
+
+
 def extract_checked(body: str) -> set[str]:
     """Channel names already ticked in an existing issue body."""
     checked: set[str] = set()
@@ -170,7 +185,7 @@ def extract_checked(body: str) -> set[str]:
             continue
         match = _CHECKBOX_RE.match(line)
         if match and match.group(1).strip().lower() == "x":
-            checked.add(match.group(2).strip())
+            checked.add(_canonical_name(match.group(2)))
     return checked
 
 
@@ -187,7 +202,7 @@ def merge_checked(section: str, existing_body: str) -> str:
     lines = []
     for line in section.splitlines():
         match = _CHECKBOX_RE.match(line)
-        if match and match.group(2).strip() in checked:
+        if match and _canonical_name(match.group(2)) in checked:
             lines.append(f"- [x] {match.group(2).strip()}")
         else:
             lines.append(line)

--- a/src/benchmark_radar/social.py
+++ b/src/benchmark_radar/social.py
@@ -3,9 +3,10 @@
 Every day the radar workflow appends a short "Daily social post" section to the
 day's GitHub Issue. The section carries the two sentences the post can be built
 from, a benchmark insight read off the day's evidence and a repo-change summary
-read off the day's git history, plus a per-channel checklist. Ticking a channel
-in the issue marks that day's post as sent; the workflow re-applies those ticks
-when it re-renders the same day's issue, so a retry never resets progress.
+read off the day's git history, a ready-to-copy 发布文案 sample from
+config/social.yml, plus a per-channel checklist. Ticking a channel in the issue
+marks that day's post as sent; the workflow re-applies those ticks when it
+re-renders the same day's issue, so a retry never resets progress.
 """
 
 from __future__ import annotations
@@ -51,6 +52,13 @@ class GitChange:
 
 def _escape(text: str) -> str:
     return text.replace("|", "\\|").replace("\n", " ").strip()
+
+
+def load_post_sample(path: Path) -> str | None:
+    """Read the ready-to-copy 发布文案 from config/social.yml, if any."""
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    sample = (data.get("social") or {}).get("post_sample")
+    return str(sample).strip() if sample else None
 
 
 def load_channels(path: Path, *, daily_only: bool = False) -> list[dict]:
@@ -215,6 +223,7 @@ def render_social_section(
     commit_subjects: list[str],
     channels: list[dict],
     checked: set[str] | None = None,
+    post_sample: str | None = None,
 ) -> str:
     """Render the section that gets appended to the day's radar issue."""
     checked = checked or set()
@@ -233,6 +242,15 @@ def render_social_section(
         lines.extend(["_Latest commits:_", ""])
         lines.extend(f"- {_escape(subject)}" for subject in commit_subjects)
         lines.append("")
+    if post_sample:
+        lines.extend(
+            [
+                "**发布文案示例** (copy-paste for today's post):",
+                "",
+                post_sample,
+                "",
+            ]
+        )
     lines.extend(
         [
             "**Posting checklist** - tick a channel after today's post is sent there:",

--- a/src/benchmark_radar/social.py
+++ b/src/benchmark_radar/social.py
@@ -1,12 +1,13 @@
-"""Daily social post material for each day's radar issue (issue #88 follow-up).
+"""Daily social post material for each day's radar run (issue #88 follow-up).
 
-Every day the radar workflow appends a short "Daily social post" section to the
-day's GitHub Issue. The section carries the two sentences the post can be built
-from, a benchmark insight read off the day's evidence and a repo-change summary
-read off the day's git history, a ready-to-copy 发布文案 sample from
-config/social.yml, plus a per-channel checklist. Ticking a channel in the issue
-marks that day's post as sent; the workflow re-applies those ticks when it
-re-renders the same day's issue, so a retry never resets progress.
+Every day the radar workflow renders a short "Daily social post" section to
+out/social.md (fetchable from the evidence artifact; the daily GitHub Issue
+that used to carry it was retired in issue #37). The section carries the two
+sentences the post can be built from, a benchmark insight read off the day's
+evidence and a repo-change summary read off the day's git history, a
+ready-to-copy 发布文案 sample from config/social.yml, plus a per-channel
+checklist. When a previous render is supplied with ``--existing-body``, ticks
+already made are re-applied so a re-run never resets posting progress.
 """
 
 from __future__ import annotations

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -303,6 +303,42 @@ def test_every_pass_over_a_day_derives_the_same_briefing(monkeypatch, tmp_path):
     assert first["bullets"]
 
 
+def test_items_json_keeps_the_merged_day_evidence_on_a_same_day_rerun(monkeypatch, tmp_path):
+    """Issue #88: the social insight reads out/items.json, so a same-day rerun
+    must not replace the day's evidence with the latest pass alone. The merged
+    union keeps both passes' items (issue #104 identity rule)."""
+    first = RadarItem(
+        source="GitHub",
+        source_id="org/repo",
+        title="First benchmark",
+        url="https://github.com/org/repo",
+        published_at=datetime.now(UTC),
+        summary="Benchmark suite for language model evaluation.",
+    )
+    second = RadarItem(
+        source="GitHub",
+        source_id="org/repo-2",
+        title="Second benchmark",
+        url="https://github.com/org/repo-2",
+        published_at=datetime.now(UTC),
+        summary="Benchmark suite for language model evaluation.",
+    )
+    monkeypatch.setitem(SOURCE_FETCHERS, "github", lambda config, since, limit: [first])
+    monkeypatch.setitem(SOURCE_FETCHERS, "arxiv", lambda config, since, limit: [first])
+    monkeypatch.setitem(SOURCE_FETCHERS, "huggingface", lambda config, since, limit: [first])
+    monkeypatch.setattr("sys.argv", _briefing_argv(tmp_path))
+
+    cli.main()
+    monkeypatch.setitem(SOURCE_FETCHERS, "github", lambda config, since, limit: [second])
+    monkeypatch.setitem(SOURCE_FETCHERS, "arxiv", lambda config, since, limit: [second])
+    monkeypatch.setitem(SOURCE_FETCHERS, "huggingface", lambda config, since, limit: [second])
+    cli.main()
+
+    payload = json.loads((tmp_path / "items.json").read_text(encoding="utf-8"))
+    titles = {item["title"] for item in payload["evidence_items"]}
+    assert {"First benchmark", "Second benchmark"} <= titles
+
+
 def test_a_briefing_is_written_without_any_api_key(monkeypatch, tmp_path):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     _stub_sources(monkeypatch, datetime.now(UTC))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -407,6 +407,21 @@ def test_daily_radar_yml_enables_and_requires_questions_in_production():
     assert str(env.get("OPENAI_QUESTIONS_REQUIRED")).lower() == "true"
 
 
+def test_daily_radar_yml_renders_social_material_instead_of_an_issue():
+    """Issue #37: the daily GitHub Issue was retired once the dashboard and
+    site/feed.xml became the reading surface. The social posting material must
+    still be rendered deterministically into the evidence artifact."""
+    workflow_path = Path(".github/workflows/daily-radar.yml")
+    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    assert "publish-issue" not in workflow["jobs"]
+    social_step = next(
+        step
+        for step in workflow["jobs"]["build-report"]["steps"]
+        if step.get("name") == "Render daily social post material"
+    )
+    assert "--social-output out/social.md" in social_step["run"]
+
+
 def test_questions_required_raises_without_a_flag_or_key(monkeypatch, tmp_path):
     monkeypatch.setenv("OPENAI_QUESTIONS_REQUIRED", "true")
     _stub_sources(monkeypatch, datetime.now(UTC))

--- a/tests/test_social.py
+++ b/tests/test_social.py
@@ -107,6 +107,21 @@ def test_parse_git_log_ties_files_to_the_right_commit_when_blank_precedes_files(
     ]
 
 
+def test_load_channels_daily_only_filters_launch_channels(tmp_path: Path):
+    path = tmp_path / "social.yml"
+    path.write_text(
+        "social:\n"
+        "  channels:\n"
+        "    - name: X / Twitter\n"
+        "      daily: true\n"
+        "    - name: DEV Community\n"
+        "      daily: false\n",
+        encoding="utf-8",
+    )
+    assert [c["name"] for c in load_channels(path, daily_only=True)] == ["X / Twitter"]
+    assert [c["name"] for c in load_channels(path)] == ["X / Twitter", "DEV Community"]
+
+
 def test_render_section_lists_every_channel_unchecked(tmp_path: Path):
     channels_path = tmp_path / "social.yml"
     channels_path.write_text(
@@ -148,6 +163,21 @@ def test_merge_checked_keeps_prior_ticks_and_leaves_new_channels_unchecked():
     assert "- [x] LinkedIn" in merged
     assert "- [ ] X / Twitter" in merged
     assert "- [ ] 知乎" in merged
+
+
+def test_merge_checked_keeps_ticks_for_escaped_channel_names():
+    # A channel named with a pipe renders escaped (\\|) in the issue body.
+    # extract_checked must unescape it so the tick survives the next render.
+    section = render_social_section(
+        "insight",
+        "repo change",
+        [],
+        [{"name": "Community | General"}, {"name": "LinkedIn"}],
+    )
+    existing = "## 🗣 Daily social post\n\n- [x] Community \\| General\n- [ ] LinkedIn\n"
+    merged = merge_checked(section, existing)
+    assert "- [x] Community \\| General" in merged
+    assert "- [ ] LinkedIn" in merged
 
 
 def test_extract_checked_only_reads_the_social_section():

--- a/tests/test_social.py
+++ b/tests/test_social.py
@@ -122,6 +122,18 @@ def test_load_channels_daily_only_filters_launch_channels(tmp_path: Path):
     assert [c["name"] for c in load_channels(path)] == ["X / Twitter", "DEV Community"]
 
 
+def test_load_channels_daily_only_keeps_everything_when_no_channel_sets_daily(tmp_path: Path):
+    path = tmp_path / "social.yml"
+    path.write_text(
+        "social:\n  channels:\n    - name: X / Twitter\n    - name: 知乎\n",
+        encoding="utf-8",
+    )
+    assert [c["name"] for c in load_channels(path, daily_only=True)] == [
+        "X / Twitter",
+        "知乎",
+    ]
+
+
 def test_render_section_lists_every_channel_unchecked(tmp_path: Path):
     channels_path = tmp_path / "social.yml"
     channels_path.write_text(

--- a/tests/test_social.py
+++ b/tests/test_social.py
@@ -1,0 +1,202 @@
+import json
+from pathlib import Path
+
+from benchmark_radar import cli
+from benchmark_radar.social import (
+    SECTION_HEADING,
+    GitChange,
+    build_insight_sentence,
+    extract_checked,
+    load_channels,
+    merge_checked,
+    parse_git_log,
+    render_social_section,
+    summarize_repo_changes,
+)
+
+
+def test_insight_sentence_names_the_top_signal():
+    items = [
+        {
+            "title": "A/Bench",
+            "source": "GitHub",
+            "total_score": 40.0,
+            "score_max": 100.0,
+        },
+        {
+            "title": "Top | Signal",
+            "source": "Hugging Face",
+            "total_score": 72.4,
+            "score_max": 100.0,
+        },
+    ]
+    sentence = build_insight_sentence(items)
+    assert "2 items across GitHub, Hugging Face" in sentence
+    assert "Top | Signal" in sentence
+    assert "Hugging Face, 72/100" in sentence
+
+
+def test_insight_sentence_empty():
+    assert "no new" in build_insight_sentence([])
+
+
+def test_repo_sentence_empty():
+    sentence, highlights = summarize_repo_changes([])
+    assert sentence == "No code changes in the last 24 hours."
+    assert highlights == []
+
+
+def test_repo_sentence_names_areas_by_human_labels():
+    changes = [
+        GitChange("Fix classifier", ("src/benchmark_radar/cli.py", "tests/test_cli.py")),
+        GitChange("Add feeds", ("data/model_cards.yml", "site/data/radar.json")),
+    ]
+    sentence, _ = summarize_repo_changes(changes)
+    assert sentence.startswith("2 commits in the last 24 hours")
+    assert "radar code" in sentence
+    assert "registry data" in sentence
+    assert "tests" in sentence
+
+
+def test_repo_sentence_hides_automated_and_merge_subjects_from_highlights():
+    changes = [
+        GitChange("Record daily radar snapshot", ("data/snapshots/2026-08-10.json",)),
+        GitChange("Merge pull request #177", ()),
+        GitChange("Fix source labeling", ("src/benchmark_radar/sources.py",)),
+    ]
+    sentence, highlights = summarize_repo_changes(changes)
+    assert sentence.startswith("3 commits")
+    assert highlights == ["Fix source labeling"]
+
+
+def test_parse_git_log_handles_commit_blocks():
+    text = (
+        "abc123\0Record daily radar snapshot\n"
+        "data/snapshots/2026-08-10.json\n"
+        "\n"
+        "def456\0Fix the classifier\n"
+        "src/benchmark_radar/cli.py\n"
+        "tests/test_cli.py\n"
+        "\n"
+    )
+    changes = parse_git_log(text)
+    assert changes == [
+        GitChange("Record daily radar snapshot", ("data/snapshots/2026-08-10.json",)),
+        GitChange("Fix the classifier", ("src/benchmark_radar/cli.py", "tests/test_cli.py")),
+    ]
+
+
+def test_parse_git_log_ties_files_to_the_right_commit_when_blank_precedes_files():
+    # Real `git log --name-only` output places the blank separator before the
+    # file list and emits nothing but the header for a no-diff merge commit.
+    # Files must land on the commit whose header they follow, not the previous
+    # one, or the repo-change sentence loses every area.
+    text = (
+        "abc123\0Merge pull request #1\n"
+        "def456\0Fix the classifier\n"
+        "\n"
+        "src/benchmark_radar/cli.py\n"
+        "ghi789\0Record daily radar snapshot\n"
+        "\n"
+        "data/snapshots/2026-08-10.json\n"
+    )
+    assert parse_git_log(text) == [
+        GitChange("Merge pull request #1", ()),
+        GitChange("Fix the classifier", ("src/benchmark_radar/cli.py",)),
+        GitChange("Record daily radar snapshot", ("data/snapshots/2026-08-10.json",)),
+    ]
+
+
+def test_render_section_lists_every_channel_unchecked(tmp_path: Path):
+    channels_path = tmp_path / "social.yml"
+    channels_path.write_text(
+        "social:\n  channels:\n    - name: X / Twitter\n    - name: 知乎\n",
+        encoding="utf-8",
+    )
+    section = render_social_section(
+        "insight",
+        "repo change",
+        [],
+        load_channels(channels_path),
+    )
+    assert SECTION_HEADING in section
+    assert "**Benchmark update:** insight" in section
+    assert "**Repo change:** repo change" in section
+    assert "- [ ] X / Twitter" in section
+    assert "- [ ] 知乎" in section
+    assert "- [x]" not in section
+
+
+def test_merge_checked_keeps_prior_ticks_and_leaves_new_channels_unchecked():
+    section = render_social_section(
+        "insight",
+        "repo change",
+        [],
+        [
+            {"name": "X / Twitter"},
+            {"name": "LinkedIn"},
+            {"name": "知乎"},
+        ],
+    )
+    existing = (
+        "# 📡 AI Benchmark & Data Radar\n\n"
+        "## 🗣 Daily social post\n\n"
+        "- [x] LinkedIn\n"
+        "- [ ] X / Twitter\n"
+    )
+    merged = merge_checked(section, existing)
+    assert "- [x] LinkedIn" in merged
+    assert "- [ ] X / Twitter" in merged
+    assert "- [ ] 知乎" in merged
+
+
+def test_extract_checked_only_reads_the_social_section():
+    body = (
+        "## At a glance\n\n- [x] Some checklist elsewhere\n\n"
+        "## 🗣 Daily social post\n\n"
+        "- [x] LinkedIn\n- [ ] X / Twitter\n"
+    )
+    assert extract_checked(body) == {"LinkedIn"}
+
+
+def test_social_command_writes_section(monkeypatch, tmp_path: Path):
+    items_path = tmp_path / "items.json"
+    items_path.write_text(
+        json.dumps(
+            {
+                "evidence_items": [
+                    {
+                        "title": "A/Bench",
+                        "source": "GitHub",
+                        "total_score": 55.0,
+                        "score_max": 100.0,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    channels_path = tmp_path / "social.yml"
+    channels_path.write_text(
+        "social:\n  channels:\n    - name: X / Twitter\n    - name: LinkedIn\n",
+        encoding="utf-8",
+    )
+    output = tmp_path / "social.md"
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "benchmark-radar",
+            "social",
+            "--items",
+            str(items_path),
+            "--channels",
+            str(channels_path),
+            "--social-output",
+            str(output),
+        ],
+    )
+    cli.main()
+    body = output.read_text(encoding="utf-8")
+    assert SECTION_HEADING in body
+    assert "1 item across GitHub" in body
+    assert "- [ ] X / Twitter" in body

--- a/tests/test_social.py
+++ b/tests/test_social.py
@@ -142,6 +142,27 @@ def test_render_section_lists_every_channel_unchecked(tmp_path: Path):
     assert "- [x]" not in section
 
 
+def test_render_section_includes_the_copy_paste_post_sample():
+    section = render_social_section(
+        "insight",
+        "repo change",
+        [],
+        [{"name": "LinkedIn"}],
+        post_sample=(
+            "一个反常识的发现：样本。\n"
+            "源码和分析详见：https://github.com/ktwu01/benchmark-radar/issues/150"
+        ),
+    )
+    assert "**发布文案示例** (copy-paste for today's post):" in section
+    assert "一个反常识的发现：样本。" in section
+    assert "issues/150" in section
+
+
+def test_render_section_omits_post_sample_when_none_configured():
+    section = render_social_section("insight", "repo change", [], [{"name": "LinkedIn"}])
+    assert "**发布文案示例**" not in section
+
+
 def test_merge_checked_keeps_prior_ticks_and_leaves_new_channels_unchecked():
     section = render_social_section(
         "insight",
@@ -208,7 +229,12 @@ def test_social_command_writes_section(monkeypatch, tmp_path: Path):
     )
     channels_path = tmp_path / "social.yml"
     channels_path.write_text(
-        "social:\n  channels:\n    - name: X / Twitter\n    - name: LinkedIn\n",
+        "social:\n"
+        "  post_sample: |-\n"
+        "    一个反常识的发现：样本。\n"
+        "  channels:\n"
+        "    - name: X / Twitter\n"
+        "    - name: LinkedIn\n",
         encoding="utf-8",
     )
     output = tmp_path / "social.md"
@@ -230,3 +256,4 @@ def test_social_command_writes_section(monkeypatch, tmp_path: Path):
     assert SECTION_HEADING in body
     assert "1 item across GitHub" in body
     assert "- [ ] X / Twitter" in body
+    assert "一个反常识的发现：样本。" in body


### PR DESCRIPTION
## What

Adds the daily social posting workflow from issue #88 to the radar's daily run. Since the dashboard and `site/feed.xml` already cover the reading surface (issue #37), the daily GitHub Issue is retired: `publish-issue` is removed from `daily-radar.yml`, and `build-report` now renders the posting material deterministically into `out/social.md` inside the evidence artifact.

Each day's `out/social.md` carries:

- **Benchmark update:** one factual sentence read off the day's merged evidence (`out/items.json`), e.g. "Today's radar surfaced 236 items across GitHub, Hugging Face, Semantic Scholar, OpenAlex; top signal: ...".
- **Repo change:** one sentence summarizing the last 24 hours of git history ("N commits across radar code, registry data, ..."), plus up to three recent commit subjects.
- **发布文案示例:** a ready-to-copy Chinese post sample read from `post_sample` in `config/social.yml`, anchored to the L0-L5 analysis at issue #150.
- **Posting checklist:** a `- [ ]` per-channel list from `config/social.yml`, now the user's real posting surface: 18 WeChat groups (WeChat Moment through TB Sci) plus the platform channels, with 即刻 removed. Pipe-named `HLE V2 | Core` escapes correctly; ticks survive re-renders via `--existing-body`.

The `benchmark-radar social` subcommand renders everything deterministically (never by a model), so it works even when the GPT briefing fails. Channel list and post sample are editable in `config/social.yml`.

## Why

Issue #88's first-post checklist listed 20+ channels. The user posts daily and wants, per day: a simple benchmark-insight sentence, a simple repo-change sentence, a copy-paste 发布文案, and a checkable per-channel list. The daily Issue that once carried this was closed because feed.xml + the GUI display cover the reading surface.

## What changed

- `src/benchmark_radar/social.py` (new): insight + repo-change sentences, git-log parsing, section render, tick preservation (`merge_checked`).
- `src/benchmark_radar/cli.py`: new `social` subcommand, dispatched before the radar config load.
- `config/social.yml` (new): default channel list (incl. 18 WeChat groups) and `post_sample`.
- `.github/workflows/daily-radar.yml`: `publish-issue` removed; `build-report` renders `out/social.md`; checkout fetches full history.
- `out/items.json` now carries the merged UTC-day union so a same-day rerun does not shrink the day's evidence.
- `tests/test_social.py`, `tests/test_cli.py` (new coverage incl. the merged-day items.json test).

## Verification

- `ruff check .` and `ruff format --check .` clean.
- `pytest -q`: 674 passed.
- Smoke-tested `benchmark-radar social` against real repo history, the pipe channel, and tick re-application.
- Independent opencode-agent review: APPROVE WITH NITS; all flagged gaps closed in follow-up commits.