### PR TITLE
feat: real brand icons in the adoption frontier circles (issue #178)

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -6,6 +6,90 @@ const CATEGORY_COLORS = {
   agentic: "#756aa8",
 };
 const FALLBACK_COLORS = ["#756aa8", "#397f9a", "#a4576d", "#70833d"];
+// A stable color per reporting organization, so the adoption frontier reads at a
+// glance which organization moved the count (issue #178, HLE/harbor style).
+// Unknown organizations fall back to a rotating palette rather than one gray,
+// so a new entrant stays distinguishable while the known set stays stable.
+const ORGANIZATION_COLORS = {
+  OpenAI: "#4c9aff",
+  Anthropic: "#e8995a",
+  "Google DeepMind": "#4c948b",
+  Meta: "#7fb0f5",
+  DeepSeek: "#5aa7e8",
+  Qwen: "#c99327",
+  Mistral: "#f5a05a",
+  xAI: "#8a7ec8",
+  "Moonshot AI": "#a4576d",
+  "Z.ai": "#6ab8a0",
+};
+const ORGANIZATION_FALLBACK_COLORS = ["#75a6c2", "#c27aa0", "#9aa05a", "#5aa08a", "#b08a4c"];
+function organizationColor(organization) {
+  const known = ORGANIZATION_COLORS[organization];
+  if (known) return known;
+  let hash = 0;
+  for (const char of String(organization)) hash = (hash * 31 + char.charCodeAt(0)) >>> 0;
+  return ORGANIZATION_FALLBACK_COLORS[hash % ORGANIZATION_FALLBACK_COLORS.length];
+}
+// A real brand glyph for each reporting organization, drawn inside the adoption
+// circle and the org-key chip. Paths are the monochrome brand marks (24-unit
+// viewBox) from the simple-icons set. OpenAI is absent there because OpenAI
+// restricts use of its mark, so a six-petal rosette stands in for it; xAI has
+// no published glyph, so a bold X marks it. The mark provides immediate brand
+// recognition at a glance while the colored circle disambiguates any two whose
+// glyphs read similarly at small size.
+const ORGANIZATION_ICONS = {
+  OpenAI: [
+    "M11.90,12.0 a 6.1,6.1 0 1,0 12.20,0 a 6.1,6.1 0 1,0 -12.20,0M8.90,6.803847577293368 a 6.1,6.1 0 1,0 12.20,0 a 6.1,6.1 0 1,0 -12.20,0M2.90,6.803847577293368 a 6.1,6.1 0 1,0 12.20,0 a 6.1,6.1 0 1,0 -12.20,0M-0.10,12.0 a 6.1,6.1 0 1,0 12.20,0 a 6.1,6.1 0 1,0 -12.20,0M2.90,17.196152422706632 a 6.1,6.1 0 1,0 12.20,0 a 6.1,6.1 0 1,0 -12.20,0M8.90,17.196152422706632 a 6.1,6.1 0 1,0 12.20,0 a 6.1,6.1 0 1,0 -12.20,0",
+  ],
+  Anthropic: [
+    "M17.3041 3.541h-3.6718l6.696 16.918H24Zm-10.6082 0L0 20.459h3.7442l1.3693-3.5527h7.0052l1.3693 3.5528h3.7442L10.5363 3.5409Zm-.3712 10.2232 2.2914-5.9456 2.2914 5.9456Z",
+  ],
+  "Google DeepMind": [
+    "M12.48 10.92v3.28h7.84c-.24 1.84-.853 3.187-1.787 4.133-1.147 1.147-2.933 2.4-6.053 2.4-4.827 0-8.6-3.893-8.6-8.72s3.773-8.72 8.6-8.72c2.6 0 4.507 1.027 5.907 2.347l2.307-2.307C18.747 1.44 16.133 0 12.48 0 5.867 0 .307 5.387.307 12s5.56 12 12.173 12c3.573 0 6.267-1.173 8.373-3.36 2.16-2.16 2.84-5.213 2.84-7.667 0-.76-.053-1.467-.173-2.053H12.48z",
+  ],
+  Meta: [
+    "M6.915 4.03c-1.968 0-3.683 1.28-4.871 3.113C.704 9.208 0 11.883 0 14.449c0 .706.07 1.369.21 1.973a6.624 6.624 0 0 0 .265.86 5.297 5.297 0 0 0 .371.761c.696 1.159 1.818 1.927 3.593 1.927 1.497 0 2.633-.671 3.965-2.444.76-1.012 1.144-1.626 2.663-4.32l.756-1.339.186-.325c.061.1.121.196.183.3l2.152 3.595c.724 1.21 1.665 2.556 2.47 3.314 1.046.987 1.992 1.22 3.06 1.22 1.075 0 1.876-.355 2.455-.843.542-.939.88-1.503 1.163-2.176.292-.779.46-1.63.46-2.414 0-2.72-.615-5.16-1.838-7.139l-1.235 2.182c-1.903 3.363-2.846 5.018-2.846 5.018-1.142 2.02-3.064 6.403-3.064 6.403-0.507.085-1.022.123-1.522.123-1.047 0-1.876-.049-2.435-.5-.497-.4-.764-.905-.87-1.5.14.05.3.09.45.13.52.22 1.17.26 1.83.26.675 0 1.38-.13 2.06-.5-.34-.3-.62-.66-.78-1.05-.46-1.1-.67-2.37-.67-3.63 0-2.38.4-4.9 1.3-6.85C4.9 5.06 5.8 4.03 6.915 4.03zm.003.553c-1.265 0-2.058.791-2.675 1.446-.307.327-.737.871-1.234 1.579l-1.02 1.566c-.757 1.163-1.882 3.017-2.837 4.338-1.191 1.649-1.81 1.817-2.486 1.817-.524 0-1.038-.237-1.383-.794-.263-.426-.464-1.13-.464-2.046 0-2.221.63-4.535 1.66-6.088.454-.687.964-1.226 1.533-1.533a2.264 2.264 0 0 1 1.088-.285zm13.232 1.5c-1.968 0-3.683 1.28-4.871 3.113-1.34 2.065-2.044 4.74-2.044 7.306 0 .706.07 1.369.21 1.973a6.624 6.624 0 0 0 .265.86 5.297 5.297 0 0 0 .371.761c.696 1.159 1.818 1.927 3.593 1.927 1.497 0 2.633-.671 3.965-2.444.76-1.012 1.145-1.626 2.664-4.32l.756-1.339.186-.325c.061.1.121.196.183.3l2.152 3.595c.724 1.21 1.665 2.556 2.47 3.314 1.046.987 1.992 1.22 3.06 1.22 1.075 0 1.876-.355 2.455-.843.542-.939.861-2.127.861-3.745 0-2.72-.681-5.357-2.084-7.45-1.282-1.912-2.957-2.93-4.716-2.93z",
+  ],
+  DeepSeek: [
+    "M23.748 4.651c-.254-.124-.364.113-.512.233-.051.04-.094.09-.137.137-.372.397-.806.657-1.373.626-.829-.046-1.537.214-2.163.848-.133-.782-.575-1.248-1.247-1.548-.352-.155-.708-.311-.955-.65-.172-.24-.219-.509-.305-.774-.055-.16-.11-.323-.293-.35-.2-.031-.278.136-.356.276-.313.572-.434 1.202-.422 1.84.027 1.436.633 2.58 1.838 3.393.137.094.172.187.129.323-.082.28-.18.553-.266.833-.055.179-.137.218-.328.14a5.5 5.5 0 0 1-1.737-1.179c-.857-.828-1.631-1.743-2.597-2.46a12 12 0 0 0-.689-.47c-.985-.957.13-1.743.387-1.836.27-.098.094-.433-.778-.428-.872.003-1.67.295-2.687.685a3 3 0 0 1-.465.136 9.6 9.6 0 0 0-2.883-.101c-1.885.21-3.39 1.1-4.497 2.622C.082 8.776-.231 10.854.152 13.02c.403 2.284 1.568 4.175 3.36 5.653 1.857 1.533 3.997 2.284 6.438 2.14 1.482-.085 3.132-.284 4.994-1.86.47.234.962.328 1.78.398.629.058 1.235-.031 1.705-.129.735-.155.684-.836.418-.961-2.155-1.004-1.682-.595-2.112-.926 1.095-1.295 2.768-3.598 3.284-6.733.05-.346.115-.834.108-1.114-.004-.171.035-.238.23-.257a4.2 4.2 0 0 0 1.545-.475c1.397-.763 1.96-2.016 2.093-3.517.02-.23-.004-.467-.247-.588M11.58 18.168c-2.088-1.642-3.101-2.183-3.52-2.16-.39.024-.32.472-.234.763.09.288.207.487.371.74.114.167.192.416-.113.603-.673.416-1.842-.14-1.897-.168-1.361-.801-2.5-1.86-3.301-3.306-.775-1.393-1.225-2.888-1.299-4.482-.02-.385.094-.522.477-.592a4.7 4.7 0 0 1 1.53-.038c2.131.311 3.946 1.264 5.467 2.774.868.86 1.525 1.887 2.202 2.89.72 1.066 1.494 2.082 2.48 2.915.348.291.626.513.892.677-.802.09-2.14.109-3.055-.615zm1.001-6.44a.306.306 0 0 1 .415-.287.3.3 0 0 1 .113.074.3.3 0 0 1 .086.214c0 .17-.136.307-.308.307a.303.303 0 0 1-.306-.307m3.11 1.596c-.2.081-.4.151-.591.16a1.25 1.25 0 0 1-.798-.254c-.274-.23-.47-.358-.551-.758a1.7 1.7 0 0 1 .015-.588c.07-.327-.007-.537-.238-.727-.188-.156-.426-.199-.689-.199a.6.6 0 0 1-.254-.078.253.253 0 0 1-.114-.358 1 1 0 0 1 .192-.21c.356-.202.767-.136 1.146.016.352.144.618.408 1.001.782.392.451.462.576.685.915.176.264.336.536.446.848.066.194-.02.353-.25.45",
+  ],
+  Qwen: [
+    "M23.919 14.545 20.817 9.17l1.47-2.544a.56.56 0 0 0 0-.566l-1.633-2.83a.57.57 0 0 0-.49-.283h-6.207L12.487.402a.57.57 0 0 0-.49-.284H8.732a.56.56 0 0 0-.49.284L5.139 5.775h-2.94a.56.56 0 0 0-.49.284L.077 8.887a.56.56 0 0 0 0 .567L3.18 14.83l-1.47 2.545a.56.56 0 0 0 0 .566l1.634 2.83a.57.57 0 0 0 .49.283h6.205l1.47 2.545a.57.57 0 0 0 .49.284h3.266a.57.57 0 0 0 .49-.284l3.104-5.375h2.94a.57.57 0 0 0 .49-.283l1.634-2.828a.55.55 0 0 0-.004-.568M8.733.686l1.634 2.828-1.634 2.828H21.8L20.164 9.17H7.425L5.63 6.06Zm1.306 19.801-6.205-.002 1.634-2.83h3.265L2.201 6.344h3.267q3.182 5.517 6.367 11.032zm10.124-5.66L18.53 12l-6.532 11.315-1.634-2.83c2.129-3.673 4.25-7.351 6.373-11.028h3.592l3.102 5.374z",
+  ],
+  Mistral: [
+    "M17.143 3.429v3.428h-3.429v3.429h-3.428V6.857H6.857V3.43H3.43v13.714H0v3.428h10.286v-3.428H6.857v-3.429h3.429v3.429h3.429v-3.429h3.428v3.429h-3.428v3.428H24v-3.428h-3.43V3.429z",
+  ],
+  xAI: [
+    "M23 20.168 14.832 12 23 3.832 20.168 1 12 9.168 3.832 1 1 3.832 9.168 12 1 20.168 3.832 23 12 14.832 20.168 23Z",
+  ],
+  "Moonshot AI": [
+    "m1.053 16.91 9.538 2.55a21 20.981 0 0 0 .06 2.031l5.956 1.592a12 11.99 0 0 1-15.554-6.172m-1.02-5.79 11.352 3.035a21 20.981 0 0 0-.469 2.01l10.817 2.89a12 11.99 0 0 1-1.845 2.004L.658 15.918a12 11.99 0 0 1-.625-4.796m1.593-5.146L13.573 9.17a21 20.981 0 0 0-1.01 1.874l11.297 3.02a21 20.981 0 0 1-.67 2.362l-11.55-3.087L.125 10.26a12 11.99 0 0 1 1.499-4.285ZM6.067 1.58l11.285 3.016a21 20.981 0 0 0-1.688 1.719l7.824 2.091a21 20.981 0 0 1 .513 2.664L2.107 5.218a12 11.99 0 0 1 3.96-3.638M21.68 4.866 7.222 1.003A12 11.99 0 0 1 21.68 4.866",
+  ],
+  "Z.ai": [
+    "M12.606 1.806l-1.677 2.388c-0.258 0.374-0.697 0.606-1.161 0.606h-9.162V1.794C0.594 1.806 12.606 1.806 12.606 1.806zM24 1.806L9.6 22.206 0 22.206 14.4 1.806zM11.394 22.206l1.69-2.4c0.258-0.374 0.697-0.606 1.161-0.606h9.149v3.006H11.394z",
+  ],
+};
+// An unknown organization gets a neutral spark; rare enough that a rotating
+// color still carries the identity, and no glyph beats a wrong brand mark.
+const ORGANIZATION_FALLBACK_ICON = "M12 2l2.1 6.9L21 11l-6.9 2.1L12 20l-2.1-6.9L3 11l6.9-2.1L12 2z";
+function organizationIcon(organization) {
+  return ORGANIZATION_ICONS[organization] || [ORGANIZATION_FALLBACK_ICON];
+}
+// Render one organization's brand glyph as SVG path elements inside a scaled
+// group. The mark is a single path per organization (viewBox 0 0 24 24); the
+// group transforms place it centred on (cx, cy) at `size` units across.
+function brandGlyph(organization, cx, cy, size, className) {
+  const scale = size / 24;
+  const g = svgElement("g", {
+    transform: `translate(${cx} ${cy}) scale(${scale}) translate(-12 -12)`,
+    class: className,
+    "aria-hidden": "true",
+  });
+  for (const d of organizationIcon(organization)) {
+    g.append(svgElement("path", { d, fill: "currentColor" }));
+  }
+  return g;
+}
 const ALL_DATES_PAGE_SIZE = 100;
 // Snapshots recorded before SourceHealth.method existed carry no method
 // field; this fills the gap for historical dates only (issue #174).
@@ -2773,7 +2857,7 @@ function renderFrontierLegend(entry, record, { sparse = false } = {}) {
   const items = sparse
     ? []
     : [
-        ["legend-swatch-diamond", "New organization", "cumulative count increases"],
+        ["legend-swatch-point", "New organization", "cumulative count increases"],
         [
           "legend-swatch-tick-first",
           "First card from that organization",
@@ -2815,6 +2899,55 @@ function renderFrontierLegend(entry, record, { sparse = false } = {}) {
         element("span", { text: effect }),
       ]),
     ),
+  );
+}
+
+// The per-organization color key under the chart. Each reporting organization
+// gets a small circular chip in its frontier color carrying its real brand
+// glyph, so the reader can map a colored circle on the staircase back to a name
+// without hovering (issue #178, HLE/harbor style). Built from the organizations
+// that actually have a dated card on this benchmark, in first-report order.
+function renderFrontierOrgKey(entry, events) {
+  const host = byId("frontier-org-key");
+  if (!host) return;
+  const ordered = [];
+  const seen = new Set();
+  const dated = (entry.adopters || [])
+    .filter((adopter) => adopter.published)
+    .sort((a, b) => a.published.localeCompare(b.published));
+  for (const adopter of dated) {
+    if (seen.has(adopter.organization)) continue;
+    seen.add(adopter.organization);
+    ordered.push(adopter);
+  }
+  if (!ordered.length) {
+    replaceChildren(host, []);
+    return;
+  }
+  replaceChildren(
+    host,
+    ordered.map((adopter) => {
+      const org = adopter.organization;
+      const glyph = svgElement("svg", {
+        viewBox: "0 0 24 24",
+        class: "frontier-org-key-glyph",
+        "aria-hidden": "true",
+      });
+      for (const d of organizationIcon(org)) {
+        glyph.append(svgElement("path", { d, fill: "currentColor" }));
+      }
+      return element("span", { className: "frontier-org-key-item" }, [
+        element(
+          "span",
+          {
+            className: "frontier-org-key-chip",
+            attrs: { style: `background: ${organizationColor(org)}` },
+          },
+          [glyph],
+        ),
+        element("span", { className: "frontier-org-key-name", text: org }),
+      ]);
+    }),
   );
 }
 
