### PR TITLE
Masthead actions: data export and WeChat/Discord contact sheet

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -4231,6 +4231,115 @@ function observationCard(item, index) {
   );
 }
 
+function observationsToCsv(observations) {
+  const columns = [
+    "date",
+    "kind",
+    "title",
+    "summary",
+    "source",
+    "event_kind",
+    "categories",
+    "organizations",
+    "url",
+    "score",
+  ];
+  const escape = (value) => {
+    const text = String(value ?? "");
+    return /[",\n\r]/.test(text) ? `"${text.replaceAll('"', '""')}"` : text;
+  };
+  const rows = observations.map((item) =>
+    [
+      item.snapshot_date,
+      item.observation_kind,
+      escape(item.title),
+      escape(item.summary || ""),
+      escape(item.source),
+      escape(item.event_kind),
+      escape((item.categories || []).join("; ")),
+      escape((item.organizations || []).join("; ")),
+      escape(item.url || item.primary_artifact_url || ""),
+      Number(item.total_score || 0).toFixed(2),
+    ].join(","),
+  );
+  return [columns.join(","), ...rows].join("\r\n");
+}
+
+function downloadText(filename, text, mimeType = "text/plain") {
+  const blob = new Blob([text], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.append(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}
+
+// The export dialog (issue #193) does two things at once: it states the
+// usecase that makes this more than a dump, and it puts one-click downloads
+// behind a single control. The usecase is the reason the site exists for a
+// reader doing related-work research: find every benchmark on a topic, or take
+// the whole corpus with you. The JSON link and the client-side CSV are both
+// derived from the same in-memory data the dashboard renders, so an export can
+// never disagree with the screen it came from.
+function openExport() {
+  const dialog = byId("export-dialog");
+  if (!state.data) return;
+  const filtered = filteredObservations();
+  replaceChildren(byId("export-content"), [
+    element("p", { className: "detail-source", text: "Benchmark Radar · data export" }),
+    element("h2", {
+      className: "detail-title export-title",
+      text: "Take the data with you",
+      attrs: { id: "export-title" },
+    }),
+    element("p", {
+      className: "detail-summary",
+      text:
+        "Doing related-work research, or hunting for a benchmark on a topic? " +
+        "This database aggregates every benchmark, evaluation, and dataset the " +
+        "radar has surfaced, and you can query it by topic, source, or " +
+        "organization before you export. The full corpus below is the same data " +
+        "the dashboard renders.",
+    }),
+    element("div", { className: "export-actions" }, [
+      element("a", {
+        className: "primary-link",
+        text: "Download full dataset (JSON)",
+        attrs: { href: "data/radar.json", download: "benchmark-radar.json" },
+      }),
+      element("button", {
+        className: "secondary-link export-csv-button",
+        text: `Download current view (CSV · ${filtered.length} rows)`,
+        attrs: { type: "button" },
+      }),
+      element("a", {
+        className: "secondary-link",
+        text: "Leaderboard (CSV)",
+        attrs: { href: "data/leaderboard.csv", download: "leaderboard.csv" },
+      }),
+    ]),
+    element("p", {
+      className: "discovery-note",
+      text:
+        `${allObservations().length} observations across ` +
+        `${state.data.snapshot_count} daily snapshots.`,
+    }),
+  ]);
+  byId("export-content")
+    .querySelector(".export-csv-button")
+    .addEventListener("click", () => {
+      downloadText(
+        `benchmark-radar-${state.todayDate === "all" ? "all" : state.todayDate}.csv`,
+        observationsToCsv(filtered),
+        "text/csv;charset=utf-8",
+      );
+    });
+  dialog.showModal();
+}
+
 function bindEvents() {
   document.querySelectorAll("[data-view]").forEach((button) => {
     button.addEventListener("click", () => {
@@ -4361,6 +4470,11 @@ function bindEvents() {
   // Reachable without a record in hand, for a reader who wants the method
   // before they trust any single row.
   byId("rubric-nav").addEventListener("click", () => openRubric());
+  byId("badge-export").addEventListener("click", openExport);
+  byId("export-close").addEventListener("click", () => byId("export-dialog").close());
+  byId("export-dialog").addEventListener("click", (event) => {
+    if (event.target === byId("export-dialog")) byId("export-dialog").close();
+  });
 }
 
 const REPO_SLUG = "ktwu01/benchmark-radar";

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -4231,6 +4231,30 @@ function observationCard(item, index) {
   );
 }
 
+const CONTACT_EMAIL = "ktwu01@gmail.com";
+const WECHAT_ID = "ktwu001";
+const DISCORD_ID = "ktwu01";
+
+const BRAND_ICON_PATHS = {
+  email: "M3 5h18a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1Zm9 6.9L4.2 6h15.6L12 11.9Zm-8 6.6V8.9l8 5.9 8-5.9v9.6H4Z",
+  wechat:
+    "M8.691 2.188C3.891 2.188 0 5.476 0 9.53c0 2.212 1.17 4.203 3.002 5.55a.59.59 0 0 1 .213.665l-.39 1.48c-.019.07-.048.141-.048.213 0 .163.13.295.29.295a.326.326 0 0 0 .167-.054l1.903-1.114a.864.864 0 0 1 .717-.098 10.16 10.16 0 0 0 2.837.403c.276 0 .543-.027.811-.05a6.127 6.127 0 0 1-.253-1.72c0-3.571 3.437-6.467 7.678-6.467.233 0 .463.013.694.031C17.02 4.792 13.205 2.188 8.69 2.188Zm-2.6 4.408c.654 0 1.184.517 1.184 1.154 0 .637-.53 1.154-1.184 1.154-.654 0-1.184-.517-1.184-1.154 0-.637.53-1.154 1.184-1.154Zm5.51 0c.654 0 1.184.517 1.184 1.154 0 .637-.53 1.154-1.184 1.154-.654 0-1.184-.517-1.184-1.154 0-.637.53-1.154 1.184-1.154Zm7.835 3.124c-3.858 0-6.984 2.667-6.984 5.957 0 3.29 3.126 5.957 6.984 5.957.848 0 1.663-.146 2.418-.408a.622.622 0 0 1 .516.07l1.371.802a.235.235 0 0 0 .12.039.213.213 0 0 0 .208-.213c0-.052-.02-.102-.035-.153l-.28-1.067a.426.426 0 0 1 .153-.479c1.359-1.111 2.2-2.707 2.2-4.548 0-3.29-3.126-5.957-6.984-5.957Zm-3.865 3.594c.55 0 .996.435.996.971 0 .537-.446.972-.996.972-.55 0-.996-.435-.996-.972 0-.536.446-.971.996-.971Zm7.729 0c.55 0 .996.435.996.971 0 .537-.446.972-.996.972-.55 0-.996-.435-.996-.972 0-.536.446-.971.996-.971Z",
+  discord:
+    "M20.317 4.3698a19.7913 19.7913 0 0 0-4.8851-1.5152.0741.0741 0 0 0-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 0 0-.0785-.037 19.7363 19.7363 0 0 0-4.8852 1.515.0699.0699 0 0 0-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 0 0 .0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 0 0 .0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 0 0-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 0 1-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 0 1 .0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 0 1 .0785.0095c.1202.099.246.1981.3728.2924a.077.077 0 0 1-.0066.1276 12.2986 12.2986 0 0 1-1.873.8914.0766.0766 0 0 0-.0407.1067c.3604.698.7719 1.3628 1.225 1.9932a.076.076 0 0 0 .0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 0 0 .0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 0 0-.0312-.0286ZM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0957 2.1568 2.419 0 1.3332-.9555 2.4189-2.1569 2.4189Zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0957 2.1568 2.419 0 1.3332-.946 2.4189-2.1568 2.4189Z",
+  repo:
+    "M12.75 21a3.25 3.25 0 0 1 3.25-3.25h4.25a.75.75 0 0 0 .75-.75V3.75a.75.75 0 0 0-.75-.75H13.5A3.5 3.5 0 0 0 10 6.5v14.25a3.25 3.25 0 0 1-3.25 3.25Zm-3.5-2.25a2.75 2.75 0 0 1 2.75-2.75h6.25a.75.75 0 0 0 .75-.75V3.75a.75.75 0 0 0-.75-.75h-5A3.25 3.25 0 0 0 9.5 6.5v12.25a.75.75 0 0 1-.75.75ZM3 21.5a2.75 2.75 0 0 0 2.75 2.75h8.75a.75.75 0 0 0 0-1.5H5.75A1.25 1.25 0 0 1 4.5 21.5V3.75A1.25 1.25 0 0 1 5.75 2.5H8A.75.75 0 0 0 8 1H5.75A2.75 2.75 0 0 0 3 3.75Z",
+};
+
+function brandIcon(name) {
+  const svg = svgElement("svg", {
+    viewBox: "0 0 24 24",
+    class: "brand-icon",
+    "aria-hidden": "true",
+  });
+  svg.appendChild(svgElement("path", { d: BRAND_ICON_PATHS[name] }));
+  return svg;
+}
+
 function observationsToCsv(observations) {
   const columns = [
     "date",
@@ -4337,6 +4361,56 @@ function openExport() {
         "text/csv;charset=utf-8",
       );
     });
+  dialog.showModal();
+}
+
+// The contact dialog (issue #191) keeps every reach-out channel in one place:
+// email, WeChat, and Discord. Rendering it as a dialog rather than a bare
+// mailto link means a reader lands on a choice rather than being launched out
+// of the page on a guess.
+function openContact() {
+  const dialog = byId("contact-dialog");
+  replaceChildren(byId("contact-content"), [
+    element("p", { className: "detail-source", text: "Benchmark Radar" }),
+    element("h2", {
+      className: "detail-title contact-title",
+      text: "Get in touch",
+      attrs: { id: "contact-title" },
+    }),
+    element("p", {
+      className: "detail-summary",
+      text:
+        "A wrong row in the adoption ranking is a real bug. So is a connector " +
+        "that stopped collecting, or a benchmark you expected the radar to see.",
+    }),
+    element("ul", { className: "contact-list" }, [
+      element("li", {}, [
+        element("span", { className: "contact-label" }, [
+          brandIcon("email"),
+          element("strong", { text: "Email" }),
+        ]),
+        element("a", {
+          className: "contact-value",
+          text: CONTACT_EMAIL,
+          attrs: { href: `mailto:${CONTACT_EMAIL}` },
+        }),
+      ]),
+      element("li", {}, [
+        element("span", { className: "contact-label" }, [
+          brandIcon("wechat"),
+          element("strong", { text: "WeChat" }),
+        ]),
+        element("span", { className: "contact-value", text: `ID ${WECHAT_ID}` }),
+      ]),
+      element("li", {}, [
+        element("span", { className: "contact-label" }, [
+          brandIcon("discord"),
+          element("strong", { text: "Discord" }),
+        ]),
+        element("span", { className: "contact-value", text: `ID ${DISCORD_ID}` }),
+      ]),
+    ]),
+  ]);
   dialog.showModal();
 }
 
@@ -4471,9 +4545,15 @@ function bindEvents() {
   // before they trust any single row.
   byId("rubric-nav").addEventListener("click", () => openRubric());
   byId("badge-export").addEventListener("click", openExport);
+  byId("badge-wechat").addEventListener("click", openContact);
+  byId("badge-discord").addEventListener("click", openContact);
   byId("export-close").addEventListener("click", () => byId("export-dialog").close());
   byId("export-dialog").addEventListener("click", (event) => {
     if (event.target === byId("export-dialog")) byId("export-dialog").close();
+  });
+  byId("contact-close").addEventListener("click", () => byId("contact-dialog").close());
+  byId("contact-dialog").addEventListener("click", (event) => {
+    if (event.target === byId("contact-dialog")) byId("contact-dialog").close();
   });
 }
 

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -203,6 +203,27 @@ th {
   background: var(--panel);
 }
 
+/* The export control is a <button>, not an <a>, because it opens a dialog
+   instead of navigating. Without these resets a button renders with the user
+   agent's default chrome (grey background, distinct font) over the repo-badge
+   styling shared with the links beside it. */
+button.repo-badge {
+  appearance: none;
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+
+button.repo-badge svg {
+  width: 0.9rem;
+  height: 0.9rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-width: 2;
+}
+
 .repo-badge-count {
   font-variant-numeric: tabular-nums;
   font-weight: 700;
@@ -3098,6 +3119,53 @@ dialog::backdrop {
   margin: 0.35rem 0 0;
   color: var(--muted);
   font-size: 0.85rem;
+}
+
+.export-actions {
+  display: grid;
+  gap: 0.6rem;
+  margin: 1.5rem 0;
+}
+
+.export-actions .primary-link,
+.export-actions .secondary-link {
+  display: block;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--line);
+  font-family: var(--utility);
+  font-size: 0.72rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.export-actions .primary-link {
+  border-color: var(--blue);
+  color: var(--blue);
+}
+
+.export-actions .primary-link:hover {
+  background: var(--blue);
+  color: var(--panel);
+}
+
+.export-actions button.secondary-link {
+  width: 100%;
+  appearance: none;
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+  letter-spacing: 0.05em;
+  text-align: left;
+  text-transform: uppercase;
+}
+
+.export-actions .secondary-link:hover {
+  border-color: var(--ink);
+  color: var(--ink);
+}
+
+.export-title {
+  font-size: clamp(1.8rem, 4vw, 2.8rem);
 }
 
 .supporting-signals {

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -224,8 +224,10 @@ button.repo-badge svg {
   stroke-width: 2;
 }
 
-/* Brand marks (WeChat and Discord) are single-color glyphs with no meaningful
-   stroke form, so they fill instead of outline. */
+/* Brand marks (WeChat, Discord, and the GitHub repo octicon) are single-color
+   glyphs with no meaningful stroke form, so they fill instead of outline. The
+   GitHub repo octicon also appears on the star badge, which is an <a>, so the
+   selector covers both link and button badges. */
 .repo-badge svg.brand-icon {
   width: 0.9rem;
   height: 0.9rem;

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -203,10 +203,10 @@ th {
   background: var(--panel);
 }
 
-/* The export control is a <button>, not an <a>, because it opens a dialog
-   instead of navigating. Without these resets a button renders with the user
-   agent's default chrome (grey background, distinct font) over the repo-badge
-   styling shared with the links beside it. */
+/* The export and contact controls are <button>s, not <a>s, because they open
+   dialogs instead of navigating. Without these resets a button renders with
+   the user agent's default chrome (grey background, distinct font) over the
+   repo-badge styling shared with the links beside it. */
 button.repo-badge {
   appearance: none;
   background: transparent;
@@ -222,6 +222,15 @@ button.repo-badge svg {
   stroke: currentColor;
   stroke-linecap: round;
   stroke-width: 2;
+}
+
+/* Brand marks (WeChat and Discord) are single-color glyphs with no meaningful
+   stroke form, so they fill instead of outline. */
+.repo-badge svg.brand-icon {
+  width: 0.9rem;
+  height: 0.9rem;
+  fill: currentColor;
+  stroke: none;
 }
 
 .repo-badge-count {
@@ -3166,6 +3175,49 @@ dialog::backdrop {
 
 .export-title {
   font-size: clamp(1.8rem, 4vw, 2.8rem);
+}
+
+.contact-list {
+  margin: 1.5rem 0 0;
+  padding: 0;
+  border-top: 1px solid var(--line);
+  list-style: none;
+}
+
+.contact-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.9rem 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.contact-label {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.contact-label svg {
+  width: 1.1rem;
+  height: 1.1rem;
+  fill: currentColor;
+  stroke: none;
+}
+
+.contact-label strong {
+  font-family: var(--utility);
+  font-size: 0.7rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.contact-value {
+  color: var(--blue);
+  font-family: var(--display);
+  font-size: 1.05rem;
+  word-break: break-all;
 }
 
 .supporting-signals {

--- a/site/index.html
+++ b/site/index.html
@@ -61,9 +61,11 @@
           <span class="repo-badge-label">RSS</span>
         </a>
         <!--
-          The export button opens a dialog rather than linking out: handing
-          over a dataset needs a moment of explanation about what is being
-          exported. Reachable without navigating away from the current view.
+          These three open dialogs rather than linking out: exporting a dataset
+          needs a moment of explanation about what is being handed over, and the
+          WeChat and Discord buttons open one contact sheet that keeps email,
+          WeChat, and Discord in a single place. Reachable without navigating
+          away from the current view.
         -->
         <button
           type="button"
@@ -78,6 +80,44 @@
             <path d="M4 21h16"></path>
           </svg>
           <span class="repo-badge-label">Data</span>
+        </button>
+        <button
+          type="button"
+          class="repo-badge"
+          id="badge-wechat"
+          aria-haspopup="dialog"
+          title="Contact on WeChat · ID ktwu001"
+        >
+          <svg class="brand-icon" viewBox="0 0 24 24" aria-hidden="true">
+            <path
+              d="M8.691 2.188C3.891 2.188 0 5.476 0 9.53c0 2.212 1.17 4.203 3.002 5.55a.59.59 0 0 1 .213.665l-.39 1.48c-.019.07-.048.141-.048.213 0 .163.13.295.29.295a.326.326 0 0 0 .167-.054l1.903-1.114a.864.864 0 0 1 .717-.098 10.16 10.16 0 0 0 2.837.403c.276 0 .543-.027.811-.05a6.127 6.127 0 0 1-.253-1.72c0-3.571 3.437-6.467 7.678-6.467.233 0 .463.013.694.031C17.02 4.792 13.205 2.188 8.69 2.188z"
+            ></path>
+            <path
+              d="M20.196 9.72c-3.858 0-6.984 2.667-6.984 5.957 0 3.29 3.126 5.957 6.984 5.957.848 0 1.663-.146 2.418-.408a.622.622 0 0 1 .516.07l1.371.802a.235.235 0 0 0 .12.039.213.213 0 0 0 .208-.213c0-.052-.02-.102-.035-.153l-.28-1.067a.426.426 0 0 1 .153-.479c1.359-1.111 2.2-2.707 2.2-4.548 0-3.29-3.126-5.957-6.984-5.957z"
+            ></path>
+            <circle cx="5.59" cy="9.72" r="1.184"></circle>
+            <circle cx="11.1" cy="9.72" r="1.184"></circle>
+            <circle cx="16.331" cy="13.31" r=".996"></circle>
+            <circle cx="20.06" cy="13.31" r=".996"></circle>
+          </svg>
+          <span class="repo-badge-label">WeChat</span>
+        </button>
+        <button
+          type="button"
+          class="repo-badge"
+          id="badge-discord"
+          aria-haspopup="dialog"
+          title="Contact on Discord · ID ktwu01"
+        >
+          <svg class="brand-icon" viewBox="0 0 24 24" aria-hidden="true">
+            <path
+              d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.865-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.058a.082.082 0 0 0 .031.056 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.291.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.061 0a.074.074 0 0 1 .079.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z"
+            ></path>
+            <path
+              d="M8.02 15.331c-1.182 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.419 0 1.333-.956 2.419-2.157 2.419zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.419 0 1.333-.946 2.419-2.157 2.419z"
+            ></path>
+          </svg>
+          <span class="repo-badge-label">Discord</span>
         </button>
         <!--
           Each badge is a call to action, not a link to a roster. Starring has no
@@ -534,6 +574,16 @@
         aria-label="Close data export"
       >×</button>
       <div id="export-content"></div>
+    </dialog>
+
+    <dialog id="contact-dialog" aria-labelledby="contact-title">
+      <button
+        class="dialog-close"
+        id="contact-close"
+        type="button"
+        aria-label="Close contact options"
+      >×</button>
+      <div id="contact-content"></div>
     </dialog>
 
     <footer>

--- a/site/index.html
+++ b/site/index.html
@@ -134,7 +134,17 @@
             rel="noopener noreferrer"
             title="Open the repository and star it"
           >
-            <span aria-hidden="true">★</span>
+            <svg class="brand-icon" viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                d="M12.75 21a3.25 3.25 0 0 1 3.25-3.25h4.25a.75.75 0 0 0 .75-.75V3.75a.75.75 0 0 0-.75-.75H13.5A3.5 3.5 0 0 0 10 6.5v14.25a3.25 3.25 0 0 1-3.25 3.25Z"
+              ></path>
+              <path
+                d="M9.25 21.5a2.75 2.75 0 0 1 2.75-2.75h6.25a.75.75 0 0 0 .75-.75V3.75a.75.75 0 0 0-.75-.75h-5A3.25 3.25 0 0 0 10 6.5v14.75a.75.75 0 0 1-.75.75Z"
+              ></path>
+              <path
+                d="M3 21.5a2.75 2.75 0 0 0 2.75 2.75h8.75a.75.75 0 0 0 0-1.5H5.75A1.25 1.25 0 0 1 4.5 21.5V3.75A1.25 1.25 0 0 1 5.75 2.5H8A.75.75 0 0 0 8 1H5.75A2.75 2.75 0 0 0 3 3.75Z"
+              ></path>
+            </svg>
             <span class="repo-badge-label">Star</span>
             <span class="repo-badge-count" data-count>—</span>
           </a>

--- a/site/index.html
+++ b/site/index.html
@@ -61,6 +61,25 @@
           <span class="repo-badge-label">RSS</span>
         </a>
         <!--
+          The export button opens a dialog rather than linking out: handing
+          over a dataset needs a moment of explanation about what is being
+          exported. Reachable without navigating away from the current view.
+        -->
+        <button
+          type="button"
+          class="repo-badge"
+          id="badge-export"
+          aria-haspopup="dialog"
+          title="Export the dataset"
+        >
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M12 3v12"></path>
+            <path d="m7 8 5 5 5-5"></path>
+            <path d="M4 21h16"></path>
+          </svg>
+          <span class="repo-badge-label">Data</span>
+        </button>
+        <!--
           Each badge is a call to action, not a link to a roster. Starring has no
           GET endpoint (GitHub requires an authenticated POST with a CSRF token,
           so no third-party page can star on a visitor's behalf), so the star
@@ -505,6 +524,16 @@
         aria-label="Close scoring rubric"
       >×</button>
       <div id="rubric-content"></div>
+    </dialog>
+
+    <dialog id="export-dialog" aria-labelledby="export-title">
+      <button
+        class="dialog-close"
+        id="export-close"
+        type="button"
+        aria-label="Close data export"
+      >×</button>
+      <div id="export-content"></div>
     </dialog>
 
     <footer>

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -249,10 +249,10 @@ def test_records_expand_inline_without_an_exclusive_accordion_or_record_modal():
     assert "detail-dialog" not in script
     # A shared details[name] would force one row closed when another opens.
     assert "attrs: { name:" not in script
-    # The two dialogs on the page are non-record chrome: the scoring rubric and
-    # the data export. Record detail must stay inline, so any third showModal()
-    # is a regression to a record modal.
-    assert script.count(".showModal()") == 2
+    # The three dialogs on the page are non-record chrome: the scoring rubric,
+    # the data export, and the contact sheet. Record detail must stay inline,
+    # so any fourth showModal() is a regression to a record modal.
+    assert script.count(".showModal()") == 3
 
 
 def test_hugging_face_expansion_links_to_the_full_card():

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -249,7 +249,10 @@ def test_records_expand_inline_without_an_exclusive_accordion_or_record_modal():
     assert "detail-dialog" not in script
     # A shared details[name] would force one row closed when another opens.
     assert "attrs: { name:" not in script
-    assert script.count(".showModal()") == 1
+    # The two dialogs on the page are non-record chrome: the scoring rubric and
+    # the data export. Record detail must stay inline, so any third showModal()
+    # is a regression to a record modal.
+    assert script.count(".showModal()") == 2
 
 
 def test_hugging_face_expansion_links_to_the_full_card():


### PR DESCRIPTION
Top-right masthead action badges: data export, WeChat/Discord contact sheet, and the star badge now uses the GitHub repo octicon.

## Add one-click data export (issue #193)
The masthead now has a Data button that opens an export dialog with the related-work usecase stated up front (query by topic/source/organization), then hands over the corpus:
- **Download full dataset (JSON)** — the same in-memory data the dashboard renders, one click
- **Download current view (CSV)** — the currently filtered subset, generated client-side
- **Leaderboard (CSV)** — the static leaderboard

## Add WeChat/Discord contact sheet (issue #191)
The masthead now has WeChat and Discord badges that open one contact sheet covering email, WeChat (ID `ktwu001`), and Discord (ID `ktwu01`).

## Star badge uses the GitHub repo octicon
The star badge swapped its `★` glyph for the GitHub repo octicon, keeping the countable star label and the link that takes readers to the repo where Starring happens.

## Commits
- `3848227` feat: add one-click data export dialog in masthead (issue #193)
- `df5ddc2` feat: add WeChat/Discord contact sheet in masthead (issue #191)
- `999cecc` style: use the GitHub repo octicon for the star badge

Closes #193, closes #191
