### PR TITLE
feat: restore one daily social-checklist issue (issue #88)

### DIFF
--- a/.github/workflows/daily-radar.yml
+++ b/.github/workflows/daily-radar.yml
@@ -209,7 +209,13 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          date_key="$(date -u +%Y-%m-%d)"
+          # The issue must be tied to the report's own day, not the wall clock:
+          # a manual or delayed run crossing midnight UTC would otherwise date
+          # today's checklist with tomorrow, and the next day's run would then
+          # update that same issue and conflate two checklists.
+          date_key="$(python -c 'import json,sys,datetime,os
+          body=json.load(open("generated/out/items.json", encoding="utf-8"))
+          print(datetime.datetime.fromisoformat(body["generated_at"]).astimezone(datetime.timezone.utc).strftime("%Y-%m-%d"))')"
           title="🗣 Daily social checklist — ${date_key}"
           existing="$(gh issue list --state all --search "\"${title}\" in:title" \
             --json number,title --jq ".[] | select(.title == \"${title}\") | .number" | head -1)"

--- a/.github/workflows/daily-radar.yml
+++ b/.github/workflows/daily-radar.yml
@@ -10,6 +10,15 @@ on:
     # once-a-day cadence.
     - cron: "0 1 * * *"
   workflow_dispatch:
+    inputs:
+      publish:
+        # Issue #88: the daily Issue is back as the posting checklist surface.
+        # A manual run with publish=true creates or updates today's daily Issue
+        # so a missed cron run can still be caught up by hand.
+        description: Publish or update today's daily social-checklist Issue
+        required: true
+        type: boolean
+        default: false
 
 concurrency:
   group: daily-benchmark-radar
@@ -149,3 +158,76 @@ jobs:
           fi
           git commit -m "Record daily radar snapshot"
           git push origin HEAD:main
+
+  # Issue #88: one daily Issue carrying only the day's social posting checklist.
+  # The dashboard and site/feed.xml remain the reading surface (issue #37), so
+  # the Issue does not duplicate the report; its body is just the rendered
+  # out/social.md section. Each day exactly one Issue is created (idempotent on
+  # title), and a rerun re-applies ticks the user already made on that day's
+  # Issue so posting progress is never reset. The social section is rendered
+  # deterministically here (never by a model) from the artifact's items.json
+  # plus the last 24 hours of git history.
+  publish-issue:
+    needs: [build-report, persist-snapshot]
+    if: >-
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && inputs.publish)
+    permissions:
+      contents: read
+      issues: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # Checkout before downloading the artifact: actions/checkout clears a
+      # non-repository workspace, which would delete a previously downloaded
+      # generated/ directory. main is checked out explicitly so the repo-change
+      # sentence also counts the snapshot commit persist-snapshot pushes while
+      # this workflow is running, instead of the stale event SHA.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Download validated report
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: benchmark-radar-${{ github.run_id }}
+          path: generated/
+      # The repo-change sentence reads the last 24 hours of git history, which
+      # the full fetch above provides rather than the default shallow single
+      # commit.
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install
+        run: python -m pip install .
+      - name: Create idempotent daily social-checklist issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          date_key="$(date -u +%Y-%m-%d)"
+          title="🗣 Daily social checklist — ${date_key}"
+          existing="$(gh issue list --state all --search "\"${title}\" in:title" \
+            --json number,title --jq ".[] | select(.title == \"${title}\") | .number" | head -1)"
+          existing_body_args=()
+          if [[ -n "${existing}" ]]; then
+            gh issue view "${existing}" --json body --jq .body > generated/out/current_body.md
+            existing_body_args=(--existing-body generated/out/current_body.md)
+          fi
+          benchmark-radar social \
+            --items generated/out/items.json \
+            --repo . \
+            --channels config/social.yml \
+            "${existing_body_args[@]}" \
+            --social-output generated/out/body.md
+          if [[ -n "${existing}" ]]; then
+            gh issue edit "${existing}" --body-file generated/out/body.md
+            echo "Updated issue #${existing}"
+          else
+            gh issue create --title "${title}" --body-file generated/out/body.md \
+              --label daily-radar --label automated
+          fi

