### PR TITLE
Apply the issue #248 homepage review: title-led rows, integer scores, no chips

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -2317,7 +2317,13 @@ function allObservations() {
   );
   state.observations = [...evidence, ...attention].sort((a, b) => {
     const dateOrder = String(b.snapshot_date).localeCompare(String(a.snapshot_date));
-    return dateOrder || Number(b.total_score || 0) - Number(a.total_score || 0);
+    if (dateOrder) return dateOrder;
+    const scoreOrder = Number(b.total_score || 0) - Number(a.total_score || 0);
+    if (scoreOrder) return scoreOrder;
+    // Attention rows carry no priority, so within a day they order by the
+    // event timestamp the row displays, keeping the visible order consistent
+    // with the "Sort: Date ↓" caption.
+    return String(eventTimestamp(b)).localeCompare(String(eventTimestamp(a)));
   });
   return state.observations;
 }

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -381,6 +381,7 @@ const I18N = {
     "normal": "正常",
     "need attention": "需关注",
     "Sort: Priority ↓": "排序:优先度 ↓",
+    "Sort: Date, then Priority ↓": "排序:日期,再按优先度 ↓",
     // --- Leaderboard ---------------------------------------------------------
     "Model Card Adoption Rank": "模型卡采用排名",
     "Which benchmarks do model cards report?": "模型卡报告了哪些基准?",
@@ -1670,8 +1671,12 @@ function renderToday({ resultsOnly = false } = {}) {
   byId("today-breakdown").textContent =
     `${evidenceCount} ${t("normal")} · ${attentionCount} ${t("need attention")}`;
   // The list is sorted by priority within a day; say so at the point of use
-  // rather than making the reader infer it (issue #248).
-  byId("today-sort").textContent = t("Sort: Priority ↓");
+  // rather than making the reader infer it. In All dates mode the archive is
+  // ordered by date first and priority second, so the caption says so
+  // (issue #248).
+  byId("today-sort").textContent = showingAllDates
+    ? t("Sort: Date, then Priority ↓")
+    : t("Sort: Priority ↓");
   replaceChildren(
     byId("today-list"),
     visibleObservations.length
@@ -2513,7 +2518,8 @@ function openRubric(item = null, versionOverride = null) {
 
   // Selection policy belongs to the record's scan, not its shared scoring
   // rubric version. Older v2 records were genuinely filtered at 40, while new
-  // v2 records retain everything eligible and use 40 only for this badge.
+  // v2 records retain everything eligible and use 40 only as the
+  // recommendation marker.
   const selectedDay = dailySnapshot();
   const recommendationScore = item
     ? item.recommendation_score
@@ -2530,7 +2536,7 @@ function openRubric(item = null, versionOverride = null) {
           text:
             `${t("Every record matching at least one taxonomy category is retained. A score of")} ` +
             `${Number(recommendationScore).toFixed(2)} ${t(
-              "or above adds the Recommended badge; it does not control inclusion. Watchlisted artifacts are also retained.",
+              "or above marks the item as recommended; it does not control inclusion. Watchlisted artifacts are also retained.",
             )}`,
         })
       : historicalMinimum !== undefined && historicalMinimum !== null

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -382,6 +382,7 @@ const I18N = {
     "need attention": "需关注",
     "Sort: Priority ↓": "排序:优先度 ↓",
     "Sort: Date, then Priority ↓": "排序:日期,再按优先度 ↓",
+    "Sort: Date ↓": "排序:日期 ↓",
     // --- Leaderboard ---------------------------------------------------------
     "Model Card Adoption Rank": "模型卡采用排名",
     "Which benchmarks do model cards report?": "模型卡报告了哪些基准?",
@@ -1671,12 +1672,16 @@ function renderToday({ resultsOnly = false } = {}) {
   byId("today-breakdown").textContent =
     `${evidenceCount} ${t("normal")} · ${attentionCount} ${t("need attention")}`;
   // The list is sorted by priority within a day; say so at the point of use
-  // rather than making the reader infer it. In All dates mode the archive is
-  // ordered by date first and priority second, so the caption says so
+  // rather than making the reader infer it. Attention rows carry no priority,
+  // so a kind-filtered attention set falls back to date order, and in All
+  // dates mode the archive is ordered by date first and priority second
   // (issue #248).
-  byId("today-sort").textContent = showingAllDates
-    ? t("Sort: Date, then Priority ↓")
-    : t("Sort: Priority ↓");
+  const priorityScored = visibleObservations.some((item) => Number(item.total_score) > 0);
+  byId("today-sort").textContent = !priorityScored
+    ? t("Sort: Date ↓")
+    : showingAllDates
+      ? t("Sort: Date, then Priority ↓")
+      : t("Sort: Priority ↓");
   replaceChildren(
     byId("today-list"),
     visibleObservations.length
@@ -6011,7 +6016,16 @@ function observationCard(item, index) {
   const metadata = isAttention
     ? element("div", { className: "signal-meta" }, [
         element("span", { className: "attention-badge", text: t("attention") }),
-        element("span", { text: `${item.source} · ${eventVerb(item)}` }),
+        element("span", {
+          text: `${item.source} · ${eventVerb(item)}`,
+          // The relative time on the row carries the exact timestamp on
+          // hover, matching the evidence rows (issue #248).
+          attrs: {
+            title: eventTimestamp(item)
+              ? `${formatDate(eventTimestamp(item), { dateStyle: "medium", timeStyle: "short" })} UTC`
+              : "",
+          },
+        }),
       ])
     : recordMeta(item);
   const summary = (item.summary || "").trim()

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -363,12 +363,24 @@ const I18N = {
     "Date:": "日期:",
     "Search benchmarks…": "搜索基准…",
     "Refresh data": "刷新数据",
-    "Matching observations": "匹配结果",
+    "Today's radar": "今日雷达",
     "Show more results": "显示更多结果",
     Sources: "来源",
     "All-time totals": "全部统计",
     All: "全部",
-    "view.today.matching": "匹配结果",
+    // --- Today view row and metrics -----------------------------------------
+    "Updated": "更新于",
+    "Released": "发布于",
+    "Just now": "刚刚",
+    "{n}m ago": "{n} 分钟前",
+    "{n}h ago": "{n} 小时前",
+    "{n}d ago": "{n} 天前",
+    "yesterday": "昨天",
+    "result": "条结果",
+    "results": "条结果",
+    "normal": "正常",
+    "need attention": "需关注",
+    "Sort: Priority ↓": "排序:优先度 ↓",
     // --- Leaderboard ---------------------------------------------------------
     "Model Card Adoption Rank": "模型卡采用排名",
     "Which benchmarks do model cards report?": "模型卡报告了哪些基准?",
@@ -550,8 +562,6 @@ const I18N = {
     "Why it matters": "为什么重要",
     // --- Score blocks --------------------------------------------------------
     "Priority score": "优先度评分",
-    Recommended: "推荐",
-    "Recommended to review": "推荐复核",
     "Priority score meets this scan's": "本次扫描的优先度分数达到",
     " triage threshold; not an endorsement.": " 分诊阈值,并非背书。",
     "not an endorsement": "并非背书",
@@ -1058,15 +1068,9 @@ function scoreMax(item = null) {
 }
 
 function scoreBlock(item) {
-  const score = Number(item.total_score || 0);
-  const max = scoreMax(item);
+  const score = Math.round(Number(item.total_score || 0));
+  const max = Math.round(scoreMax(item));
   const width = Math.max(0, Math.min(100, (score / max) * 100));
-  const recommendationScore = Number(item.recommendation_score);
-  const triagePrefix = t("Priority score meets this scan's");
-  const triageSuffix = t(" triage threshold; not an endorsement.");
-  const recommendationExplanation = Number.isFinite(recommendationScore)
-    ? `${triagePrefix} ${recommendationScore.toFixed(0)}-point${triageSuffix}`
-    : `${triagePrefix}${triageSuffix}`;
   const trackFill = element("span", {});
   const track = element("div", { className: "score-track" }, [trackFill]);
   trackFill.style.width = `${width}%`;
@@ -1077,7 +1081,7 @@ function scoreBlock(item) {
     className: "score-label score-explain",
     attrs: {
       type: "button",
-      "aria-label": `${t("Priority score")} ${score.toFixed(2)} ${t("of")} ${max.toFixed(2)}. ${t("How is this scored?")}`,
+      "aria-label": `${t("Priority score")} ${score} ${t("of")} ${max}. ${t("How is this scored?")}`,
     },
   }, [
     element("span", { text: t("Priority score") }),
@@ -1091,42 +1095,82 @@ function scoreBlock(item) {
     openRubric(item);
   });
   return element("div", { className: "score" }, [
-    ...(item.recommended
-      ? [
-          element("span", {
-            className: "recommendation-badge",
-            text: t("Recommended"),
-            attrs: {
-              title: recommendationExplanation,
-              "aria-label": `${t("Recommended to review")}. ${recommendationExplanation}`,
-            },
-          }),
-        ]
-      : []),
     element("div", { className: "score-value" }, [
-      element("strong", { text: score.toFixed(2) }),
-      element("span", { text: `/ ${max.toFixed(2)}` }),
+      element("strong", { text: String(score) }),
+      element("span", { text: `/ ${max}` }),
     ]),
     track,
     explain,
   ]);
 }
 
-function pillBar(item) {
-  const pills = [
-    ...(item.watchlist
-      ? [element("span", { className: "pill pill-watchlist", text: `★ ${item.watchlist}` })]
+function titleCase(value) {
+  return String(value)
+    .replaceAll("_", " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+// The timestamp that best describes when the observed event happened. The
+// updated_at field only exists for update events, so fall back through the
+// publish and discovery times rather than dropping the time entirely.
+function eventTimestamp(item) {
+  if (item.updated_at) return item.updated_at;
+  if (item.published_at) return item.published_at;
+  return item.discovered_at || "";
+}
+
+// Time is one of the highest-signal attributes on a Today page, so rows show
+// how long ago an event happened instead of a bare "UPDATED" (issue #248).
+function relativeTime(iso) {
+  if (!iso) return "";
+  const time = new Date(iso).getTime();
+  if (!Number.isFinite(time)) return "";
+  const minutes = Math.max(0, Math.round((Date.now() - time) / 60000));
+  if (minutes < 1) return t("Just now");
+  if (minutes < 60) return t("{n}m ago", { n: minutes });
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return t("{n}h ago", { n: hours });
+  const days = Math.round(hours / 24);
+  if (days <= 1) return t("yesterday");
+  if (days < 7) return t("{n}d ago", { n: days });
+  return formatDate(iso, { dateStyle: "medium" });
+}
+
+function eventVerb(item) {
+  const kind = String(item.event_kind || "");
+  const verb = kind === "updated" ? t("Updated") : kind === "released" ? t("Released") : titleCase(kind);
+  const time = relativeTime(eventTimestamp(item));
+  return time ? `${verb} ${time}` : verb;
+}
+
+// The collapsed row carries a plain-text provenance line instead of the six
+// uppercase chips: source and event in normal typography, at most two
+// categories, everything else under expansion (issue #248).
+function recordMeta(item) {
+  const categories = item.categories || [];
+  const visible = categories.slice(0, 2).map(titleCase);
+  const extra = categories.length - visible.length;
+  return element("div", { className: "record-meta" }, [
+    element("span", { className: "meta-source", text: item.source }),
+    element("span", {
+      className: "meta-event",
+      text: eventVerb(item),
+      attrs: {
+        title: eventTimestamp(item)
+          ? `${formatDate(eventTimestamp(item), { dateStyle: "medium", timeStyle: "short" })} UTC`
+          : "",
+      },
+    }),
+    ...(visible.length
+      ? visible.map((category) => element("span", { className: "meta-category", text: category }))
+      : [element("span", { className: "meta-category", text: t("uncategorized") })]),
+    ...(extra > 0
+      ? [element("span", { className: "meta-more", text: `+${extra}` })]
       : []),
-    element("span", { className: "pill pill-source", text: item.source }),
-    element("span", { className: "pill pill-event", text: item.event_kind }),
-    ...(item.categories || []).map((category) =>
-      element("span", { className: "pill", text: category.replaceAll("_", " ") }),
-    ),
-  ];
-  if (!(item.categories || []).length) {
-    pills.push(element("span", { className: "pill", text: t("uncategorized") }));
-  }
-  return element("div", { className: "pill-bar" }, pills);
+    ...(item.watchlist
+      ? [element("span", { className: "meta-watchlist", text: `★ ${item.watchlist}` })]
+      : []),
+  ]);
 }
 
 function definition(label, value) {
@@ -1620,8 +1664,14 @@ function renderToday({ resultsOnly = false } = {}) {
   ).length;
   const attentionCount = observations.length - evidenceCount;
   byId("today-count").textContent =
-    `${observations.length} ${observations.length === 1 ? t("result") : t("results")} · ` +
-    `${evidenceCount} ${t("evidence")} · ${attentionCount} ${t("attention")}`;
+    `${observations.length} ${observations.length === 1 ? t("result") : t("results")}`;
+  // The two classes are mutually exclusive, so name them instead of leaving
+  // EVIDENCE and ATTENTION as unexplained jargon (issue #248).
+  byId("today-breakdown").textContent =
+    `${evidenceCount} ${t("normal")} · ${attentionCount} ${t("need attention")}`;
+  // The list is sorted by priority within a day; say so at the point of use
+  // rather than making the reader infer it (issue #248).
+  byId("today-sort").textContent = t("Sort: Priority ↓");
   replaceChildren(
     byId("today-list"),
     visibleObservations.length
@@ -2596,10 +2646,15 @@ function expandedRecord(item, teaser) {
       attrs: { href: safeHttpUrl(item.url), target: "_blank", rel: "noopener noreferrer" },
     }),
   ]);
+  const categoryLine = (item.categories || []).length
+    ? (item.categories || []).map(titleCase).join(" · ")
+    : t("uncategorized");
   return element("div", { className: "record-detail" }, [
     element("p", {
       className: "detail-source",
-      text: `${item.source} · ${item.event_kind} · ${item.snapshot_date}`,
+      text:
+        `${item.source} · ${eventVerb(item)} · ${categoryLine}` +
+        `${item.watchlist ? ` · ★ ${item.watchlist}` : ""} · ${item.snapshot_date}`,
     }),
     element("p", {
       className: item.summary ? "detail-summary" : "detail-summary signal-nodesc",
@@ -5950,9 +6005,9 @@ function observationCard(item, index) {
   const metadata = isAttention
     ? element("div", { className: "signal-meta" }, [
         element("span", { className: "attention-badge", text: t("attention") }),
-        element("span", { text: `${item.source} · ${item.event_kind}` }),
+        element("span", { text: `${item.source} · ${eventVerb(item)}` }),
       ])
-    : pillBar(item);
+    : recordMeta(item);
   const summary = (item.summary || "").trim()
     ? shorten(item.summary)
     : t("No description published at the source.");
@@ -5962,8 +6017,10 @@ function observationCard(item, index) {
       text: String(index + 1).padStart(2, "0"),
     }),
     element("div", { className: "record-heading" }, [
-      metadata,
+      // The benchmark title leads the row; the provenance line follows it
+      // instead of classifying the item before it is named (issue #248).
       element("h3", { text: item.title }),
+      metadata,
       ...(item.watchlist && item.watchlist_note
         ? [element("p", { className: "signal-tldr", text: item.watchlist_note })]
         : []),

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -1073,9 +1073,10 @@ function scoreBlock(item) {
   const raw = Number(item.total_score || 0);
   const max = Number(scoreMax(item));
   // Issue #248: a 100-point score rounds to an integer (68, not 68.46), but
-  // legacy 0-4 records use meaningful halves, so keep one decimal there. The
-  // track always uses the raw value, so it never misrepresents the ratio.
-  const precision = max > 10 ? 0 : 1;
+  // legacy 0-4 records carry meaningful hundredths (3.01, 2.94), so they keep
+  // two decimals. The track always uses the raw value, so it never
+  // misrepresents the ratio.
+  const precision = max > 10 ? 0 : 2;
   const score = raw.toFixed(precision);
   const maxDisplay = precision === 0 ? String(Math.round(max)) : String(max);
   const width = Math.max(0, Math.min(100, (raw / max) * 100));

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -1070,9 +1070,15 @@ function scoreMax(item = null) {
 }
 
 function scoreBlock(item) {
-  const score = Math.round(Number(item.total_score || 0));
-  const max = Math.round(scoreMax(item));
-  const width = Math.max(0, Math.min(100, (score / max) * 100));
+  const raw = Number(item.total_score || 0);
+  const max = Number(scoreMax(item));
+  // Issue #248: a 100-point score rounds to an integer (68, not 68.46), but
+  // legacy 0-4 records use meaningful halves, so keep one decimal there. The
+  // track always uses the raw value, so it never misrepresents the ratio.
+  const precision = max > 10 ? 0 : 1;
+  const score = raw.toFixed(precision);
+  const maxDisplay = precision === 0 ? String(Math.round(max)) : String(max);
+  const width = Math.max(0, Math.min(100, (raw / max) * 100));
   const trackFill = element("span", {});
   const track = element("div", { className: "score-track" }, [trackFill]);
   trackFill.style.width = `${width}%`;
@@ -1083,7 +1089,7 @@ function scoreBlock(item) {
     className: "score-label score-explain",
     attrs: {
       type: "button",
-      "aria-label": `${t("Priority score")} ${score} ${t("of")} ${max}. ${t("How is this scored?")}`,
+      "aria-label": `${t("Priority score")} ${score} ${t("of")} ${maxDisplay}. ${t("How is this scored?")}`,
     },
   }, [
     element("span", { text: t("Priority score") }),
@@ -1098,8 +1104,8 @@ function scoreBlock(item) {
   });
   return element("div", { className: "score" }, [
     element("div", { className: "score-value" }, [
-      element("strong", { text: String(score) }),
-      element("span", { text: `/ ${max}` }),
+      element("strong", { text: score }),
+      element("span", { text: `/ ${maxDisplay}` }),
     ]),
     track,
     explain,

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -32,9 +32,12 @@ html {
 
 body {
   margin: 0;
+  /* The graph-paper grid keeps the Radar identity without competing with the
+     row separators, card borders, and score tracks drawn over it: cut its
+     contrast in half (issue #248). */
   background:
-    linear-gradient(90deg, rgb(37 94 168 / 3%) 1px, transparent 1px) 0 0 / 32px 32px,
-    linear-gradient(rgb(37 94 168 / 3%) 1px, transparent 1px) 0 0 / 32px 32px,
+    linear-gradient(90deg, rgb(37 94 168 / 1.5%) 1px, transparent 1px) 0 0 / 32px 32px,
+    linear-gradient(rgb(37 94 168 / 1.5%) 1px, transparent 1px) 0 0 / 32px 32px,
     var(--canvas);
   color: var(--ink);
   font-family: var(--body);
@@ -117,9 +120,6 @@ footer {
 #today-view .section-title h2,
 .heading-note,
 .date-control,
-.filter-panel label,
-.signal-meta,
-.score-label,
 footer,
 th {
   font-family: var(--utility);
@@ -446,6 +446,13 @@ h2 {
   display: grid;
   gap: 0.45rem;
   color: var(--muted);
+  /* Filter names are UI labels, not machine values, so they use the body
+     face at normal case instead of the uppercase mono metadata system
+     (issue #248). */
+  font-family: var(--body);
+  font-size: 0.8rem;
+  letter-spacing: normal;
+  text-transform: none;
 }
 
 select,
@@ -493,6 +500,21 @@ input {
 
 .section-title span {
   color: var(--muted);
+}
+
+/* Counts and the sort caption sit right of the heading; the spans inherit
+   the uppercase mono treatment because they are machine values (issue #248). */
+.results-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem 1rem;
+  align-items: baseline;
+  justify-content: flex-end;
+  text-align: right;
+}
+
+#today-sort {
+  white-space: nowrap;
 }
 
 /* The day's narrative shares the right sidebar with the health and corpus
@@ -755,6 +777,16 @@ input {
   border-left: 3px solid var(--line);
 }
 
+.pill {
+  padding: 0.15rem 0.45rem;
+  border: 1px solid var(--line);
+  color: var(--muted);
+  font-family: var(--utility);
+  font-size: 0.6rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
 .pill-confidence {
   flex: none;
   align-self: flex-start;
@@ -838,7 +870,7 @@ input {
 
 .record-summary {
   display: grid;
-  grid-template-columns: 26px 38px minmax(0, 1fr) 170px;
+  grid-template-columns: 26px 38px minmax(0, 1fr) 150px;
   gap: 1rem;
   align-items: start;
   padding: 1.5rem 0;
@@ -855,7 +887,7 @@ input {
    selector, which restores exactly the one-character-per-line wrap it exists to
    prevent. A class degrades to "unstyled but readable" instead. */
 .record-summary.record-summary-unranked {
-  grid-template-columns: 26px minmax(0, 1fr) 170px;
+  grid-template-columns: 26px minmax(0, 1fr) 150px;
 }
 
 .record-summary::before {
@@ -883,6 +915,12 @@ input {
 
 .record-summary:hover::before {
   border-color: var(--blue);
+}
+
+/* The whole row is the click target; a subtle wash announces the affordance
+   before the chevron is noticed (issue #248). */
+.record-summary:hover {
+  background: color-mix(in srgb, var(--panel) 55%, transparent);
 }
 
 .record-card[open] {
@@ -961,41 +999,52 @@ input {
   display: flex;
   flex-wrap: wrap;
   gap: 0.35rem 0.8rem;
+  align-items: baseline;
+  margin-bottom: 0.35rem;
   color: var(--blue-deep);
+  /* Provenance is a UI label, not a machine value: body face, normal case
+     (issue #248). */
+  font-family: var(--body);
+  font-size: 0.82rem;
+  letter-spacing: normal;
+  text-transform: none;
 }
 
-.pill-bar {
+/* The collapsed row's provenance line: source, event time, and at most two
+   categories in plain text, dot-separated, so the title leads and no chip
+   competes with it (issue #248). */
+.record-meta {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.3rem;
-}
-
-.pill {
-  padding: 0.15rem 0.45rem;
-  border: 1px solid var(--line);
+  align-items: baseline;
+  row-gap: 0.2rem;
+  margin-bottom: 0.35rem;
   color: var(--muted);
-  font-family: var(--utility);
-  font-size: 0.6rem;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
+  font-size: 0.82rem;
 }
 
-.pill-source {
-  border-color: var(--ink);
+.record-meta span + span::before {
+  content: "·";
+  margin-inline: 0.45rem;
+  color: var(--line);
+}
+
+.record-meta .meta-source {
   color: var(--ink);
   font-weight: 600;
 }
 
-.pill-event {
-  border-color: var(--blue);
+.record-meta .meta-event {
   color: var(--blue-deep);
 }
 
-.pill-watchlist {
-  border-color: var(--gold);
-  background: rgb(201 147 39 / 12%);
+.record-meta .meta-more {
+  color: var(--muted);
+}
+
+.record-meta .meta-watchlist {
   color: #7d5c14;
-  font-weight: 700;
+  font-weight: 600;
 }
 
 /* The one line saying why a tracked artifact matters, ahead of upstream prose. */
@@ -1024,20 +1073,7 @@ input {
   align-items: stretch;
   align-self: center;
   justify-self: end;
-  width: 170px;
-}
-
-.recommendation-badge {
-  align-self: flex-start;
-  margin-bottom: 0.45rem;
-  padding: 0.2rem 0.45rem;
-  border: 1px solid var(--blue);
-  color: var(--blue-deep);
-  font-family: var(--utility);
-  font-size: 0.65rem;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
+  width: 150px;
 }
 
 .score-value {
@@ -1045,11 +1081,14 @@ input {
   grid-template-columns: 1fr auto;
   align-items: baseline;
   width: 100%;
-  font-family: var(--display);
+  /* A score is a machine value, so it reads in the mono system; the display
+     face stays reserved for the benchmark titles, which now dominate the row
+     (issue #248). */
+  font-family: var(--utility);
 }
 
 .score-value strong {
-  font-size: 2.15rem;
+  font-size: 1.15rem;
   line-height: 1;
 }
 
@@ -1078,6 +1117,12 @@ input {
 .score-label {
   margin-top: 0.3rem;
   color: var(--muted);
+  /* The score's caption is a UI label, not a machine value: body face,
+     normal case. */
+  font-family: var(--body);
+  font-size: 0.7rem;
+  letter-spacing: normal;
+  text-transform: none;
 }
 
 /* The label is a button, but it keeps the label's typography: the affordance

--- a/site/index.html
+++ b/site/index.html
@@ -276,8 +276,8 @@
           <div>
             <div class="section-title">
               <h2 data-i18n="Today's radar">Today's radar</h2>
-              <div class="results-meta">
-                <span id="today-count" aria-live="polite"></span>
+              <div class="results-meta" aria-live="polite">
+                <span id="today-count"></span>
                 <span id="today-breakdown"></span>
                 <span id="today-sort"></span>
               </div>

--- a/site/index.html
+++ b/site/index.html
@@ -275,8 +275,12 @@
         <div class="content-grid">
           <div>
             <div class="section-title">
-              <h2 data-i18n="view.today.matching">Matching observations</h2>
-              <span id="today-count" aria-live="polite"></span>
+              <h2 data-i18n="Today's radar">Today's radar</h2>
+              <div class="results-meta">
+                <span id="today-count" aria-live="polite"></span>
+                <span id="today-breakdown"></span>
+                <span id="today-sort"></span>
+              </div>
             </div>
             <div class="signal-list" id="today-list"></div>
             <button class="secondary-link today-show-more" id="today-show-more" type="button" hidden data-i18n="Show more results">

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -55,12 +55,15 @@ def test_priority_score_is_reachably_explained():
     assert "How is this scored?" in script
 
 
-def test_recommendation_threshold_is_a_badge_not_an_inclusion_gate():
+def test_recommendation_threshold_does_not_gate_inclusion_and_rows_carry_no_badge():
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
 
-    assert 'className: "recommendation-badge"' in script
-    assert 'text: t("Recommended")' in script
-    assert "Recommended to review" in script
+    # Issue #248: the badge was removed because it flagged most top-ranked
+    # rows and so communicated nothing. The rubric still explains that the
+    # threshold does not control inclusion.
+    assert "recommendation-badge" not in script
+    assert 'text: t("Recommended")' not in script
+    assert "Recommended to review" not in script
     assert "not an endorsement" in script
     assert "it does not control inclusion" in script
     assert "Every record matching at least one taxonomy category is retained" in script
@@ -250,7 +253,8 @@ def test_today_view_has_one_filterable_observation_list_and_one_source_status():
     html = Path("site/index.html").read_text(encoding="utf-8")
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
 
-    assert html.count("Matching observations") == 1
+    # The heading appears in the data-i18n key and the visible text.
+    assert html.count("Today's radar") == 2
     assert 'id="today-list"' in html
     assert 'id="filters"' in html
     assert 'id="kind-filter"' in html


### PR DESCRIPTION
Closes the open checklist items in #248 and the layout/typography feedback from the issue comments.

## Changes

**Rows (issue #248 body)**
- Removed the RECOMMENDED badge: it flagged most top-ranked rows and communicated nothing. The rubric still explains the threshold does not control inclusion.
- Priority score no longer competes with the title: integer on the 100-point scale (68, not 68.46), small mono type, track kept at raw ratio. Legacy 0-4 records keep two decimals since they carry meaningful hundredths.
- Six uppercase pill chips replaced by a plain-text provenance line: source, relative event time, up to two categories (+N remainder). Full categories and watchlist move under expansion.
- Relative times everywhere: "Updated 42m ago", "Released yesterday", exact timestamp on hover. Attention rows too.

**Results header (issue comments)**
- Heading renamed "Matching observations" -> "Today's radar".
- Metrics line now reads "140 normal · 14 need attention" (no more unexplained EVIDENCE/ATTENTION) with "Sort: Priority ↓" caption at the point of use; the caption adapts to All dates (Date, then Priority) and attention-only (Date) views.
- aria-live covers the whole results-meta group so filter changes announce the breakdown.

**Typography (issue comments)**
- Mono restricted to machine values (scores, counts, dates); filter labels, score caption, and provenance use the body face.
- Background grid contrast halved; rows get a subtle hover highlight; whole row remains the click target.

## Test plan
- 794 pytest tests pass; ruff check + format clean
- Verified in the browser: heading, counts, sort caption, row layout (title first, meta line, integer score, no badge), expanded detail, attention rows
- Codex review clean after 4 rounds (rubric copy, sort caption accuracy, attention timestamps/order, legacy score precision, aria-live)