### PR TITLE
feat(dashboard): render daily GPT prose in Chinese (issue #231)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,5 @@ OPENAI_API_KEY=
 # OPENAI_QUESTIONS=            # "true" enables daily question generation
 # OPENAI_QUESTIONS_REQUIRED=   # "true" fails the run if Q&A cannot be produced
 # OPENAI_BRIEFING_MODEL=       # model id; defaults to gpt-5.6
+# OPENAI_BRIEFING_ZH=          # "true" also renders the briefing in Chinese
+# OPENAI_QUESTIONS_ZH=         # "true" also renders the Q&A answers in Chinese

--- a/.github/workflows/daily-radar.yml
+++ b/.github/workflows/daily-radar.yml
@@ -89,6 +89,11 @@ jobs:
           # absence.
           OPENAI_QUESTIONS: "true"
           OPENAI_QUESTIONS_REQUIRED: "true"
+          # Issue #231: render the day's GPT briefing and Q&A prose in
+          # Simplified Chinese as well. Each flag is independent; a failed
+          # translation never fails the run, it just leaves the zh fields out.
+          OPENAI_BRIEFING_ZH: "true"
+          OPENAI_QUESTIONS_ZH: "true"
         run: benchmark-radar
       # The day's social post material used to live on a daily GitHub Issue
       # (issue #88), but that Issue stopped earning its keep once the dashboard

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -186,6 +186,14 @@ function t(key, params) {
   return value;
 }
 
+// The day's GPT prose (briefing bullets, caveat, Q&A answers) is English by
+// default. Under the Chinese interface the snapshot's zh rendering is
+// preferred when the run produced it (issue #231); a day whose zh fields are
+// absent falls back to English.
+function l10nProse(en, zh) {
+  return getLang() === "zh" && zh ? zh : en;
+}
+
 function initialLang() {
   const param = new URLSearchParams(window.location.search).get("lang");
   if (LANGS.includes(param)) return param;
@@ -322,6 +330,25 @@ const I18N = {
     Rubric: "评分标准",
     "Daily briefing": "每日简报",
     "Questions for today": "今日问答",
+    // The Q&A question strings are fixed (questions.py QUESTION_GROUPS) and
+    // stored in English in every snapshot, so they are translated here against
+    // the exact stored text rather than by a second server-side field (issue
+    // #231). Group titles ship the same way.
+    "What arrived": "今日新增",
+    "What is still moving": "仍在变动",
+    "What it means": "这意味着什么",
+    "What benchmarks, datasets, or evaluation methods did the radar first see today?":
+      "雷达今天首次看到了哪些基准、数据集或评估方法？",
+    "Which of today's arrivals document how they score an answer?":
+      "今天的哪些新增条目记录了它们如何给答案评分？",
+    "Which artifacts the radar already tracked moved measurably, and over what span?":
+      "雷达已跟踪的哪些条目出现了可测变动，跨度如何？",
+    "Which of that movement is corroborated by more than one connector?":
+      "其中哪些变动得到了不止一个数据源的印证？",
+    "What should someone building or evaluating AI systems do differently today?":
+      "构建或评估 AI 系统的人今天应该做哪些不同的选择？",
+    "What does today's evidence fail to show, and what would change the reading?":
+      "今天的证据未能说明什么，什么会改变这一解读？",
     Search: "搜索",
     "Title, summary, or source": "标题、摘要或来源",
     "Scan date": "扫描日期",
@@ -1215,10 +1242,11 @@ function briefingEvidenceList(citations) {
 
 function briefingDetails(briefing, citations) {
   const provenance = briefingProvenance(briefing);
-  const caveat = briefing.caveat
+  const caveatText = l10nProse(briefing.caveat, briefing.caveat_zh);
+  const caveat = caveatText
     ? element("p", { className: "daily-briefing-caveat" }, [
         element("strong", { text: t("Caveat: ") }),
-        document.createTextNode(String(briefing.caveat)),
+        document.createTextNode(String(caveatText)),
       ])
     : null;
   const evidence = briefingEvidenceList(citations);
@@ -1241,7 +1269,9 @@ function briefingDetails(briefing, citations) {
 // leaving the reader with a heading above blank space.
 function renderDailyBriefing(day) {
   const briefing = day.briefing || {};
-  const bullets = Array.isArray(briefing.bullets) ? briefing.bullets : [];
+  const enBullets = Array.isArray(briefing.bullets) ? briefing.bullets : [];
+  const zhBullets = Array.isArray(briefing.bullets_zh) ? briefing.bullets_zh : [];
+  const bullets = getLang() === "zh" && zhBullets.length ? zhBullets : enBullets;
   const citations = validBriefingCitations(briefing.citations);
   // A briefing carrying another day's date describes the wrong day, so it is
   // withheld rather than shown beside this date's listings.
@@ -1357,7 +1387,7 @@ function answerBlock(answer) {
   const detail = element("div", { className: "answer-detail" }, [
     element("p", { className: "answer-plain" }, [
       element("em", { text: t("In plain English: ") }),
-      document.createTextNode(String(answer?.plain_english || "")),
+      document.createTextNode(l10nProse(String(answer?.plain_english || ""), answer?.plain_chinese)),
     ]),
     citations,
     // Stated on the answer rather than hidden in a tooltip: "the evidence does
@@ -1372,13 +1402,13 @@ function answerBlock(answer) {
       : []),
     element("p", { className: "answer-takeaway" }, [
       element("strong", { text: t("Takeaway: ") }),
-      document.createTextNode(String(answer?.takeaway || "")),
+      document.createTextNode(l10nProse(String(answer?.takeaway || ""), answer?.takeaway_zh)),
     ]),
     // The counter-view is the point of the format: an answer that only ever
     // confirms itself teaches a reader nothing about how much to trust it.
     element("p", { className: "answer-counter-view" }, [
       element("strong", { text: t("Counter-view: ") }),
-      document.createTextNode(String(answer?.counter_view || "")),
+      document.createTextNode(l10nProse(String(answer?.counter_view || ""), answer?.counter_view_zh)),
     ]),
   ]);
   return element("article", { className: "answer" }, [
@@ -1386,9 +1416,9 @@ function answerBlock(answer) {
     // beneath it rather than pinned to the question's own line, so a scan of a
     // day's answers stays a scan of the questions themselves.
     element("h4", { className: "answer-question" }, [
-      document.createTextNode(String(answer?.question || "")),
+      document.createTextNode(t(String(answer?.question || ""))),
     ]),
-    element("p", { className: "answer-signal", text: String(answer?.signal || "") }),
+    element("p", { className: "answer-signal", text: l10nProse(String(answer?.signal || ""), answer?.signal_zh) }),
     meta,
     element("details", { className: "answer-disclosure" }, [
       element("summary", { className: "answer-disclosure-summary" }, [
@@ -1436,7 +1466,7 @@ function renderDailyQuestions(day) {
       element("section", { className: "question-group" }, [
         element("h3", {
           className: "question-group-title",
-          text: String(group?.title || "Questions"),
+          text: t(String(group?.title || "Questions")),
         }),
         ...answers,
       ]),

--- a/src/benchmark_radar/briefing.py
+++ b/src/benchmark_radar/briefing.py
@@ -14,7 +14,7 @@ import tiktoken
 
 from .corpus import build_corpus
 from .findings import first_seen_items
-from .http import post_json
+from .http import RequestError, post_json
 from .models import AttentionObservation, RadarItem, RadarRun
 from .snapshots import merge_snapshots, snapshot_for_run
 
@@ -532,8 +532,15 @@ def generate_daily_briefing(
     api_key: str,
     *,
     model: str = DEFAULT_BRIEFING_MODEL,
+    translate_zh: bool = False,
 ) -> GeneratedBriefing:
-    """Ask GPT for grounded synthesis and retain proof of the real API call."""
+    """Ask GPT for grounded synthesis and retain proof of the real API call.
+
+    With translate_zh, one extra call renders the validated bullets and caveat
+    in Simplified Chinese (issue #231). A translation failure must not cost the
+    day its English briefing, so it is reported as a warning and the zh fields
+    are simply absent; the dashboard falls back to English.
+    """
     evidence_packet = briefing_input(history, current, deterministic_findings)
     # This loop used to discard 41 of 51 selected records without recording it,
     # so a run that reached the model with 20% of its evidence published a
@@ -645,6 +652,22 @@ def generate_daily_briefing(
         "caveat": caveat,
         "citations": citations,
     }
+    if translate_zh:
+        # Function-level import: translate_zh imports this module's OpenAI
+        # plumbing at module scope, so a module-level import here would cycle.
+        from .translate_zh import translate_briefing_to_zh
+
+        try:
+            zh = translate_briefing_to_zh(bullets, caveat, api_key, model=model)
+            metadata["bullets_zh"] = zh["bullets_zh"]
+            metadata["caveat_zh"] = zh["caveat_zh"]
+            metadata["zh_translation"] = {
+                "model": zh["model"],
+                "response_id": zh["response_id"],
+                "usage": zh["usage"],
+            }
+        except (BriefingError, RequestError, ValueError) as error:
+            print(f"::warning title=zh briefing translation skipped::{error}")
     return GeneratedBriefing(bullets=bullets, metadata=metadata)
 
 

--- a/src/benchmark_radar/briefing.py
+++ b/src/benchmark_radar/briefing.py
@@ -660,7 +660,11 @@ def generate_daily_briefing(
         try:
             zh = translate_briefing_to_zh(bullets, caveat, api_key, model=model)
             metadata["bullets_zh"] = zh["bullets_zh"]
-            metadata["caveat_zh"] = zh["caveat_zh"]
+            # A day with insights but no caveat has no caveat_zh; the key is
+            # omitted rather than stored empty, because snapshot validation
+            # rejects empty zh fields and the dashboard falls back per field.
+            if zh.get("caveat_zh"):
+                metadata["caveat_zh"] = zh["caveat_zh"]
             metadata["zh_translation"] = {
                 "model": zh["model"],
                 "response_id": zh["response_id"],

--- a/src/benchmark_radar/cli.py
+++ b/src/benchmark_radar/cli.py
@@ -531,6 +531,13 @@ def main() -> None:
         "true",
         "yes",
     }
+    # Issue #231: optional Simplified Chinese rendering of the day's GPT prose,
+    # one extra call each. Each flag is independent of its generation flag, so
+    # a run can translate the briefing without translating the Q&A and vice
+    # versa. A failed translation never fails the run: the zh fields are absent
+    # and the dashboard shows English.
+    briefing_zh = os.getenv("OPENAI_BRIEFING_ZH", "").lower() in {"1", "true", "yes"}
+    questions_zh = os.getenv("OPENAI_QUESTIONS_ZH", "").lower() in {"1", "true", "yes"}
     daily_briefing = deterministic_findings
     briefing_metadata: dict = {
         "generator": "deterministic-fallback",
@@ -544,6 +551,7 @@ def main() -> None:
                 deterministic_findings,
                 api_key,
                 model=os.getenv("OPENAI_BRIEFING_MODEL", "").strip() or "gpt-5.6",
+                translate_zh=briefing_zh,
             )
             daily_briefing = generated.bullets
             briefing_metadata = generated.metadata
@@ -575,6 +583,7 @@ def main() -> None:
                 api_key,
                 model=os.getenv("OPENAI_BRIEFING_MODEL", "").strip() or "gpt-5.6",
                 config=config,
+                translate_zh=questions_zh,
             )
         except (BriefingError, RequestError, ValueError) as error:
             if questions_required:

--- a/src/benchmark_radar/questions.py
+++ b/src/benchmark_radar/questions.py
@@ -41,8 +41,9 @@ from .briefing import (
     _usage,
     briefing_input,
 )
-from .http import post_json
+from .http import RequestError, post_json
 from .stats import build_registry, stat_index
+from .translate_zh import ZH_ANSWER_FIELDS, translate_answers_to_zh
 
 QA_SCHEMA_VERSION = 1
 MAX_ANSWER_CHARS = 600
@@ -383,8 +384,15 @@ def generate_daily_questions(
     *,
     model: str = DEFAULT_BRIEFING_MODEL,
     config: dict[str, Any] | None = None,
+    translate_zh: bool = False,
 ) -> dict[str, Any]:
-    """Answer today's question set, one call per group, and keep the proof."""
+    """Answer today's question set, one call per group, and keep the proof.
+
+    With translate_zh, one extra call renders every answer's prose in
+    Simplified Chinese (issue #231). A translation failure must not cost the
+    day its English answers, so it is reported as a warning and the zh fields
+    are simply absent; the dashboard falls back to English.
+    """
     registry = build_registry(history, current, config)
     stats_by_id = stat_index(registry)
     base = briefing_input(history, current, deterministic_findings)
@@ -434,7 +442,19 @@ def generate_daily_questions(
             }
         )
 
-    return {
+    zh_translation: dict[str, Any] | None = None
+    if translate_zh:
+        flat = [answer for group in groups for answer in group["answers"]]
+        try:
+            zh_answers, zh_meta = translate_answers_to_zh(flat, api_key, model=model)
+            for answer, zh in zip(flat, zh_answers, strict=True):
+                for zh_field in ZH_ANSWER_FIELDS:
+                    answer[zh_field] = zh[zh_field]
+            zh_translation = zh_meta
+        except (BriefingError, RequestError, ValueError) as error:
+            print(f"::warning title=zh Q&A translation skipped::{error}")
+
+    result = {
         "schema_version": QA_SCHEMA_VERSION,
         "date": current.get("date"),
         "status": "generated",
@@ -448,3 +468,6 @@ def generate_daily_questions(
         "calls": len(groups),
         "coverage": base.get("coverage"),
     }
+    if zh_translation:
+        result["zh_translation"] = zh_translation
+    return result

--- a/src/benchmark_radar/questions.py
+++ b/src/benchmark_radar/questions.py
@@ -448,8 +448,11 @@ def generate_daily_questions(
         try:
             zh_answers, zh_meta = translate_answers_to_zh(flat, api_key, model=model)
             for answer, zh in zip(flat, zh_answers, strict=True):
+                # Empty English prose fields get no zh rendering; the field is
+                # left absent so the dashboard falls back per field.
                 for zh_field in ZH_ANSWER_FIELDS:
-                    answer[zh_field] = zh[zh_field]
+                    if zh_field in zh:
+                        answer[zh_field] = zh[zh_field]
             zh_translation = zh_meta
         except (BriefingError, RequestError, ValueError) as error:
             print(f"::warning title=zh Q&A translation skipped::{error}")

--- a/src/benchmark_radar/snapshots.py
+++ b/src/benchmark_radar/snapshots.py
@@ -198,6 +198,38 @@ def _validate_briefing(briefing: Any, *, source: str, date: str) -> None:
     for bullet in bullets:
         if not isinstance(bullet, str) or not bullet.strip():
             raise SnapshotError(f"{source}: briefing.bullets entries must be non-empty strings")
+    # Optional Chinese rendering (issue #231). Present only when the run asked
+    # for it and the translation passed; when present it must mirror the
+    # English, because the dashboard swaps the two arrays wholesale.
+    bullets_zh = briefing.get("bullets_zh")
+    if bullets_zh is not None:
+        if not isinstance(bullets_zh, list) or len(bullets_zh) != len(bullets):
+            raise SnapshotError(
+                f"{source}: briefing.bullets_zh must be an array matching bullets in count"
+            )
+        for bullet in bullets_zh:
+            if not isinstance(bullet, str) or not bullet.strip():
+                raise SnapshotError(
+                    f"{source}: briefing.bullets_zh entries must be non-empty strings"
+                )
+    if briefing.get("caveat_zh") is not None and (
+        not isinstance(briefing["caveat_zh"], str) or not briefing["caveat_zh"].strip()
+    ):
+        raise SnapshotError(f"{source}: briefing.caveat_zh must be a non-empty string")
+    zh_translation = briefing.get("zh_translation")
+    if zh_translation is not None:
+        if (
+            not isinstance(zh_translation, dict)
+            or not str(zh_translation.get("model") or "").strip()
+            or not str(zh_translation.get("response_id") or "").startswith("resp_")
+        ):
+            raise SnapshotError(f"{source}: OpenAI briefing zh_translation is invalid")
+        usage = zh_translation.get("usage")
+        if not isinstance(usage, dict) or any(
+            not isinstance(usage.get(field), int) or usage[field] < 0
+            for field in ("input_tokens", "output_tokens", "total_tokens")
+        ):
+            raise SnapshotError(f"{source}: OpenAI briefing zh_translation usage is invalid")
     if briefing.get("generator") != "openai-responses":
         return
     if not str(briefing.get("model") or "").strip():
@@ -226,6 +258,42 @@ def _validate_briefing(briefing: Any, *, source: str, date: str) -> None:
             or not str(citation.get("url") or "").startswith(("https://", "http://"))
         ):
             raise SnapshotError(f"{source}: OpenAI briefing citation is invalid")
+
+
+def _validate_questions(questions: Any, *, source: str, date: str) -> None:
+    if not isinstance(questions, dict):
+        raise SnapshotError(f"{source}: questions must be an object")
+    if questions.get("status") != "generated":
+        return
+    if questions.get("date") != date:
+        raise SnapshotError(
+            f"{source}: questions date {questions.get('date')!r} "
+            f"does not match snapshot date {date!r}"
+        )
+    groups = questions.get("groups")
+    if not isinstance(groups, list):
+        raise SnapshotError(f"{source}: generated questions must hold a groups array")
+    # Optional Chinese rendering (issue #231): the zh answer fields are
+    # accepted when present and never required, so snapshots written before the
+    # feature stay valid.
+    for group_index, group in enumerate(groups):
+        if not isinstance(group, dict) or not isinstance(group.get("answers"), list):
+            raise SnapshotError(
+                f"{source}: questions group {group_index} is missing its answers array"
+            )
+        for answer_index, answer in enumerate(group["answers"]):
+            if not isinstance(answer, dict):
+                raise SnapshotError(
+                    f"{source}: questions group {group_index} answer {answer_index} "
+                    "must be an object"
+                )
+            for field in ("signal_zh", "plain_chinese", "takeaway_zh", "counter_view_zh"):
+                value = answer.get(field)
+                if value is not None and (not isinstance(value, str) or not value.strip()):
+                    raise SnapshotError(
+                        f"{source}: questions group {group_index} answer {answer_index} "
+                        f"{field} must be a non-empty string when present"
+                    )
 
 
 def _validate_attention(attention: Any, *, source: str) -> None:
@@ -350,6 +418,9 @@ def validate_snapshot(snapshot: dict[str, Any], *, source: str = "snapshot") -> 
     # silently regenerate, so it fails loudly here.
     if "briefing" in snapshot:
         _validate_briefing(snapshot["briefing"], source=source, date=snapshot["date"])
+    # Optional: snapshots written before the daily Q&A was persisted stay valid.
+    if "questions" in snapshot:
+        _validate_questions(snapshot["questions"], source=source, date=snapshot["date"])
 
 
 def normalize_snapshot(snapshot: dict[str, Any], *, source: str = "snapshot") -> dict[str, Any]:

--- a/src/benchmark_radar/translate_zh.py
+++ b/src/benchmark_radar/translate_zh.py
@@ -41,9 +41,12 @@ from .http import post_json
 # the day's prose, not its evidence packet, so it needs far less headroom.
 MAX_ZH_REQUEST_TOKENS = 30_000
 MAX_ZH_OUTPUT_TOKENS = 4_000
-# Chinese prose is more compact than English, but a translated bullet must not
-# silently grow past the reading length its English original was capped at.
-MAX_ZH_BULLET_CHARS = 1_000
+# Generation assembles a bullet from an 800-char finding and an 800-char
+# rationale plus markers (briefing.py), so an assembled bullet can reach
+# roughly 1,700 chars. The zh rendering is capped at the same ceiling rather
+# than a shorter one, or long valid briefings would silently lose their
+# Chinese rendering every day.
+MAX_BULLET_CHARS = 1_800
 MAX_ZH_CAVEAT_CHARS = 1_400
 MAX_ZH_ANSWER_CHARS = 900
 
@@ -56,8 +59,9 @@ _ZH_INSTRUCTIONS = (
     "Hard rules, in priority order:\n"
     "1. Preserve every token of the form E### (evidence id) or S### (statistic id) "
     "exactly, including the leading letter.\n"
-    "2. Preserve every run of Arabic digits exactly, including decimals, percentages, "
-    "and thousands separators (3, 20, 40, 12.5, 40%, 4,000). Never write a quantity "
+    "2. Preserve every run of Arabic digits exactly, including its sign, "
+    "decimals, percentages, and thousands separators (-5%, 3, 20, 40, 12.5, 40%, "
+    "4,000). Never write a quantity "
     "with a Chinese numeral such as 三 or 二十. The translated prose must contain "
     "exactly the same Arabic digit runs as the English.\n"
     "3. For briefing bullets, keep the English structural markers exactly as written: "
@@ -74,12 +78,13 @@ _ZH_INSTRUCTIONS = (
 )
 
 _BULLET_MARKERS = ("Why it matters:", "Evidence:")
-_CONFIDENCE_PHRASE = re.compile(r"\b(?:High|Medium|Low|Moderate|Mixed)\s+confidence\.?\s*$")
+_CONFIDENCE_LEVEL = re.compile(r"\b(High|Medium|Low|Moderate|Mixed)\s+confidence\.?\s*$")
 _ID_TOKEN = re.compile(r"\b[ES]\d{3}\b")
 # Mirrors the English Q&A validator's number shape so the same "every digit
-# survives" check works in either language; thousands separators are normalized
-# away so 4,000 and 4000 compare equal.
-_DIGIT_RUN = re.compile(r"\d[\d,]*(?:\.\d+)?")
+# survives" check works in either language. Sign and percent sign are part of
+# the quantity (-5% and 5 are different measurements); thousands separators
+# are normalized away so 4,000 and 4000 compare equal.
+_DIGIT_RUN = re.compile(r"[-+]?\d[\d,]*(?:\.\d+)?%?")
 
 # One prose field per answer, in the shape the dashboard reads. The zh name of
 # the plain-English field stays `plain_chinese` because the answer already
@@ -161,6 +166,19 @@ def _digit_runs(text: str) -> list[str]:
     return sorted(token.replace(",", "") for token in _DIGIT_RUN.findall(text))
 
 
+def _require_zh_text(value: Any, *, field: str, max_chars: int) -> str:
+    """A translation that comes back empty is a failure, not prose to store.
+
+    An empty zh field would pass grounding on a digit-free English original
+    and then fail snapshot validation at save time, so it is rejected here,
+    where the caller can still fall back to the English rendering.
+    """
+    text = _output_text(value, field=field, max_chars=max_chars)
+    if not text:
+        raise BriefingError(f"zh translation returned an empty {field}")
+    return text
+
+
 def _check_grounding(en_text: str, zh_text: str, field: str) -> None:
     """Reject a translation that dropped, renamed, or changed an id or a number."""
     if set(_ID_TOKEN.findall(en_text)) != set(_ID_TOKEN.findall(zh_text)):
@@ -179,8 +197,16 @@ def _check_bullet(en_bullet: str, zh_bullet: str) -> None:
     for marker in _BULLET_MARKERS:
         if marker in en_bullet and marker not in zh_bullet:
             raise BriefingError(f"zh briefing bullet dropped the marker {marker!r}")
-    if _CONFIDENCE_PHRASE.search(en_bullet) and not _CONFIDENCE_PHRASE.search(zh_bullet):
-        raise BriefingError("zh briefing bullet dropped the confidence marker")
+    en_confidence = _CONFIDENCE_LEVEL.search(en_bullet)
+    if en_confidence:
+        zh_confidence = _CONFIDENCE_LEVEL.search(zh_bullet)
+        if not zh_confidence:
+            raise BriefingError("zh briefing bullet dropped the confidence marker")
+        # Presence alone is not enough: the dashboard publishes this level, so
+        # translating "Medium confidence." as "High confidence." would put a
+        # fabricated reading on the page.
+        if zh_confidence.group(1).lower() != en_confidence.group(1).lower():
+            raise BriefingError("zh briefing bullet changed the confidence level")
     _check_grounding(en_bullet, zh_bullet, "briefing bullet")
 
 
@@ -231,7 +257,8 @@ def translate_briefing_to_zh(
     fall back to the English-only briefing.
     """
     en_bullets = [
-        _output_text(bullet, field="briefing bullet", max_chars=800) for bullet in bullets
+        _output_text(bullet, field="briefing bullet", max_chars=MAX_BULLET_CHARS)
+        for bullet in bullets
     ]
     en_caveat = _output_text(caveat, field="caveat", max_chars=1_000)
     parsed, meta = _translate(
@@ -245,16 +272,22 @@ def translate_briefing_to_zh(
     if len(raw_bullets) != len(en_bullets):
         raise BriefingError("zh briefing returned the wrong number of bullets")
     bullets_zh = [
-        _output_text(item, field="bullet_zh", max_chars=MAX_ZH_BULLET_CHARS)
+        _require_zh_text(item, field="bullet_zh", max_chars=MAX_BULLET_CHARS)
         for item in raw_bullets
     ]
     for en, zh in zip(en_bullets, bullets_zh, strict=True):
         _check_bullet(en, zh)
-    caveat_zh = _output_text(
-        parsed.get("caveat_zh"), field="caveat_zh", max_chars=MAX_ZH_CAVEAT_CHARS
-    )
-    _check_grounding(en_caveat, caveat_zh, "caveat")
-    return {**meta, "bullets_zh": bullets_zh, "caveat_zh": caveat_zh}
+    result = {**meta, "bullets_zh": bullets_zh}
+    # An empty caveat is a legitimate briefing shape (the day had insights but
+    # no caveat), so it is skipped rather than translated; a non-empty caveat
+    # whose zh rendering comes back empty is a translation failure.
+    if en_caveat:
+        caveat_zh = _require_zh_text(
+            parsed.get("caveat_zh"), field="caveat_zh", max_chars=MAX_ZH_CAVEAT_CHARS
+        )
+        _check_grounding(en_caveat, caveat_zh, "caveat")
+        result["caveat_zh"] = caveat_zh
+    return result
 
 
 def translate_answers_to_zh(
@@ -302,8 +335,15 @@ def translate_answers_to_zh(
             raise BriefingError("zh translation returned a malformed answer")
         zh_answer: dict[str, Any] = {"index": index}
         for en_field, zh_field in _ANSWER_FIELD_PAIRS:
-            value = _output_text(item.get(zh_field), field=zh_field, max_chars=MAX_ZH_ANSWER_CHARS)
-            _check_grounding(en_answer[en_field], value, zh_field)
+            en_value = en_answer[en_field]
+            if not en_value:
+                # Nothing to translate; leave the zh field absent so the
+                # dashboard falls back to the (empty) English field.
+                continue
+            value = _require_zh_text(
+                item.get(zh_field), field=zh_field, max_chars=MAX_ZH_ANSWER_CHARS
+            )
+            _check_grounding(en_value, value, zh_field)
             zh_answer[zh_field] = value
         translated.append(zh_answer)
     return translated, meta

--- a/src/benchmark_radar/translate_zh.py
+++ b/src/benchmark_radar/translate_zh.py
@@ -65,8 +65,8 @@ _ZH_INSTRUCTIONS = (
     "with a Chinese numeral such as 三 or 二十. The translated prose must contain "
     "exactly the same Arabic digit runs as the English.\n"
     "3. For briefing bullets, keep the English structural markers exactly as written: "
-    "the phrases \"Why it matters:\" and \"Evidence:\", and the trailing confidence "
-    "phrase such as \"High confidence.\" or \"Medium confidence.\". Translate only the "
+    'the phrases "Why it matters:" and "Evidence:", and the trailing confidence '
+    'phrase such as "High confidence." or "Medium confidence.". Translate only the '
     "prose around them. The dashboard splits bullets on these markers.\n"
     "4. Keep proper nouns that are identifiers or names (benchmark names, repository "
     "names, model names, paper titles) as-is or in their common English form.\n"
@@ -182,9 +182,7 @@ def _require_zh_text(value: Any, *, field: str, max_chars: int) -> str:
 def _check_grounding(en_text: str, zh_text: str, field: str) -> None:
     """Reject a translation that dropped, renamed, or changed an id or a number."""
     if set(_ID_TOKEN.findall(en_text)) != set(_ID_TOKEN.findall(zh_text)):
-        raise BriefingError(
-            f"zh translation of {field} dropped or changed an E###/S### id"
-        )
+        raise BriefingError(f"zh translation of {field} dropped or changed an E###/S### id")
     if _digit_runs(en_text) != _digit_runs(zh_text):
         raise BriefingError(
             f"zh translation of {field} changed a quantity; every Arabic digit "

--- a/src/benchmark_radar/translate_zh.py
+++ b/src/benchmark_radar/translate_zh.py
@@ -1,0 +1,309 @@
+"""Simplified Chinese rendering of the dashboard's validated English prose.
+
+Issue #231: the dashboard's interface chrome (labels, buttons, help text) is
+translated in the browser through the I18N table in site/assets/app.js, but the
+daily briefing and the Q&A answers are model prose generated at runtime, so a
+Chinese reader toggling the interface still saw English paragraphs. This module
+translates that prose on the same run that generates it, one extra OpenAI call
+each for the briefing and for the Q&A answers.
+
+The English text is the source of truth: it was validated against the evidence
+packet and the stat registry before this module runs. Translation therefore
+re-validates the output instead of trusting it. Any translation that drops,
+renames, or reorders an E###/S### id or a quantity is rejected, and the day
+keeps only the English rendering.
+
+A rounding hazard deserves its own rule: Chinese numerals (三, 二十) are never
+allowed, because the dashboard and the report print figures from the registry
+and the Q&A validator rejects prose that states a number the registry does not
+hold. The translator must carry every Arabic digit run over verbatim.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from .briefing import (
+    DEFAULT_BRIEFING_MODEL,
+    RESPONSES_URL,
+    BriefingError,
+    _extract_response_text,
+    _output_text,
+    _request_token_estimate,
+    _usage,
+)
+from .http import post_json
+
+# Sizing note (issue #231): the briefing's own generation is budgeted at
+# 60,000 request tokens and 4,000 output tokens. A translation call repeats
+# the day's prose, not its evidence packet, so it needs far less headroom.
+MAX_ZH_REQUEST_TOKENS = 30_000
+MAX_ZH_OUTPUT_TOKENS = 4_000
+# Chinese prose is more compact than English, but a translated bullet must not
+# silently grow past the reading length its English original was capped at.
+MAX_ZH_BULLET_CHARS = 1_000
+MAX_ZH_CAVEAT_CHARS = 1_400
+MAX_ZH_ANSWER_CHARS = 900
+
+_ZH_INSTRUCTIONS = (
+    "Role: You are the translator for the AI Benchmark Radar dashboard.\n\n"
+    "You translate validated English prose into natural, fluent Simplified Chinese "
+    "(zh-CN). The English text you receive is the source of truth: every fact, "
+    "quantity, citation, and caveat in it was verified before it reached you, so you "
+    "translate meaning and never add, drop, soften, or reorder anything.\n\n"
+    "Hard rules, in priority order:\n"
+    "1. Preserve every token of the form E### (evidence id) or S### (statistic id) "
+    "exactly, including the leading letter.\n"
+    "2. Preserve every run of Arabic digits exactly, including decimals, percentages, "
+    "and thousands separators (3, 20, 40, 12.5, 40%, 4,000). Never write a quantity "
+    "with a Chinese numeral such as 三 or 二十. The translated prose must contain "
+    "exactly the same Arabic digit runs as the English.\n"
+    "3. For briefing bullets, keep the English structural markers exactly as written: "
+    "the phrases \"Why it matters:\" and \"Evidence:\", and the trailing confidence "
+    "phrase such as \"High confidence.\" or \"Medium confidence.\". Translate only the "
+    "prose around them. The dashboard splits bullets on these markers.\n"
+    "4. Keep proper nouns that are identifiers or names (benchmark names, repository "
+    "names, model names, paper titles) as-is or in their common English form.\n"
+    "5. Write idiomatic Simplified Chinese that a reader familiar with AI evaluation "
+    "would understand.\n\n"
+    "Output: the fields defined by the schema. bullets_zh must have exactly as many "
+    "entries as the input bullets, in the same order. answers_zh must have exactly as "
+    "many entries as the input answers, each carrying the same index."
+)
+
+_BULLET_MARKERS = ("Why it matters:", "Evidence:")
+_CONFIDENCE_PHRASE = re.compile(r"\b(?:High|Medium|Low|Moderate|Mixed)\s+confidence\.?\s*$")
+_ID_TOKEN = re.compile(r"\b[ES]\d{3}\b")
+# Mirrors the English Q&A validator's number shape so the same "every digit
+# survives" check works in either language; thousands separators are normalized
+# away so 4,000 and 4000 compare equal.
+_DIGIT_RUN = re.compile(r"\d[\d,]*(?:\.\d+)?")
+
+# One prose field per answer, in the shape the dashboard reads. The zh name of
+# the plain-English field stays `plain_chinese` because the answer already
+# carries plain_english; the rest mirror the English field with a _zh suffix.
+_ANSWER_FIELD_PAIRS = (
+    ("signal", "signal_zh"),
+    ("plain_english", "plain_chinese"),
+    ("takeaway", "takeaway_zh"),
+    ("counter_view", "counter_view_zh"),
+)
+# The zh field names the snapshot carries per answer; the dashboard reads these
+# exact keys. Exported so questions.py can attach them without re-declaring.
+ZH_ANSWER_FIELDS = tuple(zh_field for _, zh_field in _ANSWER_FIELD_PAIRS)
+
+_BRIEFING_ZH_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "bullets_zh": {"type": "array", "items": {"type": "string"}},
+        "caveat_zh": {"type": "string"},
+    },
+    "required": ["bullets_zh", "caveat_zh"],
+    "additionalProperties": False,
+}
+
+_ANSWERS_ZH_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "answers_zh": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "index": {"type": "integer"},
+                    "signal_zh": {"type": "string"},
+                    "plain_chinese": {"type": "string"},
+                    "takeaway_zh": {"type": "string"},
+                    "counter_view_zh": {"type": "string"},
+                },
+                "required": [
+                    "index",
+                    "signal_zh",
+                    "plain_chinese",
+                    "takeaway_zh",
+                    "counter_view_zh",
+                ],
+                "additionalProperties": False,
+            },
+        }
+    },
+    "required": ["answers_zh"],
+    "additionalProperties": False,
+}
+
+
+def _payload(
+    model: str, serialized: str, schema: dict[str, Any], schema_name: str
+) -> dict[str, Any]:
+    return {
+        "model": model,
+        "instructions": _ZH_INSTRUCTIONS,
+        "input": serialized,
+        "reasoning": {"effort": "medium"},
+        "text": {
+            "verbosity": "medium",
+            "format": {
+                "type": "json_schema",
+                "name": schema_name,
+                "strict": True,
+                "schema": schema,
+            },
+        },
+        "max_output_tokens": MAX_ZH_OUTPUT_TOKENS,
+        "store": False,
+    }
+
+
+def _digit_runs(text: str) -> list[str]:
+    """Every quantity in a piece of prose, thousands separators normalized."""
+    return sorted(token.replace(",", "") for token in _DIGIT_RUN.findall(text))
+
+
+def _check_grounding(en_text: str, zh_text: str, field: str) -> None:
+    """Reject a translation that dropped, renamed, or changed an id or a number."""
+    if set(_ID_TOKEN.findall(en_text)) != set(_ID_TOKEN.findall(zh_text)):
+        raise BriefingError(
+            f"zh translation of {field} dropped or changed an E###/S### id"
+        )
+    if _digit_runs(en_text) != _digit_runs(zh_text):
+        raise BriefingError(
+            f"zh translation of {field} changed a quantity; every Arabic digit "
+            "must survive verbatim"
+        )
+
+
+def _check_bullet(en_bullet: str, zh_bullet: str) -> None:
+    """Reject a translated bullet the dashboard's splitter could not parse."""
+    for marker in _BULLET_MARKERS:
+        if marker in en_bullet and marker not in zh_bullet:
+            raise BriefingError(f"zh briefing bullet dropped the marker {marker!r}")
+    if _CONFIDENCE_PHRASE.search(en_bullet) and not _CONFIDENCE_PHRASE.search(zh_bullet):
+        raise BriefingError("zh briefing bullet dropped the confidence marker")
+    _check_grounding(en_bullet, zh_bullet, "briefing bullet")
+
+
+def _translate(
+    packet: dict[str, Any],
+    schema: dict[str, Any],
+    schema_name: str,
+    api_key: str,
+    model: str,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """One translation call; returns (parsed object, provenance metadata)."""
+    serialized = json.dumps(packet, ensure_ascii=False, separators=(",", ":"))
+    payload = _payload(model, serialized, schema, schema_name)
+    request_tokens = _request_token_estimate(payload, model)
+    if request_tokens > MAX_ZH_REQUEST_TOKENS:
+        raise BriefingError("zh translation input exceeds the request token budget")
+    response = post_json(
+        RESPONSES_URL,
+        payload,
+        headers={"Authorization": f"Bearer {api_key}"},
+        attempts=4,
+        timeout=90.0,
+    )
+    try:
+        parsed = json.loads(_extract_response_text(response))
+    except json.JSONDecodeError as error:
+        raise BriefingError("OpenAI zh translation output is not valid JSON") from error
+    if not isinstance(parsed, dict):
+        raise BriefingError("OpenAI zh translation output is not an object")
+    return parsed, {
+        "model": str(response.get("model") or model),
+        "response_id": str(response.get("id") or ""),
+        "usage": _usage(response),
+    }
+
+
+def translate_briefing_to_zh(
+    bullets: list[str],
+    caveat: str,
+    api_key: str,
+    *,
+    model: str = DEFAULT_BRIEFING_MODEL,
+) -> dict[str, Any]:
+    """Translate one day's validated briefing bullets and caveat into Chinese.
+
+    Returns the zh prose plus the translation call's provenance. Raises
+    BriefingError on any structural or grounding violation so the caller can
+    fall back to the English-only briefing.
+    """
+    en_bullets = [
+        _output_text(bullet, field="briefing bullet", max_chars=800) for bullet in bullets
+    ]
+    en_caveat = _output_text(caveat, field="caveat", max_chars=1_000)
+    parsed, meta = _translate(
+        {"bullets": en_bullets, "caveat": en_caveat},
+        _BRIEFING_ZH_SCHEMA,
+        "daily_radar_briefing_zh",
+        api_key,
+        model,
+    )
+    raw_bullets = parsed.get("bullets_zh") or []
+    if len(raw_bullets) != len(en_bullets):
+        raise BriefingError("zh briefing returned the wrong number of bullets")
+    bullets_zh = [
+        _output_text(item, field="bullet_zh", max_chars=MAX_ZH_BULLET_CHARS)
+        for item in raw_bullets
+    ]
+    for en, zh in zip(en_bullets, bullets_zh, strict=True):
+        _check_bullet(en, zh)
+    caveat_zh = _output_text(
+        parsed.get("caveat_zh"), field="caveat_zh", max_chars=MAX_ZH_CAVEAT_CHARS
+    )
+    _check_grounding(en_caveat, caveat_zh, "caveat")
+    return {**meta, "bullets_zh": bullets_zh, "caveat_zh": caveat_zh}
+
+
+def translate_answers_to_zh(
+    answers: list[dict[str, Any]],
+    api_key: str,
+    *,
+    model: str = DEFAULT_BRIEFING_MODEL,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Translate every prose field of one day's answers in a single call.
+
+    Returns (zh answers aligned to the input by position, provenance). Raises
+    BriefingError on a count, shape, or grounding violation.
+    """
+    en_answers = []
+    for index, answer in enumerate(answers):
+        en_answers.append(
+            {
+                "index": index,
+                **{
+                    en_field: _output_text(
+                        answer.get(en_field), field=en_field, max_chars=MAX_ZH_ANSWER_CHARS
+                    )
+                    for en_field, _ in _ANSWER_FIELD_PAIRS
+                },
+            }
+        )
+    parsed, meta = _translate(
+        {"answers": en_answers},
+        _ANSWERS_ZH_SCHEMA,
+        "daily_radar_answers_zh",
+        api_key,
+        model,
+    )
+    raw = parsed.get("answers_zh") or []
+    if len(raw) != len(en_answers):
+        raise BriefingError("zh translation returned the wrong number of answers")
+    try:
+        by_index = {int(item.get("index")): item for item in raw}
+    except (TypeError, ValueError) as error:
+        raise BriefingError("zh translation returned a malformed answer index") from error
+    translated: list[dict[str, Any]] = []
+    for index, en_answer in enumerate(en_answers):
+        item = by_index.get(index)
+        if not isinstance(item, dict):
+            raise BriefingError("zh translation returned a malformed answer")
+        zh_answer: dict[str, Any] = {"index": index}
+        for en_field, zh_field in _ANSWER_FIELD_PAIRS:
+            value = _output_text(item.get(zh_field), field=zh_field, max_chars=MAX_ZH_ANSWER_CHARS)
+            _check_grounding(en_answer[en_field], value, zh_field)
+            zh_answer[zh_field] = value
+        translated.append(zh_answer)
+    return translated, meta

--- a/tests/fixtures/daily_briefing_zh.json
+++ b/tests/fixtures/daily_briefing_zh.json
@@ -1,0 +1,114 @@
+{
+ "date": "2026-08-12",
+ "briefing": {
+  "bullets": [
+   "Several new releases in this captured feed bind benchmarks to deployment context: web-access APIs are compared across quality, latency, cost, and error rate; document segmentation includes a reference scorer and cloud-VLM comparison; and a device-specific benchmark targets reproducible 7B testing on Jetson hardware. Why it matters: Evaluators should choose suites that reproduce the intended stack and expose operational trade-offs, rather than treating a task score as sufficient evidence for deployment selection. Evidence: E001, E003, E015. High confidence.",
+   "An older-format bullet without the Why it matters structure, still stating its own evidence and confidence inline. Evidence: E004, E007. Medium confidence."
+  ],
+  "caveat": "Only 25 of 164 corpus evidence records were injected, so these findings describe the selected slice rather than the full captured feed. Brave and OpenReview were unavailable, no attention signal was observed today, and comparable history is insufficient for a cross-day trend. Tracked metric deltas were not used because each came from a single connector and was therefore uncorroborated.",
+  "citations": [
+   {
+    "id": "E001",
+    "source": "Hugging Face",
+    "title": "nutrientdocs/doc-split-benchmark",
+    "url": "https://huggingface.co/datasets/nutrientdocs/doc-split-benchmark"
+   },
+   {
+    "id": "E003",
+    "source": "Hugging Face",
+    "title": "nativeport/web-access-api-benchmarks",
+    "url": "https://huggingface.co/datasets/nativeport/web-access-api-benchmarks"
+   },
+   {
+    "id": "E015",
+    "source": "GitHub",
+    "title": "drwjkirkpatrick-web/jetson-llm-benchmark",
+    "url": "https://github.com/drwjkirkpatrick-web/jetson-llm-benchmark"
+   },
+   {
+    "id": "E004",
+    "source": "GitHub",
+    "title": "kizz-tech/agentic-evidence-lab",
+    "url": "https://github.com/kizz-tech/agentic-evidence-lab"
+   },
+   {
+    "id": "E007",
+    "source": "GitHub",
+    "title": "lhao17202-hue/MemoraiBench",
+    "url": "https://github.com/lhao17202-hue/MemoraiBench"
+   },
+   {
+    "id": "E008",
+    "source": "GitHub",
+    "title": "sands-lab/nika",
+    "url": "https://github.com/sands-lab/nika"
+   },
+   {
+    "id": "E002",
+    "source": "Hugging Face",
+    "title": "bielik-benchmark-datasets/polish-fast-benchmarks",
+    "url": "https://huggingface.co/datasets/bielik-benchmark-datasets/polish-fast-benchmarks"
+   },
+   {
+    "id": "E011",
+    "source": "GitHub",
+    "title": "kenzychew/DocExtract",
+    "url": "https://github.com/kenzychew/DocExtract"
+   },
+   {
+    "id": "E014",
+    "source": "Hugging Face",
+    "title": "darthludious/adaption-preference-trace-decisions",
+    "url": "https://huggingface.co/datasets/darthludious/adaption-preference-trace-decisions"
+   }
+  ],
+  "date": "2026-08-12",
+  "generator": "openai-responses",
+  "input": {
+   "attention_items": 14,
+   "characters": 49917,
+   "coverage": {
+    "attention_injected": 14,
+    "corpus_attention_records": 14,
+    "corpus_evidence_records": 164,
+    "evidence_dropped": 0,
+    "evidence_dropped_for_size": 0,
+    "evidence_dropped_for_tokens": 0,
+    "evidence_injected": 25,
+    "evidence_selected": 25,
+    "history_days": 14,
+    "tracked_artifacts_injected": 40
+   },
+   "evidence_items": 25,
+   "history_days": 14,
+   "request_tokens_estimate": 17784,
+   "tracked_artifacts": 40
+  },
+  "model": "gpt-5.6-sol",
+  "response_id": "resp_0f627c56d3db355a016a7be80d44d88196903119ee9a89f841",
+  "status": "insight",
+  "usage": {
+   "cached_input_tokens": 0,
+   "input_tokens": 15111,
+   "output_tokens": 1325,
+   "reasoning_tokens": 904,
+   "total_tokens": 16436
+  },
+  "bullets_zh": [
+   "本次捕获的流中，多个新发布将基准与实际部署场景绑定：网络访问 API 在质量、延迟、成本和错误率上被对比；文档切分包含参考评分器和云端 VLM 对比；一个面向设备的基准专注于在 Jetson 硬件上进行可复现的 7B 测试。Why it matters: 评估者应选择能复现目标技术栈并揭示运行权衡的评测套件，而不是把任务分数当作部署选型的充分证据。Evidence: E001, E003, E015. High confidence.",
+   "一条没有 Why it matters 结构的旧格式条目，仍在其正文中说明自身的证据与置信度。Evidence: E004, E007. Medium confidence."
+  ],
+  "caveat_zh": "仅注入了 164 条语料证据记录中的 25 条，因此这些发现描述的是所选切片而非完整捕获流。Brave 和 OpenReview 不可用，今天未观察到注意力信号，且可比较的历史不足以支撑跨日趋势。跟踪的指标变化未使用，因为每条都来自单一数据源，未得到交叉印证。",
+  "zh_translation": {
+   "model": "gpt-5.6-2026-08-01",
+   "response_id": "resp_zh_br",
+   "usage": {
+    "input_tokens": 500,
+    "cached_input_tokens": 0,
+    "output_tokens": 320,
+    "reasoning_tokens": 10,
+    "total_tokens": 820
+   }
+  }
+ }
+}

--- a/tests/fixtures/daily_questions_zh.json
+++ b/tests/fixtures/daily_questions_zh.json
@@ -1,0 +1,129 @@
+{
+ "date": "2026-08-08",
+ "questions": {
+  "schema_version": 1,
+  "date": "2026-08-08",
+  "generator": "openai-responses",
+  "model": "gpt-5",
+  "comparable": false,
+  "comparability_note": "No certified comparison window: collection changed on 2026-08-06.",
+  "calls": 3,
+  "usage": {
+   "input_tokens": 41234,
+   "output_tokens": 2810
+  },
+  "groups": [
+   {
+    "id": "arrivals",
+    "title": "What arrived",
+    "answers": [
+     {
+      "question": "What benchmarks, datasets, or evaluation methods did the radar first see today?",
+      "signal": "Most of today's first-observed records are agentic evaluation harnesses.",
+      "plain_english": "Most new items today test whether a model can carry out a task, not just answer a question.",
+      "takeaway": "Expect harness setup cost, not just a scoring script.",
+      "counter_view": "The feed is keyword-filtered, so agentic wording may be over-represented.",
+      "stat_ids": [
+       "S001"
+      ],
+      "evidence_ids": [
+       "E001"
+      ],
+      "confidence": "medium",
+      "sufficient_evidence": true,
+      "cited_stats": [
+       {
+        "id": "S001",
+        "label": "First-observed records today",
+        "value": 40,
+        "unit": "count",
+        "window": "today"
+       }
+      ],
+      "cited_evidence": [
+       {
+        "id": "E001",
+        "title": "A harness for long-horizon agent tasks",
+        "url": "https://arxiv.org/abs/2608.00001",
+        "source": "arxiv"
+       }
+      ],
+      "signal_zh": "今天首次观察到的记录大多是智能体评估框架。",
+      "plain_chinese": "今天的大部分新条目测试的是模型能否执行一项任务，而不仅仅是回答问题。",
+      "takeaway_zh": "预期的成本在于框架搭建，而不只是一个评分脚本。",
+      "counter_view_zh": "该流按关键词过滤，因此智能体相关措辞可能被过度代表。"
+     },
+     {
+      "question": "Which of today's arrivals document how they score an answer?",
+      "signal": "Scoring documentation is absent from the captured metadata for most arrivals.",
+      "plain_english": "For most new items we cannot tell how they decide an answer is correct.",
+      "takeaway": "Treat unscored arrivals as unverified until the repository is read.",
+      "counter_view": "No credible counter-view found.",
+      "stat_ids": [],
+      "evidence_ids": [],
+      "confidence": "low",
+      "sufficient_evidence": false,
+      "cited_stats": [],
+      "cited_evidence": [],
+      "signal_zh": "大多数新增条目的捕获元数据中没有评分文档。",
+      "plain_chinese": "对于大多数新条目，我们无法判断它们如何判定一个答案是否正确。",
+      "takeaway_zh": "在阅读仓库之前，将未评分的新增条目视为未经核实。",
+      "counter_view_zh": "未找到可信的反方观点。"
+     }
+    ]
+   },
+   {
+    "id": "movement",
+    "title": "What is still moving",
+    "answers": [
+     {
+      "question": "Which artifacts the radar already tracked moved measurably, and over what span?",
+      "signal": "Tracked artifacts moved on cumulative download counts across their whole tracked span.",
+      "plain_english": "Some items the radar has followed for a while kept gaining downloads overall.",
+      "takeaway": "Read the movement as a total since first sighting, not as a one-day jump.",
+      "counter_view": "Only one connector reported the movement, so it is uncorroborated.",
+      "stat_ids": [
+       "S014",
+       "S021"
+      ],
+      "evidence_ids": [],
+      "confidence": "low",
+      "sufficient_evidence": true,
+      "cited_stats": [
+       {
+        "id": "S014",
+        "label": "Tracked artifacts with movement",
+        "value": 12,
+        "unit": "count",
+        "window": "since 2026-07-23 (17 days)"
+       },
+       {
+        "id": "S021",
+        "label": "Mean days between sightings",
+        "value": 1234.56789,
+        "unit": "days",
+        "window": "today"
+       }
+      ],
+      "cited_evidence": [],
+      "signal_zh": "被跟踪的条目在其整个跟踪跨度内以累计下载量变动。",
+      "plain_chinese": "雷达跟踪了一段时间的一些条目总体仍在增加下载量。",
+      "takeaway_zh": "把变动理解为自首次发现以来的累计值，而非某一天的跳跃。",
+      "counter_view_zh": "只有单一数据源报告了该变动，因此未得到交叉印证。"
+     }
+    ]
+   }
+  ],
+  "zh_translation": {
+   "model": "gpt-5.6-2026-08-01",
+   "response_id": "resp_zh_qa",
+   "usage": {
+    "input_tokens": 900,
+    "cached_input_tokens": 0,
+    "output_tokens": 700,
+    "reasoning_tokens": 40,
+    "total_tokens": 1600
+   }
+  }
+ }
+}

--- a/tests/render_briefing_harness.mjs
+++ b/tests/render_briefing_harness.mjs
@@ -80,8 +80,13 @@ globalThis.window = { addEventListener: () => {}, location: { search: "", hash: 
 globalThis.fetch = () => new Promise(() => {});
 
 const harness =
-  `globalThis.__render = { renderDailyBriefing };\n${source}`;
+  `globalThis.__render = { renderDailyBriefing, setLang, getLang };\n${source}`;
 new Function(harness)();
+
+// A caller may pass "zh" as a third argument to exercise the Chinese rendering
+// (issue #231); default stays English.
+const lang = process.argv[3];
+if (lang) globalThis.__render.setLang(lang);
 
 const fixturePath = process.argv[2] || join(here, "fixtures", "daily_briefing.json");
 const day = JSON.parse(readFileSync(fixturePath, "utf8"));

--- a/tests/render_questions_harness.mjs
+++ b/tests/render_questions_harness.mjs
@@ -87,11 +87,16 @@ globalThis.fetch = () => new Promise(() => {});
 // the export is placed at the TOP of the harness: it then captures the render
 // helpers before any bootstrap statement can throw on a browser-only API.
 const harness =
-  `globalThis.__render = { renderDailyQuestions, formatStatValue };\n${source}`;
+  `globalThis.__render = { renderDailyQuestions, formatStatValue, setLang, getLang };\n${source}`;
 // A bootstrap failure is NOT swallowed. The stubs above cover every browser API
 // app.js touches on load, so a throw here means the real script would break in a
 // browser too, and a renderer test that still passed would be hiding it.
 new Function(harness)();
+
+// A caller may pass "zh" as a third argument to exercise the Chinese rendering
+// (issue #231); default stays English.
+const lang = process.argv[3];
+if (lang) globalThis.__render.setLang(lang);
 
 // A caller may pass a different fixture to exercise an absent or stale Q&A.
 const fixturePath = process.argv[2] || join(here, "fixtures", "daily_questions.json");

--- a/tests/test_briefing.py
+++ b/tests/test_briefing.py
@@ -578,9 +578,7 @@ def _briefing_zh_response(bullets_zh, caveat_zh):
                 "content": [
                     {
                         "type": "output_text",
-                        "text": json.dumps(
-                            {"bullets_zh": bullets_zh, "caveat_zh": caveat_zh}
-                        ),
+                        "text": json.dumps({"bullets_zh": bullets_zh, "caveat_zh": caveat_zh}),
                     }
                 ],
             }
@@ -619,16 +617,12 @@ def test_generate_daily_briefing_translates_to_chinese_when_requested(monkeypatc
                                             "finding": (
                                                 "Memory evaluation is moving toward persistence."
                                             ),
-                                            "why_it_matters": (
-                                                "Teams need longitudinal tests."
-                                            ),
+                                            "why_it_matters": ("Teams need longitudinal tests."),
                                             "evidence_ids": ["E001"],
                                             "confidence": "medium",
                                         }
                                     ],
-                                    "caveat": (
-                                        "One captured release does not establish a trend."
-                                    ),
+                                    "caveat": ("One captured release does not establish a trend."),
                                 }
                             ),
                         }
@@ -657,8 +651,12 @@ def test_generate_daily_briefing_translates_to_chinese_when_requested(monkeypatc
     monkeypatch.setattr("benchmark_radar.translate_zh.post_json", fake_translate)
 
     result = generate_daily_briefing(
-        [current], current, ["Insufficient comparable history."], "secret",
-        model="gpt-5.6", translate_zh=True,
+        [current],
+        current,
+        ["Insufficient comparable history."],
+        "secret",
+        model="gpt-5.6",
+        translate_zh=True,
     )
 
     assert "Evidence: E001" in result.bullets[0]
@@ -697,9 +695,7 @@ def test_generate_daily_briefing_keeps_english_when_zh_translation_fails(monkeyp
                                             "finding": (
                                                 "Memory evaluation is moving toward persistence."
                                             ),
-                                            "why_it_matters": (
-                                                "Teams need longitudinal tests."
-                                            ),
+                                            "why_it_matters": ("Teams need longitudinal tests."),
                                             "evidence_ids": ["E001"],
                                             "confidence": "medium",
                                         }
@@ -722,10 +718,7 @@ def test_generate_daily_briefing_keeps_english_when_zh_translation_fails(monkeyp
 
     def fake_translate(url, payload, **kwargs):
         return _briefing_zh_response(
-            [
-                "记忆评估正在向持久化方向发展。团队需要纵向测试。"
-                "Evidence: E001. Medium confidence."
-            ],
+            ["记忆评估正在向持久化方向发展。团队需要纵向测试。Evidence: E001. Medium confidence."],
             "仅一个发布不足以确立趋势。",
         )
 
@@ -733,8 +726,12 @@ def test_generate_daily_briefing_keeps_english_when_zh_translation_fails(monkeyp
     monkeypatch.setattr("benchmark_radar.translate_zh.post_json", fake_translate)
 
     result = generate_daily_briefing(
-        [current], current, ["Insufficient comparable history."], "secret",
-        model="gpt-5.6", translate_zh=True,
+        [current],
+        current,
+        ["Insufficient comparable history."],
+        "secret",
+        model="gpt-5.6",
+        translate_zh=True,
     )
 
     assert "Why it matters" in result.bullets[0]

--- a/tests/test_briefing.py
+++ b/tests/test_briefing.py
@@ -566,3 +566,177 @@ def test_briefing_packet_reports_how_much_of_the_corpus_reached_the_model():
     assert coverage["corpus_evidence_records"] == 5
     assert coverage["evidence_injected"] == 5
     assert coverage["evidence_dropped_for_size"] == 0
+
+
+def _briefing_zh_response(bullets_zh, caveat_zh):
+    return {
+        "id": "resp_zh",
+        "model": "gpt-5.6-2026-08-01",
+        "output": [
+            {
+                "type": "message",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": json.dumps(
+                            {"bullets_zh": bullets_zh, "caveat_zh": caveat_zh}
+                        ),
+                    }
+                ],
+            }
+        ],
+        "usage": {
+            "input_tokens": 500,
+            "output_tokens": 300,
+            "total_tokens": 800,
+            "input_tokens_details": {"cached_tokens": 0},
+            "output_tokens_details": {"reasoning_tokens": 20},
+        },
+    }
+
+
+def test_generate_daily_briefing_translates_to_chinese_when_requested(monkeypatch):
+    item = _item(1, title="MemoryBench: Long-horizon personal memory")
+    item.summary = "Measures memory persistence."
+    item.event_kind = "released"
+    current = snapshot_for_run(_run([item]))
+
+    def fake_briefing(url, payload, **kwargs):
+        return {
+            "id": "resp_real",
+            "model": "gpt-5.6-2026-08-01",
+            "output": [
+                {
+                    "type": "message",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": json.dumps(
+                                {
+                                    "status": "insight",
+                                    "insights": [
+                                        {
+                                            "finding": (
+                                                "Memory evaluation is moving toward persistence."
+                                            ),
+                                            "why_it_matters": (
+                                                "Teams need longitudinal tests."
+                                            ),
+                                            "evidence_ids": ["E001"],
+                                            "confidence": "medium",
+                                        }
+                                    ],
+                                    "caveat": (
+                                        "One captured release does not establish a trend."
+                                    ),
+                                }
+                            ),
+                        }
+                    ],
+                }
+            ],
+            "usage": {
+                "input_tokens": 8123,
+                "output_tokens": 241,
+                "total_tokens": 8364,
+                "input_tokens_details": {"cached_tokens": 100},
+                "output_tokens_details": {"reasoning_tokens": 80},
+            },
+        }
+
+    def fake_translate(url, payload, **kwargs):
+        return _briefing_zh_response(
+            [
+                "记忆评估正在向持久化方向发展。Why it matters: 团队需要纵向测试。"
+                "Evidence: E001. Medium confidence."
+            ],
+            "仅一个发布不足以确立趋势。",
+        )
+
+    monkeypatch.setattr("benchmark_radar.briefing.post_json", fake_briefing)
+    monkeypatch.setattr("benchmark_radar.translate_zh.post_json", fake_translate)
+
+    result = generate_daily_briefing(
+        [current], current, ["Insufficient comparable history."], "secret",
+        model="gpt-5.6", translate_zh=True,
+    )
+
+    assert "Evidence: E001" in result.bullets[0]
+    assert result.metadata["bullets_zh"][0] == (
+        "记忆评估正在向持久化方向发展。Why it matters: 团队需要纵向测试。"
+        "Evidence: E001. Medium confidence."
+    )
+    assert result.metadata["caveat_zh"] == "仅一个发布不足以确立趋势。"
+    assert result.metadata["zh_translation"]["response_id"] == "resp_zh"
+
+
+def test_generate_daily_briefing_keeps_english_when_zh_translation_fails(monkeypatch):
+    # A translation that drops the "Why it matters" marker would render as one
+    # unparsable paragraph on the dashboard, so it is rejected and the day keeps
+    # its English-only briefing rather than failing the whole run.
+    item = _item(1, title="MemoryBench: Long-horizon personal memory")
+    item.summary = "Measures memory persistence."
+    item.event_kind = "released"
+    current = snapshot_for_run(_run([item]))
+
+    def fake_briefing(url, payload, **kwargs):
+        return {
+            "id": "resp_real",
+            "model": "gpt-5.6-2026-08-01",
+            "output": [
+                {
+                    "type": "message",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": json.dumps(
+                                {
+                                    "status": "insight",
+                                    "insights": [
+                                        {
+                                            "finding": (
+                                                "Memory evaluation is moving toward persistence."
+                                            ),
+                                            "why_it_matters": (
+                                                "Teams need longitudinal tests."
+                                            ),
+                                            "evidence_ids": ["E001"],
+                                            "confidence": "medium",
+                                        }
+                                    ],
+                                    "caveat": "One captured release does not establish a trend.",
+                                }
+                            ),
+                        }
+                    ],
+                }
+            ],
+            "usage": {
+                "input_tokens": 8123,
+                "output_tokens": 241,
+                "total_tokens": 8364,
+                "input_tokens_details": {"cached_tokens": 100},
+                "output_tokens_details": {"reasoning_tokens": 80},
+            },
+        }
+
+    def fake_translate(url, payload, **kwargs):
+        return _briefing_zh_response(
+            [
+                "记忆评估正在向持久化方向发展。团队需要纵向测试。"
+                "Evidence: E001. Medium confidence."
+            ],
+            "仅一个发布不足以确立趋势。",
+        )
+
+    monkeypatch.setattr("benchmark_radar.briefing.post_json", fake_briefing)
+    monkeypatch.setattr("benchmark_radar.translate_zh.post_json", fake_translate)
+
+    result = generate_daily_briefing(
+        [current], current, ["Insufficient comparable history."], "secret",
+        model="gpt-5.6", translate_zh=True,
+    )
+
+    assert "Why it matters" in result.bullets[0]
+    assert "bullets_zh" not in result.metadata
+    assert "caveat_zh" not in result.metadata

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -407,6 +407,71 @@ def test_daily_radar_yml_enables_and_requires_questions_in_production():
     assert str(env.get("OPENAI_QUESTIONS_REQUIRED")).lower() == "true"
 
 
+def test_daily_radar_yml_enables_chinese_rendering_in_production():
+    """Issue #231: production must ask for the zh rendering, or the flags would
+    exist but never be set and the Chinese dashboard would always show English."""
+    workflow_path = Path(".github/workflows/daily-radar.yml")
+    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    collect_step = next(
+        step
+        for step in workflow["jobs"]["build-report"]["steps"]
+        if step.get("name") == "Collect evidence and public attention"
+    )
+    env = collect_step["env"]
+    assert str(env.get("OPENAI_BRIEFING_ZH")).lower() == "true"
+    assert str(env.get("OPENAI_QUESTIONS_ZH")).lower() == "true"
+
+
+def test_zh_flags_reach_the_briefing_and_questions_generators(monkeypatch, tmp_path):
+    """The env flags are read once and passed through as translate_zh so the
+    generators own the translation call and its failure handling."""
+    monkeypatch.setenv("OPENAI_API_KEY", "secret")
+    monkeypatch.setenv("OPENAI_BRIEFING_ZH", "true")
+    monkeypatch.setenv("OPENAI_QUESTIONS", "true")
+    monkeypatch.setenv("OPENAI_QUESTIONS_ZH", "true")
+    _stub_sources(monkeypatch, datetime.now(UTC))
+    monkeypatch.setattr("sys.argv", _briefing_argv(tmp_path))
+    captured = {}
+
+    def fake_briefing(*args, **kwargs):
+        captured["briefing"] = kwargs.get("translate_zh")
+        return GeneratedBriefing(
+            bullets=["A real GPT synthesis. Evidence: E001."],
+            metadata={
+                "generator": "openai-responses",
+                "model": "gpt-5.6",
+                "response_id": "resp_real",
+                "usage": {"input_tokens": 8000, "output_tokens": 200, "total_tokens": 8200},
+                "input": {"evidence_items": 30},
+                "citations": [],
+            },
+        )
+
+    def fake_questions(*args, **kwargs):
+        captured["questions"] = kwargs.get("translate_zh")
+        return {
+            "schema_version": 1,
+            "date": datetime.now(UTC).date().isoformat(),
+            "status": "generated",
+            "generator": "openai-responses",
+            "model": "gpt-5.6",
+            "comparable": False,
+            "comparability_note": "no certified window",
+            "groups": [],
+            "stat_registry": [],
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+            "calls": 3,
+            "coverage": {},
+        }
+
+    monkeypatch.setattr(cli, "generate_daily_briefing", fake_briefing)
+    monkeypatch.setattr(cli, "generate_daily_questions", fake_questions)
+
+    cli.main()
+
+    assert captured == {"briefing": True, "questions": True}
+
+
 def test_daily_radar_yml_renders_social_material_instead_of_an_issue():
     """Issue #88: the dashboard and site/feed.xml remain the reading surface
     (issue #37), so the daily Issue carries only the social posting checklist.

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -422,3 +422,107 @@ def test_question_requests_do_not_retain_data_server_side():
     payload = questions._payload("gpt-5.6", "{}")
 
     assert payload["store"] is False
+
+
+def test_generate_daily_questions_translates_answers_to_chinese_when_requested(monkeypatch):
+    import json
+
+    current = snapshot_for_run(_run([_item(1), _item(2)]))
+
+    def fake_questions(url, payload, **kwargs):
+        prompt_questions = json.loads(payload["input"])["questions"]
+        return {
+            "id": "resp_qa",
+            "model": "gpt-5.6-2026-08-01",
+            "output": [
+                {
+                    "type": "message",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": json.dumps(
+                                {
+                                    "answers": [
+                                        {
+                                            "question": question,
+                                            "signal": "No supporting evidence today.",
+                                            "plain_english": (
+                                                "Nothing in the captured feed supports an "
+                                                "answer today."
+                                            ),
+                                            "takeaway": "Treat the day as quiet.",
+                                            "counter_view": "No credible counter-view found.",
+                                            "stat_ids": [],
+                                            "evidence_ids": [],
+                                            "confidence": "low",
+                                            "sufficient_evidence": False,
+                                        }
+                                        for question in prompt_questions
+                                    ]
+                                }
+                            ),
+                        }
+                    ],
+                }
+            ],
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "total_tokens": 150,
+                "input_tokens_details": {"cached_tokens": 0},
+                "output_tokens_details": {"reasoning_tokens": 5},
+            },
+        }
+
+    def fake_translate(url, payload, **kwargs):
+        count = len(json.loads(payload["input"])["answers"])
+        return {
+            "id": "resp_zh",
+            "model": "gpt-5.6-2026-08-01",
+            "output": [
+                {
+                    "type": "message",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": json.dumps(
+                                {
+                                    "answers_zh": [
+                                        {
+                                            "index": index,
+                                            "signal_zh": "今天没有支持性的证据。",
+                                            "plain_chinese": "今天的捕获流中没有任何内容支持答案。",
+                                            "takeaway_zh": "把今天视为平静的一天。",
+                                            "counter_view_zh": "未找到可信的反方观点。",
+                                        }
+                                        for index in range(count)
+                                    ]
+                                }
+                            ),
+                        }
+                    ],
+                }
+            ],
+            "usage": {
+                "input_tokens": 500,
+                "output_tokens": 300,
+                "total_tokens": 800,
+                "input_tokens_details": {"cached_tokens": 0},
+                "output_tokens_details": {"reasoning_tokens": 20},
+            },
+        }
+
+    monkeypatch.setattr("benchmark_radar.questions.post_json", fake_questions)
+    monkeypatch.setattr("benchmark_radar.translate_zh.post_json", fake_translate)
+
+    result = questions.generate_daily_questions(
+        [], current, [], "secret", model="gpt-5.6", translate_zh=True
+    )
+
+    answers = [a for group in result["groups"] for a in group["answers"]]
+    assert len(answers) == 6
+    assert all(
+        a["signal_zh"] and a["plain_chinese"] and a["takeaway_zh"] and a["counter_view_zh"]
+        for a in answers
+    )
+    assert result["zh_translation"]["response_id"] == "resp_zh"

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -879,7 +879,7 @@ def test_daily_briefing_renders_scannable_insight_blocks():
     assert "parts.body" in script
 
 
-def _rendered_briefing(fixture: str | None = None):
+def _rendered_briefing(fixture: str | None = None, lang: str | None = None):
     """Run the real briefing renderer over a fixture and return the DOM tree."""
     import json
     import shutil
@@ -891,7 +891,12 @@ def _rendered_briefing(fixture: str | None = None):
 
         pytest.skip("node is not installed")
     result = subprocess.run(
-        [node, "tests/render_briefing_harness.mjs", *([fixture] if fixture else [])],
+        [
+            node,
+            "tests/render_briefing_harness.mjs",
+            *([fixture] if fixture else []),
+            *([lang] if lang else []),
+        ],
         capture_output=True,
         text=True,
         timeout=60,
@@ -937,6 +942,46 @@ def test_rendered_briefing_splits_each_bullet_into_head_body_and_meta():
     assert "Evidence:" not in subtext(fbhead)
     assert "Medium confidence" in subtext(fbmeta)
     assert "2 sources" in subtext(fbmeta)
+
+
+def test_rendered_briefing_shows_chinese_when_the_snapshot_has_it():
+    """Under the zh interface, the snapshot's zh rendering replaces the English.
+
+    The zh bullets are validated at generation to carry the same E### ids, the
+    same markers, and the same digits, so the renderer treats them as drop-in
+    replacements: markers still split, evidence still lifts to the meta line.
+    """
+    nodes = list(_flatten(_rendered_briefing("tests/fixtures/daily_briefing_zh.json", "zh")))
+    insights = [n for n in nodes if n["className"] == "briefing-insight"]
+
+    assert len(insights) == 2
+    head = next(n for n in insights[0]["children"] if n["className"] == "briefing-insight-head")
+    body = next(n for n in insights[0]["children"] if n["className"] == "briefing-insight-body")
+    meta = next(n for n in insights[0]["children"] if n["className"] == "briefing-insight-meta")
+    assert "本次捕获的流中" in head["text"]
+    assert "评估者应选择能复现目标技术栈" in body["text"]
+    # The zh bullet keeps the English markers, so the splitter still removes them
+    # from the running text just as it does for English bullets.
+    assert "Why it matters" not in head["text"]
+    assert "Evidence:" not in body["text"]
+    assert "High" in meta["text"]
+    # The translated caveat is shown instead of the English one.
+    caveat = next(n for n in nodes if n["className"] == "daily-briefing-caveat")
+    assert "仅注入了" in caveat["text"]
+    assert "Only 25 of 164" not in caveat["text"]
+
+
+def test_rendered_briefing_falls_back_to_english_without_zh_fields():
+    """A day whose snapshot carries no zh fields stays English under zh."""
+    nodes = list(_flatten(_rendered_briefing("tests/fixtures/daily_briefing.json", "zh")))
+    heads = [
+        n["text"]
+        for n in nodes
+        if n["className"] == "briefing-insight-head" and n["text"].startswith("Several")
+    ]
+    assert heads and "Several new releases in this captured feed" in heads[0]
+    caves = [n["text"] for n in nodes if n["className"] == "daily-briefing-caveat"]
+    assert caves and "Only 25 of 164" in caves[0]
 
 
 def test_today_view_renders_the_daily_questions_under_the_briefing():
@@ -1024,7 +1069,7 @@ def test_daily_questions_link_only_validated_http_evidence():
     assert "validBriefingCitations(answer?.cited_evidence)" in script
 
 
-def _rendered_questions(fixture: str | None = None):
+def _rendered_questions(fixture: str | None = None, lang: str | None = None):
     """Run the real renderer over a fixture and return the resulting DOM tree.
 
     Source assertions cannot distinguish "renders the answer" from "mentions the
@@ -1041,7 +1086,12 @@ def _rendered_questions(fixture: str | None = None):
 
         pytest.skip("node is not installed")
     result = subprocess.run(
-        [node, "tests/render_questions_harness.mjs", *([fixture] if fixture else [])],
+        [
+            node,
+            "tests/render_questions_harness.mjs",
+            *([fixture] if fixture else []),
+            *([lang] if lang else []),
+        ],
         capture_output=True,
         text=True,
         timeout=60,
@@ -1084,6 +1134,33 @@ def test_rendered_questions_carry_every_answer_field_and_registry_value():
     assert "Evidence is insufficient to answer this today." in text
     assert "No certified comparison window" in text
     assert "Answered by gpt-5 in 3 calls" in text
+
+
+def test_rendered_questions_show_chinese_prose_and_questions_under_zh():
+    """Under zh, fixed question strings come from the I18N table and the day's
+    answer prose from the snapshot's zh fields when the run produced them."""
+    nodes = list(_flatten(_rendered_questions("tests/fixtures/daily_questions_zh.json", "zh")))
+    classes = {n["className"] for n in nodes}
+    text = next(iter(nodes))["text"]
+
+    assert {"question-group", "answer", "answer-signal", "answer-takeaway"} <= classes
+    # Group titles and the fixed question strings translate through the table.
+    assert "今日新增" in text
+    assert "雷达今天首次看到了哪些基准、数据集或评估方法？" in text
+    # The model prose is the snapshot's zh rendering, not the English original.
+    assert "今天首次观察到的记录大多是智能体评估框架。" in text
+    assert "Most of today's first-observed records" not in text
+    assert "未找到可信的反方观点。" in text
+
+
+def test_rendered_questions_keep_english_prose_when_zh_fields_are_absent():
+    """Without zh prose fields, only the fixed question strings translate."""
+    nodes = list(_flatten(_rendered_questions("tests/fixtures/daily_questions.json", "zh")))
+    text = next(iter(nodes))["text"]
+
+    assert "雷达今天首次看到了哪些基准、数据集或评估方法？" in text
+    assert "Most of today's first-observed records are agentic evaluation harnesses." in text
+    assert "今天首次观察到的记录大多是智能体评估框架。" not in text
 
 
 def test_dashboard_and_markdown_format_statistics_identically():

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -1147,6 +1147,166 @@ def test_snapshot_persists_and_validates_openai_provenance():
     assert snapshot["briefing"]["usage"]["input_tokens"] == 8000
 
 
+def test_validate_snapshot_accepts_a_briefing_with_chinese_rendering():
+    run = radar_run()
+    run.daily_briefing = ["Grounded GPT finding. Evidence: E001. High confidence."]
+    run.daily_briefing_metadata = {
+        "generator": "openai-responses",
+        "model": "gpt-5.6",
+        "response_id": "resp_123",
+        "usage": {"input_tokens": 8000, "output_tokens": 200, "total_tokens": 8200},
+        "input": {"evidence_items": 40},
+        "citations": [
+            {
+                "id": "E001",
+                "title": "MemoryBench",
+                "url": "https://example.test/memory",
+                "source": "arXiv",
+            }
+        ],
+        "bullets_zh": ["有据可依的 GPT 发现。Evidence: E001. High confidence."],
+        "caveat_zh": "仅注入部分记录。",
+        "zh_translation": {
+            "model": "gpt-5.6-2026-08-01",
+            "response_id": "resp_zh",
+            "usage": {"input_tokens": 500, "output_tokens": 300, "total_tokens": 800},
+        },
+    }
+
+    snapshot = snapshot_for_run(run)
+    validate_snapshot(snapshot)
+
+    assert snapshot["briefing"]["bullets_zh"] == [
+        "有据可依的 GPT 发现。Evidence: E001. High confidence."
+    ]
+
+
+def test_validate_snapshot_rejects_a_mismatched_zh_bullet_array():
+    run = radar_run()
+    run.daily_briefing = ["Grounded GPT finding. Evidence: E001.", "Second finding."]
+    run.daily_briefing_metadata = {
+        "generator": "openai-responses",
+        "model": "gpt-5.6",
+        "response_id": "resp_123",
+        "usage": {"input_tokens": 8000, "output_tokens": 200, "total_tokens": 8200},
+        "input": {"evidence_items": 40},
+        "citations": [],
+        "bullets_zh": ["只有一条。"],
+    }
+
+    snapshot = snapshot_for_run(run)
+    with pytest.raises(SnapshotError, match="matching bullets in count"):
+        validate_snapshot(snapshot)
+
+
+def test_validate_snapshot_rejects_an_empty_zh_caveat():
+    run = radar_run()
+    run.daily_briefing = ["Grounded GPT finding. Evidence: E001."]
+    run.daily_briefing_metadata = {
+        "generator": "openai-responses",
+        "model": "gpt-5.6",
+        "response_id": "resp_123",
+        "usage": {"input_tokens": 8000, "output_tokens": 200, "total_tokens": 8200},
+        "input": {"evidence_items": 40},
+        "citations": [],
+        "bullets_zh": ["有据可依的 GPT 发现。Evidence: E001."],
+        "caveat_zh": "   ",
+    }
+
+    snapshot = snapshot_for_run(run)
+    with pytest.raises(SnapshotError, match="caveat_zh must be a non-empty string"):
+        validate_snapshot(snapshot)
+
+
+def test_validate_snapshot_accepts_generated_questions_with_chinese_fields():
+    run = radar_run()
+    snapshot = snapshot_for_run(run)
+    snapshot["questions"] = {
+        "schema_version": 1,
+        "date": snapshot["date"],
+        "status": "generated",
+        "generator": "openai-responses",
+        "model": "gpt-5.6",
+        "groups": [
+            {
+                "id": "arrivals",
+                "title": "What arrived",
+                "answers": [
+                    {
+                        "question": "Q1?",
+                        "signal": "One.",
+                        "plain_english": "One.",
+                        "takeaway": "One.",
+                        "counter_view": "None.",
+                        "signal_zh": "一个。",
+                        "plain_chinese": "一个。",
+                        "takeaway_zh": "一个。",
+                        "counter_view_zh": "无。",
+                    }
+                ],
+            }
+        ],
+        "zh_translation": {
+            "model": "gpt-5.6-2026-08-01",
+            "response_id": "resp_zh",
+            "usage": {"input_tokens": 500, "output_tokens": 300, "total_tokens": 800},
+        },
+    }
+    validate_snapshot(snapshot)
+
+
+def test_validate_snapshot_rejects_an_empty_zh_answer_field():
+    run = radar_run()
+    snapshot = snapshot_for_run(run)
+    snapshot["questions"] = {
+        "schema_version": 1,
+        "date": snapshot["date"],
+        "status": "generated",
+        "groups": [
+            {
+                "id": "arrivals",
+                "answers": [
+                    {
+                        "question": "Q1?",
+                        "signal": "One.",
+                        "plain_chinese": "  ",
+                    }
+                ],
+            }
+        ],
+    }
+
+    with pytest.raises(SnapshotError, match="plain_chinese must be a non-empty string"):
+        validate_snapshot(snapshot)
+
+
+def test_validate_snapshot_accepts_questions_written_before_the_zh_feature():
+    # Snapshots written before issue #231 never carried zh answer fields; they
+    # must keep validating.
+    run = radar_run()
+    snapshot = snapshot_for_run(run)
+    snapshot["questions"] = {
+        "schema_version": 1,
+        "date": snapshot["date"],
+        "status": "generated",
+        "groups": [
+            {
+                "id": "arrivals",
+                "answers": [
+                    {
+                        "question": "Q1?",
+                        "signal": "One.",
+                        "plain_english": "One.",
+                        "takeaway": "One.",
+                        "counter_view": "None.",
+                    }
+                ],
+            }
+        ],
+    }
+    validate_snapshot(snapshot)
+
+
 def test_write_snapshot_preserves_the_briefing_across_passes(tmp_path):
     morning = radar_run()
     morning.daily_briefing = ["Committed by the first pass."]

--- a/tests/test_translate_zh.py
+++ b/tests/test_translate_zh.py
@@ -94,6 +94,77 @@ def test_briefing_translation_rejects_a_missing_confidence_marker(monkeypatch):
         translate_briefing_to_zh([_EN_BULLET], "caveat", "k")
 
 
+def test_briefing_translation_rejects_a_changed_confidence_level(monkeypatch):
+    # Presence alone is not enough: swapping Medium for High would publish a
+    # fabricated confidence reading on the dashboard.
+    swapped = _ZH_BULLET.replace("High confidence.", "Medium confidence.")
+    _run(monkeypatch, {"bullets_zh": [swapped], "caveat_zh": "x"})
+
+    with pytest.raises(BriefingError, match="confidence level"):
+        translate_briefing_to_zh([_EN_BULLET], "caveat", "k")
+
+
+def test_briefing_translation_rejects_an_empty_bullet(monkeypatch):
+    _run(monkeypatch, {"bullets_zh": [""], "caveat_zh": "x"})
+
+    with pytest.raises(BriefingError, match="empty bullet_zh"):
+        translate_briefing_to_zh([_EN_BULLET], "caveat", "k")
+
+
+def test_briefing_translation_rejects_an_empty_caveat(monkeypatch):
+    _run(monkeypatch, {"bullets_zh": [_ZH_BULLET], "caveat_zh": ""})
+
+    with pytest.raises(BriefingError, match="empty caveat_zh"):
+        translate_briefing_to_zh([_EN_BULLET], "caveat", "k")
+
+
+def test_briefing_translation_omits_caveat_zh_when_the_english_caveat_is_empty(monkeypatch):
+    # A day with insights but no caveat is legitimate; the zh field is left
+    # absent rather than stored empty (snapshot validation rejects empties).
+    _run(monkeypatch, {"bullets_zh": [_ZH_BULLET], "caveat_zh": ""})
+
+    result = translate_briefing_to_zh([_EN_BULLET], "", "k")
+
+    assert result["bullets_zh"] == [_ZH_BULLET]
+    assert "caveat_zh" not in result
+
+
+def test_briefing_translation_rejects_a_dropped_sign(monkeypatch):
+    en = "Downloads fell -5% today. Why it matters: Usage cooled. Evidence: E001. Low confidence."
+    zh = "下载量今日上升 5%。Why it matters: 使用降温。Evidence: E001. Low confidence."
+    _run(monkeypatch, {"bullets_zh": [zh], "caveat_zh": "x"})
+
+    with pytest.raises(BriefingError, match="changed a quantity"):
+        translate_briefing_to_zh([en], "caveat", "k")
+
+
+def test_briefing_translation_rejects_a_dropped_percent_sign(monkeypatch):
+    en = "Coverage reached 40% today. Why it matters: Gaps narrow. Evidence: E001. Low confidence."
+    zh = "覆盖率今日达到 40。Why it matters: 差距缩小。Evidence: E001. Low confidence."
+    _run(monkeypatch, {"bullets_zh": [zh], "caveat_zh": "x"})
+
+    with pytest.raises(BriefingError, match="changed a quantity"):
+        translate_briefing_to_zh([en], "caveat", "k")
+
+
+def test_briefing_translation_accepts_a_fully_assembled_long_bullet(monkeypatch):
+    # Generation assembles a bullet from an 800-char finding plus an 800-char
+    # rationale, so the translator must accept bullets well past 800 chars or
+    # every long briefing would silently lose its Chinese rendering.
+    finding = "Long finding. " * 57
+    why = "Long rationale. " * 50
+    en = f"{finding} Why it matters: {why} Evidence: E001. High confidence."
+    zh_finding = "这是一个很长的中文发现。" * 57
+    zh_why = "这是一条很长的中文理由。" * 50
+    zh = f"{zh_finding} Why it matters: {zh_why} Evidence: E001. High confidence."
+    assert len(en) > 800
+    _run(monkeypatch, {"bullets_zh": [zh], "caveat_zh": "x"})
+
+    result = translate_briefing_to_zh([en], "caveat", "k")
+
+    assert result["bullets_zh"] == [zh]
+
+
 def test_briefing_translation_rejects_a_wrong_bullet_count(monkeypatch):
     _run(monkeypatch, {"bullets_zh": [_ZH_BULLET, _ZH_BULLET], "caveat_zh": "x"})
 
@@ -238,3 +309,64 @@ def test_answers_translation_rejects_a_malformed_index(monkeypatch):
 
     with pytest.raises(BriefingError, match="malformed answer index"):
         translate_answers_to_zh(answers, "k")
+
+
+def test_answers_translation_rejects_an_empty_zh_field(monkeypatch):
+    answers = [
+        {
+            "signal": "One signal.",
+            "plain_english": "One.",
+            "takeaway": "One.",
+            "counter_view": "None.",
+        }
+    ]
+    _run(
+        monkeypatch,
+        {
+            "answers_zh": [
+                {
+                    "index": 0,
+                    "signal_zh": "",
+                    "plain_chinese": "一个。",
+                    "takeaway_zh": "一个。",
+                    "counter_view_zh": "无。",
+                }
+            ]
+        },
+    )
+
+    with pytest.raises(BriefingError, match="empty signal_zh"):
+        translate_answers_to_zh(answers, "k")
+
+
+def test_answers_translation_omits_zh_fields_for_empty_english_fields(monkeypatch):
+    # An answer field that is empty in English has nothing to translate; the zh
+    # field is left absent so the dashboard falls back per field, and the empty
+    # string never reaches snapshot validation.
+    answers = [
+        {
+            "signal": "",
+            "plain_english": "One.",
+            "takeaway": "One.",
+            "counter_view": "None.",
+        }
+    ]
+    _run(
+        monkeypatch,
+        {
+            "answers_zh": [
+                {
+                    "index": 0,
+                    "signal_zh": "",
+                    "plain_chinese": "一个。",
+                    "takeaway_zh": "一个。",
+                    "counter_view_zh": "无。",
+                }
+            ]
+        },
+    )
+
+    zh, _ = translate_answers_to_zh(answers, "k")
+
+    assert "signal_zh" not in zh[0]
+    assert zh[0]["plain_chinese"] == "一个。"

--- a/tests/test_translate_zh.py
+++ b/tests/test_translate_zh.py
@@ -1,0 +1,240 @@
+"""The zh translation pass re-validates grounding it claims to preserve."""
+
+import json
+
+import pytest
+
+from benchmark_radar.briefing import BriefingError
+from benchmark_radar.translate_zh import translate_answers_to_zh, translate_briefing_to_zh
+
+
+def _fake_response(text: str) -> dict:
+    return {
+        "id": "resp_zh",
+        "model": "gpt-5.6-2026-08-01",
+        "output": [
+            {
+                "type": "message",
+                "content": [{"type": "output_text", "text": text}],
+            }
+        ],
+        "usage": {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "total_tokens": 150,
+            "input_tokens_details": {"cached_tokens": 0},
+            "output_tokens_details": {"reasoning_tokens": 5},
+        },
+    }
+
+
+def _run(monkeypatch, payload: dict) -> None:
+    def fake_post(url, body, **kwargs):
+        assert url == "https://api.openai.com/v1/responses"
+        return _fake_response(json.dumps(payload))
+
+    monkeypatch.setattr("benchmark_radar.translate_zh.post_json", fake_post)
+
+
+_EN_BULLET = (
+    "Memory evaluation is moving toward persistence. Why it matters: Teams need "
+    "longitudinal tests. Evidence: E001. High confidence."
+)
+_ZH_BULLET = (
+    "记忆评估正在向持久化方向发展。Why it matters: 团队需要纵向测试。"
+    "Evidence: E001. High confidence."
+)
+
+
+def test_briefing_translation_preserves_markers_ids_and_digits(monkeypatch):
+    _run(monkeypatch, {"bullets_zh": [_ZH_BULLET], "caveat_zh": "仅一个发布。"})
+
+    result = translate_briefing_to_zh(
+        [_EN_BULLET], "One captured release does not establish a trend.", "k", model="gpt-5.6"
+    )
+
+    assert result["bullets_zh"] == [_ZH_BULLET]
+    assert result["caveat_zh"] == "仅一个发布。"
+    assert result["response_id"] == "resp_zh"
+    assert result["usage"]["total_tokens"] == 150
+
+
+def test_briefing_translation_rejects_a_dropped_marker(monkeypatch):
+    dropped = "记忆评估正在向持久化方向发展。团队需要纵向测试。Evidence: E001. High confidence."
+    _run(monkeypatch, {"bullets_zh": [dropped], "caveat_zh": "x"})
+
+    with pytest.raises(BriefingError, match="dropped the marker"):
+        translate_briefing_to_zh([_EN_BULLET], "caveat", "k")
+
+
+def test_briefing_translation_rejects_a_changed_evidence_id(monkeypatch):
+    changed = _ZH_BULLET.replace("E001", "E002")
+    _run(monkeypatch, {"bullets_zh": [changed], "caveat_zh": "x"})
+
+    with pytest.raises(BriefingError, match="dropped or changed an E###/S### id"):
+        translate_briefing_to_zh([_EN_BULLET], "caveat", "k")
+
+
+def test_briefing_translation_rejects_a_chinese_numeral(monkeypatch):
+    # The quantity 3 must survive as the Arabic digit; a Chinese numeral is a
+    # rounding hazard because the dashboard prints figures from the registry.
+    en = "3 suites arrived. Why it matters: Choice widens. Evidence: E001. Low confidence."
+    zh = "三个套件到达。Why it matters: 选择变多。Evidence: E001. Low confidence."
+    _run(monkeypatch, {"bullets_zh": [zh], "caveat_zh": "x"})
+
+    with pytest.raises(BriefingError, match="changed a quantity"):
+        translate_briefing_to_zh([en], "caveat", "k")
+
+
+def test_briefing_translation_rejects_a_missing_confidence_marker(monkeypatch):
+    no_confidence = _ZH_BULLET.replace(" High confidence.", "")
+    _run(monkeypatch, {"bullets_zh": [no_confidence], "caveat_zh": "x"})
+
+    with pytest.raises(BriefingError, match="confidence marker"):
+        translate_briefing_to_zh([_EN_BULLET], "caveat", "k")
+
+
+def test_briefing_translation_rejects_a_wrong_bullet_count(monkeypatch):
+    _run(monkeypatch, {"bullets_zh": [_ZH_BULLET, _ZH_BULLET], "caveat_zh": "x"})
+
+    with pytest.raises(BriefingError, match="wrong number of bullets"):
+        translate_briefing_to_zh([_EN_BULLET], "caveat", "k")
+
+
+def test_answers_translation_aligns_every_prose_field_by_index(monkeypatch):
+    answers = [
+        {
+            "signal": "Most of today's records are agentic harnesses.",
+            "plain_english": "Most new items test task execution, not recall.",
+            "takeaway": "Expect setup cost, not just a scorer.",
+            "counter_view": "The feed is keyword-filtered.",
+        },
+        {
+            "signal": "Scoring documentation is mostly absent.",
+            "plain_english": "We cannot tell how correctness is judged.",
+            "takeaway": "Treat unscored arrivals as unverified.",
+            "counter_view": "No credible counter-view found.",
+        },
+    ]
+    _run(
+        monkeypatch,
+        {
+            "answers_zh": [
+                {
+                    "index": 0,
+                    "signal_zh": "今天的记录大多是智能体框架。",
+                    "plain_chinese": "大多数新条目测试的是任务执行而非记忆。",
+                    "takeaway_zh": "预期成本在于搭建。",
+                    "counter_view_zh": "该流按关键词过滤。",
+                },
+                {
+                    "index": 1,
+                    "signal_zh": "评分文档大多缺失。",
+                    "plain_chinese": "我们无法判断正确性如何判定。",
+                    "takeaway_zh": "将未评分条目视为未经核实。",
+                    "counter_view_zh": "未找到可信的反方观点。",
+                },
+            ]
+        },
+    )
+
+    zh, meta = translate_answers_to_zh(answers, "k", model="gpt-5.6")
+
+    assert [item["index"] for item in zh] == [0, 1]
+    assert zh[0]["signal_zh"] == "今天的记录大多是智能体框架。"
+    assert zh[1]["counter_view_zh"] == "未找到可信的反方观点。"
+    assert meta["response_id"] == "resp_zh"
+
+
+def test_answers_translation_rejects_a_dropped_digit(monkeypatch):
+    answers = [
+        {
+            "signal": "40 records arrived today.",
+            "plain_english": "Forty items.",
+            "takeaway": "Expect setup.",
+            "counter_view": "Filtered feed.",
+        }
+    ]
+    # The model rendered the 40 as a Chinese numeral in the translated signal.
+    _run(
+        monkeypatch,
+        {
+            "answers_zh": [
+                {
+                    "index": 0,
+                    "signal_zh": "今天到达了四十条记录。",
+                    "plain_chinese": "四十个条目。",
+                    "takeaway_zh": "预期搭建。",
+                    "counter_view_zh": "过滤后的流。",
+                }
+            ]
+        },
+    )
+
+    with pytest.raises(BriefingError, match="changed a quantity"):
+        translate_answers_to_zh(answers, "k")
+
+
+def test_answers_translation_rejects_a_wrong_answer_count(monkeypatch):
+    answers = [
+        {
+            "signal": "One signal.",
+            "plain_english": "One.",
+            "takeaway": "One.",
+            "counter_view": "None.",
+        }
+    ]
+    _run(
+        monkeypatch,
+        {
+            "answers_zh": [
+                {
+                    "index": 0,
+                    "signal_zh": "一个信号。",
+                    "plain_chinese": "一个。",
+                    "takeaway_zh": "一个。",
+                    "counter_view_zh": "无。",
+                },
+                {
+                    "index": 1,
+                    "signal_zh": "另一个。",
+                    "plain_chinese": "另一个。",
+                    "takeaway_zh": "另一个。",
+                    "counter_view_zh": "无。",
+                },
+            ]
+        },
+    )
+
+    with pytest.raises(BriefingError, match="wrong number of answers"):
+        translate_answers_to_zh(answers, "k")
+
+
+def test_answers_translation_rejects_a_malformed_index(monkeypatch):
+    """A missing or non-numeric index must fail as a BriefingError, not leak a
+    TypeError up to the generator that called the translator."""
+    answers = [
+        {
+            "signal": "One signal.",
+            "plain_english": "One.",
+            "takeaway": "One.",
+            "counter_view": "None.",
+        }
+    ]
+    _run(
+        monkeypatch,
+        {
+            "answers_zh": [
+                {
+                    "index": "zero",
+                    "signal_zh": "一个信号。",
+                    "plain_chinese": "一个。",
+                    "takeaway_zh": "一个。",
+                    "counter_view_zh": "无。",
+                }
+            ]
+        },
+    )
+
+    with pytest.raises(BriefingError, match="malformed answer index"):
+        translate_answers_to_zh(answers, "k")


### PR DESCRIPTION
Closes #231.

## What
The dashboard's interface chrome was already translated client-side, but the
daily briefing bullets/caveat and the Q&A answers are model prose generated at
runtime, so a Chinese reader toggling the interface still saw English
paragraphs. This adds an optional, env-gated translation pass that renders
that prose in Simplified Chinese on the same run that generates it.

## How
- `src/benchmark_radar/translate_zh.py` (new): one extra OpenAI call each for
  the briefing and for all Q&A answers. The English text is the source of
  truth, so the output is re-validated: every `E###`/`S###` id and every
  Arabic digit run must survive verbatim (Chinese numerals like 三 are
  rejected), and briefing bullets must keep the `Why it matters:` / `Evidence:`
  markers and the trailing confidence phrase the dashboard splits on.
- Generators accept `translate_zh=`; a failed or ungrounded translation is
  caught, reported as a `::warning`, and the zh fields are omitted so the day
  keeps its English rendering. Translation never fails a run.
- Optional snapshot fields: `bullets_zh`, `caveat_zh`, per-answer
  `signal_zh`/`plain_chinese`/`takeaway_zh`/`counter_view_zh`, and
  `zh_translation` provenance. All optional, so snapshots written before this
  feature keep validating.
- The fixed question strings and group titles (constant in `QUESTION_GROUPS`)
  are translated client-side against the exact stored text, zero extra cost.
- Gated by `OPENAI_BRIEFING_ZH` / `OPENAI_QUESTIONS_ZH`; the production
  workflow sets both.

## Acceptance (from the issue)
- zh fields optional, English fallback when absent or when translation fails
- one extra call per generator (briefing + one shared call for all answers)
- E###/S### ids, Arabic digits, and structural markers preserved
- env-gated, on by default in the production workflow

## Verification
- 730 tests pass (new `tests/test_translate_zh.py`, plus zh coverage in
  briefing/questions/snapshots/cli/site suites); `ruff check` clean.
- Historical snapshots rebuild unchanged (25 daily snapshots).
- zh DOM rendering verified via the render harnesses.