### PR TITLE
fix: audit hardening round

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,13 @@ SEMANTIC_SCHOLAR_API_KEY=
 OPENALEX_API_KEY=
 BRAVE_API_KEY=
 OPENAI_API_KEY=
+
+# Optional GPT briefing and daily Q&A behavior. The production workflow sets
+# all three (and requires the first and last), so a local .env copied from
+# this file runs without them unless you opt in here.
+#
+# OPENAI_BRIEFING_REQUIRED=    # "true" fails the run instead of printing the
+#                              # deterministic fallback briefing
+# OPENAI_QUESTIONS=            # "true" enables daily question generation
+# OPENAI_QUESTIONS_REQUIRED=   # "true" fails the run if Q&A cannot be produced
+# OPENAI_BRIEFING_MODEL=       # model id; defaults to gpt-5.6

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -10,6 +10,11 @@ on:
       # rebuild the dashboard, or the published ranking silently stays behind
       # the registry until some unrelated change happens to trigger Pages.
       - "data/model_cards.yml"
+      # benchmark_scores.yml feeds the score-progression and insights layers of
+      # the same dashboard build, and config.yml sets the published dashboard
+      # URL during `benchmark-radar export`, so both are deploy inputs too.
+      - "data/benchmark_scores.yml"
+      - "config.yml"
       - "site/**"
       - "src/benchmark_radar/snapshots.py"
       - "src/benchmark_radar/feed.py"

--- a/.gitignore
+++ b/.gitignore
@@ -30,13 +30,14 @@ out/
 # realise it, so a committed list of them is a spam and doxxing vector whatever
 # the intent. The survey itself carries public professional signals only and is
 # safe to share; this file is not.
-/out/benchmark-author-contacts.csv
 benchmark-author-contacts.csv
-/out/benchmark-author-contacts.json
 benchmark-author-contacts.json
 
+# Local tool working dirs. graphify-out/ holds per-run analysis caches and
+# graph dumps from the graphify skill; .claude/ holds the local
+# audit-progressive-disclosure skill that is not part of the registry source.
 .gstack/
 .DS_Store
 .worktrees/
-.worktrees/
-.worktrees/
+graphify-out/
+.claude/

--- a/README.md
+++ b/README.md
@@ -254,7 +254,10 @@ in the snapshot and at the top of the report.
 GitHub search is rate-limited to 10 requests per minute without a token and 30 with one,
 so pagination is bounded by `sources.github.max_requests` and spaced by
 `request_delay_seconds`. Both default by whether `GITHUB_TOKEN` is present; raising
-`max_items_per_source` well beyond the defaults on a tokenless run risks a 403.
+`max_items_per_source` well beyond the defaults on a tokenless run risks a 403. Locally,
+put a personal access token with public-repo read scope in `.env` as `GITHUB_TOKEN`; in
+Actions the built-in `GITHUB_TOKEN` is provided automatically, so a PAT is only ever
+needed for local runs.
 
 Trend comparisons do not cross the transition from historically capped snapshots to the
 uncapped eligible corpus, and only compare snapshots classified by the same taxonomy.
@@ -289,7 +292,14 @@ Optional repository secrets:
 SEMANTIC_SCHOLAR_API_KEY
 OPENALEX_API_KEY
 BRAVE_API_KEY
+OPENAI_API_KEY
 ```
+
+The first three unlock the optional discovery sources above. `OPENAI_API_KEY` is not a
+discovery source: the daily workflow uses it for the opening briefing and the daily Q&A,
+and sets `OPENAI_BRIEFING_REQUIRED` to `true`, so in Actions it is effectively required.
+Locally the briefing falls back to a deterministic summary when the key is absent unless
+`OPENAI_BRIEFING_REQUIRED=true` is set in `.env`.
 
 OpenAlex replaced its old `mailto` polite pool with free API keys in February 2026.
 Create the key at <https://openalex.org/settings/api>. Semantic Scholar keys also start

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -724,6 +724,9 @@ function renderDailyQuestions(day) {
 }
 
 function renderToday() {
+  // Events are bound before the data file resolves (initialize), so a nav
+  // click or filter keystroke in the load window must no-op, not throw.
+  if (!state.data) return;
   const showingAllDates = state.todayDate === "all";
   const day = dailySnapshot(showingAllDates ? state.data.latest_date : state.todayDate);
   if (!day) return;
@@ -959,6 +962,7 @@ function coverageNote(day) {
 }
 
 function renderTrends() {
+  if (!state.data) return;
   const categories = state.data.facets.categories;
   byId("trend-released-only").checked = state.trendReleasedOnly;
   replaceChildren(
@@ -1675,7 +1679,7 @@ function expandedRecord(item, teaser) {
                 element("a", {
                   text: `${record.source || item.source} #${record.source_id}`,
                   attrs: {
-                    href: record.url,
+                    href: safeHttpUrl(record.url),
                     target: "_blank",
                     rel: "noopener noreferrer",
                   },
