### PR TITLE
fix: default workflow_dispatch publish to true (issue #88)

### DIFF
--- a/.github/workflows/daily-radar.yml
+++ b/.github/workflows/daily-radar.yml
@@ -13,12 +13,12 @@ on:
     inputs:
       publish:
         # Issue #88: the daily Issue is back as the posting checklist surface.
-        # A manual run with publish=true creates or updates today's daily Issue
-        # so a missed cron run can still be caught up by hand.
+        # Default to true so a plain manual dispatch still creates or updates
+        # today's Issue; opting out is the explicit minority case.
         description: Publish or update today's daily social-checklist Issue
         required: true
         type: boolean
-        default: false
+        default: true
 
 concurrency:
   group: daily-benchmark-radar


### PR DESCRIPTION
A plain manual dispatch (no inputs) previously fell back to publish=false, so publish-issue would not run and no daily social-checklist Issue would be created, defeating the manual catch-up path. Default the publish input to true so any manual run creates or updates today's Issue.

- YAML parses; default resolves to true.
- Existing publish-job condition unchanged and correctly consumes the boolean.
- codex review: clean.