### PR TITLE
Today page: scannable insight blocks and tighter hierarchy (issue #203)

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -435,6 +435,64 @@ function briefingContent(line, citations) {
   return nodes;
 }
 
+// A briefing bullet is model prose of the form "The claim. Why it matters:
+// the point. Evidence: E001, E002. High confidence." For a scan to meet the
+// takeaway first and the support on demand, that one paragraph is split into a
+// short head, an optional body, and a metadata line carrying the confidence and
+// the source count. Bullets that do not follow the shape (older days) fall back
+// to the whole line as the head with no body or meta.
+function briefingParts(line) {
+  let text = String(line).trim();
+  let confidence = "";
+  const confidenceMatch = text.match(/\b(High|Medium|Low|Moderate|Mixed)\s+confidence\.?\s*$/i);
+  if (confidenceMatch) {
+    confidence = confidenceMatch[1];
+    text = text.slice(0, confidenceMatch.index).trim();
+  }
+  // Lift the trailing "Evidence: E001, E002." clause out of the prose in both
+  // the split and the fallback shapes, so the IDs never stay in the running
+  // sentences a scan of the findings has to wade through.
+  const sources = (text.match(/\bE\d{3}\b/g) || []).length;
+  text = text.replace(/\s*\.?\s*Evidence:\s*((?:E\d{3}\s*,\s*)*E\d{3})\.?\s*/i, "").trim();
+  const whyIndex = text.search(/\bWhy it matters:\s*/i);
+  if (whyIndex === -1) return { head: text, body: "", confidence, sources };
+  const head = text.slice(0, whyIndex).trim();
+  const body = text
+    .slice(whyIndex + "Why it matters:".length)
+    .trim();
+  return { head, body, confidence, sources };
+}
+
+function briefingMeta(parts) {
+  const chips = [];
+  if (parts.confidence) {
+    chips.push(element("span", {
+      className: `briefing-chip briefing-chip-${parts.confidence.toLowerCase()}`,
+      text: `${parts.confidence} confidence`,
+    }));
+  }
+  if (parts.sources > 0) {
+    chips.push(element("span", {
+      className: "briefing-chip briefing-chip-sources",
+      text: `${parts.sources} ${parts.sources === 1 ? "source" : "sources"}`,
+    }));
+  }
+  if (!chips.length) return null;
+  return element("p", { className: "briefing-insight-meta" }, chips);
+}
+
+function briefingInsight(line, citations) {
+  const parts = briefingParts(line);
+  const head = element("h3", { className: "briefing-insight-head" },
+    briefingContent(parts.head || line, citations));
+  // The body is the "why it matters" support under the head, and the evidence
+  // clause was lifted out of it into the metadata chips by briefingParts.
+  const body = parts.body
+    ? element("p", { className: "briefing-insight-body" }, briefingContent(parts.body, citations))
+    : null;
+  return element("article", { className: "briefing-insight" }, [head, body, briefingMeta(parts)]);
+}
+
 function briefingProvenance(briefing) {
   if (briefing.generator !== "openai-responses") return null;
   const usage = briefing.usage || {};
@@ -508,10 +566,11 @@ function renderDailyBriefing(day) {
     byId("daily-briefing-body"),
     usable.length
       ? [
-          element("ul", { className: "daily-briefing-list" },
-          // Model prose remains text nodes. Only exact evidence IDs present in
-          // the snapshot's validated citation map become links.
-          usable.map((line) => element("li", {}, briefingContent(line, citations)))),
+          // Model prose becomes a scannable insight block per bullet: a short
+          // head (the takeaway), the "why it matters" support beneath it, and a
+          // metadata line carrying confidence and source count instead of
+          // paragraph-wide prose and mid-sentence evidence IDs.
+          ...usable.map((line) => briefingInsight(line, citations)),
           briefingDetails(briefing, citations),
         ]
       : [
@@ -592,6 +651,25 @@ function answerBlock(answer) {
   // support (Tab to focus, Enter/Space to toggle) for free and stays collapsed
   // on load because no `open` attribute is rendered.
   const citations = answerCitations(answer);
+  const sourceCount = validBriefingCitations(answer?.cited_evidence).length;
+  const meta = element("p", { className: "answer-meta" }, [
+    ...(confidence
+      ? [
+          element("span", {
+            className: `pill pill-confidence pill-confidence-${confidence}`,
+            text: `${confidence} confidence`,
+          }),
+        ]
+      : []),
+    ...(sourceCount
+      ? [
+          element("span", {
+            className: "answer-source-count",
+            text: `${sourceCount} ${sourceCount === 1 ? "source" : "sources"}`,
+          }),
+        ]
+      : []),
+  ]);
   const detail = element("div", { className: "answer-detail" }, [
     element("p", { className: "answer-plain" }, [
       element("em", { text: "In plain English: " }),
@@ -620,30 +698,17 @@ function answerBlock(answer) {
     ]),
   ]);
   return element("article", { className: "answer" }, [
-    // The confidence sits on the question's own line: it qualifies the answer
-    // that follows, so a reader should meet it before reading the claim.
+    // Question first, confidence and sources as a de-emphasized metadata row
+    // beneath it rather than pinned to the question's own line, so a scan of a
+    // day's answers stays a scan of the questions themselves.
     element("h4", { className: "answer-question" }, [
       document.createTextNode(String(answer?.question || "")),
-      ...(confidence
-        ? [
-            element("span", {
-              className: `pill pill-confidence pill-confidence-${confidence}`,
-              text: `${confidence} confidence`,
-            }),
-          ]
-        : []),
     ]),
     element("p", { className: "answer-signal", text: String(answer?.signal || "") }),
+    meta,
     element("details", { className: "answer-disclosure" }, [
       element("summary", { className: "answer-disclosure-summary" }, [
-        element("span", {
-          className: "answer-disclosure-label",
-          // Promise only what expanding actually reveals: an answer with no
-          // citations must not advertise "sources" it does not carry.
-          text: citations
-            ? "Read the full answer, sources and takeaway"
-            : "Read the full answer and takeaway",
-        }),
+        element("span", { className: "answer-disclosure-label", text: "View analysis" }),
       ]),
       detail,
     ]),

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -89,7 +89,7 @@ footer {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  min-height: 94px;
+  min-height: 72px;
   border-bottom: 1px solid var(--ink);
 }
 
@@ -263,7 +263,7 @@ button.repo-badge svg {
 .view-nav button,
 .view-nav a {
   min-width: 112px;
-  padding: 1rem 1.25rem;
+  padding: 0.85rem 1.25rem;
   border: 0;
   border-right: 1px solid var(--line);
   background: transparent;
@@ -407,31 +407,87 @@ input {
 }
 
 /* The day's narrative leads the view, so it reads as prose rather than as
-   another panel competing with the listings below it. */
+   another panel competing with the listings below it. The heavy bordered box
+   is dropped: whitespace and the section titles carry the separation, and
+   narrow measure keeps the findings scannable without a long line length. */
 .daily-briefing {
-  margin-bottom: 1.5rem;
-  padding: 0.9rem 1.4rem;
-  border: 1px solid var(--ink);
-  background: var(--panel);
+  margin-bottom: 2.25rem;
+  max-width: 78ch;
 }
 
 .daily-briefing-title {
-  margin-bottom: 0.6rem;
+  margin-bottom: 1rem;
+  padding-bottom: 0.6rem;
+  border-bottom: 1px solid var(--ink);
   font-size: 1rem;
 }
 
-.daily-briefing-list {
-  margin: 0;
-  padding-left: 1.2rem;
+/* Each briefing bullet becomes its own insight: a bold takeaway head, the
+   "why it matters" support beneath it, and a quiet metadata chip row. */
+.briefing-insight + .briefing-insight {
+  margin-top: 1.35rem;
 }
 
-.daily-briefing-list li + li {
-  margin-top: 0.4rem;
+.briefing-insight-head {
+  margin: 0 0 0.3rem;
+  font-family: var(--display);
+  font-size: 1.12rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  line-height: 1.25;
+}
+
+.briefing-insight-body {
+  margin: 0 0 0.45rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.briefing-insight-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin: 0;
+}
+
+.briefing-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.14rem 0.5rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--muted);
+  font-family: var(--utility);
+  font-size: 0.66rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.briefing-chip-high {
+  border-color: var(--sea);
+  color: var(--sea);
+}
+
+.briefing-chip-medium {
+  border-color: var(--gold);
+  color: #7d5c14;
+}
+
+.briefing-chip-low,
+.briefing-chip-moderate {
+  border-color: var(--line);
+  color: var(--muted);
+}
+
+.briefing-chip-sources {
+  border-color: var(--ink);
+  color: var(--ink);
+  font-weight: 600;
 }
 
 .briefing-evidence-link {
   color: var(--blue-deep);
-  font-weight: 650;
+  font-weight: 500;
   text-decoration: underline;
   text-decoration-thickness: 0.08em;
   text-underline-offset: 0.14em;
@@ -442,8 +498,8 @@ input {
 }
 
 .daily-briefing-details {
-  margin-top: 0.85rem;
-  padding-top: 0.7rem;
+  margin-top: 1.1rem;
+  padding-top: 0.8rem;
   border-top: 1px solid var(--line);
 }
 
@@ -494,14 +550,14 @@ input {
 }
 
 .daily-questions {
-  margin-bottom: 1.5rem;
-  padding: 0.9rem 1.4rem;
-  border: 1px solid var(--ink);
-  background: var(--panel);
+  margin-bottom: 2.25rem;
+  max-width: 78ch;
 }
 
 .daily-questions-title {
-  margin-bottom: 0.6rem;
+  margin-bottom: 1rem;
+  padding-bottom: 0.6rem;
+  border-bottom: 1px solid var(--ink);
   font-size: 1rem;
 }
 
@@ -529,16 +585,13 @@ input {
 }
 
 .answer + .answer {
-  margin-top: 0.9rem;
+  margin-top: 1.15rem;
 }
 
 .answer-question {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: baseline;
-  gap: 0.5rem;
-  margin: 0 0 0.3rem;
-  font-size: 0.95rem;
+  margin: 0 0 0.25rem;
+  font-size: 1rem;
+  line-height: 1.3;
 }
 
 .answer-signal,
@@ -547,6 +600,27 @@ input {
 .answer-counter-view {
   margin: 0.35rem 0 0;
   font-size: 0.9rem;
+}
+
+.answer-signal {
+  color: var(--ink);
+  font-weight: 500;
+}
+
+.answer-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin: 0.45rem 0 0;
+}
+
+.answer-source-count {
+  align-self: center;
+  color: var(--muted);
+  font-family: var(--utility);
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
 }
 
 .answer-plain {
@@ -586,8 +660,25 @@ input {
 
 .pill-confidence {
   flex: none;
+  align-self: flex-start;
   font-weight: 600;
   text-transform: lowercase;
+}
+
+.pill-confidence-high {
+  border-color: var(--sea);
+  color: var(--sea);
+}
+
+.pill-confidence-medium {
+  border-color: var(--gold);
+  color: #7d5c14;
+}
+
+.pill-confidence-low,
+.pill-confidence-moderate {
+  border-color: var(--line);
+  color: var(--muted);
 }
 
 /* The full answer (explanation, sources, takeaway, counter-view) is collapsed
@@ -3423,7 +3514,7 @@ footer {
   }
 
   .masthead {
-    min-height: 76px;
+    min-height: 64px;
   }
 
   /* Keep the badges reachable on narrow screens, but drop the word so the

--- a/tests/fixtures/daily_briefing.json
+++ b/tests/fixtures/daily_briefing.json
@@ -1,0 +1,98 @@
+{
+  "date": "2026-08-12",
+  "briefing": {
+    "bullets": [
+      "Several new releases in this captured feed bind benchmarks to deployment context: web-access APIs are compared across quality, latency, cost, and error rate; document segmentation includes a reference scorer and cloud-VLM comparison; and a device-specific benchmark targets reproducible 7B testing on Jetson hardware. Why it matters: Evaluators should choose suites that reproduce the intended stack and expose operational trade-offs, rather than treating a task score as sufficient evidence for deployment selection. Evidence: E001, E003, E015. High confidence.",
+      "An older-format bullet without the Why it matters structure, still stating its own evidence and confidence inline. Evidence: E004, E007. Medium confidence."
+    ],
+    "caveat": "Only 25 of 164 corpus evidence records were injected, so these findings describe the selected slice rather than the full captured feed. Brave and OpenReview were unavailable, no attention signal was observed today, and comparable history is insufficient for a cross-day trend. Tracked metric deltas were not used because each came from a single connector and was therefore uncorroborated.",
+    "citations": [
+      {
+        "id": "E001",
+        "source": "Hugging Face",
+        "title": "nutrientdocs/doc-split-benchmark",
+        "url": "https://huggingface.co/datasets/nutrientdocs/doc-split-benchmark"
+      },
+      {
+        "id": "E003",
+        "source": "Hugging Face",
+        "title": "nativeport/web-access-api-benchmarks",
+        "url": "https://huggingface.co/datasets/nativeport/web-access-api-benchmarks"
+      },
+      {
+        "id": "E015",
+        "source": "GitHub",
+        "title": "drwjkirkpatrick-web/jetson-llm-benchmark",
+        "url": "https://github.com/drwjkirkpatrick-web/jetson-llm-benchmark"
+      },
+      {
+        "id": "E004",
+        "source": "GitHub",
+        "title": "kizz-tech/agentic-evidence-lab",
+        "url": "https://github.com/kizz-tech/agentic-evidence-lab"
+      },
+      {
+        "id": "E007",
+        "source": "GitHub",
+        "title": "lhao17202-hue/MemoraiBench",
+        "url": "https://github.com/lhao17202-hue/MemoraiBench"
+      },
+      {
+        "id": "E008",
+        "source": "GitHub",
+        "title": "sands-lab/nika",
+        "url": "https://github.com/sands-lab/nika"
+      },
+      {
+        "id": "E002",
+        "source": "Hugging Face",
+        "title": "bielik-benchmark-datasets/polish-fast-benchmarks",
+        "url": "https://huggingface.co/datasets/bielik-benchmark-datasets/polish-fast-benchmarks"
+      },
+      {
+        "id": "E011",
+        "source": "GitHub",
+        "title": "kenzychew/DocExtract",
+        "url": "https://github.com/kenzychew/DocExtract"
+      },
+      {
+        "id": "E014",
+        "source": "Hugging Face",
+        "title": "darthludious/adaption-preference-trace-decisions",
+        "url": "https://huggingface.co/datasets/darthludious/adaption-preference-trace-decisions"
+      }
+    ],
+    "date": "2026-08-12",
+    "generator": "openai-responses",
+    "input": {
+      "attention_items": 14,
+      "characters": 49917,
+      "coverage": {
+        "attention_injected": 14,
+        "corpus_attention_records": 14,
+        "corpus_evidence_records": 164,
+        "evidence_dropped": 0,
+        "evidence_dropped_for_size": 0,
+        "evidence_dropped_for_tokens": 0,
+        "evidence_injected": 25,
+        "evidence_selected": 25,
+        "history_days": 14,
+        "tracked_artifacts_injected": 40
+      },
+      "evidence_items": 25,
+      "history_days": 14,
+      "request_tokens_estimate": 17784,
+      "tracked_artifacts": 40
+    },
+    "model": "gpt-5.6-sol",
+    "response_id": "resp_0f627c56d3db355a016a7be80d44d88196903119ee9a89f841",
+    "status": "insight",
+    "usage": {
+      "cached_input_tokens": 0,
+      "input_tokens": 15111,
+      "output_tokens": 1325,
+      "reasoning_tokens": 904,
+      "total_tokens": 16436
+    }
+  }
+}

--- a/tests/render_briefing_harness.mjs
+++ b/tests/render_briefing_harness.mjs
@@ -1,0 +1,100 @@
+// Executes the dashboard's daily-briefing renderer against a fixture shaped
+// exactly like `briefing.py` writes into a snapshot, and prints the resulting
+// DOM tree as JSON for the Python test to assert on. This mirrors the Q&A
+// harness: source assertions alone cannot tell "renders insight blocks" from
+// "mentions the word insight", so the renderer is run for real against a
+// minimal DOM rather than grepped.
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(here, "..", "site", "assets", "app.js"), "utf8");
+
+class StubNode {
+  constructor(tag) {
+    this.tag = tag;
+    this.className = "";
+    this.children = [];
+    this.attributes = {};
+    this._text = "";
+    this.hidden = false;
+  }
+  set textContent(value) {
+    this._text = String(value);
+    this.children = [];
+  }
+  get textContent() {
+    return this.children.length
+      ? this.children.map((child) => child.textContent).join("")
+      : this._text;
+  }
+  setAttribute(key, value) {
+    this.attributes[key] = String(value);
+  }
+  append(child) {
+    this.children.push(child);
+  }
+  replaceChildren(...children) {
+    this.children = children;
+  }
+  addEventListener() {}
+  querySelectorAll() {
+    return [];
+  }
+  querySelector() {
+    return null;
+  }
+  getContext() {
+    return null;
+  }
+}
+
+class StubText {
+  constructor(value) {
+    this.tag = "#text";
+    this.children = [];
+    this.attributes = {};
+    this.className = "";
+    this._text = String(value);
+  }
+  get textContent() {
+    return this._text;
+  }
+}
+
+const registry = new Map();
+globalThis.document = {
+  createElement: (tag) => new StubNode(tag),
+  createElementNS: (_ns, tag) => new StubNode(tag),
+  createTextNode: (value) => new StubText(value),
+  getElementById: (id) => {
+    if (!registry.has(id)) registry.set(id, new StubNode("div"));
+    return registry.get(id);
+  },
+  addEventListener: () => {},
+  querySelectorAll: () => [],
+  querySelector: () => null,
+};
+globalThis.window = { addEventListener: () => {}, location: { search: "", hash: "" } };
+globalThis.fetch = () => new Promise(() => {});
+
+const harness =
+  `globalThis.__render = { renderDailyBriefing };\n${source}`;
+new Function(harness)();
+
+const fixturePath = process.argv[2] || join(here, "fixtures", "daily_briefing.json");
+const day = JSON.parse(readFileSync(fixturePath, "utf8"));
+globalThis.__render.renderDailyBriefing(day);
+
+function walk(node) {
+  return {
+    tag: node.tag,
+    className: node.className || "",
+    href: node.attributes?.href || "",
+    text: node.textContent,
+    children: (node.children || []).map(walk),
+  };
+}
+
+console.log(JSON.stringify(walk(document.getElementById("daily-briefing-body")), null, 2));

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -782,6 +782,91 @@ def test_daily_briefing_collapses_verbose_evidence_details_by_default():
     assert 'attrs: { open: "" }' not in script
 
 
+def test_daily_briefing_renders_scannable_insight_blocks():
+    """Issue #203: a briefing bullet is one scannable block, not a dense paragraph.
+
+    The model prose "claim. Why it matters: point." is split into a takeaway
+    head, the support underneath, and a quiet metadata row carrying confidence
+    and source count. Evidence IDs move out of the running prose and into that
+    row, so a scan meets the findings before any citation.
+    """
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    assert "function briefingParts(line)" in script
+    assert "function briefingInsight(line, citations)" in script
+    assert '"briefing-insight-head"' in script
+    assert '"briefing-insight-body"' in script
+    assert '"briefing-insight-meta"' in script
+    assert "briefing-chip-sources" in script
+    # The takeaway is pulled out of the wider prose by the "Why it matters"
+    # split, never by guessing at sentence boundaries.
+    assert "text.search(/\\bWhy it matters:\\s*/i)" in script
+    # The evidence clause is lifted out of the body into the metadata, so the
+    # IDs read as a source count rather than competing with the conclusion.
+    assert "replace(/\\s*\\.?\\s*Evidence:" in script
+    assert "parts.body" in script
+
+
+def _rendered_briefing(fixture: str | None = None):
+    """Run the real briefing renderer over a fixture and return the DOM tree."""
+    import json
+    import shutil
+    import subprocess
+
+    node = shutil.which("node")
+    if not node:
+        import pytest
+
+        pytest.skip("node is not installed")
+    result = subprocess.run(
+        [node, "tests/render_briefing_harness.mjs", *([fixture] if fixture else [])],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def test_rendered_briefing_splits_each_bullet_into_head_body_and_meta():
+    nodes = list(_flatten(_rendered_briefing()))
+    insights = [n for n in nodes if n["className"] == "briefing-insight"]
+    classnames = " ".join(n["className"] for n in nodes)
+
+    assert len(insights) == 2
+    assert "briefing-insight-head" in classnames
+    assert "briefing-insight-body" in classnames
+    assert "briefing-insight-meta" in classnames
+    assert "briefing-chip-sources" in classnames
+
+    def subtext(node):
+        return node["text"]
+
+    # The structured bullet splits cleanly: the takeaway is only the head prose
+    # (nothing past the "Why it matters" split), the body carries the support,
+    # and the metadata names the confidence and source count.
+    structured = insights[0]
+    head = next(n for n in structured["children"] if n["className"] == "briefing-insight-head")
+    body = next(n for n in structured["children"] if n["className"] == "briefing-insight-body")
+    meta = next(n for n in structured["children"] if n["className"] == "briefing-insight-meta")
+    assert subtext(head).startswith("Several new releases in this captured feed")
+    assert "Why it matters" not in subtext(head)
+    assert subtext(body).startswith("Evaluators should choose suites")
+    assert "Evidence:" not in subtext(body)
+    assert "High confidence" in subtext(meta)
+    assert "3 sources" in subtext(meta)
+
+    # An older bullet without the "Why it matters" structure degrades to a head
+    # with no body, yet its evidence and confidence still move to the metadata.
+    fallback = insights[1]
+    fbhead = next(n for n in fallback["children"] if n["className"] == "briefing-insight-head")
+    fbmeta = next(n for n in fallback["children"] if n["className"] == "briefing-insight-meta")
+    assert subtext(fbhead).startswith("An older-format bullet")
+    assert "Evidence:" not in subtext(fbhead)
+    assert "Medium confidence" in subtext(fbmeta)
+    assert "2 sources" in subtext(fbmeta)
+
+
 def test_today_view_renders_the_daily_questions_under_the_briefing():
     html = Path("site/index.html").read_text(encoding="utf-8")
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
@@ -1085,6 +1170,30 @@ def test_rendered_answers_hide_supporting_detail_behind_a_collapsed_disclosure()
     assert "carry out a task" in all_detail  # a plain-English explanation
     assert "Treat unscored arrivals as unverified" in all_detail  # a takeaway
     assert "keyword-filtered" in all_detail  # a counter-view
+
+
+def test_rendered_answers_hold_confidence_as_metadata_not_question_text():
+    """Issue #203: confidence is a small badge beneath the question, not text
+    pinned to the question's own line, and sources are counted alongside it."""
+    nodes = list(_flatten(_rendered_questions()))
+    answers = [n for n in nodes if n["className"] == "answer"]
+    assert len(answers) == 3
+
+    for answer in answers:
+        question = next(n for n in answer["children"] if n["className"] == "answer-question")
+        # The question line carries the question and nothing else; the
+        # confidence badge lives in its own metadata row below the signal.
+        assert question["children"] and all(n["tag"] == "#text" for n in question["children"])
+        metas = [n for n in answer["children"] if n["className"] == "answer-meta"]
+        assert metas
+        meta_text = metas[0]["text"]
+        assert " confidence" in meta_text
+        assert any("pill-confidence" in n["className"] for n in nodes)
+
+    # The disclosure's label is the short prompt, not the repeated long sentence.
+    summary = next(n for n in nodes if n["className"] == "answer-disclosure-summary")
+    assert "View analysis" in summary["text"]
+    assert "READ the full answer" not in summary["text"].upper()
 
 
 def test_leaderboard_coverage_counts_are_native_disclosures():


### PR DESCRIPTION
Closes #203

## What changed
- **Daily Briefing → insight blocks**: each model bullet now splits into a bold takeaway head, the "why it matters" support, and a metadata chip row (`High confidence` + `3 sources`). Evidence IDs lift out of the running prose.
- **Q&A hierarchy**: question → one-line signal → a metadata row (confidence badge + source count) → collapsed "View analysis" detail. Confidence is no longer welded to the question text.
- **Visual**: dropped the full-viewport boxed panels for section-title dividers + whitespace; constrained narrative to `78ch`; tightened masthead/nav spacing.

## Test evidence
- New runnable briefing render harness + fixture (mirrors the Q&A harness).
- New tests: insight head/body/meta splitting, the no-"Why it matters" fallback, and confidence-as-metadata.
- Full suite: **698 passed**; `node --check` clean.

## Preview note
Pages deploys only from `main`, so there's no auto preview URL for this branch. `benchmark-radar derive`/`classify` then `python3 -m http.server` in `site/` to review locally; my headless screenshot is at `/tmp/opencode/today_desktop.png`.