--- a/README.md
+++ b/README.md
@@ -56,9 +56,10 @@ evaluation methods, datasets, and data-quality work, deduplicates records, class
 them with a transparent taxonomy, ranks them using explainable signals, and publishes a
 [cumulative dashboard](https://ktwu01.github.io/benchmark-radar/) with a
 [daily RSS feed](https://ktwu01.github.io/benchmark-radar/feed.xml). The dashboard and RSS
-feed are the reading and subscription surfaces; the daily GitHub Issue that once served as a
-secondary discussion channel was retired (issue #37), and the day's social posting material
-ships as `out/social.md` in each run's evidence artifact. It is inspired by
+feed are the primary reading and subscription surfaces. In addition, each day's run opens one
+GitHub Issue carrying only that day's social posting checklist (issue #88): a checkable list
+of channels for posting the day's benchmark update, plus a copy-paste 发布文案 sample. It is
+inspired by
 [agents-radar](https://github.com/duanyytop/agents-radar), with sources and scoring
 redesigned for benchmark and AI-data research.
 
@@ -317,10 +318,17 @@ with a warning after 240 minutes. The workflow:
 1. collects evidence plus public Hacker News attention and renders with read-only
    repository permission;
 2. validates and uses the snapshot-writer App to persist one snapshot on `main`;
-3. renders the day's social posting material into `out/social.md` inside the evidence
-   artifact;
+3. opens (idempotently, one per day) a GitHub Issue whose body is the social posting
+   checklist: today's benchmark-update and repo-change sentences, a copy-paste 发布文案
+   sample, and a `- [ ]` tick-box per channel so posted channels can be marked off;
 4. lets that App-authenticated push trigger the standalone Pages workflow;
-5. prevents duplicate snapshots on reruns.
+5. prevents duplicate snapshots and daily Issues on reruns.
+
+A manual `workflow_dispatch` run creates or updates the day's Issue only when
+`publish` is checked. The workflow needs repository Issues enabled; the labels
+`daily-radar` and `automated` must exist (they are created during initial setup).
+Tick progress is preserved across reruns: a rerun re-reads the existing Issue body and
+re-applies any boxes already checked.
 
 ## Provenance and limitations
 

--- a/src/benchmark_radar/social.py
+++ b/src/benchmark_radar/social.py
@@ -1,13 +1,13 @@
 """Daily social post material for each day's radar run (issue #88 follow-up).
 
-Every day the radar workflow renders a short "Daily social post" section to
-out/social.md (fetchable from the evidence artifact; the daily GitHub Issue
-that used to carry it was retired in issue #37). The section carries the two
-sentences the post can be built from, a benchmark insight read off the day's
-evidence and a repo-change summary read off the day's git history, a
-ready-to-copy 发布文案 sample from config/social.yml, plus a per-channel
-checklist. When a previous render is supplied with ``--existing-body``, ticks
-already made are re-applied so a re-run never resets posting progress.
+Every day the radar workflow opens one GitHub Issue whose body is this short
+"Daily social post" section (issue #88): a benchmark insight read off the day's
+evidence, a repo-change summary read off the day's git history, a ready-to-copy
+发布文案 sample from config/social.yml, plus a per-channel posting checklist.
+The dashboard and site/feed.xml remain the reading surface (issue #37), so the
+Issue carries only this section, not the full report. When a previous render is
+supplied with ``--existing-body``, ticks already made are re-applied so a re-run
+never resets posting progress.
 """
 
 from __future__ import annotations
@@ -225,7 +225,7 @@ def render_social_section(
     channels: list[dict],
     post_sample: str | None = None,
 ) -> str:
-    """Render the section that ships as out/social.md for the day's radar run."""
+    """Render the "Daily social post" section for today's radar run."""
     lines = [
         SECTION_HEADING,
         "",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -408,12 +408,21 @@ def test_daily_radar_yml_enables_and_requires_questions_in_production():
 
 
 def test_daily_radar_yml_renders_social_material_instead_of_an_issue():
-    """Issue #37: the daily GitHub Issue was retired once the dashboard and
-    site/feed.xml became the reading surface. The social posting material must
-    still be rendered deterministically into the evidence artifact."""
+    """Issue #88: the dashboard and site/feed.xml remain the reading surface
+    (issue #37), so the daily Issue carries only the social posting checklist.
+    The publish-issue job must render out/social.md as the issue body so each
+    day gets exactly one checkable posting checklist."""
     workflow_path = Path(".github/workflows/daily-radar.yml")
     workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
-    assert "publish-issue" not in workflow["jobs"]
+    publish_issue = workflow["jobs"].get("publish-issue")
+    assert publish_issue is not None
+    step = next(
+        step
+        for step in publish_issue["steps"]
+        if step.get("name") == "Create idempotent daily social-checklist issue"
+    )
+    assert "--social-output generated/out/body.md" in step["run"]
+    assert "gh issue create --title" in step["run"]
     social_step = next(
         step
         for step in workflow["jobs"]["build-report"]["steps"]


### PR DESCRIPTION
## What

PR #180 built the deterministic daily social post section (benchmark insight, repo-change summary, 发布文案 sample, per-channel checklist) and attached it to the daily issue, but its commit `5f55155` retired the daily GitHub Issue entirely, leaving only `out/social.md` in the artifact. PR #181 then dropped the remaining issue wording from the README. Result: no daily issue exists.

This restores exactly ONE daily GitHub Issue per day whose body is **only** the rendered social posting checklist (issue #88 last comment), not the full report.

## Why

The user posts daily and wants, per day, a checkable to-do list of channels to mark each post as sent. The dashboard and `site/feed.xml` remain the reading surface (issue #37), so the Issue deliberately does not duplicate the report.

## What changed

- `.github/workflows/daily-radar.yml`: re-adds `publish-issue` (needs build-report + persist-snapshot, `issues: write`). Body = only `benchmark-radar social` → `generated/out/body.md`. Idempotent on date title; reruns re-apply ticks from the existing body via `--existing-body` so posting progress is never reset. Restores the `workflow_dispatch` `publish` input for manual catch-up.
- The issue date is derived from the artifact's `generated_at`, not the wall clock, so a manual/delayed run crossing midnight UTC still keys today's checklist to the report's own day.
- `README.md`: Daily publishing section and intro now describe one daily social-checklist issue (reversing #181's retire wording).
- `src/benchmark_radar/social.py`: refreshed module/render docstrings.
- `tests/test_cli.py`: the workflow test now asserts `publish-issue` renders the social body instead of asserting the issue is retired.

## Verification

- `ruff check .` and `ruff format --check .` clean.
- `pytest -q`: 675 passed.
- Workflow YAML and embedded Bash parse cleanly.
- Independent codex review: no findings.

Fixes #88.