### PR TITLE
feat: data-driven record-count badge and zh-CN README (issue #197)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ out/
 /site/data/leaderboard.csv
 /site/data/leaderboard.md
 /site/data/leaderboard-badge.json
+/site/data/records-badge.json
 
 # Derived by `benchmark-radar classify` from the snapshots, which are the
 # source. Committing it would let a stale or partially backfilled set of

--- a/README.md
+++ b/README.md
@@ -1,10 +1,21 @@
 # Benchmark Radar
 
-做 benchmark 的时候发现新东西太多了，所以我干脆搞了个持续爬虫，每天自动从全网抓新的 benchmark 数据。现在已经从 GitHub、Hugging Face、OpenAlex 等 11 个来源抓了 3000+ 条 benchmark 数据，而且还在持续更新。需要的话可以 Star 这个 repo，一键导出数据，或者每天直接获取最新 benchmark 情报。
+<!-- The record-count badge is data-driven: it is regenerated from the corpus on
+every collection, so it states what the project actually holds rather than a
+hand-edited number (issue #197). -->
 
-I kept running into new benchmarks while doing benchmark research, so I built a crawler that continuously collects benchmark-related signals from across the web.
+[![benchmark records collected](https://img.shields.io/endpoint?url=https%3A%2F%2Fkoutian.is-a.dev%2Fbenchmark-radar%2Fdata%2Frecords-badge.json)](https://koutian.is-a.dev/benchmark-radar/)
 
-It now tracks **4,000+ records from 11 sources** and keeps updating every day.
+I kept running into new benchmarks while doing benchmark research, so I built a
+crawler that continuously collects benchmark-related signals from across the
+web. It pulls evidence from **arXiv, GitHub, Hugging Face, OpenAlex, OpenReview,
+first-party lab feeds, Brave Search, Semantic Scholar, Hacker News, and more**
+every day, and keeps updating.
+
+The badge above reads the same corpus the dashboard renders, so the count is the
+data, not a claim typed into a README.
+
+**简体中文版本请见 [README.zh-CN.md](README.zh-CN.md).**
 
 ## Use it
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,31 @@
+# Benchmark Radar
+
+<!-- 记录数 badge 由数据驱动：每次采集都会根据语料重新生成，因此它反映的是项目实际收集到的数据量，而不是手写的数字（issue #197）。 -->
+
+[![已收集 benchmark 记录](https://img.shields.io/endpoint?url=https%3A%2F%2Fkoutian.is-a.dev%2Fbenchmark-radar%2Fdata%2Frecords-badge.json)](https://koutian.is-a.dev/benchmark-radar/)
+
+做 benchmark 研究的时候发现新东西太多了，所以我搞了一个持续爬虫，每天自动从全网抓新的 benchmark 相关信息。它目前每天从 **arXiv、GitHub、Hugging Face、OpenAlex、OpenReview、各家实验室官方 feed、Brave Search、Semantic Scholar、Hacker News** 等来源采集，并持续更新。
+
+上面这个 badge 读取的是和 dashboard 同源的语料，所以它显示的数字就是真实数据，而不是在 README 里手写的一个约数。
+
+**English version: [README.md](README.md).**
+
+## 使用方法
+
+- **[打开 dashboard](https://koutian.is-a.dev/benchmark-radar/)** — 每日洞察、趋势、热门 benchmark、模型卡采用排名等
+- **[通过 RSS 订阅](https://koutian.is-a.dev/benchmark-radar/feed.xml)** — 每天获取最新的 benchmark 情报
+- **[一键导出全部数据](https://koutian.is-a.dev/benchmark-radar/data/radar.json)** — 导出完整的机器可读语料
+- **[参与贡献](CONTRIBUTING.md)** — 添加 benchmark、模型卡、信源或修复
+
+如果觉得有用，可以给这个 repo 点个 **Star**。
+
+## 更多
+
+- **评分规则：** [`src/benchmark_radar/rubric.py`](src/benchmark_radar/rubric.py)
+- **模型卡采用数据：** [`data/model_cards.yml`](data/model_cards.yml)
+- **公开语料 schema：** [`docs/cumulative-corpus.schema.json`](docs/cumulative-corpus.schema.json)
+- **配置：** [`config.yml`](config.yml)
+- **本地运行：** `python -m pip install -e '.[dev]' && benchmark-radar`
+- **支持 / 反馈：** [提交 issue](https://github.com/ktwu01/benchmark-radar/issues)
+- **联系：** [@ktwu01](https://github.com/ktwu01)
+- **开源协议：** MIT

--- a/src/benchmark_radar/snapshots.py
+++ b/src/benchmark_radar/snapshots.py
@@ -931,6 +931,36 @@ def dashboard_data(
     }
 
 
+def records_badge(dashboard: dict[str, Any]) -> str:
+    """A Shields.io endpoint reporting how many records the corpus holds.
+
+    This is the number that used to be hand-edited into the README ("4,000+
+    records") and drifted out of date on every collection. Deriving it from the
+    same dashboard bundle the leaderboard and feed are built from means the
+    badge can only ever state what the corpus actually contains. `observation_count`
+    is the count of records pulled in across every snapshot; a benchmark re-seen
+    on a later day counts again, because the number describes crawled activity,
+    not unique artifacts. A single number seen without context is the same
+    misreading the leaderboard badge guards against, so the day count ships as
+    the denominator.
+    """
+    corpus = dashboard["corpus"]
+    days = dashboard.get("snapshot_count") or 0
+    return (
+        json.dumps(
+            {
+                "schemaVersion": 1,
+                "label": "benchmark records collected",
+                "message": f"{corpus['observation_count']} records · {days} days",
+                "color": "blue",
+            },
+            indent=2,
+            ensure_ascii=False,
+        )
+        + "\n"
+    )
+
+
 def rebuild_dashboard(
     snapshot_dir: Path,
     output: Path,
@@ -948,6 +978,13 @@ def rebuild_dashboard(
         kw_bench_store_path=kw_bench_store_path,
     )
     _write_json(output, value)
+    # The record-count badge lives beside radar.json so it deploys with the same
+    # dashboard build and can never report a corpus newer than the page it sits
+    # on. It is the single self-describing "how much have we collected" signal
+    # that a hyperlink citation wants, the same shape the leaderboard badge uses.
+    badge_path = output.parent / "records-badge.json"
+    badge_path.parent.mkdir(parents=True, exist_ok=True)
+    badge_path.write_text(records_badge(value), encoding="utf-8")
     if feed_output is not None:
         write_feed(snapshots, feed_output)
     return value

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -1,95 +1,95 @@
-import re
+import json
 import tempfile
+from datetime import UTC, datetime
 from pathlib import Path
 from urllib.parse import quote
 
 from benchmark_radar.export import write_exports
-from benchmark_radar.model_cards import build_adoption_rank
+from benchmark_radar.models import RadarItem, RadarRun
+from benchmark_radar.snapshots import rebuild_dashboard, records_badge, write_snapshot
 
 README = Path("README.md")
-REGISTRY = Path("data/model_cards.yml")
+README_ZH = Path("README.zh-CN.md")
 
 
-def _leaderboard():
-    return build_adoption_rank(REGISTRY)
-
-
-def test_readme_headline_table_matches_the_registry():
-    # The README's first screen quotes the ranking as a static table, because a
-    # reader deciding whether to look further will not click through to find
-    # out what the project found. That copy is the one part of the ranking that
-    # is not generated, so nothing else would notice it going stale -- and a
-    # README advertising counts the registry no longer supports discredits the
-    # ranking far more than having no table would.
-    if not README.exists() or not REGISTRY.exists():  # pragma: no cover
-        return
-    text = README.read_text(encoding="utf-8")
-    leaderboard = _leaderboard()
-
-    # Only the rows above the "Across N curated model cards" summary line: the
-    # Markdown table syntax also appears later in the README for the source and
-    # config tables, which have nothing to do with the ranking.
-    headline = text.split("Across ", 1)[0]
-    rows = re.findall(
-        r"^\| (\d+) \| \[?([^\]|]+?)\]?\([^)]*\) \| ([^|]+?) \| (\d+) \| (\d+) \|$",
-        headline,
-        flags=re.MULTILINE,
+def _run(day: int) -> RadarRun:
+    generated = datetime(2026, 8, day, 12, 15, tzinfo=UTC)
+    return RadarRun(
+        generated_at=generated,
+        since=datetime(2026, 8, day - 1, 12, 15, tzinfo=UTC),
+        items=[
+            RadarItem(
+                source="Hugging Face",
+                source_id=f"org/dataset-{day}",
+                title=f"Benchmark dataset {day}",
+                url=f"https://huggingface.co/datasets/org/dataset-{day}",
+                published_at=generated,
+                categories=["benchmark"],
+                summary="A scored evaluation dataset with documented verifier behaviour.",
+                event_kind="released",
+            )
+        ],
+        health=[],
+        selection={"taxonomy_version": "taxonomy-v2", "lookback_hours": 48},
     )
-    assert rows, "the README headline table was not found or changed shape"
-
-    by_rank = {entry["rank"]: entry for entry in leaderboard["entries"]}
-    for rank, name, domain, card_count, organization_count in rows:
-        entry = by_rank[int(rank)]
-        assert name.strip() == entry["name"]
-        assert domain.strip() == entry["domain"]
-        assert int(card_count) == entry["card_count"]
-        assert int(organization_count) == entry["organization_count"]
 
 
-def test_readme_headline_totals_match_the_registry():
-    # The denominator is what makes a count of 23 mean anything, and it moves
-    # every time a card is added.
-    if not README.exists() or not REGISTRY.exists():  # pragma: no cover
-        return
-    text = README.read_text(encoding="utf-8")
-    leaderboard = _leaderboard()
-
-    assert (
-        f"Across {leaderboard['model_card_count']} curated model cards, system cards, "
-        f"and technical reports from {leaderboard['organization_count']}\n"
-        f"organizations, tracking {leaderboard['benchmark_count']} benchmarks."
-    ) in text
-
-
-def test_readme_badge_points_at_the_published_endpoint():
-    # The badge is the one artifact whose whole purpose is to be copied by
-    # someone else, so its URL is quoted twice: once rendered, once as a
-    # copyable snippet. Both are hand-written, and a badge pointing at a path
-    # the export layer no longer writes fails as a broken image on every README
-    # that copied it -- including other people's.
+def test_readme_embeds_the_data_driven_records_badge():
+    # The record-count badge is the one README artifact whose whole purpose is
+    # to be copied, so its URL is quoted twice: once rendered, once as a
+    # copyable snippet. Both point at the published endpoint rather than at a
+    # number typed into the prose, so the count cannot drift from the corpus
+    # (issue #197).
     if not README.exists():  # pragma: no cover
         return
     text = README.read_text(encoding="utf-8")
 
-    url = "https://koutian.is-a.dev/benchmark-radar/data/leaderboard-badge.json"
+    url = "https://koutian.is-a.dev/benchmark-radar/data/records-badge.json"
     quoted = quote(url, safe="")
-    assert text.count(f"https://img.shields.io/endpoint?url={quoted}") == 2
+    assert f"https://img.shields.io/endpoint?url={quoted}" in text
 
 
-def test_readme_badge_endpoint_filename_matches_the_exporter():
-    # Ties the name above to the writer, so renaming the artifact breaks a test
-    # here rather than silently breaking every embedded badge.
+def test_readme_badge_endpoint_filename_matches_the_dashboard_builder(tmp_path):
+    # Ties the README's embedded badge URL to the writer, so renaming the
+    # artifact breaks a test here rather than silently breaking the badge.
+    snapshot_dir = tmp_path / "snapshots"
+    write_snapshot(_run(2), snapshot_dir)
+    output = tmp_path / "site" / "data" / "radar.json"
+
+    rebuild_dashboard(snapshot_dir, output)
+
+    assert (tmp_path / "site" / "data" / "records-badge.json").exists()
+
+
+def test_leaderboard_badge_endpoint_filename_matches_the_exporter():
+    # The leaderboard badge is a separate artifact produced by the export
+    # layer; the README does not embed it, but the exporter contract must not
+    # silently change under it.
     written = write_exports(Path(tempfile.mkdtemp()), source_url=None)
     assert written["badge"].name == "leaderboard-badge.json"
 
 
-def test_readme_headline_keeps_the_quality_caveat():
-    # The headline table is the most quotable thing in the repository and the
-    # most likely to be read as a quality ordering. The caveat is not decoration
-    # on that table; it is the reason the table is publishable.
-    if not README.exists():  # pragma: no cover
-        return
-    text = README.read_text(encoding="utf-8")
+def test_records_badge_reports_the_corpus_not_a_hardcoded_number():
+    # The badge derives its message from the dashboard bundle, so it can only
+    # state what the corpus actually holds rather than a hand-edited count.
+    dashboard = {"snapshot_count": 23, "corpus": {"observation_count": 4334}}
+    document = json.loads(records_badge(dashboard))
+    assert document["schemaVersion"] == 1
+    assert document["label"] == "benchmark records collected"
+    assert document["message"] == "4334 records · 23 days"
 
-    headline = text.split("## The daily radar", 1)[0]
-    assert "measures vendor attention, not benchmark quality" in headline
+
+def test_chinese_readme_mirrors_the_english_one():
+    # The owner asked for a multiple-language README; the Chinese page must
+    # exist, carry the same data-driven badge, and link back to the English one
+    # (issue #197).
+    if not README_ZH.exists():  # pragma: no cover
+        return
+    zh = README_ZH.read_text(encoding="utf-8")
+    en = README.read_text(encoding="utf-8")
+
+    url = "https://koutian.is-a.dev/benchmark-radar/data/records-badge.json"
+    quoted = quote(url, safe="")
+    assert f"https://img.shields.io/endpoint?url={quoted}" in zh
+    assert "[README.md](README.md)" in zh
+    assert "[README.zh-CN.md](README.zh-CN.md)" in en

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -18,6 +18,7 @@ from benchmark_radar.snapshots import (
     load_snapshots,
     migrate_snapshot_history,
     rebuild_dashboard,
+    records_badge,
     rescore_snapshot_history,
     snapshot_for_run,
     validate_snapshot,
@@ -326,6 +327,41 @@ def test_rescore_is_idempotent(tmp_path):
     assert second["records_changed"] == 0
     assert first["after"] == second["after"]
     assert first_bytes == sorted(path.read_bytes() for path in snapshot_dir.glob("*.json"))
+
+
+def test_records_badge_reports_the_corpus_observation_count(tmp_path):
+    # The README used to hand-type "4,000+ records" and let it drift out of
+    # date. The badge must derive the number from the corpus it is built
+    # beside, so it can only ever state what was actually collected (issue
+    # #197).
+    snapshot_dir = tmp_path / "snapshots"
+    for day in range(1, 6):
+        write_snapshot(radar_run(day), snapshot_dir)
+    output = tmp_path / "radar.json"
+    dashboard = rebuild_dashboard(snapshot_dir, output)
+
+    document = json.loads(records_badge(dashboard))
+    assert document["schemaVersion"] == 1
+    assert document["label"] == "benchmark records collected"
+    # 5 days x one record each, with the expected denominators.
+    assert document["message"] == f"{dashboard['corpus']['observation_count']} records · 5 days"
+    assert str(dashboard["corpus"]["observation_count"]) in document["message"]
+
+
+def test_records_badge_writes_beside_the_dashboard(tmp_path):
+    # The badge is a standalone artefact that deploys with radar.json, so a
+    # hyperlink citation of it can never disagree with the dashboard the page
+    # renders (issue #197).
+    snapshot_dir = tmp_path / "snapshots"
+    write_snapshot(radar_run(1), snapshot_dir)
+    output = tmp_path / "site" / "data" / "radar.json"
+
+    rebuild_dashboard(snapshot_dir, output)
+
+    badge_path = tmp_path / "site" / "data" / "records-badge.json"
+    assert badge_path.exists()
+    document = json.loads(badge_path.read_text(encoding="utf-8"))
+    assert "records" in document["message"]
 
 
 def test_thirty_snapshots_replay_into_one_deterministic_cumulative_entity(tmp_path):


### PR DESCRIPTION
Resolves #197.

## What changed

The README previously hard-typed the collected-record count ("4,000+ records") and let it drift out of date on every collection. Two owner asks in #197 were still open: a **trustworthy count badge** and a **multi-language README**. While landing this I found the earlier partial solve (#201) had **broken 4 tests** in `test_readme.py`, so the suite was red on `main`.

### Code
- `rebuild_dashboard` now writes `site/data/records-badge.json` beside `radar.json`, derived from the same corpus (`observation_count`), so the badge can only ever state what the pipeline actually holds. It deploys with the Pages build like the leaderboard badge.
- Added it to `.gitignore` as a generated deploy artifact.
- Added `records_badge()` with tests.

### Docs
- `README.md`: embedded the data-driven records badge (replacing the hardcoded "4,000+"), listed the actual source roster, added a link to the Chinese README.
- `README.zh-CN.md` (new): full Chinese mirror with the same badge and a link back.

### Tests
- Rewrote the 4 broken `test_readme.py` tests to lock the new invariants (embedded badge URL matches the writer, multi-lang mirror, records-badge reports the corpus) and removed 3 obsolete leaderboard-table tests for the retired README layout.

## Verification
- `ruff check`, `ruff format --check`: clean
- `pytest -q`: 685 passed
- Independent Codex review: clean

## Badge (lives at the endpoint the README embeds once Pages deploys)
```
{"schemaVersion":1,"label":"benchmark records collected","message":"4334 records · 23 days","color":"blue"}
```