### PR TITLE
fix(site): force equal utility button dimensions

### DIFF
--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -168,6 +168,7 @@ th {
 }
 
 .masthead-end {
+  --utility-button-size: 2.6rem;
   display: flex;
   gap: 0.7rem;
   flex-wrap: wrap;
@@ -181,10 +182,17 @@ th {
   align-items: center;
 }
 
+.repo-badges .repo-badge {
+  width: var(--utility-button-size);
+  height: var(--utility-button-size);
+}
+
 .repo-badge {
   display: inline-flex;
-  min-height: 2rem;
-  min-width: 2rem;
+  width: var(--utility-button-size);
+  height: var(--utility-button-size);
+  min-width: var(--utility-button-size);
+  min-height: var(--utility-button-size);
   gap: 0.4rem;
   align-items: center;
   justify-content: center;
@@ -3547,8 +3555,9 @@ footer {
   }
 
   .repo-badge {
-    min-width: 2.2rem;
-    padding-inline: 0.5rem;
+    width: var(--utility-button-size);
+    min-width: var(--utility-button-size);
+    padding-inline: 0;
   }
 
   .view-nav {

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -3557,6 +3557,12 @@ footer {
     padding-inline: 0;
   }
 
+  .repo-badges .repo-badge {
+    width: auto;
+    min-width: var(--utility-button-size);
+    padding-inline: 0.5rem;
+  }
+
   .view-nav {
     overflow-x: auto;
   }

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -183,15 +183,11 @@ th {
 }
 
 .repo-badges .repo-badge {
-  width: var(--utility-button-size);
-  height: var(--utility-button-size);
+  min-height: var(--utility-button-size);
 }
 
 .repo-badge {
   display: inline-flex;
-  width: var(--utility-button-size);
-  height: var(--utility-button-size);
-  min-width: var(--utility-button-size);
   min-height: var(--utility-button-size);
   gap: 0.4rem;
   align-items: center;
@@ -3557,6 +3553,7 @@ footer {
   .repo-badge {
     width: var(--utility-button-size);
     min-width: var(--utility-button-size);
+    height: var(--utility-button-size);
     padding-inline: 0;
   }
 

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -148,7 +148,10 @@ def test_top_right_utilities_use_shared_icon_geometry_and_contact_control():
     assert 'id="badge-discord"' not in html
     assert 'id="lang-toggle"' in html
     assert 'class="repo-badge"' in html
-    assert "min-height: 2rem" in styles
+    assert "--utility-button-size: 2.6rem" in styles
+    assert "width: var(--utility-button-size)" in styles
+    assert "height: var(--utility-button-size)" in styles
+    assert ".repo-badges .repo-badge" in styles
     assert "flex: 0 0 0.9rem" in styles
     assert ".repo-badge svg," in styles
 

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -149,8 +149,8 @@ def test_top_right_utilities_use_shared_icon_geometry_and_contact_control():
     assert 'id="lang-toggle"' in html
     assert 'class="repo-badge"' in html
     assert "--utility-button-size: 2.6rem" in styles
-    assert "width: var(--utility-button-size)" in styles
     assert "height: var(--utility-button-size)" in styles
+    assert "width: var(--utility-button-size)" in styles
     assert ".repo-badges .repo-badge" in styles
     assert "flex: 0 0 0.9rem" in styles
     assert ".repo-badge svg," in styles


### PR DESCRIPTION
## Summary
- force every top-right utility control to one fixed 2.6rem square
- apply the same dimensions to nested repository badges
- add regression assertions for shared width and height

## Test plan
- ruff check .
- ruff format --check .
- pytest -q tests/test_site.py tests/test_feed.py