### PR TITLE
fix(questions): stop an uncited 100 from passing Q&A validation (issue #165)

### DIFF
--- a/src/benchmark_radar/questions.py
+++ b/src/benchmark_radar/questions.py
@@ -212,13 +212,20 @@ def _payload(model: str, serialized: str) -> dict[str, Any]:
 _PROSE_FIELDS = ("signal", "plain_english", "takeaway", "counter_view")
 # Quantities the model may write without citing a statistic: ordinals and small
 # counts that describe its own answer ("both readings", "the first of two")
-# rather than measurements of the corpus.
-_ALLOWED_BARE_NUMBERS = {"0", "1", "2", "3", "100"}
+# rather than measurements of the corpus. `100` is deliberately absent: it is a
+# plausible corpus measurement, not a self-referential count, so a bare one is
+# a falsifiable claim.
+_ALLOWED_BARE_NUMBERS = {"0", "1", "2", "3"}
 _NUMBER = re.compile(r"\d[\d,]*(?:\.\d+)?")
 # Characters that glue a digit run into a version, id, or other code rather
 # than leaving it a free-standing measurement ("26-001", "S001", "v2.001",
 # "doi:10.1000"). A token abutting one of these is an identifier fragment.
 _IDENTIFIER_GLUE = set("-._/:#")
+# The registry's own notes and the instructions carry the caveat that category
+# shares overlap and do not sum to 100%. That negative phrasing, and only that
+# phrasing, lets a 100 appear without a citable statistic; a bare "sum to 100%"
+# claim is not sanctioned.
+_CAVEAT_HUNDRED = re.compile(r"do\s+not\s+sum\s+to\s+100\s*%")
 
 
 def _is_identifier_fragment(text: str, match: re.Match[str]) -> bool:
@@ -270,10 +277,16 @@ def _reject_uncited_quantities(
         allowed.update(_registry_number_forms(stat))
     for field in _PROSE_FIELDS:
         text = str(answer.get(field) or "")
+        # The registry's own notes and the instructions supply the caveat
+        # "shares do not sum to 100%"; reproducing it must not fail the day.
+        # Only that sanctioned context exempts a 100, never a bare percentage.
+        caveat_spans = [m.span() for m in _CAVEAT_HUNDRED.finditer(text)]
         for match in _NUMBER.finditer(text):
             token = match.group(0)
             # A year or a date fragment is context, not a measurement.
             if token in allowed or token.rstrip(",") in allowed:
+                continue
+            if token == "100" and any(start <= match.start() < end for start, end in caveat_spans):
                 continue
             if re.fullmatch(r"20\d\d", token):
                 continue

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -259,6 +259,88 @@ def test_prose_may_not_state_a_number_the_registry_does_not_hold():
         )
 
 
+def test_prose_may_not_state_an_uncited_hundred():
+    # 100 is not in the bare-number allowlist: it is a plausible corpus
+    # measurement, not an ordinal or a self-referential count, so a model may
+    # not state it without a statistic that computes to 100. Previously it was
+    # allowlisted (issue #165) and let a fabricated quantity through.
+    stats = {"S001": {"id": "S001", "label": "x", "value": 2, "unit": "count"}}
+    answer = {
+        "signal": "100 benchmarks arrived today.",
+        "plain_english": "",
+        "takeaway": "",
+        "counter_view": "",
+    }
+
+    with pytest.raises(BriefingError, match="uncited quantity"):
+        questions._reject_uncited_quantities(answer, stats)
+
+
+def test_an_uncited_hundred_is_fine_when_a_statistic_is_hundred():
+    # Removing 100 from the bare allowlist must not reject a quantity the
+    # registry actually computed: a registry value of 100 remains citable.
+    stats = {"S001": {"id": "S001", "label": "share", "value": 100, "unit": "percent"}}
+
+    questions._reject_uncited_quantities(
+        {"signal": "100 percent share.", "plain_english": "", "takeaway": "", "counter_view": ""},
+        stats,
+    )
+
+
+def test_an_uncited_hundred_percent_caveat_is_fine():
+    # The registry's own notes and the instructions supply the caveat "shares do
+    # not sum to 100%". The model may reproduce that sanctioned wording even
+    # when no statistic computes to 100; the exemption is the caveat, not every
+    # percentage (issue #165 / Codex review).
+    stats = {"S001": {"id": "S001", "label": "x", "value": 2, "unit": "count"}}
+
+    questions._reject_uncited_quantities(
+        {
+            "signal": "category shares do not sum to 100%.",
+            "plain_english": "",
+            "takeaway": "",
+            "counter_view": "",
+        },
+        stats,
+    )
+
+
+def test_an_unsupported_percentage_is_still_rejected():
+    # Only the sanctioned negative caveat exempts a 100; a fabricated percentage
+    # such as "100% of today's records" must still fail when no statistic
+    # computes to 100 (issue #165 / Codex review).
+    stats = {"S001": {"id": "S001", "label": "x", "value": 2, "unit": "count"}}
+
+    with pytest.raises(BriefingError, match="uncited quantity"):
+        questions._reject_uncited_quantities(
+            {
+                "signal": "100% of today's records are benchmarks.",
+                "plain_english": "",
+                "takeaway": "",
+                "counter_view": "",
+            },
+            stats,
+        )
+
+
+def test_a_positive_sum_to_hundred_is_not_the_sanctioned_caveat():
+    # The exemption is the registry's negative caveat ("do not sum to 100%").
+    # The affirmative "shares sum to 100%" is a fabricated claim, not that
+    # caveat, and must be rejected when no statistic computes to 100.
+    stats = {"S001": {"id": "S001", "label": "x", "value": 2, "unit": "count"}}
+
+    with pytest.raises(BriefingError, match="uncited quantity"):
+        questions._reject_uncited_quantities(
+            {
+                "signal": "category shares sum to 100%.",
+                "plain_english": "",
+                "takeaway": "",
+                "counter_view": "",
+            },
+            stats,
+        )
+
+
 def test_prose_may_state_identifier_fragments_the_registry_does_not_hold():
     # "26-001", "S001", "v2.001", "2026-001," are version and artifact codes,
     # not corpus measurements, so they must not fail a day's Q&A (a production


### PR DESCRIPTION
Resolves #165.

- Remove `100` from the bare-number allowlist so a fabricated quantity (e.g. "100 benchmarks arrived today") cannot pass validation.
- Permit `100` only inside the sanctioned caveat that category shares do not sum to 100%, so reproducing the registry's own wording stays valid.
- Add regression tests for the rejection and the still-citable cases.

Verified: ruff clean, tests pass.