### PR TITLE
Fix saturation identity and dashboard feedback regressions

### DIFF
--- a/scripts/test_openreview_gh.py
+++ b/scripts/test_openreview_gh.py
@@ -27,12 +27,13 @@ def main():
     invitation = "ICLR.cc/2026/Conference/-/Submission"
     notes = client.get_notes(invitation=invitation, limit=5)
     print(f"SUCCESS: Got {len(notes)} notes from {invitation}")
-    
+
     for n in notes:
         title = n.content.get("title", {}).get("value", "N/A")
         print(f"  {n.id}: {title[:80]}")
-    
+
     return 0
+
 
 if __name__ == "__main__":
     exit(main())

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -75,20 +75,61 @@ const ORGANIZATION_FALLBACK_ICON = "M12 2l2.1 6.9L21 11l-6.9 2.1L12 20l-2.1-6.9L
 function organizationIcon(organization) {
   return ORGANIZATION_ICONS[organization] || [ORGANIZATION_FALLBACK_ICON];
 }
+
+// Score points identify models, not just the companies that published them.
+// Use model-family marks where the family has its own recognizable identity;
+// otherwise the organization mark remains the honest fallback. The paths are
+// monochrome 24-unit marks from Lobe Icons (MIT licensed).
+const MODEL_FAMILY_ICONS = {
+  Claude: [
+    "M4.709 15.955l4.72-2.647.08-.23-.08-.128H9.2l-.79-.048-2.698-.073-2.339-.097-2.266-.122-.571-.121L0 11.784l.055-.352.48-.321.686.06 1.52.103 2.278.158 1.652.097 2.449.255h.389l.055-.157-.134-.098-.103-.097-2.358-1.596-2.552-1.688-1.336-.972-.724-.491-.364-.462-.158-1.008.656-.722.881.06.225.061.893.686 1.908 1.476 2.491 1.833.365.304.145-.103.019-.073-.164-.274-1.355-2.446-1.446-2.49-.644-1.032-.17-.619a2.97 2.97 0 01-.104-.729L6.283.134 6.696 0l.996.134.42.364.62 1.414 1.002 2.229 1.555 3.03.456.898.243.832.091.255h.158V9.01l.128-1.706.237-2.095.23-2.695.08-.76.376-.91.747-.492.584.28.48.685-.067.444-.286 1.851-.559 2.903-.364 1.942h.212l.243-.242.985-1.306 1.652-2.064.73-.82.85-.904.547-.431h1.033l.76 1.129-.34 1.166-1.064 1.347-.881 1.142-1.264 1.7-.79 1.36.073.11.188-.02 2.856-.606 1.543-.28 1.841-.315.833.388.091.395-.328.807-1.969.486-2.309.462-3.439.813-.042.03.049.061 1.549.146.662.036h1.622l3.02.225.79.522.474.638-.079.485-1.215.62-1.64-.389-3.829-.91-1.312-.329h-.182v.11l1.093 1.068 2.006 1.81 2.509 2.33.127.578-.322.455-.34-.049-2.205-1.657-.851-.747-1.926-1.62h-.128v.17l.444.649 2.345 3.521.122 1.08-.17.353-.608.213-.668-.122-1.374-1.925-1.415-2.167-1.143-1.943-.14.08-.674 7.254-.316.37-.729.28-.607-.461-.322-.747.322-1.476.389-1.924.315-1.53.286-1.9.17-.632-.012-.042-.14.018-1.434 1.967-2.18 2.945-1.726 1.845-.414.164-.717-.37.067-.662.401-.589 2.388-3.036 1.44-1.882.93-1.086-.006-.158h-.055L4.132 18.56l-1.13.146-.487-.456.061-.746.231-.243 1.908-1.312-.006.006z",
+  ],
+  Gemini: [
+    "M20.616 10.835a14.147 14.147 0 01-4.45-3.001 14.111 14.111 0 01-3.678-6.452.503.503 0 00-.975 0 14.134 14.134 0 01-3.679 6.452 14.155 14.155 0 01-4.45 3.001c-.65.28-1.318.505-2.002.678a.502.502 0 000 .975c.684.172 1.35.397 2.002.677a14.147 14.147 0 014.45 3.001 14.112 14.112 0 013.679 6.453.502.502 0 00.975 0c.172-.685.397-1.351.677-2.003a14.145 14.145 0 013.001-4.45 14.113 14.113 0 016.453-3.678.503.503 0 000-.975 13.245 13.245 0 01-2.003-.678z",
+  ],
+  Grok: [
+    "M9.27 15.29l7.978-5.897c.391-.29.95-.177 1.137.272.98 2.369.542 5.215-1.41 7.169-1.951 1.954-4.667 2.382-7.149 1.406l-2.711 1.257c3.889 2.661 8.611 2.003 11.562-.953 2.341-2.344 3.066-5.539 2.388-8.42l.006.007c-.983-4.232.242-5.924 2.75-9.383.06-.082.12-.164.179-.248l-3.301 3.305v-.01L9.267 15.292M7.623 16.723c-2.792-2.67-2.31-6.801.071-9.184 1.761-1.763 4.647-2.483 7.166-1.425l2.705-1.25a7.808 7.808 0 00-1.829-1A8.975 8.975 0 005.984 5.83c-2.533 2.536-3.33 6.436-1.962 9.764 1.022 2.487-.653 4.246-2.34 6.022-.599.63-1.199 1.259-1.682 1.925l7.62-6.815",
+  ],
+};
+
+function modelIcon(model, organization) {
+  const name = String(model || "");
+  if (/\bclaude\b/i.test(name)) return MODEL_FAMILY_ICONS.Claude;
+  if (/\bgemini\b/i.test(name)) return MODEL_FAMILY_ICONS.Gemini;
+  if (/\bgrok\b/i.test(name)) return MODEL_FAMILY_ICONS.Grok;
+  return organizationIcon(organization);
+}
+
 // Render one organization's brand glyph as SVG path elements inside a scaled
 // group. The mark is a single path per organization (viewBox 0 0 24 24); the
 // group transforms place it centred on (cx, cy) at `size` units across.
