### PR TITLE
Fix stale dashboard and snapshot publication paths

### DIFF
--- a/.github/workflows/daily-radar.yml
+++ b/.github/workflows/daily-radar.yml
@@ -60,6 +60,10 @@ jobs:
           fi
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # A queued/manual run must build from the latest main, not the event
+          # SHA captured when it was dispatched. Otherwise its full-history
+          # artifact can be older than the snapshot commit it eventually writes.
+          ref: main
           fetch-depth: 0
           persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -109,6 +113,13 @@ jobs:
           --repo .
           --channels config/social.yml
           --social-output out/social.md
+      - name: Isolate the target-day snapshot
+        shell: bash
+        run: |
+          set -euo pipefail
+          snapshot_date="$(python -c 'import datetime, json; value=json.load(open("out/items.json", encoding="utf-8"))["generated_at"]; print(datetime.datetime.fromisoformat(value.replace("Z", "+00:00")).date().isoformat())')"
+          cp "data/snapshots/${snapshot_date}.json" "out/snapshot-${snapshot_date}.json"
+          printf '%s\n' "${snapshot_date}" > out/snapshot-date.txt
       - name: Upload evidence artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -149,7 +160,18 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p data/snapshots
-          cp generated/data/snapshots/*.json data/snapshots/
+          snapshot_date="$(cat generated/out/snapshot-date.txt)"
+          snapshot_path="generated/out/snapshot-${snapshot_date}.json"
+          test -f "${snapshot_path}"
+          if test -f "data/snapshots/${snapshot_date}.json"; then
+            current_generated="$(jq -r '.generated_at' "data/snapshots/${snapshot_date}.json")"
+            incoming_generated="$(jq -r '.generated_at' "${snapshot_path}")"
+            if [[ "${current_generated}" > "${incoming_generated}" ]]; then
+              echo "::error::Refusing to replace a newer ${snapshot_date} snapshot"
+              exit 1
+            fi
+          fi
+          cp "${snapshot_path}" "data/snapshots/${snapshot_date}.json"
           git config user.name "benchmark-radar[bot]"
           git config user.email "benchmark-radar[bot]@users.noreply.github.com"
           git add data/snapshots

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,6 +16,10 @@ on:
       - "data/benchmark_scores.yml"
       - "config.yml"
       - "site/**"
+      # The dashboard build imports the package transitively through
+      # snapshots.py. Keep the trigger broad so a new scoring, insight, rubric,
+      # or export dependency cannot merge without rebuilding the published site.
+      - "src/benchmark_radar/**"
       - "src/benchmark_radar/snapshots.py"
       - "src/benchmark_radar/feed.py"
       - "src/benchmark_radar/corpus.py"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -417,6 +417,27 @@ def test_pages_rebuilds_when_any_package_module_changes():
     assert "src/benchmark_radar/**" in paths
 
 
+def test_daily_radar_persists_only_a_fresh_target_day_snapshot():
+    """A queued run must not overlay its full, potentially stale history."""
+    workflow_path = Path(".github/workflows/daily-radar.yml")
+    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    build_steps = workflow["jobs"]["build-report"]["steps"]
+    checkout = next(
+        step for step in build_steps if step.get("uses", "").startswith("actions/checkout@")
+    )
+    assert checkout["with"]["ref"] == "main"
+    assert any(step.get("name") == "Isolate the target-day snapshot" for step in build_steps)
+    persist_script = next(
+        step["run"]
+        for step in workflow["jobs"]["persist-snapshot"]["steps"]
+        if step.get("name") == "Persist UTC snapshot"
+    )
+    assert "snapshot-date.txt" in persist_script
+    assert "snapshot-${snapshot_date}.json" in persist_script
+    assert "Refusing to replace a newer" in persist_script
+    assert "generated/data/snapshots/*.json" not in persist_script
+
+
 def test_daily_radar_yml_enables_chinese_rendering_in_production():
     """Issue #231: production must ask for the zh rendering, or the flags would
     exist but never be set and the Chinese dashboard would always show English."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -407,6 +407,16 @@ def test_daily_radar_yml_enables_and_requires_questions_in_production():
     assert str(env.get("OPENAI_QUESTIONS_REQUIRED")).lower() == "true"
 
 
+def test_pages_rebuilds_when_any_package_module_changes():
+    """Dashboard output depends on transitive package imports, not snapshots.py alone."""
+    workflow_path = Path(".github/workflows/pages.yml")
+    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    # PyYAML's YAML 1.1 loader parses the GitHub Actions `on` key as True.
+    trigger = workflow.get("on", workflow.get(True))
+    paths = next(iter(trigger.values()))["paths"]
+    assert "src/benchmark_radar/**" in paths
+
+
 def test_daily_radar_yml_enables_chinese_rendering_in_production():
     """Issue #231: production must ask for the zh rendering, or the flags would
     exist but never be set and the Chinese dashboard would always show English."""


### PR DESCRIPTION
## Summary

- rebuild Pages when any `src/benchmark_radar/**` module changes
- build daily runs from fresh `main`
- persist only the target-day snapshot and refuse to replace a newer same-day snapshot
- add regression tests for both workflow contracts

## Why

The dashboard trigger allowlist could leave production stale after package changes. Queued/manual daily runs could publish an older full snapshot history over newer `main` data.

## Validation

- `pytest -q` — 744 passed
- `ruff check .`
- `ruff format --check .`
- `git diff --check`
