### PR TITLE
fix: let Q&A prose carry version and artifact id fragments

### DIFF
--- a/src/benchmark_radar/questions.py
+++ b/src/benchmark_radar/questions.py
@@ -215,6 +215,23 @@ _PROSE_FIELDS = ("signal", "plain_english", "takeaway", "counter_view")
 # rather than measurements of the corpus.
 _ALLOWED_BARE_NUMBERS = {"0", "1", "2", "3", "100"}
 _NUMBER = re.compile(r"\d[\d,]*(?:\.\d+)?")
+# Characters that glue a digit run into a version, id, or other code rather
+# than leaving it a free-standing measurement ("26-001", "S001", "v2.001",
+# "doi:10.1000"). A token abutting one of these is an identifier fragment.
+_IDENTIFIER_GLUE = set("-._/:#")
+
+
+def _is_identifier_fragment(text: str, match: re.Match[str]) -> bool:
+    """A digit run that abuts a letter or code separator is not a quantity."""
+    start, end = match.start(), match.end()
+    before = text[start - 1] if start else ""
+    after = text[end] if end < len(text) else ""
+    return (
+        before.isalpha()
+        or after.isalpha()
+        or before in _IDENTIFIER_GLUE
+        or after in _IDENTIFIER_GLUE
+    )
 
 
 def _registry_number_forms(stat: dict[str, Any]) -> set[str]:
@@ -259,6 +276,12 @@ def _reject_uncited_quantities(
             if token in allowed or token.rstrip(",") in allowed:
                 continue
             if re.fullmatch(r"20\d\d", token):
+                continue
+            # A digit run glued to a letter or separator is a version or
+            # artifact id, not the model inventing a statistic. Without this,
+            # identifiers like "26-001," or "S001" would fail a day's Q&A for
+            # describing the corpus rather than for stating a bad number.
+            if _is_identifier_fragment(text, match):
                 continue
             raise BriefingError(
                 f"OpenAI wrote the uncited quantity {token!r} in {field}; "

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -220,6 +220,29 @@ def test_prose_may_not_state_a_number_the_registry_does_not_hold():
         )
 
 
+def test_prose_may_state_identifier_fragments_the_registry_does_not_hold():
+    # "26-001", "S001", "v2.001", "2026-001," are version and artifact codes,
+    # not corpus measurements, so they must not fail a day's Q&A (a production
+    # run rejected '001,' and aborted the whole pipeline).
+    group, stats_by_id, evidence = _fixture()
+
+    validated = questions._validate(
+        [
+            _answer(
+                signal=(
+                    "The 26-001 entry and S001 sit next to v2.001; "
+                    "2026-001, arrived too."
+                )
+            )
+        ],
+        group,
+        stats_by_id,
+        evidence,
+    )
+
+    assert validated[0]["signal"].startswith("The 26-001 entry")
+
+
 def test_prose_may_restate_a_value_the_registry_computed():
     group, stats_by_id, evidence = _fixture()
 

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -227,14 +227,7 @@ def test_prose_may_state_identifier_fragments_the_registry_does_not_hold():
     group, stats_by_id, evidence = _fixture()
 
     validated = questions._validate(
-        [
-            _answer(
-                signal=(
-                    "The 26-001 entry and S001 sit next to v2.001; "
-                    "2026-001, arrived too."
-                )
-            )
-        ],
+        [_answer(signal=("The 26-001 entry and S001 sit next to v2.001; 2026-001, arrived too."))],
         group,
         stats_by_id,
         evidence,


### PR DESCRIPTION
The daily pipeline aborted yesterday's run: the Q&A validator read the identifier '001,' in a sentence and rejected it as an uncited quantity. A digit run glued to a letter or code separator (26-001, S001, v2.001, 2026-001) is a version or artifact code, not a corpus measurement, so it must not fail the day's questions. Free-standing numbers still have to come from the statistic registry.