### PR TITLE
Today view: results first, briefing and Q&A in the sidebar, compact toolbar

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -358,6 +358,11 @@ const I18N = {
     Organization: "机构",
     Event: "事件",
     "Clear filters": "清除筛选",
+    Filters: "筛选",
+    "More filters": "更多筛选",
+    "Date:": "日期:",
+    "Search benchmarks…": "搜索基准…",
+    "Refresh data": "刷新数据",
     "Matching observations": "匹配结果",
     "Show more results": "显示更多结果",
     Sources: "来源",
@@ -1583,6 +1588,9 @@ function renderToday({ resultsOnly = false } = {}) {
     renderDailyQuestions(day);
     syncFilters();
   }
+  // The badge tracks the secondary filters live, including during the
+  // resultsOnly re-renders that follow each drawer interaction.
+  updateFiltersCount();
   const observations = filteredObservations();
   const resultsKey = [
     state.todayDate,
@@ -2298,6 +2306,27 @@ function syncFilters() {
     state.event,
   );
   byId("search-filter").value = state.q;
+}
+
+// The trigger badge counts the secondary filters currently narrowing the
+// list, so the drawer is discoverable without opening it.
+function updateFiltersCount() {
+  const active = [
+    state.kind,
+    state.category,
+    state.source,
+    state.organization,
+    state.event,
+  ].filter(Boolean).length;
+  byId("filters-count").textContent = `(${active})`;
+}
+
+function closeFiltersDrawer() {
+  const drawer = byId("filters-drawer");
+  if (!drawer.hidden) {
+    drawer.hidden = true;
+    byId("filters-toggle").setAttribute("aria-expanded", "false");
+  }
 }
 
 function filteredObservations() {
@@ -6271,6 +6300,23 @@ function bindEvents() {
     state.event = "";
     renderToday();
   });
+  // The drawer trigger, its outside-click and Escape dismissal, and the
+  // refresh control. The drawer sits inside the #filters form, so its
+  // selects already reach the shared input handler above.
+  byId("filters-toggle").addEventListener("click", () => {
+    const drawer = byId("filters-drawer");
+    drawer.hidden = !drawer.hidden;
+    byId("filters-toggle").setAttribute("aria-expanded", String(!drawer.hidden));
+  });
+  document.addEventListener("click", (event) => {
+    if (byId("filters-drawer").hidden) return;
+    if (byId("filters").contains(event.target)) return;
+    closeFiltersDrawer();
+  });
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape") closeFiltersDrawer();
+  });
+  byId("refresh-button").addEventListener("click", refreshData);
   byId("rubric-close").addEventListener("click", () => byId("rubric-dialog").close());
   byId("rubric-dialog").addEventListener("click", (event) => {
     if (event.target === byId("rubric-dialog")) byId("rubric-dialog").close();
@@ -6384,6 +6430,33 @@ function renderStaleBanner() {
   banner.textContent = parts.join(" ");
   banner.classList.toggle("stale-banner-degraded", degraded);
   banner.hidden = false;
+}
+
+// The refresh control revalidates radar.json against the server (cache:
+// "reload" bypasses the reader's local copy) so a day rebuilt since the
+// page loaded can appear without a full reload. A failed or incompatible
+// refresh keeps the current data rather than blanking the dashboard.
+async function refreshData() {
+  try {
+    const response = await fetch("data/radar.json", { cache: "reload" });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const data = await response.json();
+    if (
+      data.schema_version !== 2 ||
+      !Array.isArray(data.days) ||
+      !data.days.length
+    ) {
+      throw new Error("No compatible snapshots");
+    }
+    state.data = data;
+    if (state.todayDate !== "all" && !state.data.facets.dates.includes(state.todayDate)) {
+      state.todayDate = state.data.latest_date;
+    }
+    closeFiltersDrawer();
+    rerenderCurrentView();
+  } catch (error) {
+    console.error(error);
+  }
 }
 
 async function initialize() {

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -114,6 +114,7 @@ footer {
 .brand small,
 .eyebrow,
 .section-title span,
+#today-view .section-title h2,
 .heading-note,
 .date-control,
 .filter-panel label,
@@ -418,7 +419,7 @@ h1 {
 }
 
 #today-view {
-  padding-top: clamp(1.75rem, 3vw, 2.75rem);
+  padding-top: clamp(0.75rem, 1vw, 1.25rem);
 }
 
 .today-toolbar {
@@ -463,7 +464,9 @@ input {
 
 .content-grid {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 320px;
+  /* The sidebar carries the daily narrative, Q&A, and the two health cards,
+     so it earns 40% against the results column's 60% (issue #248). */
+  grid-template-columns: minmax(0, 6fr) minmax(0, 4fr);
   gap: 2rem;
   align-items: start;
 }
@@ -479,6 +482,13 @@ input {
 
 .section-title h2 {
   margin-bottom: 0;
+}
+
+/* The results heading reads as a caption for the list beneath it, so it
+   carries the regular weight rather than the display h2 weight (issue #248). */
+#today-view .section-title h2 {
+  color: var(--muted);
+  font-weight: 400;
 }
 
 .section-title span {
@@ -1653,6 +1663,139 @@ td a {
   align-items: end;
   margin-bottom: 3rem;
   padding: 1.25rem;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+/* The Today toolbar is one compact row under the tabs: search, the scan
+   date, the drawer trigger, and a refresh control. Seven permanently
+   visible selects pushed the results below the fold, so the secondary
+   filters moved into a popover (issue #248). */
+.today-filters {
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.9rem 1rem;
+  align-items: center;
+  margin-bottom: 1.25rem;
+}
+
+.today-filters .search-field {
+  display: block;
+  flex: 1 1 260px;
+  margin: 0;
+}
+
+.today-filters .search-field input {
+  width: 100%;
+  min-width: 0;
+}
+
+.today-filters .date-field {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin: 0;
+  white-space: nowrap;
+}
+
+.today-filters .filters-toggle {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: baseline;
+  min-height: 44px;
+  padding: 0.6rem 1rem;
+  border: 1px solid var(--ink);
+  background: transparent;
+  font-family: var(--utility);
+  font-size: 0.68rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.today-filters .filters-toggle:hover {
+  background: var(--ink);
+  color: white;
+}
+
+.today-filters .filters-toggle[aria-expanded="true"] {
+  background: var(--ink);
+  color: white;
+}
+
+.today-filters .filters-toggle #filters-count {
+  color: var(--muted);
+}
+
+.today-filters .filters-toggle[aria-expanded="true"] #filters-count,
+.today-filters .filters-toggle:hover #filters-count {
+  color: inherit;
+}
+
+.today-filters .refresh-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0.6rem;
+  border: 1px solid var(--ink);
+  background: transparent;
+  color: var(--ink);
+}
+
+.today-filters .refresh-button:hover {
+  background: var(--ink);
+  color: white;
+}
+
+.today-filters .refresh-button svg {
+  width: 1.1rem;
+  height: 1.1rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+/* The popover floats over the results, so it stays out of the document
+   flow and cannot push the first records below the fold. */
+.filters-drawer {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  right: 0;
+  z-index: 40;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.9rem 1rem;
+  width: clamp(300px, 46vw, 560px);
+  padding: 1.25rem;
+  border: 1px solid var(--ink);
+  background: var(--panel);
+  box-shadow: var(--shadow);
+}
+
+.filters-drawer[hidden] {
+  display: none;
+}
+
+.filters-drawer label {
+  display: grid;
+  gap: 0.45rem;
+  color: var(--muted);
+}
+
+.filters-drawer .clear-button {
+  grid-column: 1 / -1;
+  justify-self: end;
 }
 
 .filter-panel input,
@@ -3826,6 +3969,18 @@ footer {
 
   .search-field {
     grid-column: auto;
+  }
+
+  /* Narrow screens give search its own row; date and the two controls sit
+     beside each other beneath it. The drawer spans the viewport. */
+  .today-filters .search-field {
+    flex-basis: 100%;
+  }
+
+  .filters-drawer {
+    left: 0;
+    right: 0;
+    width: auto;
   }
 
   footer {

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -485,15 +485,14 @@ input {
   color: var(--muted);
 }
 
-/* The day's narrative leads the view, so it reads as prose rather than as
-   another panel competing with the listings below it. The heavy bordered box
-   is dropped: whitespace and the section titles carry the separation. The
-   block spans the same width as the results grid beneath it (issue #225), so
-   it no longer floats as a half-width column with empty space to its right;
-   long lines are kept readable by capping the prose body, not the section. */
+/* The day's narrative shares the right sidebar with the health and corpus
+   cards, so it carries the same box treatment and the sidebar column
+   constrains its width instead of an explicit cap (issue #248). */
 .daily-briefing {
-  margin-bottom: 2.25rem;
-  max-width: calc(100% - 22rem);
+  margin-bottom: 1.25rem;
+  padding: 1rem 1.4rem;
+  border: 1px solid var(--ink);
+  background: var(--panel);
 }
 
 .daily-briefing-title {
@@ -632,8 +631,10 @@ input {
 }
 
 .daily-questions {
-  margin-bottom: 2.25rem;
-  max-width: calc(100% - 22rem);
+  margin-bottom: 1.25rem;
+  padding: 1rem 1.4rem;
+  border: 1px solid var(--ink);
+  background: var(--panel);
 }
 
 #daily-questions-body {
@@ -3618,14 +3619,6 @@ footer {
 
   .content-grid {
     grid-template-columns: 1fr;
-  }
-
-  /* Below 1050px the results grid loses its 320px sidebar and goes single
-     column, so the briefing's sidebar-derived width cap no longer applies
-     and it fills the view like the results beneath it (issue #225). */
-  .daily-briefing,
-  .daily-questions {
-    max-width: 100%;
   }
 
   .benchmark-workbench {

--- a/site/index.html
+++ b/site/index.html
@@ -196,23 +196,8 @@
 
     <main id="main-content" tabindex="-1">
       <section class="view" id="today-view" aria-label="Today">
-        <!-- The day's narrative, above the filters because it describes the
-             whole scan date rather than the filtered subset below it. -->
-        <section class="daily-briefing" id="daily-briefing" aria-labelledby="daily-briefing-heading">
-          <h2 class="daily-briefing-title" id="daily-briefing-heading" data-i18n="Daily briefing">Daily briefing</h2>
-          <div id="daily-briefing-body"></div>
-        </section>
-        <!-- The day's Q&A sits directly under the briefing: the briefing says
-             what changed, this answers what a reader would ask about it. Both
-             describe the whole scan date, so both stay above the filters. -->
-        <section
-          class="daily-questions"
-          id="daily-questions"
-          aria-labelledby="daily-questions-heading"
-        >
-          <h2 class="daily-questions-title" id="daily-questions-heading" data-i18n="Questions for today">Questions for today</h2>
-          <div id="daily-questions-body"></div>
-        </section>
+        <!-- The filters lead the view because they shape the matching results
+             that make up the main column beneath them. -->
         <form class="filter-panel today-filters" id="filters">
           <label class="search-field">
             <span data-i18n="Search">Search</span>
@@ -263,6 +248,23 @@
             </button>
           </div>
           <div>
+            <!-- The day's narrative and Q&A describe the whole scan date
+                 rather than the filtered subset, so they sit in the sidebar
+                 above the health and corpus cards (issue #248). The briefing
+                 says what changed, the Q&A answers what a reader would ask
+                 about it. -->
+            <section class="daily-briefing" id="daily-briefing" aria-labelledby="daily-briefing-heading">
+              <h2 class="daily-briefing-title" id="daily-briefing-heading" data-i18n="Daily briefing">Daily briefing</h2>
+              <div id="daily-briefing-body"></div>
+            </section>
+            <section
+              class="daily-questions"
+              id="daily-questions"
+              aria-labelledby="daily-questions-heading"
+            >
+              <h2 class="daily-questions-title" id="daily-questions-heading" data-i18n="Questions for today">Questions for today</h2>
+              <div id="daily-questions-body"></div>
+            </section>
             <aside class="health-panel" id="source-health-panel" aria-labelledby="health-heading">
               <details id="health-panel-details">
                 <summary>

--- a/site/index.html
+++ b/site/index.html
@@ -196,44 +196,80 @@
 
     <main id="main-content" tabindex="-1">
       <section class="view" id="today-view" aria-label="Today">
-        <!-- The filters lead the view because they shape the matching results
-             that make up the main column beneath them. -->
+        <!-- The toolbar stays one compact row so the results below stay
+             above the fold: search, the scan date, a trigger that opens the
+             secondary filters, and a refresh control. The badge on the
+             trigger counts how many secondary filters are active. -->
         <form class="filter-panel today-filters" id="filters">
           <label class="search-field">
-            <span data-i18n="Search">Search</span>
+            <span class="visually-hidden" data-i18n="Search">Search</span>
             <input
               id="search-filter"
               name="q"
               type="search"
-              placeholder="Title, summary, or source"
-              data-i18n-placeholder="Title, summary, or source"
+              placeholder="Search benchmarks…"
+              data-i18n-placeholder="Search benchmarks…"
             >
           </label>
-          <label>
-            <span data-i18n="Scan date">Scan date</span>
+          <label class="date-field">
+            <span data-i18n="Date:">Date:</span>
             <select id="today-date" name="date"></select>
           </label>
-          <label>
-            <span data-i18n="Kind">Kind</span>
-            <select id="kind-filter" name="kind"></select>
-          </label>
-          <label>
-            <span data-i18n="Category">Category</span>
-            <select id="category-filter" name="category"></select>
-          </label>
-          <label>
-            <span data-i18n="Source">Source</span>
-            <select id="source-filter" name="source"></select>
-          </label>
-          <label>
-            <span data-i18n="Organization">Organization</span>
-            <select id="organization-filter" name="organization"></select>
-          </label>
-          <label>
-            <span data-i18n="Event">Event</span>
-            <select id="event-filter" name="event"></select>
-          </label>
-          <button class="clear-button" id="clear-filters" type="button" data-i18n="Clear filters">Clear filters</button>
+          <button
+            type="button"
+            class="filters-toggle"
+            id="filters-toggle"
+            aria-expanded="false"
+            aria-controls="filters-drawer"
+          >
+            <span data-i18n="Filters">Filters</span>
+            <span id="filters-count"></span>
+          </button>
+          <button
+            type="button"
+            class="refresh-button"
+            id="refresh-button"
+            title="Refresh data"
+            aria-label="Refresh data"
+            data-i18n-title="Refresh data"
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M21 12a9 9 0 1 1-2.64-6.36"></path>
+              <path d="M21 3v6h-6"></path>
+            </svg>
+          </button>
+          <!-- Kind, category, source, organization, and event filter the
+               same list but are needed less often, so they live in a
+               popover instead of taking a row of the first viewport. -->
+          <div
+            class="filters-drawer"
+            id="filters-drawer"
+            hidden
+            aria-label="More filters"
+            data-i18n-aria="More filters"
+          >
+            <label>
+              <span data-i18n="Kind">Kind</span>
+              <select id="kind-filter" name="kind"></select>
+            </label>
+            <label>
+              <span data-i18n="Category">Category</span>
+              <select id="category-filter" name="category"></select>
+            </label>
+            <label>
+              <span data-i18n="Source">Source</span>
+              <select id="source-filter" name="source"></select>
+            </label>
+            <label>
+              <span data-i18n="Organization">Organization</span>
+              <select id="organization-filter" name="organization"></select>
+            </label>
+            <label>
+              <span data-i18n="Event">Event</span>
+              <select id="event-filter" name="event"></select>
+            </label>
+            <button class="clear-button" id="clear-filters" type="button" data-i18n="Clear filters">Clear filters</button>
+          </div>
         </form>
 
         <div class="content-grid">

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -798,15 +798,17 @@ def test_share_card_attributes_its_source_without_overlapping_the_caveat():
     assert caveat + attribution < WIDTH - 2 * MARGIN
 
 
-def test_today_view_leads_with_the_daily_briefing():
+def test_today_view_places_the_daily_briefing_in_the_sidebar():
+    """Issue #248: matching results lead the view; the briefing rides along."""
     html = Path("site/index.html").read_text(encoding="utf-8")
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
 
     assert 'id="daily-briefing"' in html
     assert 'id="daily-briefing-body"' in html
-    # The briefing describes the whole scan date, so it sits above the filters
-    # rather than inside the filtered listing beside them.
-    assert html.index('id="daily-briefing"') < html.index('id="filters"')
+    # The matching results form the main column; the briefing describes the
+    # whole scan date, so it sits in the sidebar above the Sources card.
+    assert html.index('id="today-list"') < html.index('id="daily-briefing"')
+    assert html.index('id="daily-briefing"') < html.index('id="source-health-panel"')
     assert "renderDailyBriefing(day)" in script
 
 
@@ -995,26 +997,27 @@ def test_today_view_renders_the_daily_questions_under_the_briefing():
     assert 'id="daily-questions"' in html
     assert 'id="daily-questions-body"' in html
     # The briefing says what changed and the Q&A answers what a reader would ask
-    # about it, so the Q&A follows the briefing and both sit above the filters.
+    # about it, so the Q&A follows the briefing in the sidebar, above the
+    # Sources card and below the matching results (issue #248).
     assert html.index('id="daily-briefing"') < html.index('id="daily-questions"')
-    assert html.index('id="daily-questions"') < html.index('id="filters"')
+    assert html.index('id="daily-questions"') < html.index('id="source-health-panel"')
+    assert html.index('id="today-list"') < html.index('id="daily-questions"')
     assert "renderDailyQuestions(day)" in script
     # Both describe one scan date, so neither is shown over the whole archive.
     assert 'byId("daily-questions").hidden = showingAllDates' in script
 
 
-def test_daily_questions_use_the_results_column_width_without_long_prose_lines():
-    """Issue #223: the section fills the desktop column while prose stays readable."""
+def test_daily_questions_render_in_the_sidebar_column():
+    """Issue #248: the sidebar column constrains the section, not an explicit cap."""
     styles = Path("site/assets/styles.css").read_text(encoding="utf-8")
 
     questions = styles.split(".daily-questions {", 1)[1].split("}", 1)[0]
     body = styles.split("#daily-questions-body {", 1)[1].split("}", 1)[0]
-    responsive = styles.split("@media (max-width: 1050px)", 1)[1].split(
-        "@media (max-width: 760px)", 1
-    )[0]
-    assert "max-width: calc(100% - 22rem)" in questions
+    assert "max-width: calc(100% - 22rem)" not in questions
     assert "max-width: 72ch" in body
-    assert ".daily-briefing,\n  .daily-questions" in responsive
+    # The section carries the same box treatment as the cards beside it.
+    assert "border: 1px solid var(--ink)" in questions
+    assert "background: var(--panel)" in questions
 
 
 def test_daily_questions_withhold_another_days_answers_and_name_an_absent_set():

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -263,6 +263,31 @@ def test_today_view_has_one_filterable_observation_list_and_one_source_status():
     assert "health-summary" not in html
 
 
+def test_today_toolbar_keeps_secondary_filters_in_a_popover():
+    """Issue #248: the first viewport must stay on results, so the five
+    secondary filters live in a drawer behind a trigger whose badge counts
+    the active ones, and the toolbar adds a refresh control."""
+    html = Path("site/index.html").read_text(encoding="utf-8")
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    assert 'id="filters-drawer"' in html
+    assert 'id="filters-toggle"' in html
+    assert 'id="filters-count"' in html
+    assert 'id="refresh-button"' in html
+    assert 'id="search-filter"' in html
+    assert 'id="kind-filter"' in html
+    assert 'id="category-filter"' in html
+    assert 'id="source-filter"' in html
+    assert 'id="organization-filter"' in html
+    assert 'id="event-filter"' in html
+    assert 'id="clear-filters"' in html
+    assert "function updateFiltersCount()" in script
+    assert "function closeFiltersDrawer()" in script
+    assert "function refreshData()" in script
+    assert 'fetch("data/radar.json", { cache: "reload" })' in script
+    assert "drawer.hidden = true" in script
+
+
 def test_summaries_truncate_at_a_word_boundary():
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
 


### PR DESCRIPTION
Closes nothing; implements [issue #248](https://github.com/ktwu01/benchmark-radar/issues/248).

## What changed

- Matching results now lead the Today view; the daily briefing and daily Q&A moved into the right sidebar above the SOURCES and ALL-TIME TOTALS cards (results/sidebar grid is 6:4).
- The filter bar is a single compact row: search, scan date, a **Filters (N)** trigger whose badge counts active secondary filters, and a refresh control. Kind, category, source, organization, and event live in a popover drawer (toggle, outside-click, and Escape close it).
- The refresh control revalidates `data/radar.json` with `cache: "reload"` and keeps the current data if the revalidation fails.
- Tightened first-viewport spacing: tabs to toolbar 14px, toolbar to results heading 20px; the "Matching observations" heading now shares the count caption's mono style.

## Verification

- 794 tests pass (88 in tests/test_site.py, including a new test pinning the toolbar/drawer markup).
- Layout and interactions verified in a headless browser at 1440/1050/390px: drawer open/close, badge count live updates, filter application, clear, refresh, no horizontal overflow on mobile.

This PR intentionally does not close #248; further feedback on the layout can land in follow-ups.