### PR TITLE
fix(site): unify top-right badges, merge contact, add Chinese version (issues #213, #212)

### DIFF
--- a/data/model_cards.yml
+++ b/data/model_cards.yml
@@ -1520,6 +1520,29 @@ model_cards:
       - simpleqa
       - livecodebench
 
+  - id: qwen3_8_model_card
+    organization: Qwen
+    model: Qwen3.8-27B
+    document_type: model_card
+    published: 2026-08-05
+    url: https://ollama.com/library/qwen3.8
+    retrieved_at: 2026-08-15
+    # Transcribed from the card's text-performance and VL-performance tables.
+    # The card also reports NL2Repo-Bench, DeepSWE 1.1, QwenSWEBench,
+    # CoWorkBench, JobBench, Agents' Last Exam, WebArena-Verified, AndroidWorld,
+    # RecreationBench, ClawEval-MM, SWE-MM, Vision2Web, BabyVision, CharXiv
+    # (RQ), RealWorldQA and ERQA, none of which the registry tracks.
+    benchmarks:
+      - terminal_bench
+      - swe_bench_pro
+      - ifbench
+      - gpqa_diamond
+      - hle
+      - livecodebench
+      - osworld
+      - mathvision
+      - omnidocbench
+
   - id: ai2_olmo_3
     organization: Ai2
     model: Olmo 3 (7B and 32B)

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -4587,9 +4587,10 @@ function openExport() {
 }
 
 // The contact dialog (issue #191) keeps every reach-out channel in one place:
-// email, WeChat, and Discord. Rendering it as a dialog rather than a bare
-// mailto link means a reader lands on a choice rather than being launched out
-// of the page on a guess.
+// email, WeChat, and Discord. The header badge (issue #213) merged the two
+// separate WeChat and Discord buttons into a single Contact control that
+// opens this dialog, so a reader lands on a choice rather than being launched
+// out of the page on a guess.
 function openContact() {
   const dialog = byId("contact-dialog");
   replaceChildren(byId("contact-content"), [
@@ -4774,8 +4775,7 @@ function bindEvents() {
   // before they trust any single row.
   byId("rubric-nav").addEventListener("click", () => openRubric());
   byId("badge-export").addEventListener("click", openExport);
-  byId("badge-wechat").addEventListener("click", openContact);
-  byId("badge-discord").addEventListener("click", openContact);
+  byId("badge-contact").addEventListener("click", openContact);
   byId("export-close").addEventListener("click", () => byId("export-dialog").close());
   byId("export-dialog").addEventListener("click", (event) => {
     if (event.target === byId("export-dialog")) byId("export-dialog").close();

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -224,15 +224,27 @@ button.repo-badge svg {
   stroke-width: 2;
 }
 
-/* Brand marks (WeChat, Discord, and the GitHub repo octicon) are single-color
-   glyphs with no meaningful stroke form, so they fill instead of outline. The
-   GitHub repo octicon also appears on the star badge, which is an <a>, so the
-   selector covers both link and button badges. */
+/* Brand marks (the GitHub repo octicon, star) are single-color glyphs with no
+   meaningful stroke form, so they fill instead of outline. The GitHub repo
+   octicon also appears on the star badge, which is an <a>, so the selector
+   covers both link and button badges. */
 .repo-badge svg.brand-icon {
   width: 0.9rem;
   height: 0.9rem;
   fill: currentColor;
   stroke: none;
+}
+
+/* Outline icons (globe, fork, issues) use stroke rather than fill, matching
+   the button badge icons. Applies to link and button badges alike so every
+   top-right icon renders at the same size (issue #213). */
+.repo-badge svg.outline-icon {
+  width: 0.9rem;
+  height: 0.9rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-width: 2;
 }
 
 .repo-badge-count {

--- a/site/index.html
+++ b/site/index.html
@@ -61,11 +61,30 @@
           <span class="repo-badge-label">RSS</span>
         </a>
         <!--
-          These three open dialogs rather than linking out: exporting a dataset
+          Issue #212: a language toggle so Chinese-language readers can find the
+          README translation without scanning the repo tree.
+        -->
+        <a
+          class="repo-badge"
+          id="badge-zh"
+          href="https://github.com/ktwu01/benchmark-radar/blob/main/README.zh-CN.md"
+          target="_blank"
+          rel="noopener noreferrer"
+          title="View Chinese version (中文)"
+        >
+          <svg class="outline-icon" viewBox="0 0 24 24" aria-hidden="true">
+            <circle cx="12" cy="12" r="10"></circle>
+            <path d="M2 12h20"></path>
+            <path d="M12 2a15 15 0 0 1 0 20a15 15 0 0 1 0-20"></path>
+          </svg>
+          <span class="repo-badge-label">中文</span>
+        </a>
+        <!--
+          These two open dialogs rather than linking out: exporting a dataset
           needs a moment of explanation about what is being handed over, and the
-          WeChat and Discord buttons open one contact sheet that keeps email,
-          WeChat, and Discord in a single place. Reachable without navigating
-          away from the current view.
+          contact button (issue #213) opens one sheet that keeps email, WeChat,
+          and Discord in a single place. Reachable without navigating away from
+          the current view.
         -->
         <button
           type="button"
@@ -84,40 +103,16 @@
         <button
           type="button"
           class="repo-badge"
-          id="badge-wechat"
+          id="badge-contact"
           aria-haspopup="dialog"
-          title="Contact on WeChat · ID ktwu001"
+          title="Get in touch · Email, WeChat, Discord"
         >
-          <svg class="brand-icon" viewBox="0 0 24 24" aria-hidden="true">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
             <path
-              d="M8.691 2.188C3.891 2.188 0 5.476 0 9.53c0 2.212 1.17 4.203 3.002 5.55a.59.59 0 0 1 .213.665l-.39 1.48c-.019.07-.048.141-.048.213 0 .163.13.295.29.295a.326.326 0 0 0 .167-.054l1.903-1.114a.864.864 0 0 1 .717-.098 10.16 10.16 0 0 0 2.837.403c.276 0 .543-.027.811-.05a6.127 6.127 0 0 1-.253-1.72c0-3.571 3.437-6.467 7.678-6.467.233 0 .463.013.694.031C17.02 4.792 13.205 2.188 8.69 2.188z"
-            ></path>
-            <path
-              d="M20.196 9.72c-3.858 0-6.984 2.667-6.984 5.957 0 3.29 3.126 5.957 6.984 5.957.848 0 1.663-.146 2.418-.408a.622.622 0 0 1 .516.07l1.371.802a.235.235 0 0 0 .12.039.213.213 0 0 0 .208-.213c0-.052-.02-.102-.035-.153l-.28-1.067a.426.426 0 0 1 .153-.479c1.359-1.111 2.2-2.707 2.2-4.548 0-3.29-3.126-5.957-6.984-5.957z"
-            ></path>
-            <circle cx="5.59" cy="9.72" r="1.184"></circle>
-            <circle cx="11.1" cy="9.72" r="1.184"></circle>
-            <circle cx="16.331" cy="13.31" r=".996"></circle>
-            <circle cx="20.06" cy="13.31" r=".996"></circle>
-          </svg>
-          <span class="repo-badge-label">WeChat</span>
-        </button>
-        <button
-          type="button"
-          class="repo-badge"
-          id="badge-discord"
-          aria-haspopup="dialog"
-          title="Contact on Discord · ID ktwu01"
-        >
-          <svg class="brand-icon" viewBox="0 0 24 24" aria-hidden="true">
-            <path
-              d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.865-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.058a.082.082 0 0 0 .031.056 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.291.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.061 0a.074.074 0 0 1 .079.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z"
-            ></path>
-            <path
-              d="M8.02 15.331c-1.182 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.419 0 1.333-.956 2.419-2.157 2.419zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.419 0 1.333-.946 2.419-2.157 2.419z"
+              d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"
             ></path>
           </svg>
-          <span class="repo-badge-label">Discord</span>
+          <span class="repo-badge-label">Contact</span>
         </button>
         <!--
           Each badge is a call to action, not a link to a roster. Starring has no
@@ -156,7 +151,13 @@
             rel="noopener noreferrer"
             title="Fork this repository"
           >
-            <span aria-hidden="true">⑂</span>
+            <svg class="outline-icon" viewBox="0 0 24 24" aria-hidden="true">
+              <circle cx="12" cy="18" r="3"></circle>
+              <circle cx="6" cy="6" r="3"></circle>
+              <circle cx="18" cy="6" r="3"></circle>
+              <path d="M18 9v2c0 .6-.5 1.2-1.2 1.7l-3.6 2.4"></path>
+              <path d="M6 9v2c0 .6.5 1.2 1.2 1.7l3.6 2.4"></path>
+            </svg>
             <span class="repo-badge-label">Fork</span>
             <span class="repo-badge-count" data-count>—</span>
           </a>
@@ -168,7 +169,15 @@
             rel="noopener noreferrer"
             title="Open a new issue"
           >
-            <span aria-hidden="true">◎</span>
+            <svg class="outline-icon" viewBox="0 0 24 24" aria-hidden="true">
+              <circle cx="12" cy="12" r="9"></circle>
+              <circle
+                cx="12"
+                cy="12"
+                r="3"
+                style="fill: currentColor; stroke: none"
+              ></circle>
+            </svg>
             <span class="repo-badge-label">Issues</span>
             <span class="repo-badge-count" data-count>—</span>
           </a>


### PR DESCRIPTION
Closes #213, #212.

## Changes

**Issue #213 - same size icons**
- Replaced the text glyphs `⑂` (Fork) and `◎` (Issues) with proper SVG icons so every top-right badge icon renders at the same `0.9rem` size.
- Added `.repo-badge svg.outline-icon` CSS rule for stroke-based SVGs on link badges.

**Issue #213 - merge WeChat + Discord into contact icon**
- Replaced the two separate WeChat and Discord buttons with a single Contact button (`badge-contact`) that opens the existing contact dialog (which already shows email, WeChat, and Discord).
- Updated `app.js` event bindings accordingly.

**Issue #212 - add Chinese version icon**
- Added a "中文" language toggle link with a globe SVG icon, pointing to `README.zh-CN.md` on GitHub.

## Verification
- `tests/test_site.py`: 77 passed
- `tests/test_feed.py tests/test_readme.py`: 7 passed
- `ruff check .`: all checks passed