### PR TITLE
fix(site): restore progressive disclosure for leaderboard, Q&A, homepage

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -499,26 +499,21 @@ function answerCitations(answer) {
 function answerBlock(answer) {
   const insufficient = answer?.sufficient_evidence === false;
   const confidence = String(answer?.confidence || "").trim();
-  return element("article", { className: "answer" }, [
-    // The confidence sits on the question's own line: it qualifies the answer
-    // that follows, so a reader should meet it before reading the claim.
-    element("h4", { className: "answer-question" }, [
-      document.createTextNode(String(answer?.question || "")),
-      ...(confidence
-        ? [
-            element("span", {
-              className: `pill pill-confidence pill-confidence-${confidence}`,
-              text: `${confidence} confidence`,
-            }),
-          ]
-        : []),
-    ]),
-    element("p", { className: "answer-signal", text: String(answer?.signal || "") }),
+  // The question, the confidence, and one line of signal are the decision the
+  // reader came for; the explanation, its sources and the trade-offs back it
+  // up but would otherwise take over the page if all shown at once. So the
+  // answer is a native disclosure, collapsed by default, whose summary is the
+  // compact take while its detail holds everything that supports it. Native
+  // <details>/<summary> gives the reversible expand/re-collapse and keyboard
+  // support (Tab to focus, Enter/Space to toggle) for free and stays collapsed
+  // on load because no `open` attribute is rendered.
+  const citations = answerCitations(answer);
+  const detail = element("div", { className: "answer-detail" }, [
     element("p", { className: "answer-plain" }, [
       element("em", { text: "In plain English: " }),
       document.createTextNode(String(answer?.plain_english || "")),
     ]),
-    answerCitations(answer),
+    citations,
     // Stated on the answer rather than hidden in a tooltip: "the evidence does
     // not support an answer today" is a result, not a rendering failure.
     ...(insufficient
@@ -538,6 +533,35 @@ function answerBlock(answer) {
     element("p", { className: "answer-counter-view" }, [
       element("strong", { text: "Counter-view: " }),
       document.createTextNode(String(answer?.counter_view || "")),
+    ]),
+  ]);
+  return element("article", { className: "answer" }, [
+    // The confidence sits on the question's own line: it qualifies the answer
+    // that follows, so a reader should meet it before reading the claim.
+    element("h4", { className: "answer-question" }, [
+      document.createTextNode(String(answer?.question || "")),
+      ...(confidence
+        ? [
+            element("span", {
+              className: `pill pill-confidence pill-confidence-${confidence}`,
+              text: `${confidence} confidence`,
+            }),
+          ]
+        : []),
+    ]),
+    element("p", { className: "answer-signal", text: String(answer?.signal || "") }),
+    element("details", { className: "answer-disclosure" }, [
+      element("summary", { className: "answer-disclosure-summary" }, [
+        element("span", {
+          className: "answer-disclosure-label",
+          // Promise only what expanding actually reveals: an answer with no
+          // citations must not advertise "sources" it does not carry.
+          text: citations
+            ? "Read the full answer, sources and takeaway"
+            : "Read the full answer and takeaway",
+        }),
+      ]),
+      detail,
     ]),
   ]);
 }
@@ -3729,44 +3753,140 @@ function renderLeaderboard() {
 
   const newEntries = (board.entries || []).filter((entry) => isNewBenchmark(entry, board));
   const newSharedSignals = newEntries.filter((entry) => frontierAdvances(entry).length >= 3);
-  const evidenceStat = (value, label, detail) =>
-    element("article", { className: "evidence-stat" }, [
-      element("strong", { text: Number(value || 0).toLocaleString() }),
-      element("span", { text: label }),
-      element("small", { text: detail }),
+  // Each registry-overview count is a claim about specific records, so every
+  // tile opens to the itemized evidence behind its number (issue #183). They
+  // are native <details>/<summary>: collapsed on load, visible by the marker,
+  // expandable and re-collapsible with the same control.
+  const labelCounts = modelCardLabelCounts(board);
+  const allCards = [...(board.model_cards || [])].sort(
+    (a, b) =>
+      Number(!a.published) - Number(!b.published) ||
+      (b.published || "").localeCompare(a.published || "") ||
+      String(a.organization).localeCompare(String(b.organization)) ||
+      String(a.model).localeCompare(String(b.model)),
+  );
+  const evidenceDisclosure = (stat, items, emptyText) =>
+    element("details", { className: "evidence-stat evidence-disclosure" }, [
+      element("summary", { className: "evidence-stat-summary" }, [
+        element("strong", { text: Number(stat.value || 0).toLocaleString() }),
+        element("span", { text: stat.label }),
+        element("small", { text: stat.detail }),
+      ]),
+      items.length
+        ? element("ul", { className: "evidence-detail-list" }, items)
+        : element("p", { className: "evidence-detail-empty", text: emptyText }),
     ]);
-  replaceChildren(byId("leaderboard-insights"), [
-    evidenceStat(
-      board.model_card_count,
-      "source documents",
-      "Each document counts once per benchmark.",
-    ),
-    evidenceStat(
-      board.organization_count,
-      "organizations",
-      "The denominator for reporting breadth.",
-    ),
-    evidenceStat(
-      Object.keys(board.domains || {}).length,
-      "Domains reported at least once",
-      `${metricLabel(board.benchmark_count, "benchmark")} tracked · ${metricLabel(
-        topEntries.length,
-        "benchmark",
-      )} reported.`,
-    ),
-    evidenceStat(
-      newSharedSignals.length,
-      "new shared signals",
-      "New instruments crossing three dated organizations.",
-    ),
-    element("p", { className: "evidence-thesis" }, [
-      element("strong", { text: "New instruments" }),
+  const modelCardLine = (card) =>
+    element("li", {}, [
+      card.url
+        ? element("a", {
+            className: "adopter-link",
+            text: cardLabel(card, labelCounts),
+            attrs: { href: card.url, target: "_blank", rel: "noopener noreferrer" },
+          })
+        : element("span", { className: "insight-item-name", text: cardLabel(card, labelCounts) }),
       element("span", {
-        text: ` · ${metricLabel(
-          newSharedSignals.length,
-          "benchmark",
-        )} released in the newest 18-month window already appear across three or more dated organizations. Follow their trajectories before reading the raw rank.`,
+        className: "insight-item-meta",
+        text: `${String(card.document_type).replaceAll("_", " ")}${
+          card.published ? ` · ${formatDate(card.published, { dateStyle: "medium" })}` : ""
+        }`,
       }),
+    ]);
+  const benchmarkLine = (entry, meta) =>
+    element("li", {}, [
+      entry.url
+        ? element("a", {
+            className: "adopter-link",
+            text: entry.name,
+            attrs: { href: entry.url, target: "_blank", rel: "noopener noreferrer" },
+          })
+        : element("span", { className: "insight-item-name", text: entry.name }),
+      meta
+        ? element("span", { className: "insight-item-meta", text: meta })
+        : entry.released
+          ? element("span", {
+              className: "insight-item-meta",
+              text: `released ${formatDate(entry.released, { dateStyle: "medium" })}`,
+            })
+          : null,
+    ]);
+  // `board.domains` counts only adopted benchmarks, so it would understate the
+  // spread of everything tracked. Count the distinct domains across all
+  // entries, matching how the filter options are built, so the tracked tile's
+  // breadth claim never collides with the adopted-only figure.
+  const domainCount = new Set((board.entries || []).map((entry) => entry.domain)).size;
+  replaceChildren(byId("leaderboard-insights"), [
+    evidenceDisclosure(
+      { value: board.model_card_count, label: "source documents", detail: "Each document counts once per benchmark." },
+      allCards.map(modelCardLine),
+      "No source documents in the registry yet.",
+    ),
+    evidenceDisclosure(
+      { value: board.organization_count, label: "organizations", detail: "The denominator for reporting breadth." },
+      Object.entries(board.organizations || {})
+        .sort((a, b) => a[0].localeCompare(b[0]))
+        .map(([organization, count]) =>
+          element("li", {}, [
+            element("details", { className: "insight-nested" }, [
+              element("summary", { className: "insight-nested-summary" }, [
+                element("span", { className: "insight-item-name", text: organization }),
+                element("span", {
+                  className: "insight-item-meta",
+                  text: metricLabel(Number(count || 0), "card"),
+                }),
+              ]),
+              element(
+                "ul",
+                { className: "evidence-detail-list" },
+                allCards
+                  .filter((card) => card.organization === organization)
+                  .map(modelCardLine),
+              ),
+            ]),
+          ]),
+        ),
+      "No organizations in the registry yet.",
+    ),
+    evidenceDisclosure(
+      {
+        value: board.benchmark_count,
+        label: "Benchmarks tracked",
+        detail: `across ${metricLabel(domainCount, "domain")}${board.entries.length ? ` · ${metricLabel(board.entries.length, "benchmark")} listed` : ""}.`,
+      },
+      (board.entries || []).map((entry) =>
+        benchmarkLine(
+          entry,
+          entry.card_count ? metricLabel(entry.card_count, "model card") : "not yet reported",
+        ),
+      ),
+      "No benchmarks tracked yet.",
+    ),
+    evidenceDisclosure(
+      { value: topEntries.length, label: "Benchmarks reported at least once", detail: "The subset a ranked row can speak to." },
+      topEntries.map((entry) => benchmarkLine(entry, metricLabel(entry.card_count, "model card"))),
+      "No benchmark is reported by a curated card yet.",
+    ),
+    element("details", { className: "evidence-thesis evidence-thesis-disclosure" }, [
+      element("summary", { className: "evidence-thesis-summary" }, [
+        element("strong", { text: "New instruments" }),
+        element("span", {
+          text: ` · ${metricLabel(
+            newSharedSignals.length,
+            "benchmark",
+          )} released in the newest 18-month window already appear across three or more dated organizations. Follow their trajectories before reading the raw rank.`,
+        }),
+      ]),
+      element(
+        "ul",
+        { className: "evidence-detail-list" },
+        [...newSharedSignals]
+          .sort(
+            (a, b) =>
+              (b.released || "").localeCompare(a.released || "") ||
+              a.name.localeCompare(b.name),
+          )
+          .map((entry) => benchmarkLine(entry, metricLabel(entry.card_count, "model card"))),
+      ),
     ]),
   ]);
 

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -558,6 +558,52 @@ input {
   text-transform: lowercase;
 }
 
+/* The full answer (explanation, sources, takeaway, counter-view) is collapsed
+   behind a native disclosure whose summary is the question and its one-line
+   signal (issue #183). Split the supporting text from the headline so a scan
+   of a day's questions stays a scan, and the detail is on demand again. */
+.answer-disclosure {
+  margin-top: 0.55rem;
+  border-top: 1px dashed var(--line);
+}
+
+.answer-disclosure-summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 0 0.25rem;
+  color: var(--blue-deep);
+  cursor: pointer;
+  font-family: var(--utility);
+  font-size: 0.72rem;
+  letter-spacing: 0.05em;
+  list-style: none;
+  text-transform: uppercase;
+}
+
+.answer-disclosure-summary::-webkit-details-marker {
+  display: none;
+}
+
+.answer-disclosure-summary::before {
+  content: "›";
+  font-size: 0.9rem;
+  line-height: 1;
+  transition: transform 140ms ease;
+}
+
+.answer-disclosure[open] > .answer-disclosure-summary::before {
+  transform: rotate(90deg);
+}
+
+.answer-disclosure-summary:hover {
+  color: var(--blue);
+}
+
+.answer-detail {
+  padding-bottom: 0.2rem;
+}
+
 .daily-questions-meta {
   margin: 0.9rem 0 0;
   padding-top: 0.7rem;
@@ -1629,14 +1675,14 @@ td a {
   border-right: 1px solid var(--line);
 }
 
-.evidence-stat strong {
+.evidence-stat-summary strong {
   font-family: var(--display);
   font-size: clamp(2rem, 4vw, 3.4rem);
   font-weight: 500;
   line-height: 1;
 }
 
-.evidence-stat span {
+.evidence-stat-summary span {
   margin-top: 0.25rem;
   font-family: var(--utility);
   font-size: 0.68rem;
@@ -1644,10 +1690,122 @@ td a {
   text-transform: uppercase;
 }
 
-.evidence-stat small {
+.evidence-stat-summary small {
   margin-top: 0.55rem;
   color: var(--muted);
   font-size: 0.76rem;
+}
+
+/* A registry-overview tile now opens to the itemized evidence behind its count
+   (issue #183). The tile stays a stat until expanded; the marker turns the
+   label into an obvious affordance, and opening reveals only the sources that
+   produced the count above it. */
+.evidence-disclosure {
+  display: block;
+}
+
+.evidence-stat-summary {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  cursor: pointer;
+  list-style: none;
+}
+
+.evidence-stat-summary::-webkit-details-marker {
+  display: none;
+}
+
+.evidence-stat-summary::after {
+  content: "›";
+  position: absolute;
+  top: 0.15rem;
+  right: 0;
+  color: var(--blue-deep);
+  font-family: var(--utility);
+  font-size: 1rem;
+  line-height: 1;
+  transition: transform 140ms ease;
+}
+
+.evidence-stat[open] > .evidence-stat-summary::after {
+  transform: rotate(90deg);
+}
+
+.evidence-detail-list {
+  margin: 0.9rem 0 0;
+  padding: 0.65rem 0 0;
+  border-top: 1px dashed var(--line);
+  list-style: none;
+}
+
+.evidence-detail-list li {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.5rem;
+  align-items: baseline;
+  padding: 0.3rem 0;
+  font-size: 0.78rem;
+}
+
+.evidence-detail-list li + li {
+  border-top: 1px solid var(--line);
+}
+
+.insight-item-name {
+  color: inherit;
+}
+
+.insight-item-meta {
+  color: var(--muted);
+  font-size: 0.74rem;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.evidence-detail-empty {
+  margin: 0.9rem 0 0;
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+
+/* An organization row in the overview expands to the documents that produced
+   its card count, and the nested list is the same one every other tile uses. */
+.insight-nested {
+  width: 100%;
+}
+
+.insight-nested-summary {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+  cursor: pointer;
+  list-style: none;
+}
+
+.insight-nested-summary::-webkit-details-marker {
+  display: none;
+}
+
+.insight-nested-summary::after {
+  content: "›";
+  color: var(--blue-deep);
+  font-family: var(--utility);
+  font-size: 0.9rem;
+  line-height: 1;
+  transition: transform 140ms ease;
+}
+
+.insight-nested[open] > .insight-nested-summary::after {
+  transform: rotate(90deg);
+}
+
+.insight-nested > .evidence-detail-list {
+  margin: 0.4rem 0 0;
+  padding-top: 0.3rem;
+  border-top: 1px dashed var(--line);
 }
 
 .evidence-thesis {
@@ -1657,6 +1815,37 @@ td a {
   background: color-mix(in srgb, var(--sea) 10%, transparent);
   color: var(--ink);
   font-size: 0.88rem;
+}
+
+.evidence-thesis-disclosure summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.25rem;
+  cursor: pointer;
+  list-style: none;
+}
+
+.evidence-thesis-disclosure summary::-webkit-details-marker {
+  display: none;
+}
+
+.evidence-thesis-disclosure summary::after {
+  content: "›";
+  align-self: center;
+  color: var(--blue-deep);
+  font-family: var(--utility);
+  transition: transform 140ms ease;
+}
+
+.evidence-thesis-disclosure[open] > summary::after {
+  transform: rotate(90deg);
+}
+
+.evidence-thesis-disclosure > .evidence-detail-list {
+  margin: 0.6rem 0 0;
+  padding: 0.6rem 0 0;
+  border-top: 1px dashed var(--line);
 }
 
 .benchmark-workbench {
@@ -3230,8 +3419,21 @@ footer {
     padding: 0.85rem;
   }
 
-  .evidence-stat strong {
+  .evidence-stat-summary strong {
     font-size: 2.15rem;
+  }
+
+  /* A two-column tile is ~half a phone's width, so a nowrap "name · meta"
+     row would push past the strip. Stack them so the count reads first and
+     the provenance wraps beneath it. */
+  .evidence-detail-list li {
+    grid-template-columns: 1fr;
+    gap: 0.15rem;
+  }
+
+  .insight-item-meta {
+    text-align: left;
+    white-space: normal;
   }
 
   #benchmark-shortlist {

--- a/site/index.html
+++ b/site/index.html
@@ -197,7 +197,7 @@
               </details>
             </aside>
             <aside class="health-panel corpus-totals-panel" aria-labelledby="corpus-totals-heading">
-              <details id="corpus-totals-details" open>
+              <details id="corpus-totals-details">
                 <summary>
                   <span class="health-panel-title" id="corpus-totals-heading">Corpus totals</span>
                   <span class="health-panel-status" id="corpus-totals-status"></span>

--- a/tests/render_questions_harness.mjs
+++ b/tests/render_questions_harness.mjs
@@ -103,6 +103,7 @@ function walk(node) {
     tag: node.tag,
     className: node.className || "",
     href: node.attributes?.href || "",
+    attributes: node.attributes || {},
     text: node.textContent,
     children: (node.children || []).map(walk),
   };

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -399,10 +399,13 @@ def test_today_view_shows_total_corpus_counts_by_category():
     assert 'id="corpus-totals-status"' in html
     assert "state.data.corpus?.aggregates?.topics" in script
     assert "state.data.corpus?.aggregates?.entity_types?.artifact" in script
-    # A collapsed <details> next to a long, often multi-screen record list was
-    # reported unreadable ("I cannot see it") -- default it open so the totals
-    # are visible without a click, on both wide and stacked-mobile layouts.
-    assert '<details id="corpus-totals-details" open>' in html
+    # Issue #183: the totals start collapsed so the long topic list never takes
+    # over the page, and the summary still tells the reader the total so no one
+    # has to expand it to learn how big the corpus is. No `open` attribute.
+    assert '<details id="corpus-totals-details">' in html
+    assert 'corpus-totals-details" open>' not in html
+    summary_status = 'corpus-totals-status").textContent = '
+    assert f'{summary_status}`${{totalArtifacts.toLocaleString()}} artifacts`' in script
 
 
 def test_badge_accessible_names_state_the_action():
@@ -589,8 +592,12 @@ def test_leaderboard_names_an_unadopted_benchmark_rather_than_showing_a_bare_zer
     # A tracked benchmark no curated card reports is an observation about the
     # registry, not an empty row, and the domain summary counts only adopted
     # benchmarks so it must not claim to be the same figure as the filter.
+    # Issue #183: the registry-overview coverage counts open to their itemized
+    # evidence, so the tracked-vs-reported split is legible in the tiles too.
     assert '"not yet reported in these cards"' in script
-    assert '"Domains reported at least once"' in script
+    assert '"Benchmarks tracked"' in script
+    assert '"Benchmarks reported at least once"' in script
+    assert '"not yet reported"' in script
 
 
 def test_leaderboard_domain_filter_offers_every_tracked_domain():
@@ -1008,3 +1015,93 @@ def test_rendered_questions_drop_an_evidence_citation_with_an_unsafe_url(tmp_pat
     assert not [node for node in _flatten(rendered) if node["href"]]
     # The answer itself still renders; only the unfollowable citation is dropped.
     assert any(node["className"] == "answer" for node in _flatten(rendered))
+
+
+def test_rendered_answers_hide_supporting_detail_behind_a_collapsed_disclosure():
+    """Issue #183: each Q&A keeps its headline visible but collapses its support.
+
+    The question, confidence and one-line signal stay up front; the explanation,
+    citations, takeaway and counter-view live inside a native <details> that
+    starts collapsed (no `open` attribute, so it is reversible by the same
+    control) and carries the supporting content somewhere beneath the summary.
+    """
+    nodes = list(_flatten(_rendered_questions()))
+    answers = [n for n in nodes if n["className"] == "answer"]
+    disclosures = [n for n in nodes if n["className"] == "answer-disclosure"]
+
+    assert len(answers) == 3
+    assert len(disclosures) == 3
+
+    for answer, disclosure in zip(answers, disclosures, strict=True):
+        # Every rendered answer pairs its disclosure without collapsing the
+        # headline: question + signal stay direct children of the <article>.
+        assert any(n["className"] == "answer-question" for n in answer["children"])
+        signal = next(n for n in answer["children"] if n["className"] == "answer-signal")["text"]
+        # The disclosure is collapsed on load (no `open`) and carries a visible
+        # summary affordance naming what the reader will reveal.
+        assert disclosure["tag"] == "details"
+        assert "open" not in disclosure["attributes"]
+        assert any(n["className"] == "answer-disclosure-summary" for n in disclosure["children"])
+        # The supporting detail sits below the summary and does not repeat the
+        # one-line signal that is already visible above it.
+        detail = next(n for n in disclosure["children"] if n["className"] == "answer-detail")
+        detail_text = "".join(_subtexts(detail))
+        assert detail_text
+        assert signal not in detail_text
+
+    # Across all three answers, the full explanation, takeaway and counter-view
+    # all warm up inside the disclosures rather than crowding the headlines.
+    all_detail = "".join(
+        "".join(_subtexts(detail))
+        for d in disclosures
+        for detail in d.get("children") or []
+        if detail["className"] == "answer-detail"
+    )
+    assert "carry out a task" in all_detail  # a plain-English explanation
+    assert "Treat unscored arrivals as unverified" in all_detail  # a takeaway
+    assert "keyword-filtered" in all_detail  # a counter-view
+
+
+def test_leaderboard_coverage_counts_are_native_disclosures():
+    """Issue #183: the registry-overview counts open to their itemized evidence.
+
+    Each coverage tile is a native <details> whose summary keeps the stat and
+    whose body lists the exact records behind it. No `open` attribute is added,
+    so every tile loads collapsed and can be expanded and re-collapsed with the
+    single, native (and keyboard-operable) control.
+    """
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    assert 'className: "evidence-stat evidence-disclosure"' in script
+    assert 'element("details", { className: "evidence-stat evidence-disclosure" }' in script
+    assert 'className: "evidence-stat-summary"' in script
+    assert 'className: "evidence-detail-list"' in script
+    # Collapsed by default: the disclosures are built without an `open` attribute.
+    assert '.attrs: { open' not in script
+    # The itemized evidence is wired to the counts a reader would drill into.
+    assert "Benchmarks tracked" in script
+    assert "modelCardLine" in script
+    assert "benchmarkLine" in script
+
+
+def _subtexts(node):
+    if node["tag"] == "#text":
+        return [node["text"]]
+    out = []
+    for child in node.get("children") or []:
+        out.extend(_subtexts(child))
+    return out
+
+
+def test_connector_failure_marks_the_summary_without_force_opening_the_panel():
+    """Issue #183: a connector failure must change the collapsed Sources
+    summary/status but never force the panel's body open."""
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    # The status and a failure class are set on the summary line regardless of
+    # whether the panel is expanded.
+    assert 'byId("health-status").textContent = failedCount' in script
+    assert 'classList.toggle("has-failure", failedCount > 0)' in script
+    # No code path opens the panel's body.
+    assert 'health-panel-details").open' not in script
+    assert 'health-panel-details" ].open' not in script


### PR DESCRIPTION
## Summary
Fixes #183. Every disclosure surface now follows the same progressive-disclosure contract: collapsed by default, a visible marker affordance, expand, and re-collapse with the single native control. All surfaces use native `<details>/<summary>` so keyboard (Tab / Enter / Space) and semantics/`aria` come from the browser.

- **Leaderboard coverage** (`renderLeaderboard`): the four registry-overview tiles are now `<details>` that open to their itemized evidence.
  - source documents → its model cards (document type + date)
  - organizations → each vendor row further discloses that vendor's documents
  - Benchmarks tracked → every tracked benchmark
  - Benchmarks reported at least once → the adopted subset
  - The "New instruments" thesis now also discloses the exact `newSharedSignals` benchmarks.
- **Daily Q&A** (`answerBlock`): question + confidence + one-line signal stay visible; the plain-English explanation, citations, insufficient-evidence notice, takeaway, and counter-view move behind a collapsed disclosure. The disclosure label never promises "sources" when an answer carries none.
- **Homepage defaults**: `#corpus-totals-details` no longer carries the `open` attribute (the artifact count stays in the collapsed summary). Connector failure marks the Sources summary/status but never force-opens `#health-panel-details`.

Existing working disclosures (methodology, briefing, benchmark rows, model-card rows, ledger) are untouched.

## Notes / trade-offs
- The "Doubled domains" count under Benchmarks tracked is derived from distinct `domain` across all `board.entries` (not `board.domains`, which counts adopted only), matching how the domain filter is built.
- The mobile `@media (max-width: 470px)` stacks each tile row (name above meta) so the nowrap provenance cannot overflow a two-column tile.

## Test plan
- `pytest` full suite: **678 passed** (includes the new `test_rendered_answers_hide_supporting_detail_behind_a_collapsed_disclosure`, `test_leaderboard_coverage_counts_are_native_disclosures`, `test_connector_failure_marks_the_summary_without_force_opening_the_panel`, and updated corpus-totals assertions).
- `ruff check .` clean; `node --check` on both JS files clean.

### Review status (transparency)
A `codex review --base main` pass caught and I fixed four real issues (adopted-only domain undercount, "sources" promised on uncited answers, dead `adopter-link` hover + uppercased org names, and the final two auditability gaps). The final confirmation re-run hit the Codex account usage limit and could not complete; the remaining change is the org drill-down + new-instruments disclosure verified by the button tests. Please do a visual pass in the browser before merge (leaderboard tiles and a daily question each expand/re-collapse).