### PR TITLE
fix(tests): mark social test channels as daily

### DIFF
--- a/tests/test_social.py
+++ b/tests/test_social.py
@@ -322,7 +322,9 @@ def test_social_command_writes_section(monkeypatch, tmp_path: Path):
         "    一个反常识的发现：样本。\n"
         "  channels:\n"
         "    - name: X / Twitter\n"
-        "    - name: LinkedIn\n",
+        "      daily: true\n"
+        "    - name: LinkedIn\n"
+        "      daily: true\n",
         encoding="utf-8",
     )
     output = tmp_path / "social.md"


### PR DESCRIPTION
The test's YAML channels lacked `daily: true`, so they were treated as weekly-only. On non-trigger days (UTC date offset from the weekly anchor), both channels were filtered out, leaving the checklist empty and the assertion on `- [ ] X / Twitter` failing.

Adding `daily: true` makes the channels render unconditionally, matching what the test expects.