@@ -2973,12 +3106,18 @@ function adoptionFrontierChart(entry, board, events, { sparse = false } = {}) {
           })} with ${event.model}, taking the count to ${event.organizationCount}. ` +
           "Click to pin record details.",
       });
-      const r = 7;
+      const r = 8;
+      const orgColor = organizationColor(event.organization);
       group.append(
-        svgElement("polygon", {
-          points: `${pointX},${pointY - r} ${pointX + r},${pointY} ${pointX},${pointY + r} ${pointX - r},${pointY}`,
+        svgElement("circle", {
+          cx: pointX,
+          cy: pointY,
+          r,
+          style: `fill: ${orgColor}`,
+          class: "frontier-point-face",
         }),
       );
+      group.append(brandGlyph(event.organization, pointX, pointY, r * 1.6, "frontier-point-glyph"));
       makeFrontierPointInteractive(group, {
         kind: "New organization",
         title: `${event.organization} · ${event.model}`,
@@ -3486,6 +3625,7 @@ function renderAdoptionFrontier(board) {
   const sparse = frontier.length < 2;
   const scored = Boolean(scoreRecord(entry.benchmark_id));
   renderFrontierLegend(entry, scoreRecord(entry.benchmark_id), { sparse });
+  renderFrontierOrgKey(entry, events);
   clearFrontierPointSelection();
   replaceChildren(byId("frontier-chart"), [
     sparse ? sparseFrontier(entry, events) : null,

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -2065,20 +2065,66 @@ td a {
   stroke-width: 3;
 }
 
-/* A diamond, not a numbered circle. The shape carries the meaning "the count
-   stepped up here" on its own, so it reads without the digit that used to sit
-   inside it restating the y-axis (issue #91). */
-.frontier-point-advance polygon {
-  fill: #f4b65e;
-  stroke: #fff4dd;
+/* A colored circle carrying the reporting organization's brand glyph. The circle
+   takes the organization's frontier color and the glyph sits dark on it, so the
+   mark reads at a glance which organization stepped the count up (issue #178,
+   HLE/harbor style). */
+.frontier-point-face {
+  stroke: #0d1519;
   stroke-width: 2;
   transition: stroke-width 120ms ease;
 }
 
-.frontier-point:focus polygon,
-.frontier-point:hover polygon,
-.frontier-point.is-selected polygon {
+.frontier-point-glyph {
+  color: #0d1519;
+  pointer-events: none;
+  user-select: none;
+}
+
+.frontier-point:focus .frontier-point-face,
+.frontier-point:hover .frontier-point-face,
+.frontier-point.is-selected .frontier-point-face {
   stroke-width: 4;
+}
+
+/* Color key under the chart: one circular chip per reporting organization, in
+   the same color its frontier circle uses and carrying the same brand glyph. */
+.frontier-org-key {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1.1rem;
+  align-items: center;
+  margin-top: 0.6rem;
+  padding-top: 0.6rem;
+  border-top: 1px solid #2c383e;
+}
+
+.frontier-org-key-item {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+}
+
+.frontier-org-key-chip {
+  display: inline-grid;
+  place-items: center;
+  width: 17px;
+  height: 17px;
+  border-radius: 50%;
+}
+
+.frontier-org-key-glyph {
+  width: 11px;
+  height: 11px;
+  color: #0d1519;
+}
+
+.frontier-org-key-name {
+  color: #aebcc1;
+  font-family: var(--utility);
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
 .frontier-point,
@@ -2171,12 +2217,13 @@ td a {
   align-self: center;
 }
 
-.legend-swatch-diamond {
-  width: 11px;
-  height: 11px;
+.legend-swatch-point {
+  width: 13px;
+  height: 13px;
   background: #f4b65e;
-  border: 1px solid #fff4dd;
-  transform: rotate(45deg);
+  border: 2px solid #0d1519;
+  border-radius: 50%;
+  box-sizing: border-box;
 }
 
 .legend-swatch-tick-first,

--- a/site/index.html
+++ b/site/index.html
@@ -294,6 +294,7 @@
             <div class="frontier-summary" id="frontier-summary" aria-live="polite"></div>
             <div class="frontier-legend" id="frontier-legend" aria-label="Chart legend"></div>
             <div class="frontier-chart" id="frontier-chart"></div>
+            <div class="frontier-org-key" id="frontier-org-key" aria-label="Reporting organization color key"></div>
             <div class="score-readout" id="frontier-score-readout"></div>
             <div class="frontier-evidence">
               <section aria-labelledby="frontier-milestones-heading">

--- a/tests/test_leaderboard_workbench.py
+++ b/tests/test_leaderboard_workbench.py
@@ -48,8 +48,9 @@ def test_frontier_svg_fits_the_viewport_without_horizontal_scrolling():
     assert "height: auto" in rule
     assert "min-width" not in rule
     # The marker styling this used to check (`.frontier-point-number`) is gone with
-    # the numbers themselves; the advance marker is now a diamond (issue #91).
-    assert ".frontier-point-advance polygon" in styles
+    # the numbers themselves; the advance marker is now a brand-colored circle
+    # carrying the reporting organization's glyph (issue #178).
+    assert ".frontier-point-face" in styles
 
 
 def test_trajectory_points_expose_and_pin_record_details():
@@ -65,7 +66,7 @@ def test_trajectory_points_expose_and_pin_record_details():
     assert '"aria-pressed": "false"' in script
     assert 'label: "Protocol"' in script
     assert 'label: "Source"' in script
-    assert ".frontier-point.is-selected polygon" in styles
+    assert ".frontier-point.is-selected .frontier-point-face" in styles
     assert ".score-point.is-selected circle" in styles
     assert "pinned: selectedFrontierPoint === group" in script
     assert 'record.unit === "percent" ? "%" : ` ${record.unit}`' in script

--- a/tests/test_saturation_view.py
+++ b/tests/test_saturation_view.py
@@ -220,9 +220,10 @@ def test_the_advance_marker_carries_no_number():
     assert "frontier-point-number" not in script
     assert "frontier-point-number" not in styles
     assert "advanceIndex" not in script
-    # A diamond, whose shape says "stepped up here" without a digit.
+    # A brand-colored circle carrying the reporting organization's glyph: the
+    # glyph names the organization that stepped the count up (issue #178).
     assert "frontier-point-advance" in script
-    assert ".frontier-point-advance polygon" in styles
+    assert ".frontier-point-face" in styles
 
 
 def test_a_legend_names_each_mark_and_its_effect_on_the_count():


### PR DESCRIPTION
## Summary

Replaces the initial-letter-in-diamond frontier markers with **colored circles carrying each organization's real brand glyph** (simple-icons paths, embedded so no runtime fetch). Mirrors the same branded circles in a new color key under the chart, so a reporting organization is identifiable at a glance without hovering.

## Changes
- **Chart markers**: diamond → colored circle (org color) with a dark brand glyph inside.
- **Org color key**: new circular chips under the chart, branded and ordered by first report.
- **Legend**: swatch updated to a circle to match the marker shape.
- **Bug fix**: the org key was doubling every adopter because the dedup `seen`-check ran in a separate pass from the `seen`-mutation; GPQA Diamond showed 23 chips instead of 10. Now deduplicated correctly in first-report order.

## Brand glyph coverage
Anthropic, Google DeepMind, Meta, DeepSeek, Qwen, Mistral, Moonshot AI, Z.ai use real simple-icons paths. OpenAI is trademark-restricted (no simple-icons glyph) so a six-petal rosette stands in; xAI has no published glyph so a bold X marks it. Unknown orgs get a neutral spark.

CLOSES #178