-function brandGlyph(organization, cx, cy, size, className) {
+function iconGlyph(paths, cx, cy, size, className, color = null) {
   const scale = size / 24;
   const g = svgElement("g", {
     transform: `translate(${cx} ${cy}) scale(${scale}) translate(-12 -12)`,
     class: className,
+    ...(color ? { style: `color: ${color}` } : {}),
     "aria-hidden": "true",
   });
-  for (const d of organizationIcon(organization)) {
+  for (const d of paths) {
     g.append(svgElement("path", { d, fill: "currentColor" }));
   }
   return g;
+}
+
+function brandGlyph(organization, cx, cy, size, className) {
+  return iconGlyph(organizationIcon(organization), cx, cy, size, className);
+}
+
+function modelGlyph(model, organization, cx, cy, size, className) {
+  return iconGlyph(
+    modelIcon(model, organization),
+    cx,
+    cy,
+    size,
+    className,
+    organizationColor(organization),
+  );
 }
 const ALL_DATES_PAGE_SIZE = 100;
 // Snapshots recorded before SourceHealth.method existed carry no method
@@ -4079,10 +4120,30 @@ function adoptionFrontierChart(entry, board, events, { sparse = false } = {}) {
         svgElement("circle", {
           cx: pointX,
           cy: pointY,
-          r: 5,
+          r: 9,
+          class: "score-point-face",
         }),
       );
-      group.append(brandGlyph(observation.organization, pointX, pointY, 8, "score-point-glyph"));
+      if (observation.reported_by) {
+        group.append(
+          svgElement("circle", {
+            cx: pointX,
+            cy: pointY,
+            r: 12,
+            class: "score-point-citation-ring",
+          }),
+        );
+      }
+      group.append(
+        modelGlyph(
+          observation.model,
+          observation.organization,
+          pointX,
+          pointY,
+          14,
+          "score-point-glyph",
+        ),
+      );
       makeFrontierPointInteractive(group, {
         kind: t("Readable score"),
         title: `${observation.organization} · ${observation.model}`,

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -223,13 +223,13 @@ function syncLangToggle() {
   toggle.setAttribute("title", t(titleKey));
 }
 
-function rerenderAll() {
+function rerenderCurrentView() {
   if (!state.data) return;
   renderTodayDateOptions();
-  renderToday();
-  renderLeaderboard();
-  renderTrends();
-  renderTrendMap();
+  if (state.view === "today") renderToday();
+  if (state.view === "leaderboard") renderLeaderboard();
+  if (state.view === "trends") renderTrends();
+  if (state.view === "map") renderTrendMap();
   renderStaleBanner();
   renderBuildMeta();
 }
@@ -238,7 +238,7 @@ function toggleLang() {
   setLang(getLang() === "zh" ? "en" : "zh");
   applyStaticI18n();
   syncLangToggle();
-  rerenderAll();
+  rerenderCurrentView();
 }
 
 const I18N = {
@@ -740,6 +740,7 @@ const state = {
   leaderboardShowAll: false,
   todayResultsKey: "",
   todayResultsLimit: ALL_DATES_PAGE_SIZE,
+  observations: null,
 };
 
 function element(tag, options = {}, children = []) {
@@ -758,7 +759,7 @@ function element(tag, options = {}, children = []) {
 // Coalesce bursts of input (typing in a filter box) into a single trailing
 // render, so the corpus is not re-filtered and the DOM rebuilt on every
 // keystroke. Used by the filter panels that re-render their whole view.
-function debounce(fn, waitMs = 140) {
+function debounce(fn, waitMs = 80) {
   let timer = null;
   const debounced = (...args) => {
     clearTimeout(timer);
@@ -1443,7 +1444,7 @@ function renderBuildMeta() {
   )} UTC`;
 }
 
-function renderToday() {
+function renderToday({ resultsOnly = false } = {}) {
   // Events are bound before the data file resolves (initialize), so a nav
   // click or filter keystroke in the load window must no-op, not throw.
   if (!state.data) return;
@@ -1452,17 +1453,18 @@ function renderToday() {
   if (!day) return;
   byId("today-date").value = state.todayDate;
 
-  // The briefing and connector health describe one scan, not an archive-wide
-  // result set. Hiding them in All dates mode keeps latest-day context from
-  // appearing to explain observations collected across the full history.
-  byId("daily-briefing").hidden = showingAllDates;
-  byId("daily-questions").hidden = showingAllDates;
-  byId("source-health-panel").hidden = showingAllDates;
+  if (!resultsOnly) {
+    // The briefing and connector health describe one scan, not an archive-wide
+    // result set. Hiding them in All dates mode keeps latest-day context from
+    // appearing to explain observations collected across the full history.
+    byId("daily-briefing").hidden = showingAllDates;
+    byId("daily-questions").hidden = showingAllDates;
+    byId("source-health-panel").hidden = showingAllDates;
 
-  renderDailyBriefing(day);
-  renderDailyQuestions(day);
-
-  syncFilters();
+    renderDailyBriefing(day);
+    renderDailyQuestions(day);
+    syncFilters();
+  }
   const observations = filteredObservations();
   const resultsKey = [
     state.todayDate,
@@ -1477,9 +1479,10 @@ function renderToday() {
     state.todayResultsKey = resultsKey;
     state.todayResultsLimit = ALL_DATES_PAGE_SIZE;
   }
-  const visibleObservations = showingAllDates
-    ? observations.slice(0, state.todayResultsLimit)
-    : observations;
+  // A single busy scan can carry hundreds of observations. Bound every render,
+  // not just the all-dates archive, so initial load and filter feedback never
+  // have to build the entire card list before the reader can interact.
+  const visibleObservations = observations.slice(0, state.todayResultsLimit);
   const remainingResults = observations.length - visibleObservations.length;
   const showMore = byId("today-show-more");
   showMore.hidden = remainingResults <= 0;
@@ -1504,6 +1507,11 @@ function renderToday() {
           }),
         ],
   );
+
+  if (resultsOnly) {
+    writeUrl();
+    return;
+  }
 
   const healthEntries = [
     ...day.ingest_health.map((entry) => ({
@@ -2095,6 +2103,7 @@ function healthSummary(entries) {
 }
 
 function allObservations() {
+  if (state.observations) return state.observations;
   const evidence = state.data.days.flatMap((day) =>
     day.evidence_items.map((item) => ({
       ...item,
@@ -2120,10 +2129,11 @@ function allObservations() {
       observation_kind: "attention",
     })),
   );
-  return [...evidence, ...attention].sort((a, b) => {
+  state.observations = [...evidence, ...attention].sort((a, b) => {
     const dateOrder = String(b.snapshot_date).localeCompare(String(a.snapshot_date));
     return dateOrder || Number(b.total_score || 0) - Number(a.total_score || 0);
   });
+  return state.observations;
 }
 
 function populateSelect(target, values, label, selected) {
@@ -5282,9 +5292,9 @@ function openContact() {
   dialog.showModal();
 }
 
-// renderToday() re-filters the whole corpus and rebuilds the results DOM, so
-// filter keystrokes go through a debounce instead of firing it per character.
-const scheduleTodayRender = debounce(() => renderToday());
+// Filter keystrokes only rebuild the bounded result list. Briefing, questions,
+// health, and corpus totals do not change while a reader types.
+const scheduleTodayRender = debounce(() => renderToday({ resultsOnly: true }));
 
 // Same for the leaderboard, which re-sorts the registry and rewrites the URL
 // on every keystroke otherwise.
@@ -5342,7 +5352,7 @@ function bindEvents() {
   });
   byId("today-show-more").addEventListener("click", () => {
     state.todayResultsLimit += ALL_DATES_PAGE_SIZE;
-    renderToday();
+    renderToday({ resultsOnly: true });
   });
   byId("trend-released-only").addEventListener("change", (event) => {
     state.trendReleasedOnly = event.target.checked;
@@ -5561,17 +5571,22 @@ async function initialize() {
       state.todayDate = state.data.latest_date;
     }
     renderTodayDateOptions();
-    renderToday();
-    renderLeaderboard();
-    renderTrends();
-    renderTrendMap();
     // A permalink to ?view=leaderboard on a build without the curated registry
     // has nothing to show, so fall back to Today rather than opening a blank
-    // section behind a nav entry that renderLeaderboard just hid.
+    // section behind a navigation entry that has no data.
     if (state.view === "leaderboard" && !state.data.model_card_leaderboard) {
       state.view = "today";
     }
     setView(state.view, false);
+
+    // Rendering all four views up front made the reader wait for charts and
+    // thousands of hidden nodes. Build only the requested view; the navigation
+    // handlers render another view when the reader opens it.
+    if (state.view === "today") renderToday();
+    if (state.view === "leaderboard") renderLeaderboard();
+    if (state.view === "trends") renderTrends();
+    if (state.view === "map") renderTrendMap();
+
     renderBuildMeta();
     renderStaleBanner();
     if (state.rubric && state.data.rubrics?.[state.rubric]) {

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -236,7 +236,16 @@ function applyStaticI18n() {
       node.dataset.i18nTitleEn = node.getAttribute("title") || "";
     }
     const text = table[node.dataset.i18nTitle];
-    node.setAttribute("title", text ?? node.dataset.i18nTitleEn);
+    const resolved = text ?? node.dataset.i18nTitleEn;
+    if (node.classList.contains("repo-badge")) {
+      // Native title tooltips wait roughly a second before appearing. Header
+      // utilities need immediate feedback, so CSS reads this attribute instead.
+      node.setAttribute("data-tooltip", resolved);
+      node.removeAttribute("title");
+      if (!node.hasAttribute("aria-label")) node.setAttribute("aria-label", resolved);
+    } else {
+      node.setAttribute("title", resolved);
+    }
   });
   document.querySelectorAll("[data-i18n-placeholder]").forEach((node) => {
     if (node.dataset.i18nPlaceholderEn === undefined) {
@@ -261,7 +270,9 @@ function syncLangToggle() {
   toggle.setAttribute("aria-pressed", String(zh));
   byId("lang-toggle-label").textContent = zh ? "EN" : "中";
   const titleKey = zh ? "Switch to English" : "Switch to Chinese (中文)";
-  toggle.setAttribute("title", t(titleKey));
+  toggle.setAttribute("data-tooltip", t(titleKey));
+  toggle.setAttribute("aria-label", t(titleKey));
+  toggle.setAttribute("title", "");
 }
 
 function rerenderCurrentView() {

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -597,7 +597,11 @@ input {
 
 .daily-questions {
   margin-bottom: 2.25rem;
-  max-width: 78ch;
+  max-width: calc(100% - 22rem);
+}
+
+#daily-questions-body {
+  max-width: 72ch;
 }
 
 .daily-questions-title {
@@ -3535,7 +3539,8 @@ footer {
   /* Below 1050px the results grid loses its 320px sidebar and goes single
      column, so the briefing's sidebar-derived width cap no longer applies
      and it fills the view like the results beneath it (issue #225). */
-  .daily-briefing {
+  .daily-briefing,
+  .daily-questions {
     max-width: 100%;
   }
 

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -2613,26 +2613,39 @@ td a {
   stroke-dasharray: 7 4;
 }
 
-.score-point circle {
-  fill: #6ea8dc;
-  stroke: #0d1519;
+.score-point-face {
+  fill: #f8f6ef;
+  stroke: #6ea8dc;
   stroke-width: 2;
   transition: r 120ms ease;
 }
 
 /* A third-party citation is a publisher repeating a competitor's figure. The
    ring marks it on the chart so it is not read as a first-party report. */
-.score-point-third-party circle {
-  fill: #0d1519;
-  stroke: #6ea8dc;
+.score-point-citation-ring {
+  fill: none;
+  stroke: #0d1519;
   stroke-width: 2.5;
+  stroke-dasharray: 2 2;
+  transition: r 120ms ease;
 }
 
-.score-point:focus circle,
-.score-point:hover circle,
-.score-point.is-selected circle {
-  r: 8px;
+.score-point-glyph {
+  pointer-events: none;
+  user-select: none;
+}
+
+.score-point:focus .score-point-face,
+.score-point:hover .score-point-face,
+.score-point.is-selected .score-point-face {
+  r: 10px;
   stroke-width: 4;
+}
+
+.score-point:focus .score-point-citation-ring,
+.score-point:hover .score-point-citation-ring,
+.score-point.is-selected .score-point-citation-ring {
+  r: 13px;
 }
 
 .score-best-line {

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -183,6 +183,7 @@ th {
 }
 
 .repo-badge {
+  position: relative;
   display: inline-flex;
   width: 2.6rem;
   height: 2.6rem;
@@ -198,13 +199,48 @@ th {
   letter-spacing: 0.06em;
   text-decoration: none;
   text-transform: uppercase;
-  transition: border-color 120ms ease, background 120ms ease;
+  transition: border-color 60ms ease, background 60ms ease, color 60ms ease,
+    transform 60ms ease;
 }
 
 .repo-badge:hover,
 .repo-badge:focus-visible {
   border-color: var(--ink);
-  background: var(--panel);
+  background: var(--ink);
+  color: var(--panel);
+  transform: translateY(-1px);
+}
+
+/* Utility labels should appear with the interaction, not after the browser's
+   delayed native-title timeout. JavaScript supplies the localized text. */
+.repo-badge::after {
+  position: absolute;
+  z-index: 20;
+  top: calc(100% + 0.55rem);
+  left: 50%;
+  padding: 0.38rem 0.52rem;
+  border: 1px solid var(--ink);
+  background: var(--ink);
+  color: var(--panel);
+  content: attr(data-tooltip);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  line-height: 1.2;
+  opacity: 0;
+  pointer-events: none;
+  text-transform: none;
+  transform: translate(-50%, -0.2rem);
+  transition: opacity 60ms ease, transform 60ms ease;
+  visibility: hidden;
+  white-space: nowrap;
+}
+
+.repo-badge:hover::after,
+.repo-badge:focus-visible::after {
+  opacity: 1;
+  transform: translate(-50%, 0);
+  visibility: visible;
 }
 
 /* The export and contact controls are <button>s, not <a>s, because they open
@@ -3606,6 +3642,10 @@ footer {
   .repo-badge {
     width: 2.1rem;
     height: 2.1rem;
+  }
+
+  .repo-badge::after {
+    display: none;
   }
 
   .view-nav {

--- a/tests/test_leaderboard_workbench.py
+++ b/tests/test_leaderboard_workbench.py
@@ -67,7 +67,7 @@ def test_trajectory_points_expose_and_pin_record_details():
     assert 'label: t("Protocol")' in script
     assert 'label: t("Source")' in script
     assert ".frontier-point.is-selected .frontier-point-face" in styles
-    assert ".score-point.is-selected circle" in styles
+    assert ".score-point.is-selected .score-point-face" in styles
     assert "pinned: selectedFrontierPoint === group" in script
     assert 'record.unit === "percent" ? "%" : ` ${record.unit}`' in script
     assert 'role: "group"' in script

--- a/tests/test_saturation_view.py
+++ b/tests/test_saturation_view.py
@@ -61,7 +61,25 @@ def test_a_third_party_citation_is_marked_on_the_chart():
 
     assert "score-point-third-party" in script
     assert "observation.reported_by" in script
-    assert ".score-point-third-party circle" in styles
+    assert "score-point-citation-ring" in script
+    assert ".score-point-citation-ring" in styles
+
+
+def test_score_points_carry_recognizable_model_family_marks():
+    """Issue #195: saturation points identify models before interaction."""
+    script = source("site/assets/app.js")
+    styles = source("site/assets/styles.css")
+    chart = script.split("function adoptionFrontierChart(", 1)[1].split(
+        "\nfunction clearAdoptionFrontier", 1
+    )[0]
+
+    for family in ("Claude", "Gemini", "Grok"):
+        assert f"{family}: [" in script
+    assert "modelGlyph(" in chart
+    assert "observation.model" in chart
+    assert 'r: 9,\n          class: "score-point-face"' in chart
+    assert ".score-point-glyph" in styles
+    assert "stroke: #6ea8dc" in styles.split(".score-point-face", 1)[1][:120]
 
 
 def test_the_reading_gap_is_labelled_rather_than_drawn_through():

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -98,6 +98,19 @@ def test_scan_date_can_be_reset_to_all_dates():
     assert 'byId("source-health-panel").hidden = showingAllDates' in script
 
 
+def test_dashboard_bounds_work_before_and_during_filtering():
+    """Issue #222: hidden views and unbounded card lists must not block input."""
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    assert "state.observations = [...evidence, ...attention].sort" in script
+    assert "if (state.observations) return state.observations" in script
+    assert "const visibleObservations = observations.slice(0, state.todayResultsLimit)" in script
+    assert "renderToday({ resultsOnly: true })" in script
+    assert 'if (state.view === "today") renderToday()' in script
+    assert 'if (state.view === "leaderboard") renderLeaderboard()' in script
+    assert "function rerenderCurrentView()" in script
+
+
 def test_automatic_frontier_default_does_not_leak_into_unrelated_urls():
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
 

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -172,6 +172,21 @@ def test_top_right_utilities_use_shared_icon_geometry_and_contact_control():
     assert ".repo-badge svg," in styles
 
 
+def test_top_right_utilities_have_immediate_visible_feedback():
+    """Issue #228: feedback includes a fast high-contrast state and label."""
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+    styles = Path("site/assets/styles.css").read_text(encoding="utf-8")
+
+    assert 'node.setAttribute("data-tooltip", resolved)' in script
+    assert 'node.removeAttribute("title")' in script
+    badge = styles.split(".repo-badge {", 1)[1].split("}", 1)[0]
+    feedback = styles.split(".repo-badge:hover,", 1)[1].split("}", 1)[0]
+    assert "60ms" in badge
+    assert "background: var(--ink)" in feedback
+    assert "color: var(--panel)" in feedback
+    assert "content: attr(data-tooltip)" in styles
+
+
 def test_language_toggle_and_contact_labels_are_translated():
     html = Path("site/index.html").read_text(encoding="utf-8")
     script = Path("site/assets/app.js").read_text(encoding="utf-8")

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -939,6 +939,20 @@ def test_today_view_renders_the_daily_questions_under_the_briefing():
     assert 'byId("daily-questions").hidden = showingAllDates' in script
 
 
+def test_daily_questions_use_the_results_column_width_without_long_prose_lines():
+    """Issue #223: the section fills the desktop column while prose stays readable."""
+    styles = Path("site/assets/styles.css").read_text(encoding="utf-8")
+
+    questions = styles.split(".daily-questions {", 1)[1].split("}", 1)[0]
+    body = styles.split("#daily-questions-body {", 1)[1].split("}", 1)[0]
+    responsive = styles.split("@media (max-width: 1050px)", 1)[1].split(
+        "@media (max-width: 760px)", 1
+    )[0]
+    assert "max-width: calc(100% - 22rem)" in questions
+    assert "max-width: 72ch" in body
+    assert ".daily-briefing,\n  .daily-questions" in responsive
+
+
 def test_daily_questions_withhold_another_days_answers_and_name_an_absent_set():
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
 

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -408,18 +408,20 @@ def test_openreview_success_uses_only_upstream_abstract(monkeypatch):
             self.content = data["content"]
 
     mock_notes = [
-        MockNote({
-            "id": "note-revision",
-            "forum": "stable-forum",
-            "cdate": timestamp,
-            "mdate": timestamp + 1000,
-            "content": {
-                "title": {"value": "A Conference Benchmark"},
-                "abstract": {"value": "The upstream abstract."},
-                "authors": {"value": ["Ada Radar"]},
-                "code": {"value": "https://github.com/example/benchmark"},
-            },
-        })
+        MockNote(
+            {
+                "id": "note-revision",
+                "forum": "stable-forum",
+                "cdate": timestamp,
+                "mdate": timestamp + 1000,
+                "content": {
+                    "title": {"value": "A Conference Benchmark"},
+                    "abstract": {"value": "The upstream abstract."},
+                    "authors": {"value": ["Ada Radar"]},
+                    "code": {"value": "https://github.com/example/benchmark"},
+                },
+            }
+        )
     ]
 
     class MockClient:
@@ -428,6 +430,7 @@ def test_openreview_success_uses_only_upstream_abstract(monkeypatch):
             return mock_notes
 
     import openreview.api
+
     monkeypatch.setattr(openreview.api, "OpenReviewClient", lambda **kwargs: MockClient())
     monkeypatch.setenv("OPENREVIEW_USERNAME", "test@example.com")
     monkeypatch.setenv("OPENREVIEW_PASSWORD", "testpass")
@@ -639,9 +642,11 @@ def test_release_replacement_budget_preserves_later_repository_coverage(monkeypa
 def test_new_connectors_accept_empty_upstream_results(monkeypatch, fetcher, config, empty_payload):
     if fetcher is fetch_openreview:
         import openreview.api
+
         class MockClient:
             def get_notes(self, invitation, limit):
                 return []
+
         monkeypatch.setattr(openreview.api, "OpenReviewClient", lambda **kwargs: MockClient())
         monkeypatch.setenv("OPENREVIEW_USERNAME", "test@example.com")
         monkeypatch.setenv("OPENREVIEW_PASSWORD", "testpass")
@@ -665,11 +670,13 @@ def test_new_connectors_accept_empty_upstream_results(monkeypatch, fetcher, conf
 def test_new_connectors_reject_malformed_payloads(monkeypatch, fetcher, config, malformed_payload):
     if fetcher is fetch_openreview:
         import openreview.api
+
         class MockClient:
             def get_notes(self, invitation, limit):
                 raise openreview.openreview.OpenReviewException(
                     {"name": "Error", "message": "Invalid payload"}
                 )
+
         monkeypatch.setattr(openreview.api, "OpenReviewClient", lambda **kwargs: MockClient())
         monkeypatch.setenv("OPENREVIEW_USERNAME", "test@example.com")
         monkeypatch.setenv("OPENREVIEW_PASSWORD", "testpass")
@@ -696,19 +703,23 @@ def test_new_connectors_reject_malformed_payloads(monkeypatch, fetcher, config, 
 def test_new_connectors_surface_http_failures(monkeypatch, fetcher, config):
     if fetcher is fetch_openreview:
         import openreview.api
+
         class MockClient:
             def get_notes(self, invitation, limit):
                 raise openreview.openreview.OpenReviewException(
                     {"name": "Error", "message": "HTTP 500", "status": 500}
                 )
+
         monkeypatch.setattr(openreview.api, "OpenReviewClient", lambda **kwargs: MockClient())
         monkeypatch.setenv("OPENREVIEW_USERNAME", "test@example.com")
         monkeypatch.setenv("OPENREVIEW_PASSWORD", "testpass")
         with pytest.raises(openreview.openreview.OpenReviewException):
             fetcher(config, datetime(2026, 7, 26, tzinfo=UTC), 10)
     else:
+
         def fail(url, **kwargs):
             raise RequestError("HTTP 500 from source after 3 attempts")
+
         monkeypatch.setattr("benchmark_radar.sources.get_json", fail)
 
         with pytest.raises(RequestError, match="HTTP 500"):
@@ -761,6 +772,7 @@ def test_new_connectors_surface_http_failures(monkeypatch, fetcher, config):
 def test_new_connectors_never_synthesize_missing_summary(monkeypatch, fetcher, config, payload):
     if fetcher is fetch_openreview:
         import openreview.api
+
         class MockNote:
             def __init__(self, data):
                 self.id = data["id"]
@@ -768,9 +780,11 @@ def test_new_connectors_never_synthesize_missing_summary(monkeypatch, fetcher, c
                 self.cdate = data["cdate"]
                 self.mdate = data["mdate"]
                 self.content = data["content"]
+
         class MockClient:
             def get_notes(self, invitation, limit):
                 return [MockNote(payload)]
+
         monkeypatch.setattr(openreview.api, "OpenReviewClient", lambda **kwargs: MockClient())
         monkeypatch.setenv("OPENREVIEW_USERNAME", "test@example.com")
         monkeypatch.setenv("OPENREVIEW_PASSWORD", "testpass")


### PR DESCRIPTION
## Summary

- replace anonymous score-saturation dots with larger model-family/vendor logo markers while retaining the blue score encoding
- render only the active dashboard view, cache normalized observations, cap every result render, and limit filter updates to the results list
- widen Questions for today to the same desktop content column as Daily briefing while keeping prose at a readable measure
- replace delayed native title feedback on utility icons with a 60ms high-contrast hover/focus state and localized label
- mechanically format two pre-existing Python files to clear the formatter failure already present on `main`

## Issue coverage

- Closes #195
- Revisits and strengthens #222
- Revisits and completes #223
- Closes #228

## Verification

- `python3.11 -m pytest -q` — 705 passed
- `python3.11 -m pytest tests/test_sources.py -q` — 47 passed after the formatting-only commit
- `python3.11 -m ruff check .` — clean
- `python3.11 -m ruff format --check .` — 74 files already formatted
- `node --check site/assets/app.js` — clean
- real Chrome walkthrough at desktop and narrow widths
- local Today readiness improved from about 6.3s to 1.6s; filter-to-DOM feedback measured at 134ms
- only 100 of 220 matching cards render initially; briefing and questions both measure 1328px on the desktop check