### PR TITLE
[2 points] Add Ai2 Olmo 3 to the model card registry

### DIFF
--- a/data/model_cards.yml
+++ b/data/model_cards.yml
@@ -1519,3 +1519,26 @@ model_cards:
       - gpqa_diamond
       - simpleqa
       - livecodebench
+
+  - id: ai2_olmo_3
+    organization: Ai2
+    model: Olmo 3 (7B and 32B)
+    document_type: release_post
+    published: 2025-11-20
+    url: https://allenai.org/blog/olmo3
+    retrieved_at: 2026-08-15
+    benchmarks:
+      - mmlu
+      - mmlu_pro
+      - gpqa
+      - agieval
+      - gsm8k
+      - aime
+      - humaneval
+      - mbpp
+      - livecodebench
+      - drop
+      - ifeval
+      - ifbench
+      - simpleqa
+      - bfcl


### PR DESCRIPTION
**Title:** Add Ai2 Olmo 3 to the model card registry

---

Adds one entry to `data/model_cards.yml`: Ai2's Olmo 3 release post (2025-11-20).

Ai2 was not represented in the registry, so this adds an 11th organization rather than a second document for an org already counted. Registry totals go from 30 cards / 10 organizations to 31 / 11.

**Source:** https://allenai.org/blog/olmo3 (published 2025-11-20, read 2026-08-15)

**Benchmarks recorded** (14, all resolving to ids already in the `benchmarks:` block):
`mmlu`, `mmlu_pro`, `gpqa`, `agieval`, `gsm8k`, `aime`, `humaneval`, `mbpp`, `livecodebench`, `drop`, `ifeval`, `ifbench`, `simpleqa`, `bfcl`

**Notes on judgement calls, so they can be checked rather than trusted:**

- `gpqa`, not `gpqa_diamond`. The evaluation tables label the row "GPQA" with no Diamond qualifier.
- `document_type: release_post`, not `technical_report`. The evaluation tables I read are in the blog post, and `url` points at the document the mentions were read from. The separate technical report at https://allenai.org/papers/olmo3 is a distinct document and would be a separate entry if someone reads it.
- Several reported benchmarks are deliberately **not** recorded, because they are near-misses rather than the canonical ids: "MATH" (the registry has `math_500`), "BigBench Hard" (the registry has `bigbench_extra_hard`, a different benchmark), "AlpacaEval 2 LC" (the registry has `arena_hard`). Mapping any of these onto an existing id would be exactly the silent fuzzy merge CONTRIBUTING.md rules out.
- Variant rows collapse to their canonical id per the one-mention-per-document rule: "AIME 2024" and "AIME 2025" → one `aime`; "HumanEval"/"HumanEvalPlus"/"MultiPL HumanEval" → one `humaneval`; "MBPP"/"MBPP+"/"MultiPL MBPP" → one `mbpp`; "LiveCodeBench v3" → `livecodebench`; the MMLU subject splits → one `mmlu`.

**Validation:**

```
benchmark-radar rebuild   # Rebuilt site/data/radar.json from 23 daily snapshots
ruff check .              # All checks passed
pytest -q                 # 679 passed, 4 failed
```

The 4 failures are all in `tests/test_readme.py` and reproduce on an unmodified checkout of `main` — the current README is a 27-line stub with no headline table for those tests to match against. Flagging rather than fixing, since restoring that table is a separate change.