### PR TITLE
Simplify the Explore view

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -326,7 +326,7 @@ const I18N = {
     Today: "今日",
     Leaderboard: "排行榜",
     Trends: "趋势",
-    "Trend map": "趋势图",
+    Explore: "探索",
     Rubric: "评分标准",
     "Daily briefing": "每日简报",
     "Questions for today": "今日问答",
@@ -361,7 +361,7 @@ const I18N = {
     "Matching observations": "匹配结果",
     "Show more results": "显示更多结果",
     Sources: "来源",
-    "Corpus totals": "语料统计",
+    "All-time totals": "全部统计",
     All: "全部",
     "view.today.matching": "匹配结果",
     // --- Leaderboard ---------------------------------------------------------
@@ -412,9 +412,10 @@ const I18N = {
     "pareto.readiness.note2":
       "有了这些观测数据,Harbor 风格视图可以把成本或延迟放在 x 轴、分数放在 y 轴,只连接不受支配的观测点,并用发布时间滑块揭示前沿如何移动。",
     "map.heading.note":
-      "总览概括整个语料。关系画布包含每个工件及其关联的机构、来源与主题;选择一个节点会把它带进今天的筛选器。",
+      "看看哪些内容最常出现,以及它们来自哪里。想查看某个具体条目时,再打开连接视图。",
+    "map.explorer.note": "这里有很多点。选择一个点即可查看它与什么相连,或打开匹配结果。",
     "map.detail.note":
-      "主题、来源和机构节点会设置对应的今日筛选器。工件节点会设置日期与标题搜索。",
+      "选择主题、来源或机构,即可在今日页面只看相关结果。选择条目即可查看它每次出现的记录。",
     "trends.heading.note": "计数描述的是发现数量,不是科学质量。",
     "trends.daily.title": "每日证据与关注量",
     "trends.daily.note": "类别标签会有重叠。每个条形都是独立计数,不是堆叠总量的一部分。",
@@ -568,7 +569,7 @@ const I18N = {
     "Open official benchmark source ↗": "打开官方基准来源 ↗",
     "Benchmarks": "基准",
     // --- Trends --------------------------------------------------------------
-    "Corpus rhythm": "语料节奏",
+    "Recent activity": "最近动态",
     "Signals over time": "随时间变化的信号",
     "Counts describe discovery volume, not scientific quality.": "计数描述的是发现量,不是科学质量。",
     "New by domain": "按领域的新内容",
@@ -589,11 +590,14 @@ const I18N = {
     Attention: "关注度",
     "Fetch health": "抓取状态",
     // --- Map ----------------------------------------------------------------
-    "Cumulative corpus": "累计语料",
-    "Artifacts and their context": "工件及其背景",
+    "Big picture": "整体概览",
+    "What we found": "我们发现了什么",
+    "Want more detail?": "想看更多细节?",
+    "See how everything connects": "看看所有内容如何相连",
     "view.map.note":
       "总览概括了整个语料库。关系画布包含每一个工件以及与其相连的机构、来源和主题;选择节点即可将其带入今日筛选。",
-    "Inspect a relationship": "检查一个关系",
+    "Pick a dot": "选择一个点",
+    "See what it connects to": "看看它连接了什么",
     "view.map.detail.note": "主题、来源和机构节点会设置对应的今日筛选。工件节点会设置日期和标题搜索。",
     // --- Frontier / workbench -------------------------------------------------
     "Priority & evidence": "优先度与证据",
@@ -790,6 +794,32 @@ const I18N = {
     "two versions are not directly comparable, and past records are not rescored.":
       "两个版本不可直接比较,过去的记录不会重新评分。",
     weight: "权重",
+    "Also connected to": "还连接到",
+    "At a glance": "一眼看懂",
+    "Change over": "过去",
+    "Days it appeared": "出现天数",
+    "First found": "首次发现",
+    Items: "条目",
+    "Items connected to topics, organizations, and sources": "与主题、机构和来源相连的条目",
+    "Last found": "最近发现",
+    "Latest priority score": "最新优先级分数",
+    "No organizations yet.": "还没有机构。",
+    "No sources yet.": "还没有来源。",
+    "No topics yet.": "还没有主题。",
+    "Nothing found yet.": "还没有发现任何内容。",
+    Selected: "已选择",
+    "Times found": "发现次数",
+    "What it is about": "内容主题",
+    "Where we found it": "发现来源",
+    "Who appears most": "谁出现得最多",
+    item: "条目",
+    items: "条目",
+    "not enough earlier data": "没有足够的早期数据",
+    "AI agents": "AI 智能体",
+    benchmarks: "基准",
+    datasets: "数据集",
+    evaluations: "评测",
+    "times found": "次发现",
     "with a dated card": "有日期的模型卡",
   },
 };
@@ -2587,39 +2617,42 @@ function mapFilterFor(entity) {
 function selectMapNode(entity, relatedEntities) {
   state.entity = entity.id;
   mapFilterFor(entity);
+  const typeLabel = {
+    artifact: t("item"),
+    topic: t("topic"),
+    source: t("source"),
+    organization: t("organization"),
+  }[entity.type] || entity.type;
   const topicAggregate = (state.data.corpus.aggregates.topics || []).find(
     (entry) => `topic:${entry.topic}` === entity.id,
   );
   const stats = [
-    definition("Type", entity.type),
-    definition("First seen", formatDate(entity.first_seen_at, { dateStyle: "medium" })),
-    definition("Last seen", formatDate(entity.last_seen_at, { dateStyle: "medium" })),
-    definition("Observed days", Number(entity.seen_days?.length || 0).toLocaleString()),
+    definition(t("Kind"), typeLabel),
+    definition(t("First found"), formatDate(entity.first_seen_at, { dateStyle: "medium" })),
+    definition(t("Last found"), formatDate(entity.last_seen_at, { dateStyle: "medium" })),
+    definition(t("Days it appeared"), Number(entity.seen_days?.length || 0).toLocaleString()),
     ...(entity.type === "artifact"
       ? [
-          definition("Observations", Number(entity.observation_count || 0).toLocaleString()),
+          definition(t("Times found"), Number(entity.observation_count || 0).toLocaleString()),
           definition(
-            "Latest priority",
+            t("Latest priority score"),
             entity.latest_score === null || entity.latest_score === undefined
-              ? "not scored"
+              ? t("not scored")
               : Number(entity.latest_score).toFixed(2),
           ),
         ]
       : []),
     ...(topicAggregate
       ? [
-          definition("Artifact count", topicAggregate.entity_count),
-          definition("Source breadth", topicAggregate.source_breadth),
-          // The window is nominally 7 days but divides by the days actually
-          // observed, so early in the archive "7-day" named a span that does
-          // not exist yet. The label states the span that was measured.
+          definition(t("Items"), topicAggregate.entity_count),
+          definition(t("Sources"), topicAggregate.source_breadth),
           definition(
-            `${
+            `${t("Change over")} ${
               state.data.corpus.aggregates.observed_window_days ??
               state.data.corpus.aggregates.window_days
-            }-day velocity`,
+            } ${t("days")}`,
             topicAggregate.velocity === null
-              ? "needs a prior window"
+              ? t("not enough earlier data")
               : `${topicAggregate.velocity >= 0 ? "+" : ""}${topicAggregate.velocity}/day`,
           ),
         ]
@@ -2636,19 +2669,19 @@ function selectMapNode(entity, relatedEntities) {
     window.scrollTo({ top: 0, behavior: "smooth" });
   });
   replaceChildren(byId("map-detail"), [
-    element("p", { className: "eyebrow", text: t("Selected node") }),
+    element("p", { className: "eyebrow", text: t("Selected") }),
     element("h2", { text: entity.label }),
     element("p", {
       text:
         entity.type === "artifact"
-          ? "The corresponding date and exact title search are now set for Today."
-          : `The ${entity.type} filter is now set for Today.`,
+          ? "Today is now ready to show this item."
+          : `Today is now filtered by this ${typeLabel}.`,
     }),
     element("dl", {}, stats),
     relatedEntities.length
       ? element("p", {
           className: "discovery-note",
-          text: `${t("Connected to")} ${relatedEntities
+          text: `${t("Also connected to")} ${relatedEntities
             .slice(0, 8)
             .map((related) => related.label)
             .join(", ")}${relatedEntities.length > 8 ? "…" : ""}`,
@@ -2740,34 +2773,43 @@ function renderMapInsights(corpus) {
         a.topic.localeCompare(b.topic),
     )
     .map((topic) => [
-      topic.topic.replaceAll("_", " "),
-      `${metricLabel(topic.entity_count, "artifact")} · ${metricLabel(
+      ({
+        agentic: t("AI agents"),
+        benchmark: t("benchmarks"),
+        dataset: t("datasets"),
+        evaluation: t("evaluations"),
+        data_quality: t("data quality"),
+      }[topic.topic] || topic.topic.replaceAll("_", " ")),
+      `${Number(topic.entity_count || 0).toLocaleString()} ${t("items")} · ${metricLabel(
         topic.source_breadth,
         "source",
       )}`,
     ]);
   const sourceEntries = rankedCounts(aggregates.sources).map(([source, count]) => [
     source,
-    metricLabel(count, "observation"),
+    `${Number(count || 0).toLocaleString()} ${t("times found")}`,
   ]);
   const organizationEntries = rankedCounts(aggregates.organizations).map(
-    ([organization, count]) => [organization, metricLabel(count, "observation")],
+    ([organization, count]) => [
+      organization,
+      `${Number(count || 0).toLocaleString()} ${t("times found")}`,
+    ],
   );
   const coverageEntries = [
-    [t("Artifacts"), Number(entityTypes.artifact || 0).toLocaleString()],
+    [t("Items"), Number(entityTypes.artifact || 0).toLocaleString()],
     [t("Organizations"), Number(entityTypes.organization || 0).toLocaleString()],
     [t("Authors"), Number(entityTypes.person || 0).toLocaleString()],
-    [t("Discovery sources"), Number(entityTypes.source || 0).toLocaleString()],
+    [t("Sources"), Number(entityTypes.source || 0).toLocaleString()],
     [t("Topics"), Number(entityTypes.topic || 0).toLocaleString()],
   ];
   replaceChildren(byId("map-insights"), [
-    mapInsightCard(t("Corpus coverage"), coverageEntries, t("No corpus entities yet.")),
-    mapInsightCard(t("Topic coverage"), topicEntries, t("No topics assigned yet.")),
-    mapInsightCard(t("Discovery sources"), sourceEntries, t("No discovery sources yet.")),
+    mapInsightCard(t("At a glance"), coverageEntries, t("Nothing found yet.")),
+    mapInsightCard(t("What it is about"), topicEntries, t("No topics yet.")),
+    mapInsightCard(t("Where we found it"), sourceEntries, t("No sources yet.")),
     mapInsightCard(
-      t("Most represented organizations"),
+      t("Who appears most"),
       organizationEntries,
-      t("No organizations identified yet."),
+      t("No organizations yet."),
     ),
   ]);
 }
@@ -5009,6 +5051,32 @@ function renderTrendMap() {
   if (!corpus) return;
   const entityById = new Map(corpus.entities.map((entity) => [entity.id, entity]));
   const selectedFromUrl = entityById.get(state.entity);
+  const explorer = byId("relationship-explorer");
+  const entityTypes = corpus.aggregates?.entity_types || {};
+
+  renderMapInsights(corpus);
+  byId("map-summary").textContent =
+    `${Number(entityTypes.artifact || 0).toLocaleString()} ${t("items")} · ` +
+    `${Number(entityTypes.organization || 0).toLocaleString()} ${t("organizations")} · ` +
+    `${Number(entityTypes.source || 0).toLocaleString()} ${t("sources")} · ` +
+    `${Number(entityTypes.topic || 0).toLocaleString()} ${t("topics")}`;
+
+  // A permalink to a node is an explicit request for the deep view. Otherwise
+  // keep the expensive, thousands-of-node canvas out of the DOM until the
+  // reader asks for it.
+  if (selectedFromUrl) explorer.open = true;
+  if (!explorer.dataset.renderBound) {
+    explorer.dataset.renderBound = "true";
+    explorer.addEventListener("toggle", () => {
+      if (explorer.open) renderTrendMap();
+      else replaceChildren(byId("map-canvas"), []);
+    });
+  }
+  if (!explorer.open) {
+    replaceChildren(byId("map-canvas"), []);
+    return;
+  }
+
   const artifacts = corpus.entities
     .filter((entity) => entity.type === "artifact")
     .sort(
@@ -5080,7 +5148,7 @@ function renderTrendMap() {
     // hiding every node from assistive tech. Same choice the adoption
     // frontier documents for its marker buttons.
     role: "group",
-    "aria-label": t("Artifact nodes connected to topics, organizations, and discovery sources"),
+    "aria-label": t("Items connected to topics, organizations, and sources"),
   });
   typeOrder.forEach((type) => {
     svg.append(
@@ -5092,7 +5160,12 @@ function renderTrendMap() {
           "text-anchor": "middle",
           class: "map-column-label",
         },
-        `${type}s`,
+        {
+          source: t("Sources"),
+          organization: t("Organizations"),
+          artifact: t("Items"),
+          topic: t("Topics"),
+        }[type],
       ),
     );
   });
@@ -5142,16 +5215,7 @@ function renderTrendMap() {
     });
     svg.append(group);
   });
-  renderMapInsights(corpus);
   replaceChildren(byId("map-canvas"), [svg]);
-  const authorCount = Number(corpus.aggregates?.entity_types?.person || 0);
-  byId("map-summary").textContent =
-    `${t("Showing all")} ${artifacts.length.toLocaleString()} ${t("artifacts")} · ` +
-    `${groups.organization.length.toLocaleString()} ${t("organizations")} · ` +
-    `${groups.source.length.toLocaleString()} ${t("sources")} · ${groups.topic.length.toLocaleString()} ${t("topics")}` +
-    (authorCount
-      ? ` · ${authorCount.toLocaleString()} ${t("author nodes summarized above and omitted from the canvas")}`
-      : "");
   if (selectedFromUrl) {
     const related = corpus.edges
       .filter(

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -1690,11 +1690,59 @@ td a {
 }
 
 .map-summary {
+  display: block;
+  margin-top: 0.35rem;
   color: var(--muted);
   font-family: var(--utility);
   font-size: 0.75rem;
   letter-spacing: 0.04em;
   text-transform: uppercase;
+}
+
+.relationship-explorer {
+  margin-top: 1.5rem;
+  border-top: 1px solid var(--ink);
+  border-bottom: 1px solid var(--line);
+}
+
+.relationship-explorer > summary {
+  display: flex;
+  gap: 2rem;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 0;
+  cursor: pointer;
+  list-style: none;
+}
+
+.relationship-explorer > summary::-webkit-details-marker {
+  display: none;
+}
+
+.relationship-explorer > summary::after {
+  content: "+";
+  flex: none;
+  color: var(--blue-deep);
+  font-family: var(--utility);
+  font-size: 1.5rem;
+  font-weight: 400;
+}
+
+.relationship-explorer[open] > summary::after {
+  content: "−";
+}
+
+.relationship-explorer > summary strong {
+  display: block;
+  margin-top: 0.25rem;
+  font-family: var(--display);
+  font-size: clamp(1.25rem, 2vw, 1.75rem);
+}
+
+.relationship-explorer-note {
+  max-width: 720px;
+  margin: 0 0 1rem;
+  color: var(--muted);
 }
 
 .map-insights {
@@ -3697,6 +3745,25 @@ footer {
 
   .heading-note {
     text-align: left;
+  }
+
+  .relationship-explorer > summary {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 0.75rem 1rem;
+    align-items: start;
+  }
+
+  .relationship-explorer > summary::after {
+    grid-row: 1 / span 2;
+    grid-column: 2;
+    align-self: center;
+  }
+
+  .relationship-explorer .map-summary {
+    grid-row: 2;
+    grid-column: 1;
+    margin-top: 0;
   }
 
   .frontier-heading-row {

--- a/site/index.html
+++ b/site/index.html
@@ -190,7 +190,7 @@
         Leaderboard
       </button>
       <button type="button" data-view="trends" aria-controls="trends-view" data-i18n="Trends">Trends</button>
-      <button type="button" data-view="map" aria-controls="map-view" data-i18n="Trend map">Trend map</button>
+      <button type="button" data-view="map" aria-controls="map-view" data-i18n="Explore">Explore</button>
       <button type="button" id="rubric-nav" aria-haspopup="dialog" data-i18n="Rubric">Rubric</button>
     </nav>
 
@@ -275,7 +275,7 @@
             <aside class="health-panel corpus-totals-panel" aria-labelledby="corpus-totals-heading">
               <details id="corpus-totals-details">
                 <summary>
-                  <span class="health-panel-title" id="corpus-totals-heading" data-i18n="Corpus totals">Corpus totals</span>
+                  <span class="health-panel-title" id="corpus-totals-heading" data-i18n="All-time totals">All-time totals</span>
                   <span class="health-panel-status" id="corpus-totals-status"></span>
                 </summary>
                 <ul id="corpus-totals-list"></ul>
@@ -466,40 +466,51 @@
       <section class="view" id="map-view" aria-labelledby="map-heading" hidden>
         <header class="view-heading">
           <div>
-            <p class="eyebrow" data-i18n="Cumulative corpus">Cumulative corpus</p>
-            <h1 id="map-heading" data-i18n="Artifacts and their context">Artifacts and their context</h1>
+            <p class="eyebrow" data-i18n="Big picture">Big picture</p>
+            <h1 id="map-heading" data-i18n="What we found">What we found</h1>
           </div>
           <p class="heading-note" data-i18n="map.heading.note">
-            The overview summarizes the full corpus. The relationship canvas includes every
-            artifact and connected organization, source, and topic; select a node to carry it
-            into the Today filters.
+            See what shows up most often and where it came from. Open the connections view
+            when you want to look at a specific item.
           </p>
         </header>
-        <div class="map-insights" id="map-insights" aria-label="Corpus overview"></div>
-        <p class="map-summary" id="map-summary"></p>
-        <div class="map-layout">
-          <div
-            class="map-canvas"
-            id="map-canvas"
-            role="region"
-            aria-label="Interactive artifact relationship map"
-            tabindex="0"
-          ></div>
-          <aside class="map-detail" id="map-detail" aria-live="polite">
-            <p class="eyebrow" data-i18n="Select a node">Select a node</p>
-            <h2 data-i18n="Inspect a relationship">Inspect a relationship</h2>
-            <p data-i18n="map.detail.note">
-              Topic, source, and organization nodes set the corresponding Today filter.
-              Artifact nodes set the date and title search.
-            </p>
-          </aside>
-        </div>
+        <div class="map-insights" id="map-insights" aria-label="Overview"></div>
+        <details class="relationship-explorer" id="relationship-explorer">
+          <summary>
+            <span>
+              <span class="eyebrow" data-i18n="Want more detail?">Want more detail?</span>
+              <strong data-i18n="See how everything connects">See how everything connects</strong>
+            </span>
+            <span class="map-summary" id="map-summary"></span>
+          </summary>
+          <p class="relationship-explorer-note" data-i18n="map.explorer.note">
+            There are a lot of dots here. Pick one to see what it connects to, or open the
+            matching results.
+          </p>
+          <div class="map-layout">
+            <div
+              class="map-canvas"
+              id="map-canvas"
+              role="region"
+              aria-label="Explore how items connect"
+              tabindex="0"
+            ></div>
+            <aside class="map-detail" id="map-detail" aria-live="polite">
+              <p class="eyebrow" data-i18n="Pick a dot">Pick a dot</p>
+              <h2 data-i18n="See what it connects to">See what it connects to</h2>
+              <p data-i18n="map.detail.note">
+                Choose a topic, source, or organization to show only its results on Today.
+                Choose an item to find every time it appeared.
+              </p>
+            </aside>
+          </div>
+        </details>
       </section>
 
       <section class="view" id="trends-view" aria-labelledby="trends-heading" hidden>
         <header class="view-heading">
           <div>
-            <p class="eyebrow" data-i18n="Corpus rhythm">Corpus rhythm</p>
+            <p class="eyebrow" data-i18n="Recent activity">Recent activity</p>
             <h1 id="trends-heading" data-i18n="Signals over time">Signals over time</h1>
           </div>
           <p class="heading-note" data-i18n="trends.heading.note">Counts describe discovery volume, not scientific quality.</p>

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -390,7 +390,7 @@ def test_corpus_view_progressively_discloses_the_complete_relationship_map():
     assert '<details class="relationship-explorer" id="relationship-explorer">' in html
     assert "renderMapInsights(corpus)" in script
     assert "Who appears most" in script
-    assert 'if (!explorer.open)' in script
+    assert "if (!explorer.open)" in script
     assert 'replaceChildren(byId("map-canvas"), [])' in script
     assert "if (selectedFromUrl) explorer.open = true" in script
     assert ".slice(0, 16)" not in script

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -380,16 +380,20 @@ def test_dashboard_links_are_validated_escaped_and_non_swallowing():
     assert 'replaceChildren(byId("frontier-org-key"), [])' in script
 
 
-def test_trend_map_shows_the_complete_corpus_and_summarizes_its_shape():
+def test_corpus_view_progressively_discloses_the_complete_relationship_map():
     html = Path("site/index.html").read_text(encoding="utf-8")
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
 
+    assert 'data-view="map"' in html
+    assert 'data-i18n="Explore">Explore</button>' in html
     assert 'id="map-insights"' in html
+    assert '<details class="relationship-explorer" id="relationship-explorer">' in html
     assert "renderMapInsights(corpus)" in script
-    assert "Most represented organizations" in script
-    assert '${t("Showing all")} ${artifacts.length.toLocaleString()}' in script
+    assert "Who appears most" in script
+    assert 'if (!explorer.open)' in script
+    assert 'replaceChildren(byId("map-canvas"), [])' in script
+    assert "if (selectedFromUrl) explorer.open = true" in script
     assert ".slice(0, 16)" not in script
-    assert "author nodes summarized above and omitted from the canvas" in script
 
 
 def test_trends_gate_comparisons_on_connector_coverage():


### PR DESCRIPTION
## What changed

- Rename the Trend map navigation to the plain-language **Explore** view.
- Show a small, useful overview first and move the dense connection map behind an optional expansion.
- Render the large SVG only when expanded and remove it again when collapsed.
- Replace technical terms such as corpus, artifacts, nodes, and observations with language suitable for a broad audience.
- Preserve existing `?view=map` links and automatically expand entity permalinks.
- Update Chinese translations, responsive styling, and regression coverage.

## Why

Issue #239 called for a more intuitive name, progressive disclosure, and the minimum insightful information by default. The previous page immediately exposed thousands of graph nodes and used internal data-model vocabulary.

## User impact

Readers now get the useful summary at a glance. The full connection view remains available when they want more detail, without overwhelming the default page or filling the DOM unnecessarily.

## Checks

- `PYTHONPATH=src .venv/bin/python -m pytest tests/test_site.py -q` — 87 passed
- `node --check site/assets/app.js`
- `git diff --check`
- Browser-tested collapsed, expanded, and re-collapsed states locally

Closes #239