### PR TITLE
feat(social): lead every daily checklist with the records-count badge (issue #206)

### DIFF
--- a/src/benchmark_radar/social.py
+++ b/src/benchmark_radar/social.py
@@ -23,6 +23,17 @@ import yaml
 
 SECTION_HEADING = "## 🗣 Daily social post"
 
+# Issue #206: the record-count badge (same Shields endpoint the README embeds)
+# sits at the top of every day's checklist so the corpus size is visible at a
+# glance on the posting issue. It is data-driven (snapshots.records_badge), so
+# it can only state what the corpus actually holds.
+_RECORDS_BADGE = (
+    "[![benchmark records collected]"
+    "(https://img.shields.io/endpoint?url=https%3A%2F%2Fkoutian.is-a.dev"
+    "%2Fbenchmark-radar%2Fdata%2Frecords-badge.json)]"
+    "(https://koutian.is-a.dev/benchmark-radar/)"
+)
+
 _CHECKBOX_RE = re.compile(r"^-\s+\[([ xX])\]\s+(.+)$")
 
 # Path prefixes that would otherwise read as "src", "data" etc. in a social
@@ -244,6 +255,8 @@ def render_social_section(
     today = today or date.today()
     lines = [
         SECTION_HEADING,
+        "",
+        _RECORDS_BADGE,
         "",
         "Ready-to-post material for today. Rephrase per platform; the two "
         "sentences below are the factual core.",

--- a/tests/test_social.py
+++ b/tests/test_social.py
@@ -136,6 +136,39 @@ def test_load_channels_daily_only_keeps_everything_when_no_channel_sets_daily(tm
     ]
 
 
+def test_render_section_leads_with_the_records_badge(tmp_path: Path):
+    # Issue #206: the data-driven record-count badge appears at the top of every
+    # day's checklist so the corpus size is visible at a glance on the posting
+    # issue. It points at the published Shields endpoint, never a hand-typed
+    # count, mirroring the README's embedded badge.
+    section = render_social_section(
+        "insight",
+        "repo change",
+        [],
+        [{"name": "X / Twitter"}],
+    )
+    lines = section.splitlines()
+    assert lines[0] == SECTION_HEADING
+    assert lines[1] == ""
+    assert "![benchmark records collected]" in lines[2]
+    assert "img.shields.io/endpoint" in lines[2]
+    assert "records-badge.json" in lines[2]
+
+
+def test_merge_checked_keeps_the_records_badge(tmp_path: Path):
+    # The badge sits above the checklist and carries no checkbox, so re-running
+    # with an existing body must never strip it (issue #206).
+    section = render_social_section(
+        "insight",
+        "repo change",
+        [],
+        [{"name": "X / Twitter"}],
+    )
+    existing = SECTION_HEADING + "\n\n- [x] X / Twitter\n"
+    merged = merge_checked(section, existing)
+    assert "![benchmark records collected]" in merged
+
+
 def test_render_section_lists_every_channel_unchecked(tmp_path: Path):
     channels_path = tmp_path / "social.yml"
     channels_path.write_text(

--- a/tests/test_social.py
+++ b/tests/test_social.py
@@ -4,9 +4,9 @@ from pathlib import Path
 
 from benchmark_radar import cli
 from benchmark_radar.social import (
+    _WEEKLY_ANCHOR,
     SECTION_HEADING,
     GitChange,
-    _WEEKLY_ANCHOR,
     build_insight_sentence,
     extract_checked,
     load_channels,


### PR DESCRIPTION
Adds the data-driven record-count badge (records-badge.json) to the top of every day's daily-social-checklist issue body, fulfilling the request on issue #206.

- Renders the badge markdown immediately under the section heading, above the posting checklist.
- Badge points at the published Shields endpoint; it never types a count by hand (same data-driven source the README embeds).
- merge_checked leaves the badge intact on re-runs since it carries no checkbox.

Also folds in the ruff import-order fix (I001) so CI passes on this branch.