### PR TITLE
fix: make source filter case-insensitive (issue #248)

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -2331,13 +2331,14 @@ function closeFiltersDrawer() {
 
 function filteredObservations() {
   const query = state.q.trim().toLowerCase();
+  const sourceLower = state.source.trim().toLowerCase();
   return allObservations().filter((item) => {
     const haystack = `${item.title} ${item.summary} ${item.source}`.toLowerCase();
     return (
       (state.todayDate === "all" || item.snapshot_date === state.todayDate) &&
       (!state.kind || item.observation_kind === state.kind) &&
       (!state.category || (item.categories || []).includes(state.category)) &&
-      (!state.source || item.source === state.source) &&
+      (!state.source || item.source.toLowerCase() === sourceLower) &&
       (!state.organization || (item.organizations || []).includes(state.organization)) &&
       (!state.event || item.event_kind === state.event) &&
       (!query || haystack.includes(query))


### PR DESCRIPTION
## What changed

Made the source filter in `site/assets/app.js` case-insensitive:

- `item.source === state.source` → `item.source.toLowerCase() === sourceLower`
- Now `/?source=GitHub+Release`, `/?source=First-party+feed`, `/?source=github`, etc. all work

## Why

On Aug 18, 2026, users reported `/?source=First-party+feed` and `/?source=GitHub+Release` had no visual results. Investigation showed:

1. The filter used exact string matching, which failed when URL parameters had different casing than data source names
2. `URLSearchParams` converts `+` to space (standard form encoding), so `/?source=GitHub+Release` becomes `"GitHub Release"` after parsing
3. The actual `item.source` values in the data use specific casing: `"GitHub Release"`, `"First-party feed"`

This fix makes the comparison case-insensitive, so all valid URL variations work.

## Data availability note

Separately, issue #254 documents that on Aug 18, 2026, both `First-party feed` and `GitHub Release` genuinely had 0 evidence items ingested that day (RSS keyword filter and GitHub API returned no matches). The filter fix ensures when data exists, the URL parameters work correctly.

See also: issue #254 for the data availability investigation.