### PR TITLE
fix(site): complete issue 213 utility sizing

### DIFF
--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -168,6 +168,7 @@ th {
 }
 
 .masthead-end {
+  --utility-button-size: 2.6rem;
   display: flex;
   gap: 0.7rem;
   flex-wrap: wrap;
@@ -181,9 +182,13 @@ th {
   align-items: center;
 }
 
+.repo-badges .repo-badge {
+  min-height: var(--utility-button-size);
+}
+
 .repo-badge {
   display: inline-flex;
-  min-height: 2rem;
+  min-height: var(--utility-button-size);
   min-width: 2rem;
   gap: 0.4rem;
   align-items: center;
@@ -3547,7 +3552,16 @@ footer {
   }
 
   .repo-badge {
-    min-width: 2.2rem;
+    width: var(--utility-button-size);
+    min-width: var(--utility-button-size);
+    height: var(--utility-button-size);
+    padding-inline: 0;
+  }
+
+  .repo-badges .repo-badge {
+    width: auto;
+    min-width: var(--utility-button-size);
+    height: var(--utility-button-size);
     padding-inline: 0.5rem;
   }
 

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -148,7 +148,10 @@ def test_top_right_utilities_use_shared_icon_geometry_and_contact_control():
     assert 'id="badge-discord"' not in html
     assert 'id="lang-toggle"' in html
     assert 'class="repo-badge"' in html
-    assert "min-height: 2rem" in styles
+    assert "--utility-button-size: 2.6rem" in styles
+    assert "height: var(--utility-button-size)" in styles
+    assert "width: var(--utility-button-size)" in styles
+    assert ".repo-badges .repo-badge" in styles
     assert "flex: 0 0 0.9rem" in styles
     assert ".repo-badge svg," in styles
 


### PR DESCRIPTION
## Issue #213 audit and fix

- Give every top-right utility control one shared 2.6rem height.
- Make icon-only mobile controls equal 2.6rem squares.
- Preserve natural desktop widths for visible labels.
- Preserve natural mobile widths for Star/Fork/Issues counts.
- Keep the single Contact control and Chinese language icon already present.

## Verification

- All checks passed!
- 73 files already formatted
- ........................................................................ [ 88%]
.........                                                                [100%]
81 passed in 1.30s (81 passed)
- ........................................................................ [ 10%]
........................................................................ [ 20%]
........................................................................ [ 30%]
........................................................................ [ 41%]
........................................................................ [ 51%]
........................................................................ [ 61%]
........................................................................ [ 72%]
........................................................................ [ 82%]
........................................................................ [ 92%]
....................................................                     [100%]
700 passed in 18.67s (700 passed)