### PR TITLE
fix(site): show 中/EN glyph on the language toggle

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -218,7 +218,7 @@ function syncLangToggle() {
   if (!toggle) return;
   const zh = getLang() === "zh";
   toggle.setAttribute("aria-pressed", String(zh));
-  byId("lang-toggle-label").textContent = zh ? "EN" : "中文";
+  byId("lang-toggle-label").textContent = zh ? "EN" : "中";
   const titleKey = zh ? "Switch to English" : "Switch to Chinese (中文)";
   toggle.setAttribute("title", t(titleKey));
 }

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -283,6 +283,15 @@ button.repo-badge svg {
   white-space: nowrap;
 }
 
+/* The language toggle shows its target script as a text glyph ("中" / "EN")
+   rather than a pictogram: a character reads as "language" directly, where a
+   globe or document icon does not. */
+.repo-badge-glyph {
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
 .feed-badge svg circle {
   fill: currentColor;
   stroke: none;

--- a/site/index.html
+++ b/site/index.html
@@ -75,11 +75,7 @@
           title="Switch to Chinese (中文)"
           data-i18n-title="Switch to Chinese (中文)"
         >
-          <svg class="outline-icon language-icon" viewBox="0 0 24 24" aria-hidden="true">
-            <path d="M4 5h16v14H4z"></path>
-            <path d="M7 9h10M7 12h7M7 15h4"></path>
-          </svg>
-          <span class="repo-badge-label" id="lang-toggle-label">中文</span>
+          <span class="repo-badge-glyph" id="lang-toggle-label">中</span>
         </button>
         <!--
           These two open dialogs rather than linking out: exporting a dataset

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -152,7 +152,7 @@ def test_top_right_utilities_use_shared_icon_geometry_and_contact_control():
     assert "width: 2.6rem" in styles
     assert "height: 2.6rem" in styles
     assert "grid-column: span 3" in styles
-    assert 'class="outline-icon language-icon"' in html
+    assert 'class="repo-badge-glyph" id="lang-toggle-label">中<' in html
     assert 'class="brand-icon github-icon"' in html
     assert "grid-template-columns: repeat(7, 2.1rem)" in styles
     assert "flex: 0 0 0.9rem" in styles


### PR DESCRIPTION
Replace the unintuitive document pictogram on the language toggle with the target script as a text glyph: 中 while the site is English, EN once Chinese. Drops the SVG, adds .repo-badge-glyph, updates the site test.

Test plan: ruff format/check, pytest -q (700 passed).