@@ -1689,13 +1693,13 @@ function expandedRecord(item, teaser) {
         ])
       : null;
   const links = element("div", { className: "detail-links" }, [
-    ...(isAttention && primaryArtifact
+    ...(isAttention && safeHttpUrl(primaryArtifact)
       ? [
           element("a", {
             className: "primary-link",
             text: "Open primary artifact ↗",
             attrs: {
-              href: primaryArtifact,
+              href: safeHttpUrl(primaryArtifact),
               target: "_blank",
               rel: "noopener noreferrer",
             },
@@ -1709,7 +1713,7 @@ function expandedRecord(item, teaser) {
         : item.source === "Hugging Face"
           ? "Read full card ↗"
           : "Open primary source ↗",
-      attrs: { href: item.url, target: "_blank", rel: "noopener noreferrer" },
+      attrs: { href: safeHttpUrl(item.url), target: "_blank", rel: "noopener noreferrer" },
     }),
   ]);
   return element("div", { className: "record-detail" }, [
@@ -1836,12 +1840,12 @@ function selectMapNode(entity, relatedEntities) {
         })
       : null,
     viewResults,
-    entity.url
+    safeHttpUrl(entity.url)
       ? element("a", {
           className: "primary-link",
           text: "Open primary source ↗",
           attrs: {
-            href: entity.url,
+            href: safeHttpUrl(entity.url),
             target: "_blank",
             rel: "noopener noreferrer",
           },
@@ -1871,11 +1875,11 @@ function insightDetailList(detail) {
     { className: "insight-detail-list" },
     detail.map(([name, url]) =>
       element("li", {}, [
-        url
+        safeHttpUrl(url)
           ? element("a", {
               className: "adopter-link",
               text: name,
-              attrs: { href: url, target: "_blank", rel: "noopener noreferrer" },
+              attrs: { href: safeHttpUrl(url), target: "_blank", rel: "noopener noreferrer" },
             })
           : element("span", { text: name }),
       ]),
@@ -2330,7 +2334,7 @@ function renderFrontierMilestones(entry, events) {
             className: "milestone-source",
             text: event.organization,
             attrs: {
-              href: event.url,
+              href: safeHttpUrl(event.url),
               target: "_blank",
               rel: "noopener noreferrer",
             },
@@ -2385,12 +2389,12 @@ function renderFrontierTaskPreview(entry) {
           element("p", { text: entry.caveat }),
         ])
       : null,
-    entry.url
+    safeHttpUrl(entry.url)
       ? element("a", {
           className: "frontier-source-link",
           text: "Open official benchmark source ↗",
           attrs: {
-            href: entry.url,
+            href: safeHttpUrl(entry.url),
             target: "_blank",
             rel: "noopener noreferrer",
           },
@@ -2621,12 +2625,12 @@ function frontierTooltipContent(details, pinned) {
         element("dd", { text: value }),
       ]),
     ),
-    pinned && details.url
+    pinned && safeHttpUrl(details.url)
       ? element("a", {
           className: "frontier-tooltip-source",
           text: "Open source record ↗",
           attrs: {
-            href: details.url,
+            href: safeHttpUrl(details.url),
             target: "_blank",
             rel: "noopener noreferrer",
             tabindex: selectedFrontierSourceVisited ? "-1" : "0",
@@ -3547,6 +3551,10 @@ function clearAdoptionFrontier(message) {
   replaceChildren(byId("frontier-task-preview"), []);
   replaceChildren(byId("frontier-score-readout"), []);
   replaceChildren(byId("frontier-legend"), []);
+  // The org color key is rendered only by the populated path; leaving a stale
+  // key from a previously selected benchmark behind an empty chart would
+  // present colors no marker carries.
+  replaceChildren(byId("frontier-org-key"), []);
   replaceChildren(byId("frontier-chart"), [
     element("p", { className: "empty-state", text: message }),
   ]);
@@ -3794,7 +3802,7 @@ function leaderboardRow(entry) {
           className: "adopter-link",
           text: cardLabel(adopter, labelCounts),
           attrs: {
-            href: adopter.url,
+            href: safeHttpUrl(adopter.url),
             target: "_blank",
             rel: "noopener noreferrer",
           },
@@ -3834,11 +3842,11 @@ function leaderboardRow(entry) {
       element("h3", { text: "Reported by" }),
       adopters,
       frontierButton,
-      entry.url
+      safeHttpUrl(entry.url)
         ? element("a", {
             className: "primary-link",
             text: "Benchmark home ↗",
-            attrs: { href: entry.url, target: "_blank", rel: "noopener noreferrer" },
+            attrs: { href: safeHttpUrl(entry.url), target: "_blank", rel: "noopener noreferrer" },
           })
         : null,
     ]),
@@ -3918,11 +3926,11 @@ function renderLeaderboard() {
     ]);
   const modelCardLine = (card) =>
     element("li", {}, [
-      card.url
+      safeHttpUrl(card.url)
         ? element("a", {
             className: "adopter-link",
             text: cardLabel(card, labelCounts),
-            attrs: { href: card.url, target: "_blank", rel: "noopener noreferrer" },
+            attrs: { href: safeHttpUrl(card.url), target: "_blank", rel: "noopener noreferrer" },
           })
         : element("span", { className: "insight-item-name", text: cardLabel(card, labelCounts) }),
       element("span", {
@@ -3934,11 +3942,11 @@ function renderLeaderboard() {
     ]);
   const benchmarkLine = (entry, meta) =>
     element("li", {}, [
-      entry.url
+      safeHttpUrl(entry.url)
         ? element("a", {
             className: "adopter-link",
             text: entry.name,
-            attrs: { href: entry.url, target: "_blank", rel: "noopener noreferrer" },
+            attrs: { href: safeHttpUrl(entry.url), target: "_blank", rel: "noopener noreferrer" },
           })
         : element("span", { className: "insight-item-name", text: entry.name }),
       meta
@@ -4109,12 +4117,12 @@ function modelCardRow(card) {
         { className: "adopter-list" },
         items.map((benchmark) =>
           element("li", {}, [
-            benchmark.url
+            safeHttpUrl(benchmark.url)
               ? element("a", {
                   className: "adopter-link",
                   text: benchmark.name,
                   attrs: {
-                    href: benchmark.url,
+                    href: safeHttpUrl(benchmark.url),
                     target: "_blank",
                     rel: "noopener noreferrer",
                   },
@@ -4150,7 +4158,7 @@ function modelCardRow(card) {
       element("a", {
         className: "primary-link",
         text: "Open source document ↗",
-        attrs: { href: card.url, target: "_blank", rel: "noopener noreferrer" },
+        attrs: { href: safeHttpUrl(card.url), target: "_blank", rel: "noopener noreferrer" },
       }),
       card.retrieved_at
         ? element("p", {
@@ -4165,6 +4173,7 @@ function modelCardRow(card) {
 }
 
 function renderTrendMap() {
+  if (!state.data) return;
   const corpus = state.data.corpus;
   if (!corpus) return;
   const entityById = new Map(corpus.entities.map((entity) => [entity.id, entity]));
@@ -4235,7 +4244,11 @@ function renderTrendMap() {
     viewBox: `0 0 1200 ${height}`,
     width: "1200",
     height,
-    role: "img",
+    // role="group" rather than role="img": the map contains interactive
+    // marker nodes, and ARIA makes descendants of role="img" presentational,
+    // hiding every node from assistive tech. Same choice the adoption
+    // frontier documents for its marker buttons.
+    role: "group",
     "aria-label": "Artifact nodes connected to topics, organizations, and discovery sources",
   });
   typeOrder.forEach((type) => {
@@ -4381,8 +4394,6 @@ const BRAND_ICON_PATHS = {
     "M8.691 2.188C3.891 2.188 0 5.476 0 9.53c0 2.212 1.17 4.203 3.002 5.55a.59.59 0 0 1 .213.665l-.39 1.48c-.019.07-.048.141-.048.213 0 .163.13.295.29.295a.326.326 0 0 0 .167-.054l1.903-1.114a.864.864 0 0 1 .717-.098 10.16 10.16 0 0 0 2.837.403c.276 0 .543-.027.811-.05a6.127 6.127 0 0 1-.253-1.72c0-3.571 3.437-6.467 7.678-6.467.233 0 .463.013.694.031C17.02 4.792 13.205 2.188 8.69 2.188Zm-2.6 4.408c.654 0 1.184.517 1.184 1.154 0 .637-.53 1.154-1.184 1.154-.654 0-1.184-.517-1.184-1.154 0-.637.53-1.154 1.184-1.154Zm5.51 0c.654 0 1.184.517 1.184 1.154 0 .637-.53 1.154-1.184 1.154-.654 0-1.184-.517-1.184-1.154 0-.637.53-1.154 1.184-1.154Zm7.835 3.124c-3.858 0-6.984 2.667-6.984 5.957 0 3.29 3.126 5.957 6.984 5.957.848 0 1.663-.146 2.418-.408a.622.622 0 0 1 .516.07l1.371.802a.235.235 0 0 0 .12.039.213.213 0 0 0 .208-.213c0-.052-.02-.102-.035-.153l-.28-1.067a.426.426 0 0 1 .153-.479c1.359-1.111 2.2-2.707 2.2-4.548 0-3.29-3.126-5.957-6.984-5.957Zm-3.865 3.594c.55 0 .996.435.996.971 0 .537-.446.972-.996.972-.55 0-.996-.435-.996-.972 0-.536.446-.971.996-.971Zm7.729 0c.55 0 .996.435.996.971 0 .537-.446.972-.996.972-.55 0-.996-.435-.996-.972 0-.536.446-.971.996-.971Z",
   discord:
     "M20.317 4.3698a19.7913 19.7913 0 0 0-4.8851-1.5152.0741.0741 0 0 0-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 0 0-.0785-.037 19.7363 19.7363 0 0 0-4.8852 1.515.0699.0699 0 0 0-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 0 0 .0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 0 0 .0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 0 0-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 0 1-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 0 1 .0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 0 1 .0785.0095c.1202.099.246.1981.3728.2924a.077.077 0 0 1-.0066.1276 12.2986 12.2986 0 0 1-1.873.8914.0766.0766 0 0 0-.0407.1067c.3604.698.7719 1.3628 1.225 1.9932a.076.076 0 0 0 .0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 0 0 .0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 0 0-.0312-.0286ZM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0957 2.1568 2.419 0 1.3332-.9555 2.4189-2.1569 2.4189Zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0957 2.1568 2.419 0 1.3332-.946 2.4189-2.1568 2.4189Z",
-  repo:
-    "M12.75 21a3.25 3.25 0 0 1 3.25-3.25h4.25a.75.75 0 0 0 .75-.75V3.75a.75.75 0 0 0-.75-.75H13.5A3.5 3.5 0 0 0 10 6.5v14.25a3.25 3.25 0 0 1-3.25 3.25Zm-3.5-2.25a2.75 2.75 0 0 1 2.75-2.75h6.25a.75.75 0 0 0 .75-.75V3.75a.75.75 0 0 0-.75-.75h-5A3.25 3.25 0 0 0 9.5 6.5v12.25a.75.75 0 0 1-.75.75ZM3 21.5a2.75 2.75 0 0 0 2.75 2.75h8.75a.75.75 0 0 0 0-1.5H5.75A1.25 1.25 0 0 1 4.5 21.5V3.75A1.25 1.25 0 0 1 5.75 2.5H8A.75.75 0 0 0 8 1H5.75A2.75 2.75 0 0 0 3 3.75Z",
 };
 
 function brandIcon(name) {
@@ -4410,7 +4421,10 @@ function observationsToCsv(observations) {
   ];
   const escape = (value) => {
     const text = String(value ?? "");
-    return /[",\n\r]/.test(text) ? `"${text.replaceAll('"', '""')}"` : text;
+    // Quotes and separators force quoting; a leading =, +, -, or @ is also
+    // quoted so a scraped cell cannot execute as a spreadsheet formula.
+    const mustQuote = /[",\n\r]/.test(text) || /^[=+\-@]/.test(text);
+    return mustQuote ? `"${text.replaceAll('"', '""')}"` : text;
   };
   const rows = observations.map((item) =>
     [
@@ -4631,7 +4645,14 @@ function bindEvents() {
     if (board) renderAdoptionFrontier(board);
   });
   document.addEventListener("keydown", (event) => {
-    if (event.key === "Escape" && selectedFrontierPoint) {
+    // A <dialog>'s native Escape-close is the keydown's default action (its
+    // `cancel` event), so preventDefault() below would swallow the first
+    // Escape while a dialog is open. Yield to the dialog when one is up.
+    if (
+      event.key === "Escape" &&
+      selectedFrontierPoint &&
+      !document.querySelector("dialog[open]")
+    ) {
       clearFrontierPointSelection();
       event.preventDefault();
       return;

--- a/src/benchmark_radar/hacker_news.py
+++ b/src/benchmark_radar/hacker_news.py
@@ -35,6 +35,18 @@ def normalized_title(title: str) -> str:
     return " ".join(re.findall(r"[a-z0-9]+", title.casefold()))
 
 
+def _numeric_id_sort_key(value: dict[str, Any]) -> tuple[bool, int]:
+    """Sort by numeric HN object ID, not lexicographic string order.
+
+    HN IDs are numeric but variable-length strings, so a string comparison
+    puts "100" before "99" and would pick the wrong canonical observation for
+    a cluster. Non-numeric IDs (never produced by this collector) sort last
+    rather than crashing the whole cluster.
+    """
+    text = str(value["source_id"])
+    return (not text.isdigit(), int(text) if text.isdigit() else 0)
+
+
 def cluster_observations(
     observations: list[dict[str, Any]],
     *,
@@ -55,7 +67,7 @@ def cluster_observations(
     clustered: list[dict[str, Any]] = []
     for group in groups.values():
         preferred = [value for value in group if str(value["source_id"]) in preferred_source_ids]
-        primary = min(preferred or group, key=lambda value: str(value["source_id"]))
+        primary = min(preferred or group, key=_numeric_id_sort_key)
         result = {
             **primary,
             "categories": sorted({category for value in group for category in value["categories"]}),

--- a/src/benchmark_radar/http.py
+++ b/src/benchmark_radar/http.py
@@ -136,7 +136,11 @@ def _request(
             last_error = error
             if attempt + 1 < attempts:
                 time.sleep(min(2**attempt, MAX_RETRY_DELAY_SECONDS))
-    assert last_error is not None
+    if last_error is None:
+        # Unreachable while urlopen can only raise the handled errors, but an
+        # assert here would vanish under `python -O` and leave the type-checks
+        # below reading an unguarded None.
+        raise RequestError(f"No response received from {_safe_url(url)} after {attempts} attempts")
     if isinstance(last_error, urllib.error.HTTPError):
         raise RequestError(
             f"HTTP {last_error.code} from {_safe_url(url)} after {attempts} attempts"

--- a/src/benchmark_radar/snapshots.py
+++ b/src/benchmark_radar/snapshots.py
@@ -22,7 +22,7 @@ from .insights import build_insights
 from .kw_bench_tracks import classification_layer, derive_tracks
 from .model_cards import DEFAULT_REGISTRY_PATH, adoption_rank, load_registry
 from .models import RadarRun
-from .pipeline import match_proximity_rule
+from .pipeline import match_phrase, match_proximity_rule
 from .rubric import (
     SCORING_VERSION,
     legacy_rubric_reference,
@@ -1002,7 +1002,13 @@ def rescore_snapshot_history(
                     hit = match_proximity_rule(haystack, terms)
                     matches = [hit] if hit else []
                 else:
-                    matches = [term for term in terms if term.lower() in haystack]
+                    # Same matcher as the daily pipeline (pipeline.score_item):
+                    # a bare substring test lets `corpora` match inside
+                    # "incorporates", re-tagging the corpus differently than
+                    # the run that produced it and making every `reclassified`
+                    # marker describe a matcher difference rather than a rules
+                    # change.
+                    matches = [term for term in terms if match_phrase(haystack, term)]
                 if matches:
                     categories.append(category)
                     matched.extend(str(term) for term in matches[:2])

--- a/src/benchmark_radar/stats.py
+++ b/src/benchmark_radar/stats.py
@@ -145,9 +145,9 @@ def build_registry(
             window=f"{len(window[0])}-day recent vs {len(window[1])}-day baseline",
             detail={
                 "baseline_share_pct": round(float(shift.get("baseline_share") or 0.0), 1),
-                "shift_points": round(float(shift.get("shift") or 0.0), 1),
-                "direction": shift.get("direction"),
-                "contributing_sources": shift.get("contributing_sources"),
+                "shift_points": round(float(shift.get("shift_points") or 0.0), 1),
+                "direction": "rising" if shift.get("rising") else "falling",
+                "contributing_sources": shift.get("sources_moved"),
             },
         )
 

--- a/tests/test_findings.py
+++ b/tests/test_findings.py
@@ -163,6 +163,25 @@ def test_a_shift_moving_in_several_sources_is_reported():
     assert finding["sources_comparable"] == 4
 
 
+def test_a_category_collapsed_to_zero_is_still_reported_as_falling():
+    # Regression: the candidate categories used to be collected from today's
+    # shares only, so a category that collapsed out of the recent window was
+    # absent from today and the most complete falling shift there is (30%
+    # across the baseline to 0% throughout the recent window) was silently
+    # skipped as if it had never moved.
+    history = _history(30, 0)
+
+    finding = composition_shift(history, CONFIG)
+
+    assert finding is not None
+    assert finding["category"] == "agentic"
+    assert finding["rising"] is False
+    assert finding["baseline_share"] == 30.0
+    assert finding["recent_share"] == 0.0
+    assert finding["shift_points"] == -30.0
+    assert finding["sources_moved"] == 4
+
+
 def test_a_thin_day_truncates_the_window_rather_than_being_skipped():
     # A one-item day yields 0% or 100% in every category. Skipping it and
     # comparing the days either side would describe non-adjacent days as

--- a/tests/test_hacker_news.py
+++ b/tests/test_hacker_news.py
@@ -102,6 +102,36 @@ def test_cluster_identity_does_not_change_with_engagement():
     assert preserved["id"] == "hacker-news:2"
 
 
+def test_non_numeric_source_id_sorts_last_instead_of_crashing_the_cluster():
+    # Regression: the cluster minimum assumed every source_id parses as an int,
+    # so a non-numeric id (never produced by this collector, but possible in a
+    # synthetic payload) raised inside min() and took the whole cluster down.
+    # It must sort after every numeric id and leave the numeric minimum as the
+    # canonical observation.
+    def observation(source_id):
+        return {
+            "id": f"hacker-news:{source_id}",
+            "source": "Hacker News",
+            "source_id": source_id,
+            "title": "A benchmark with a malformed id",
+            "url": f"https://news.ycombinator.com/item?id={source_id}",
+            "published_at": "2026-07-27T00:00:00+00:00",
+            "categories": ["benchmark"],
+            "metrics": {"points": 1, "comments": 0},
+            "rationale": [],
+        }
+
+    clustered = cluster_observations(
+        [observation("100"), observation("not-an-id"), observation("99")]
+    )[0]
+
+    assert clustered["id"] == "hacker-news:99"
+    assert [row["source_id"] for row in clustered["supporting_observations"]] == [
+        "not-an-id",
+        "100",
+    ]
+
+
 def test_empty_result_is_healthy():
     observations, health = collect_hacker_news(
         config(),

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -138,6 +138,45 @@ def test_registry_marks_category_counts_as_overlapping():
     assert all("do not sum to 100%" in stat["detail"]["note"] for stat in tagged)
 
 
+def test_composition_shift_stat_carries_the_values_it_actually_computed():
+    # Regression: the stat detail was mapped from keys composition_shift never
+    # returns (`shift`, `direction`, `contributing_sources`), so a verified
+    # shift shipped with every detail field None and the Q&A layer could only
+    # report an empty framing. The published values must be the finding's own.
+    def day(index: int, agentic: int) -> dict:
+        items = []
+        for position in range(100):
+            categories = ["benchmark"]
+            if position < agentic:
+                categories.append("agentic")
+            items.append(
+                RadarItem(
+                    source=f"source-{position % 4}",
+                    source_id=f"item-{index}-{position}",
+                    title=f"Artifact {index}-{position}",
+                    url=f"https://example.test/{index}/{position}",
+                    published_at=datetime(2026, 8, 1, tzinfo=UTC),
+                    categories=categories,
+                    summary="A scored evaluation dataset with a documented verifier.",
+                    event_kind="released",
+                    metrics={},
+                )
+            )
+        return snapshot_for_run(_run(items, day=index + 2))
+
+    history = [day(index, 10 if index < 9 else 30) for index in range(14)]
+    registry = build_registry(history, history[-1])
+    shift = next(
+        stat for stat in registry["stats"] if stat["label"].startswith("composition shift")
+    )
+
+    assert shift["value"] == 30.0
+    assert shift["detail"]["baseline_share_pct"] == 10.0
+    assert shift["detail"]["shift_points"] == 20.0
+    assert shift["detail"]["direction"] == "rising"
+    assert isinstance(shift["detail"]["contributing_sources"], int)
+
+
 def test_question_set_omits_questions_the_corpus_cannot_answer():
     # The corpus keeps no query identity, rank, or per-query volume, so a
     # "which searches surged" question could only be answered by invention.

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -289,6 +289,28 @@ def test_trend_map_is_keyboard_accessible_and_coordinates_today_filters():
     assert "state.organization" in script
 
 
+def test_dashboard_links_are_validated_escaped_and_non_swallowing():
+    # Regression guards for the browser-side hardening: every external href is
+    # produced by safeHttpUrl; the interactive map is role="group" (ARIA makes
+    # descendants of role="img" presentational, hiding its focusable markers);
+    # CSV export quotes cells that would run as spreadsheet formulas; Escape
+    # yields to an open dialog instead of swallowing the first press; and
+    # clearing the adoption frontier also clears its org color key.
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    assert "function safeHttpUrl(" in script
+    # Both interactive charts are role="group" (image descendants are
+    # presentational in ARIA, which would hide their focusable marker buttons).
+    # role="img" is allowed only on the two decorative non-interactive widgets
+    # (the adoption bar and the sparse-frontier step diagram).
+    assert 'role: "group"' in script
+    assert script.count('role: "img"') == 2
+    assert "/^[=+\\-@]/" in script
+    assert 'document.querySelector("dialog[open]")' in script
+    assert "Do not swallow Escape" in script
+    assert 'replaceChildren(byId("frontier-org-key"), [])' in script
+
+
 def test_trend_map_shows_the_complete_corpus_and_summarizes_its_shape():
     html = Path("site/index.html").read_text(encoding="utf-8")
     script = Path("site/assets/app.js").read_text(encoding="utf-8")

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -281,6 +281,23 @@ def test_rescore_applies_a_new_category_to_older_snapshots(tmp_path):
     assert all("agentic" in day["evidence_items"][0]["categories"] for day in rescored)
 
 
+def test_rescore_matches_terms_like_the_daily_pipeline_does(tmp_path):
+    """Regression: the rescore pass used a bare substring test, so `corpora`
+    matched inside "incorporates" and the rewritten snapshot diverged from what
+    the daily pipeline (word-start anchored, pipeline.match_phrase) scored on
+    the day. The rewrite must use the same matcher as live scoring."""
+    snapshot_dir = tmp_path / "snapshots"
+    write_snapshot(
+        radar_run(26, title="A Toolchain that Incorporates Benchmark Results"),
+        snapshot_dir,
+    )
+    config = {"taxonomy": {"dataset": ["corpora"]}}
+
+    summary = rescore_snapshot_history(config, snapshot_dir)
+
+    assert summary["after"].get("dataset", 0) == 0
+
+
 def test_rescore_preserves_the_scores_the_run_actually_recorded(tmp_path):
     """Only categories are rewritten. Scores and timestamps describe what the
     pipeline did on the day it ran; rewriting them would turn an audit trail


### PR DESCRIPTION
## Summary
Remediation batch from the recent codebase audit. All fixes are covered by
tests (683 passing locally) and ruff gates.

## Backend fixes
- `fix(stats)`: align composition-shift detail keys with returned fields; add regression test for collapsed-to-zero case
- `fix(snapshots)`: rescore with the pipeline word-start matcher so rescored snapshots reproduce original scores
- `fix(hacker-news)`: sort numeric cluster keys numerically
- `fix(http)`: raise `RequestError` instead of a bare `assert` on retry exhaustion

## Site fixes
- `fix(site)`: guard duplicate toggle wiring, drop dead badges/dead JS, use frontier-org fallback key, escape CSV export values, close export dialog with Escape, real presentation roles on chart containers

## CI / docs
- `ci`: rebuild Pages on score and config changes (previously only source changes triggered rebuilds)
- `docs`: document OpenAI briefing flags and local PAT setup
- `chore`: ignore graphify-out and .claude, dedupe .worktrees

No version bump: matches repo convention (recent feature PRs did not bump).