### PR TITLE
fix: correct under-counted single-adopter benchmarks (issue #99)

### DIFF
--- a/data/model_cards.yml
+++ b/data/model_cards.yml
@@ -876,6 +876,12 @@ model_cards:
       - tau_bench
       - livecodebench
       - mrcr
+      # HealthBench (§3.10 Health) and MLE-Bench (§5.1.3.3 AI Self-Improvement)
+      # are both evaluated explicitly in this card, read from the arXiv PDF
+      # (2601.03267). Both are OpenAI-authored instruments, which is why the
+      # card is their most complete single source.
+      - healthbench
+      - mle_bench
 
   - id: openai_o3_o4_mini_system_card
     organization: OpenAI
@@ -986,6 +992,11 @@ model_cards:
       - mmmu
       - mathvista
       - drop
+      # ChartQA and DocVQA: state-of-the-art claim in the abstract and explicit
+      # zero-shot evaluations in the Charts & Documents table (Table 18), with
+      # ANLS reported for DocVQA. Read from the arXiv PDF (2403.05530).
+      - chartqa
+      - docvqa
 
   # Benchmarks read from the Maverick instruction-tuned comparison table
   # published in this post, not from the surrounding prose. ChartQA, DocVQA,


### PR DESCRIPTION
## What

Four of the six "probably under-counted" single-adopter benchmarks in issue #99 had their edges already sitting in the registry but unlinked. I verified each by reading the actual document and added the edge:

- **google_gemini_1_5_report** += `chartqa`, `docvqa` — the abstract claims SOTA on both and Table 18 has explicit 0-shot evaluations (7 DocVQA / 13 ChartQA mentions in arXiv PDF 2403.05530).
- **openai_gpt_5_system_card** += `healthbench`, `mle_bench` — §3.10 Health reports HealthBench, §5.1.3.3 reports MLE-Bench (arXiv 2601.03267).

All four move from 1 to 2 adopters. Chronology holds (both benchmarks predate their cards). `chatbot_arena` and `livebench` remain single-adopter — I could not verify any already-tracked card document reports them, so they are left untouched rather than guessed.

## Verification
- `benchmark-radar rebuild` succeeds.
- `pytest -q`: 675 passed.
- `ruff check .` clean.
- Independent codex review: no findings.

Closes #99.