### PR TITLE
Saturation panel: score curve only, no lines, both benchmark layers reachable

### DIFF
--- a/data/benchmark_scores.yml
+++ b/data/benchmark_scores.yml
@@ -21,14 +21,28 @@
 # rows are missing-not-at-random. A progression built from model cards partly
 # measures reporting choice, not capability.
 #
-# THE JOIN RULE
+# THE COMPARABILITY RULE
 #
-# `protocol` is the comparability class. Two rows may be connected by a line ONLY
-# if `instrument` AND `protocol` are both identical. The string encodes whatever
-# the source said moves the number. Silence is not agreement: two documents that
-# both omit tool access are not evidence that their setups matched, so an
-# unstated condition is never treated as equal to another unstated condition --
-# it just means those rows do not join.
+# `protocol` is the comparability class. Two rows are comparable ONLY if
+# `instrument` AND `protocol` are both identical. The string encodes whatever the
+# source said moves the number. Silence is not agreement: two documents that both
+# omit tool access are not evidence that their setups matched, so an unstated
+# condition is never treated as equal to another unstated condition -- it just
+# means those rows are not comparable.
+#
+# This was formerly the join rule, and it drew a line between comparable rows.
+# It no longer does: the saturation chart connects nothing. A shared instrument
+# and protocol makes two numbers comparable, but a drawn segment asserts more
+# than that -- it asserts a series, with a direction. On GPQA Diamond the rule
+# connected DeepSeek-V4-Pro (90.1) to DeepSeek-V4-Flash (88.1) and rendered a
+# decline, when the later point is a smaller model rather than a regression; a
+# cross-vendor pair implied a trajectory between systems sharing nothing but a
+# protocol string. Restricting which pairs may join does not fix that, because
+# the defect is in the segment rather than in the pairing.
+#
+# Comparability is still computed and still published. It drives the paired
+# comparison readout under the chart, which states in words what a pair of dates
+# does and does not support. Prose can carry that caveat; a line cannot.
 #
 # `instrument` is the version identity, separate from `benchmark_id`. Terminal-
 # Bench 2.0 and 2.1 share a benchmark_id and are different instruments (2.1

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -686,7 +686,6 @@ const I18N = {
     "Click to pin record details": "点击固定记录详情",
     Comments: "评论",
     "Corpus coverage": "语料覆盖",
-    "Dashed score connection": "虚线分数连接",
     "Discovery sources": "发现来源",
     "Doing related-work research, or hunting for a benchmark on a topic? This database aggregates every benchmark, evaluation, and dataset the radar has surfaced, and you can query it by topic, source, or organization before you export. The full corpus below is the same data the dashboard renders.":
       "在做相关工作研究,或想按主题查找基准?这个数据库汇总了雷达发现过的每一个基准、评测与数据集,可以在导出前按主题、来源或机构查询。下方的完整语料与仪表盘渲染的是同一份数据。",
@@ -734,7 +733,6 @@ const I18N = {
     "Scoring rubric v": "评分标准 v",
     "Show the first 18 benchmarks": "显示前 18 个基准",
     "Showing all": "显示全部",
-    "Solid score connection": "实线分数连接",
     Submissions: "提交数",
     "The current rubric is v": "当前评分标准为 v",
     "This historical scan used": "本次历史扫描采用了",
@@ -751,12 +749,12 @@ const I18N = {
     "best on record": "历史最佳",
     by: "由",
     "cited by": "被引用",
-    "connected only at one instrument and protocol": "仅在单一工具与协议连接",
     contributes: "贡献",
     "here are third parties": "有第三方",
     "here is a third party": "有第三方",
     listed: "已列出",
     "no readable score in this window": "此窗口中无可读分数",
+    "one value read verbatim from a cited document": "一个从引文文档中逐字读到的数值",
     "not yet reported": "尚未报告",
     "points to zero, the floor of this metric": "指向零,该指标的底线",
     protocol: "协议",
@@ -766,8 +764,6 @@ const I18N = {
     release: "发布",
     "release date unrecorded": "未记录发布日期",
     released: "发布于",
-    "same instrument and protocol across organizations": "跨机构的相同工具与协议",
-    "same instrument and protocol, one organization only": "单一机构,相同工具与协议",
     "scale. Every number below is read from the same definition the pipeline applies.":
       "的标尺。下面每个数字都按流程应用的同一套定义读取。",
     to: "到",
@@ -4291,22 +4287,8 @@ function renderFrontierLegend(entry, record) {
     items.push([
       "legend-swatch-score",
       t("Readable score"),
-      t("connected only at one instrument and protocol"),
+      t("one value read verbatim from a cited document"),
     ]);
-    if (record.series.some((series) => series.connectable && !series.single_organization)) {
-      items.push([
-        "legend-swatch-score-line",
-        t("Solid score connection"),
-        t("same instrument and protocol across organizations"),
-      ]);
-    }
-    if (record.series.some((series) => series.connectable && series.single_organization)) {
-      items.push([
-        "legend-swatch-score-line-single-org",
-        t("Dashed score connection"),
-        t("same instrument and protocol, one organization only"),
-      ]);
-    }
   }
   replaceChildren(
     host,
@@ -4469,22 +4451,22 @@ function scoreTrackChart(entry, board) {
       );
     }
 
-    // One polyline per comparable series, and only for series the join rule
-    // permits a line through. A series confined to one date draws no line: its
-    // points are a comparison table from one document, and connecting them
-    // would turn a single publication into an apparent trend.
-    for (const series of record.series) {
-      if (!series.connectable) continue;
-      const points = series.points
-        .map((point) => `${x(point.reported_at)},${scoreY(point.value)}`)
-        .join(" ");
-      svg.append(
-        svgElement("polyline", {
-          points,
-          class: `score-line${series.single_organization ? " score-line-single-org" : ""}`,
-        }),
-      );
-    }
+    // No segment joins any two score points, in either layer.
+    //
+    // A shared instrument and protocol makes two numbers *comparable*. It does
+    // not make them a *series*, and a drawn segment asserts the second. On
+    // shipped GPQA Diamond the join rule connected DeepSeek-V4-Pro (90.1) to
+    // DeepSeek-V4-Flash (88.1) and drew a decline, when the later point is a
+    // smaller model rather than a regression over time; the cross-vendor pair
+    // (Gemma 4 31B to GLM-5.1) implied a trajectory between two systems that
+    // share nothing but a protocol string. Both are the same error the reading
+    // gap exists to prevent, and neither is fixable by restricting which pairs
+    // may join, because the defect is in the segment, not in the pairing.
+    //
+    // Comparability is still computed and still stated: it drives the paired
+    // comparison readout below the chart, which says in words what a pair of
+    // dates does and does not support. Words can carry that caveat; a line
+    // cannot.
 
     // The best-on-record marker. Drawn as a horizontal rule rather than a point
     // because it is a fact about the whole corpus to date, not about one date.

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -394,19 +394,14 @@ const I18N = {
     "Registry overview": "总览",
     "What the two layers say": "两层信息说了什么",
     "Stated findings": "明确结论",
-    "leaderboard.navigator.note":
-      "如果你还没有想好要看哪个基准,这里有几条可以直接打开。上面的搜索框可以检索登记册与抓取目录中的每一个基准。",
     "The saturation curve": "饱和曲线",
     "Benchmark reported scores over time": "基准报告分数随时间的变化",
     "All tracked benchmarks": "所有追踪的基准",
     "Search every benchmark": "搜索全部基准",
+    "Try:": "试试:",
     "Search benchmarks, tasks, domains…": "搜索基准、任务、领域…",
-    "Worked examples": "示例记录",
-    "Famous benchmarks": "知名基准",
     "{n} benchmarks": "{n} 个基准",
     "Curated registry": "精选登记册",
-    "New instruments with scores": "有分数的新工具",
-    "Deepest score records": "分数记录最全的基准",
     "No benchmark in this registry has a readable score yet.": "此登记册中还没有任何基准具有可读分数。",
     "What would make this a true Pareto frontier?": "怎样才算真正的帕累托前沿?",
     "Benchmarks by model card adoption": "按模型卡采用排名的基准",
@@ -3935,72 +3930,61 @@ function renderExternalBenchmark(board, scored, record) {
   });
 }
 
+// A handful of entry points for a reader who has nothing in mind to type, on
+// one line. This replaced a titled block with two computed subheadings and
+// eight cards: it outranked the search box it existed to support, and a reader
+// who wanted anything else read four suggestions before finding the field.
+//
+// The list is editorial rather than computed, which is the point. MMLU carries
+// only 4 readable scores here and would never place in a "deepest records"
+// ranking, but it is the name a newcomer arrives with. Short labels are used
+// because these are prompts for the search box, not record titles; each chip
+// carries the registry's full name as its accessible name and tooltip, so the
+// abbreviation never hides what will open.
+const BENCHMARK_EXAMPLES = [
+  ["mmlu", "MMLU"],
+  ["gpqa_diamond", "GPQA"],
+  ["swe_bench_verified", "SWE-bench"],
+  ["terminal_bench", "Terminal-Bench"],
+];
+
 function renderBenchmarkNavigator(board) {
-  const scored = (board.entries || []).filter(
-    (entry) => entry.card_count > 0 && scoreRecord(entry.benchmark_id),
-  );
-  const datedCount = (entry) => scoreRecord(entry.benchmark_id)?.dated_observation_count || 0;
-  // The shortlist is anchored to the score record like the panel it opens: the
-  // newest instruments that already have readable scores, then the deepest
-  // score records in the registry. The adoption stages that used to group it
-  // ("saturated reporting" and friends) described a reading the panel no
-  // longer makes.
-  const newest = scored
-    .filter((entry) => isNewBenchmark(entry, board))
-    .sort(
-      (a, b) =>
-        Number(b.benchmark_id === state.lfrontier) - Number(a.benchmark_id === state.lfrontier) ||
-        (b.released || "").localeCompare(a.released || "") ||
-        a.name.localeCompare(b.name),
-    )
-    .slice(0, 4);
-  const newestIds = new Set(newest.map((entry) => entry.benchmark_id));
-  const deepest = scored
-    .filter((entry) => !newestIds.has(entry.benchmark_id))
-    .sort(
-      (a, b) =>
-        Number(b.benchmark_id === state.lfrontier) - Number(a.benchmark_id === state.lfrontier) ||
-        datedCount(b) - datedCount(a) ||
-        (b.released || "").localeCompare(a.released || "") ||
-        a.name.localeCompare(b.name),
-    )
-    .slice(0, 4);
-  const groups = [
-    [t("New instruments with scores"), newest],
-    [t("Deepest score records"), deepest],
-  ]
-    .map(([label, entries]) => {
-      if (!entries.length) return null;
-      return element("section", { className: "benchmark-shortlist-group" }, [
-        element("h3", { text: label }),
-        element(
-          "div",
-          { className: "benchmark-shortlist-buttons" },
-          entries.map((entry) => {
-            const button = element("button", {
-              className: "benchmark-shortlist-button",
-              attrs: {
-                type: "button",
-                "aria-pressed": entry.benchmark_id === state.lfrontier ? "true" : "false",
-              },
-            }, [
-              element("span", { text: entry.name }),
-              element("small", {
-                text: metricLabel(scoreRecord(entry.benchmark_id).observation_count, "readable score"),
-              }),
-            ]);
-            button.addEventListener("click", () => {
-              selectFrontier(entry.benchmark_id);
-              renderAdoptionFrontier(board);
-              writeUrl();
-            });
-            return button;
-          }),
-        ),
-      ]);
-    })
-    .filter(Boolean);
-  replaceChildren(byId("benchmark-shortlist"), groups);
+  const host = byId("benchmark-shortlist");
+  if (host) {
+    const byBenchmarkId = new Map(
+      (board.entries || []).map((entry) => [entry.benchmark_id, entry]),
+    );
+    // Filtered against the live registry rather than trusted: an id that leaves
+    // the registry, or loses its last readable score, drops out of the line
+    // instead of rendering a chip that opens the refusal panel.
+    const chips = BENCHMARK_EXAMPLES.map(([benchmarkId, label]) => {
+      const entry = byBenchmarkId.get(benchmarkId);
+      if (!entry || !scoreRecord(benchmarkId)) return null;
+      const chip = element("button", {
+        className: "benchmark-example",
+        text: label,
+        attrs: {
+          type: "button",
+          title: entry.name,
+          "aria-label": entry.name,
+          "aria-pressed": benchmarkId === state.lfrontier ? "true" : "false",
+        },
+      });
+      chip.addEventListener("click", () => {
+        selectFrontier(benchmarkId);
+        renderAdoptionFrontier(board);
+        writeUrl();
+      });
+      return chip;
+    }).filter(Boolean);
+    replaceChildren(
+      host,
+      chips.length ? [element("span", { className: "benchmark-example-lead", text: t("Try:") }), ...chips] : [],
+    );
+  }
+  // Binds the input and kicks off the crawled-index fetch on first call; a
+  // no-op afterwards. Without it the box searches the curated layer only and
+  // the reach line undercounts, which is how it read "59 benchmarks, 1 source".
   initBenchmarkSearch();
   renderBenchmarkSearch();
 }

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -398,10 +398,12 @@ const I18N = {
     "Choose a reporting story": "选择一个报告故事",
     "leaderboard.navigator.note":
       "从能把新兴工具与成熟标准、饱和惯例区分开来的信号入手。",
-    "Reporting over time": "随时间的变化",
-    "Benchmark adoption frontier": "基准采用前沿",
+    "The saturation curve": "饱和曲线",
+    "Benchmark reported scores over time": "基准报告分数随时间的变化",
     "All tracked benchmarks": "所有追踪的基准",
-    "Frontier milestones": "前沿里程碑",
+    "New instruments with scores": "有分数的新工具",
+    "Deepest score records": "分数记录最全的基准",
+    "No benchmark in this registry has a readable score yet.": "此登记册中还没有任何基准具有可读分数。",
     "What would make this a true Pareto frontier?": "怎样才算真正的帕累托前沿?",
     "Benchmarks by model card adoption": "按模型卡采用排名的基准",
     "Benchmark name or alias": "基准名称或别名",
@@ -417,10 +419,8 @@ const I18N = {
     "Open daily Issues": "打开每日 Issue ↗",
     "Select a node": "选择一个节点",
     "All dates": "所有日期",
-    "frontier.explainer.tl1":
-      "同一时间轴上有三条读数。每个橙色菱形标记一家机构首次报告该基准,这是唯一会抬高累计次数的事件。其下的地毯为每张有日期的模型卡放一个刻度,已被计数的机构之后发布的卡显示为灰色刻度,楼梯保持水平。没有发布日期的卡无法放在时间线上,从两条带中都缺席,但仍计入上面的总数。长而平稳的一段是在这个精选登记册中观察到的报告饱和,并非对基准分数饱和的判断。",
     "frontier.explainer.sub":
-      "下面的分数轨道是另一条独立的读数:每个能从引文文档中逐字读到的数值,只在工具与协议完全一致时才相连。分数末端趋于平直通常意味着没有更新的数字可读,因此缺口被标出而不是用线穿过。",
+      "每个能从引文文档中逐字读到的数值,按该文档的发布日期放置(而非任何评测日期),只在工具与协议完全一致时才相连。末端趋于平直通常意味着没有更新的数字可读,因此缺口被标出而不是用线穿过。一条曲线是否已经饱和,由你来判读,本面板不会给出饱和分数。",
     "leaderboard.filters.note":
       "每张模型卡对同一基准只计一次。一张在四个配置中报告 AIME 的卡,与只报告一次的卡计数相同,因此冗长的附录不能压过不同的供应商。机构可以打破平局:六个供应商报告同一计数是共同标准,只有一个供应商报告则是自家风格。",
     "leaderboard.ledger.note":
@@ -452,11 +452,9 @@ const I18N = {
     "evidence record": "条证据",
     "model card": "张模型卡",
     "model cards": "张模型卡",
-    "dated organization": "家过日期机构",
-    "dated organizations": "家过日期机构",
+    "readable score": "个可读分数",
+    "readable scores": "个可读分数",
     organization: "个机构",
-    "repeat report": "次重复报告",
-    "repeat reports": "次重复报告",
     benchmark: "个基准",
     benchmarks: "个基准",
     value: "个值",
@@ -618,11 +616,7 @@ const I18N = {
     "view.map.detail.note": "主题、来源和机构节点会设置对应的今日筛选。工件节点会设置日期和标题搜索。",
     // --- Frontier / workbench -------------------------------------------------
     "Priority & evidence": "优先度与证据",
-    "Early signal": "早期信号",
-    "New & spreading": "新增且扩散中",
-    "Established": "已确立",
-    "Saturated reporting": "报告饱和",
-    "View adoption frontier ↑": "查看采用前沿 ↑",
+    "View score track ↑": "查看分数轨道 ↑",
     "Show on the chart ↑": "在图表中显示 ↑",
     "Model cards": "模型卡",
     "Best on record": "历史最佳",
@@ -687,10 +681,7 @@ const I18N = {
     "Artifact nodes connected to topics, organizations, and discovery sources":
       "连接到主题、机构与发现来源的工件节点",
     Artifacts: "工件",
-    "At least 80% of organizations in this curated registry report it; that is convention, not quality.":
-      "该精选登记册中至少 80% 的机构报告了它;这是惯例,不是质量。",
     Authors: "作者",
-    "Awaiting an independent second organization": "等待第二个独立机构",
     "Click the marker to pin these details": "点击标记以固定这些详情",
     "Click to pin record details": "点击固定记录详情",
     Comments: "评论",
@@ -703,31 +694,25 @@ const I18N = {
       "此文档呈现给读者的每个基准,各计一次。这是提及次数,不是分数:来源记录了配置,而这个登记册刻意不记录。",
     "Every record matching at least one taxonomy category is retained. A score of":
       "只要匹配至少一个分类类别的记录都会被保留。达到分数",
-    "First card from that organization": "该机构的第一张模型卡",
-    "First reporting organization": "首个报告机构",
     "How priority is scored": "优先度如何评分",
-    "Later card, organization already counted": "之后的模型卡,机构已计入",
     "Leaderboard (CSV)": "排行榜 (CSV)",
     "Most represented organizations": "出现最多的机构",
-    "New organization": "新机构",
     "No benchmark is reported by a curated card yet.": "目前还没有精选模型卡报告任何基准。",
     "No corpus entities yet.": "还没有语料实体。",
-    "No dated model-card mentions yet.": "还没有带日期的模型卡提及。",
-    "No dated report": "没有日期记录",
     "No description published at the source.": "来源没有发布描述。",
     "No discovery sources yet.": "还没有发现来源。",
     "No further description beyond the preview above.": "除了上面的预览,没有更多描述。",
     "No organizations identified yet.": "还没有识别出机构。",
-    "No score for this benchmark could be read verbatim from the cited documents, so the chart shows adoption only. An absent value is not a zero and not a plateau.":
-      "引用的文档中读不到该基准的逐字分数,因此图表只显示采用情况。缺失的数值既不是零,也不是平台期。",
     "No source documents in the registry yet.": "登记册中还没有来源文档。",
     "No topics assigned yet.": "还没有分配主题。",
     "Not a verbatim benchmark item. This description paraphrases the official source; open it for exact tasks and protocol.":
       "不是逐字的基准条目。此描述转述自官方来源;请打开它以查看确切的题目与协议。",
     "Not a verbatim benchmark item. This is an illustrative format based on the recorded domain; use the official source for exact tasks and protocol.":
       "不是逐字的基准条目。这是根据记录领域生成的示例格式;请使用官方来源查看确切的题目与协议。",
-    "Only one dated organization is visible so far. It is too early to infer a plateau.":
-      "目前只看到一个有日期的机构。推断平台期还为时过早。",
+    "No score for this benchmark could be read verbatim from the cited documents, so there is no track to draw. An absent value is not a zero and not a plateau.":
+      "无法从引文文档中逐字读到该基准的分数,因此没有可绘制的轨道。缺失的数值既不是零,也不是平台期。",
+    "No score for this benchmark could be read verbatim from the cited documents. An absent value is not a zero and not a plateau.":
+      "无法从引文文档中逐字读到该基准的分数。缺失的数值既不是零,也不是平台期。",
     "Open public discussion ↗": "打开公开讨论 ↗",
     Organizations: "机构",
     "Pinned · click the marker again or press Escape to close": "已固定 · 再次点击标记或按 Escape 关闭",
@@ -739,14 +724,8 @@ const I18N = {
     "Radar first observed": "雷达首次观察到",
     "Read full card ↗": "阅读完整模型卡 ↗",
     Recency: "新鲜度",
-    "Release date unrecorded": "未记录发布日期",
     Released: "发布于",
-    "Released in the newest 18-month window and already reported by several independent organizations.":
-      "在最近 18 个月的窗口内发布,且已被多个独立机构报告。",
     Relevance: "相关性",
-    "Reported across multiple organizations, but not yet a corpus-wide convention in this registry.":
-      "已被多个机构报告,但尚未成为本登记册中的语料级惯例。",
-    "Reporting stage": "报告阶段",
     "Representative task shape": "代表性任务形态",
     "Rubric v": "评分标准 v",
     Score: "分数",
@@ -758,15 +737,13 @@ const I18N = {
     "Solid score connection": "实线分数连接",
     Submissions: "提交数",
     "The current rubric is v": "当前评分标准为 v",
-    "This benchmark has no dated mentions.": "该基准没有带日期的提及。",
     "This historical scan used": "本次历史扫描采用了",
     "This record scores": "该记录得分",
     "This record was scored by rubric v": "该记录由评分标准 v",
-    "Too early to infer a reporting plateau": "推断报告平台期为时尚早",
     "Topic coverage": "主题覆盖",
     Topics: "主题",
     "What this score does not claim": "这个分数的含义之外",
-    "adoption trajectory": "采用轨迹",
+    "reported scores over time": "报告分数随时间的变化",
     after: "之后",
     "an inclusion cutoff. Records below it were not retained.": "为纳入门槛。低于它的记录未被保留。",
     as: "作为",
@@ -776,24 +753,14 @@ const I18N = {
     "cited by": "被引用",
     "connected only at one instrument and protocol": "仅在单一工具与协议连接",
     contributes: "贡献",
-    "count unchanged": "计数不变",
-    "cumulative count increases": "累计计数增加",
-    "cumulative distinct organizations": "累计独立机构",
-    "did not add a new organization to the frontier": "未向前沿新增机构",
-    "distinct orgs": "独立机构",
-    "first dated mention": "首次带日期的提及",
-    "first readable score": "首个可读分数",
-    "has only one dated reporting organization; it is too early to infer a plateau":
-      "只有一个带日期的报告机构;推断平台期还为时过早",
     "here are third parties": "有第三方",
     "here is a third party": "有第三方",
-    "last new organization": "最近新增机构",
     listed: "已列出",
     "no readable score in this window": "此窗口中无可读分数",
     "not yet reported": "尚未报告",
     "points to zero, the floor of this metric": "指向零,该指标的底线",
     protocol: "协议",
-    "publication time": "发布时间",
+    "document publication date": "文档发布日期",
     "quoting another vendor's figure, marked with a ring on the chart":
       "引用另一家供应商的数据,图表中以圆环标出",
     release: "发布",
@@ -803,9 +770,6 @@ const I18N = {
     "same instrument and protocol, one organization only": "单一机构,相同工具与协议",
     "scale. Every number below is read from the same definition the pipeline applies.":
       "的标尺。下面每个数字都按流程应用的同一套定义读取。",
-    "still leaves one frontier step": "仍剩一个前沿台阶",
-    "the previous frontier step": "前一个前沿台阶",
-    "the tick under the jump": "跳变下方的刻度",
     to: "到",
     "to the total": "到总分",
     "two versions are not directly comparable, and past records are not rescored.":
@@ -837,7 +801,6 @@ const I18N = {
     datasets: "数据集",
     evaluations: "评测",
     "times found": "次发现",
-    "with a dated card": "有日期的模型卡",
   },
 };
 
@@ -3016,13 +2979,12 @@ function frontierEvents(entry) {
         a.model.localeCompare(b.model),
     )
     .map((adopter) => {
+      // `advances` still feeds the leaderboard's new-instruments disclosure.
+      // The running total that went with it was the staircase's y value and has
+      // no reader now, so it is not carried.
       const advances = !seenOrganizations.has(adopter.organization);
       seenOrganizations.add(adopter.organization);
-      return {
-        ...adopter,
-        advances,
-        organizationCount: seenOrganizations.size,
-      };
+      return { ...adopter, advances };
     });
 }
 
@@ -3044,51 +3006,23 @@ function frontierAdvances(entry) {
 }
 
 function frontierDefaultEntry(board) {
-  const adopted = (board.entries || []).filter((entry) => entry.card_count > 0);
+  const scored = (board.entries || []).filter(
+    (entry) => entry.card_count > 0 && scoreRecord(entry.benchmark_id),
+  );
+  const datedCount = (entry) => scoreRecord(entry.benchmark_id)?.dated_observation_count || 0;
   const byNewestSignal = (a, b) =>
     (b.released || "").localeCompare(a.released || "") ||
-    frontierAdvances(b).length - frontierAdvances(a).length ||
+    datedCount(b) - datedCount(a) ||
     a.name.localeCompare(b.name);
   // A one-point plot is technically recent but visually says nothing. Open on
-  // the newest instrument that has already crossed three dated organizations;
-  // the full select still makes every early signal reachable and shareable.
-  const newSharedSignals = adopted.filter(
-    (entry) => isNewBenchmark(entry, board) && frontierAdvances(entry).length >= 3,
+  // the newest instrument that already carries three or more dated readings;
+  // the full select still makes every scored benchmark reachable and shareable.
+  const newScoredSignals = scored.filter(
+    (entry) => isNewBenchmark(entry, board) && datedCount(entry) >= 3,
   );
-  if (newSharedSignals.length) return [...newSharedSignals].sort(byNewestSignal)[0];
-  const sharedSignals = adopted.filter((entry) => frontierAdvances(entry).length >= 2);
-  return [...(sharedSignals.length ? sharedSignals : adopted)].sort(byNewestSignal)[0];
-}
-
-function reportingStage(entry, board) {
-  const advances = frontierAdvances(entry).length;
-  const total = Number(board.organization_count || 0);
-  if (advances < 2) {
-    return {
-      id: "early",
-      label: t("Early signal"),
-      description: t("Only one dated organization is visible so far. It is too early to infer a plateau."),
-    };
-  }
-  if (total > 0 && advances / total >= 0.8) {
-    return {
-      id: "saturated",
-      label: t("Saturated reporting"),
-      description: t("At least 80% of organizations in this curated registry report it; that is convention, not quality."),
-    };
-  }
-  if (isNewBenchmark(entry, board) && advances <= 4) {
-    return {
-      id: "emerging",
-      label: t("New & spreading"),
-      description: t("Released in the newest 18-month window and already reported by several independent organizations."),
-    };
-  }
-  return {
-    id: "established",
-    label: t("Established"),
-    description: t("Reported across multiple organizations, but not yet a corpus-wide convention in this registry."),
-  };
+  if (newScoredSignals.length) return [...newScoredSignals].sort(byNewestSignal)[0];
+  const sharedSignals = scored.filter((entry) => datedCount(entry) >= 2);
+  return [...(sharedSignals.length ? sharedSignals : scored)].sort(byNewestSignal)[0];
 }
 
 const BENCHMARK_TASK_SHAPES = {
@@ -3752,15 +3686,13 @@ function externalBenchmarkDetail(shard) {
   ];
 }
 
-// The chart chrome only describes the curated adoption layer, so it is hidden
+// The chart chrome only describes the curated score layer, so it is hidden
 // while an external record occupies the panel. Hiding is the honest direction
 // here: none of those elements could show anything but an empty state for a
 // record the curated registry does not track, and an empty chart reads as "no
-// adoption" where the truth is "not measured by this layer".
+// score" where the truth is "not measured by this layer".
 const CANONICAL_FRONTIER_CHROME = [
-  "frontier-explainer",
   "frontier-explainer-sub",
-  "frontier-summary",
   "frontier-legend",
   "frontier-chart",
   "frontier-org-key",
@@ -3778,19 +3710,20 @@ function setCanonicalFrontierChrome(visible) {
 }
 
 // Shared shell for the three external states (record, loading, unavailable):
-// heading, source badge in place of the reporting stage, the curated picker
-// still offering every canonical benchmark, and the message or detail in the
-// external container.
-function renderExternalShell(board, adopted, { eyebrow, heading, badge, message }) {
+// heading, source badge where the curated path hides it, the curated picker
+// still offering every scored canonical benchmark, and the message or detail
+// in the external container.
+function renderExternalShell(board, scored, { eyebrow, heading, badge, message }) {
   clearFrontierPointSelection();
   setCanonicalFrontierChrome(false);
   byId("frontier-eyebrow").textContent = eyebrow;
   byId("frontier-heading").textContent = heading;
   const stage = byId("frontier-stage");
   stage.className = "frontier-stage";
+  stage.hidden = false;
   stage.textContent = badge;
   replaceChildren(byId("frontier-benchmark"), [
-    ...[...adopted]
+    ...[...scored]
       .sort((a, b) => a.name.localeCompare(b.name))
       .map((entry) => option(entry.benchmark_id, entry.name, false)),
   ]);
@@ -3799,9 +3732,9 @@ function renderExternalShell(board, adopted, { eyebrow, heading, badge, message 
   ]);
 }
 
-function renderExternalBenchmark(board, adopted, record) {
+function renderExternalBenchmark(board, scored, record) {
   const meta = externalSourceMeta(record.source);
-  renderExternalShell(board, adopted, {
+  renderExternalShell(board, scored, {
     eyebrow: t("External catalog record"),
     heading: record.name,
     badge: meta.name,
@@ -3834,28 +3767,40 @@ function renderExternalBenchmark(board, adopted, record) {
 }
 
 function renderBenchmarkNavigator(board) {
-  const adopted = (board.entries || []).filter((entry) => entry.card_count > 0);
-  const stageOrder = [
-    ["emerging", t("New & spreading")],
-    ["early", t("Early signal")],
-    ["established", t("Established")],
-    ["saturated", t("Saturated reporting")],
-  ];
-  const groups = stageOrder
-    .map(([stageId, label]) => {
-      const entries = adopted
-        .filter((entry) => reportingStage(entry, board).id === stageId)
-        .sort(
-          (a, b) =>
-            Number(b.benchmark_id === state.lfrontier) -
-              Number(a.benchmark_id === state.lfrontier) ||
-            (stageId === "emerging" || stageId === "early"
-              ? (b.released || "").localeCompare(a.released || "")
-              : frontierAdvances(b).length - frontierAdvances(a).length) ||
-            (b.released || "").localeCompare(a.released || "") ||
-            a.name.localeCompare(b.name),
-        )
-        .slice(0, stageId === "emerging" ? 4 : 3);
+  const scored = (board.entries || []).filter(
+    (entry) => entry.card_count > 0 && scoreRecord(entry.benchmark_id),
+  );
+  const datedCount = (entry) => scoreRecord(entry.benchmark_id)?.dated_observation_count || 0;
+  // The shortlist is anchored to the score record like the panel it opens: the
+  // newest instruments that already have readable scores, then the deepest
+  // score records in the registry. The adoption stages that used to group it
+  // ("saturated reporting" and friends) described a reading the panel no
+  // longer makes.
+  const newest = scored
+    .filter((entry) => isNewBenchmark(entry, board))
+    .sort(
+      (a, b) =>
+        Number(b.benchmark_id === state.lfrontier) - Number(a.benchmark_id === state.lfrontier) ||
+        (b.released || "").localeCompare(a.released || "") ||
+        a.name.localeCompare(b.name),
+    )
+    .slice(0, 4);
+  const newestIds = new Set(newest.map((entry) => entry.benchmark_id));
+  const deepest = scored
+    .filter((entry) => !newestIds.has(entry.benchmark_id))
+    .sort(
+      (a, b) =>
+        Number(b.benchmark_id === state.lfrontier) - Number(a.benchmark_id === state.lfrontier) ||
+        datedCount(b) - datedCount(a) ||
+        (b.released || "").localeCompare(a.released || "") ||
+        a.name.localeCompare(b.name),
+    )
+    .slice(0, 4);
+  const groups = [
+    [t("New instruments with scores"), newest],
+    [t("Deepest score records"), deepest],
+  ]
+    .map(([label, entries]) => {
       if (!entries.length) return null;
       return element("section", { className: "benchmark-shortlist-group" }, [
         element("h3", { text: label }),
@@ -3872,7 +3817,7 @@ function renderBenchmarkNavigator(board) {
             }, [
               element("span", { text: entry.name }),
               element("small", {
-                text: `${metricLabel(frontierAdvances(entry).length, "dated organization")}`,
+                text: metricLabel(scoreRecord(entry.benchmark_id).observation_count, "readable score"),
               }),
             ]);
             button.addEventListener("click", () => {
@@ -3889,69 +3834,6 @@ function renderBenchmarkNavigator(board) {
   replaceChildren(byId("benchmark-shortlist"), groups);
   initBenchmarkSearch();
   renderBenchmarkSearch();
-}
-
-function daysBetween(start, end) {
-  if (!start || !end) return null;
-  return Math.max(
-    0,
-    Math.round(
-      (new Date(`${end}T00:00:00Z`) - new Date(`${start}T00:00:00Z`)) / 86_400_000,
-    ),
-  );
-}
-
-function renderFrontierMilestones(entry, events) {
-  const advances = events.filter((event) => event.advances);
-  const repeats = events.length - advances.length;
-  const list = element(
-    "ol",
-    { className: "frontier-milestone-list" },
-    advances.map((event, index) => {
-      const previousDate = index ? advances[index - 1].published : entry.released;
-      const elapsed = daysBetween(previousDate, event.published);
-      return element("li", {}, [
-        element("span", { className: "milestone-number", text: index + 1 }),
-        element("div", {}, [
-          element("p", {
-            className: "milestone-date",
-            text: `${formatDate(event.published, { dateStyle: "medium" })}${
-              elapsed === null
-                ? ""
-                : ` · ${metricLabel(elapsed, "day")} ${t("after")} ${
-                    index ? t("the previous frontier step") : t("release")
-                  }`
-            }`,
-          }),
-          element("a", {
-            className: "milestone-source",
-            text: event.organization,
-            attrs: {
-              href: safeHttpUrl(event.url),
-              target: "_blank",
-              rel: "noopener noreferrer",
-            },
-          }),
-          element("span", { className: "milestone-model", text: event.model }),
-        ]),
-      ]);
-    }),
-  );
-  replaceChildren(byId("frontier-milestones"), [
-    entry.released
-      ? element("p", {
-          className: "milestone-release",
-          text: `${t("Released")} ${formatDate(entry.released, { dateStyle: "medium" })}`,
-        })
-      : null,
-    list,
-    repeats
-      ? element("p", {
-          className: "milestone-repeat-note",
-          text: `${metricLabel(repeats, "repeat report")} ${t("did not add a new organization to the frontier")}.`,
-        })
-      : null,
-  ]);
 }
 
 function renderFrontierTaskPreview(entry) {
@@ -3994,50 +3876,6 @@ function renderFrontierTaskPreview(entry) {
         })
       : null,
   ]);
-}
-
-function sparseFrontier(entry, events) {
-  const first = events.find((event) => event.advances);
-  const repeatCount = Math.max(0, events.length - 1);
-  return element(
-    "div",
-    {
-      className: "frontier-sparse",
-      attrs: {
-        role: "img",
-        "aria-label": `${entry.name} ${t("has only one dated reporting organization; it is too early to infer a plateau")}.`,
-      },
-    },
-    [
-      element("div", { className: "frontier-sparse-step is-complete" }, [
-        element("span", { text: "01" }),
-        element("strong", { text: t("Benchmark released") }),
-        element("small", {
-          text: entry.released
-            ? formatDate(entry.released, { dateStyle: "medium" })
-            : t("Release date unrecorded"),
-        }),
-      ]),
-      element("div", { className: "frontier-sparse-step is-complete" }, [
-        element("span", { text: "02" }),
-        element("strong", { text: t("First reporting organization") }),
-        element("small", {
-          text: first
-            ? `${first.organization} · ${formatDate(first.published, { dateStyle: "medium" })}`
-            : t("No dated report"),
-        }),
-      ]),
-      element("div", { className: "frontier-sparse-step is-awaiting" }, [
-        element("span", { text: "03" }),
-        element("strong", { text: t("Awaiting an independent second organization") }),
-        element("small", {
-          text: repeatCount
-            ? `${metricLabel(repeatCount, "later repeat")} ${t("still leaves one frontier step")}`
-            : t("Too early to infer a reporting plateau"),
-        }),
-      ]),
-    ],
-  );
 }
 
 // --- Score progression (issue #91) ------------------------------------------
@@ -4153,12 +3991,14 @@ function renderScoreReadout(entry) {
   const host = byId("frontier-score-readout");
   if (!host) return;
   const record = scoreRecord(entry.benchmark_id);
+  // Unreachable on the canonical path (the picker only lists scored benchmarks),
+  // but the message stays honest rather than naming a chart that does not draw.
   if (!record) {
     replaceChildren(host, [
       element("p", {
         className: "score-readout-empty",
         text:
-          t("No score for this benchmark could be read verbatim from the cited documents, so the chart shows adoption only. An absent value is not a zero and not a plateau."),
+          t("No score for this benchmark could be read verbatim from the cited documents. An absent value is not a zero and not a plateau."),
       }),
     ]);
     return;
@@ -4439,34 +4279,14 @@ function enableFrontierTouchTargets(svg) {
   }, true);
 }
 
-// A legend keyed to the marks actually on the chart. The panel previously relied
-// on the prose explainer to say what orange versus gray meant, which put the key
-// several lines away from the thing it explains; issue #91 reports readers taking
-// the two for equivalent kinds of point. Each entry names the mark AND what it
-// does to the count, because "new organization" alone does not say that the other
-// kind leaves the staircase flat.
-// `sparse` suppresses the staircase and the rug in favour of the step list, so
-// their legend entries are suppressed with them: a key describing marks that are
-// not on screen is worse than no key, and many shipped benchmarks take that path.
-function renderFrontierLegend(entry, record, { sparse = false } = {}) {
+// A legend keyed to the marks actually on the chart. Only score marks remain:
+// the staircase and rug keys went with their bands, since a key describing
+// marks that are not on screen is worse than no key.
+function renderFrontierLegend(entry, record) {
   const host = byId("frontier-legend");
   if (!host) return;
   const swatch = (className) => element("span", { className: `legend-swatch ${className}` });
-  const items = sparse
-    ? []
-    : [
-        ["legend-swatch-point", t("New organization"), t("cumulative count increases")],
-        [
-          "legend-swatch-tick-first",
-          t("First card from that organization"),
-          t("the tick under the jump"),
-        ],
-        [
-          "legend-swatch-tick-repeat",
-          t("Later card, organization already counted"),
-          t("count unchanged"),
-        ],
-      ];
+  const items = [];
   if (record) {
     items.push([
       "legend-swatch-score",
@@ -4500,23 +4320,22 @@ function renderFrontierLegend(entry, record, { sparse = false } = {}) {
   );
 }
 
-// The per-organization color key under the chart. Each reporting organization
-// gets a small circular chip in its frontier color carrying its real brand
-// glyph, so the reader can map a colored circle on the staircase back to a name
-// without hovering (issue #178, HLE/harbor style). Built from the organizations
-// that actually have a dated card on this benchmark, in first-report order.
-function renderFrontierOrgKey(entry, events) {
+// The per-organization color key under the chart. Each organization with a
+// plotted score gets a small circular chip in its frontier color carrying its
+// brand glyph, so the reader can map a colored glyph on the chart back to a
+// name without hovering (issue #178, HLE/harbor style). Built from the score
+// record itself, whose observations are in date order: an organization whose
+// card carried no readable number is not keyed to a chart it does not appear
+// on.
+function renderFrontierOrgKey(record) {
   const host = byId("frontier-org-key");
   if (!host) return;
   const ordered = [];
   const seen = new Set();
-  const dated = (entry.adopters || [])
-    .filter((adopter) => adopter.published)
-    .sort((a, b) => a.published.localeCompare(b.published));
-  for (const adopter of dated) {
-    if (seen.has(adopter.organization)) continue;
-    seen.add(adopter.organization);
-    ordered.push(adopter);
+  for (const observation of record?.observations || []) {
+    if (seen.has(observation.organization)) continue;
+    seen.add(observation.organization);
+    ordered.push(observation.organization);
   }
   if (!ordered.length) {
     replaceChildren(host, []);
@@ -4524,8 +4343,7 @@ function renderFrontierOrgKey(entry, events) {
   }
   replaceChildren(
     host,
-    ordered.map((adopter) => {
-      const org = adopter.organization;
+    ordered.map((org) => {
       const glyph = svgElement("svg", {
         viewBox: "0 0 24 24",
         class: "frontier-org-key-glyph",
@@ -4549,86 +4367,65 @@ function renderFrontierOrgKey(entry, events) {
   );
 }
 
-// `sparse` means the adoption stepper is being rendered separately because it has
-// fewer than two frontier advances. The score track still draws, on its own axis,
-// so a thin adoption layer never hides a readable score.
-function adoptionFrontierChart(entry, board, events, { sparse = false } = {}) {
-  const datedCards = (board.model_cards || []).filter((card) => card.published);
+// The saturation curve: every score read verbatim from a cited document, on a
+// publication-time axis. The adoption staircase that used to lead this chart
+// was retired: a staircase of who reported when answers a different question,
+// and the score track carries strictly more of what a reader came for. So the
+// score band now gets the full height the staircase, the card rug, and the
+// inter-band gaps vacated, and the only marks on the chart are the scores, the
+// connections the join rule permits, and the reading gap.
+function scoreTrackChart(entry, board) {
   const record = scoreRecord(entry.benchmark_id);
-  // `events` may be empty when only the score track is being drawn, so both
-  // bounds are computed from whatever dates exist rather than indexing into it.
-  const startText = [entry.released, events[0]?.published, record?.first_reported_at]
-    .filter(Boolean)
-    .sort()[0];
-  // Symmetric with `startText`: the range has to cover the score track as well
-  // as the adoption track, or a score dated after the newest card -- reachable
-  // when a card carries a later `revised` date -- lands outside the viewBox and
-  // is silently clipped. Both ends therefore consider both layers.
-  const endText = [
-    events.length ? datedCards.map((card) => card.published).sort().at(-1) : null,
-    events.at(-1)?.published,
-    record?.last_reported_at,
-  ]
-    .filter(Boolean)
-    .sort()
-    .at(-1);
+  // Callers only ever select a benchmark that has a score record; this guard is
+  // for the defensive case, since a chart with no points reads as "scores went
+  // to zero here", which is worse than no chart.
+  if (!record) return null;
+  // This benchmark's own dated mentions are not drawn, but the newest one still
+  // bounds the reading-gap marker below: "still mentioned, nothing newer could
+  // be read" is a claim that needs the mention date. The registry-wide newest
+  // card is never consulted: an unrelated vendor's recent document is not
+  // evidence that this benchmark went unread (shipped Arena-Hard and Aider
+  // Polyglot have no adopter newer than their last score).
+  const lastMention = frontierEvents(entry).at(-1)?.published;
+  const startText = record.first_reported_at;
+  const endText = [lastMention, record.last_reported_at].filter(Boolean).sort().at(-1);
   const start = new Date(`${startText}T00:00:00Z`).getTime();
   const rawEnd = new Date(`${endText}T00:00:00Z`).getTime();
   const end = Math.max(rawEnd, start + 86_400_000);
   // A narrower viewBox on a narrow viewport. `width: 100%` scales height with
   // width, so a 920-unit box at 390px CSS pixels rendered the whole chart about
-  // 90px tall and the staircase became unreadable. Halving the coordinate width
+  // 90px tall and the marks became unreadable. Halving the coordinate width
   // lets the same content scale up rather than being squashed; distorting the
   // aspect ratio instead would stretch the axis text illegibly.
   const narrow = typeof window !== "undefined" && window.innerWidth <= 760;
   const width = narrow ? 520 : 920;
-  // The score band is only reserved when there is a score to draw. A benchmark
-  // with no readable value gets the original single-plot height rather than an
-  // empty lower half, which would read as "scores went to zero here".
-  const band = record ? scoreBand(record) : null;
-  const scoreHeight = record ? 132 : 0;
-  const bandGap = record ? 34 : 0;
-  // The left margin widens when a score band is present: its axis label is a
-  // metric name ("resolved", "pass@1") rather than the fixed "organizations
-  // reporting", and a 52px gutter clipped the longer ones at the viewBox edge.
-  const margin = { top: 32, right: 20, bottom: 62, left: record ? 68 : 52 };
+  const band = scoreBand(record);
+  // 480 = the old staircase plot (276) plus the band gap (34), the card rug
+  // (26) and its gap (12), over the old 132-unit strip. The y-axis is zoomed to
+  // the observed range, so the vacated height is vertical resolution for the
+  // one thing about this band a reader must not misjudge.
+  const scoreHeight = 480;
+  // The left margin is wider than the site's other charts because the axis
+  // label is a metric name ("resolved", "pass@1") rather than a fixed word,
+  // and a 52px gutter clipped the longer ones at the viewBox edge.
+  const margin = { top: 32, right: 20, bottom: 62, left: 68 };
   const plotWidth = width - margin.left - margin.right;
-  // The adoption plot collapses to nothing when its stepper is drawn separately,
-  // so the SVG carries no empty region where the step line would have been.
-  const plotHeight = sparse ? 0 : 370 - margin.top - margin.bottom;
-  // The card rug: one tick per model card, on its own band under the staircase.
-  // Repeat cards used to be plotted *on* the count axis at the running total,
-  // which put a marker at a height the card did not cause -- a card that changed
-  // nothing sat at the same y as the advance that did. Worse, several cards
-  // sharing a date stacked into each other and occluded the numbers. Giving card
-  // events their own band separates "how many organizations by this date" from
-  // "when were the cards published", which is the whole confusion in issue #91.
-  const rugHeight = sparse || !events.length ? 0 : 26;
-  const rugGap = rugHeight ? 12 : 0;
-  const height =
-    margin.top + plotHeight + rugGap + rugHeight + bandGap + scoreHeight + margin.bottom;
-  const rugTop = margin.top + plotHeight + rugGap;
-  const maxOrganizations = Math.max(1, Number(board.organization_count || 0));
+  const height = margin.top + scoreHeight + margin.bottom;
   const x = (date) =>
     margin.left +
     ((new Date(`${date}T00:00:00Z`).getTime() - start) / (end - start)) * plotWidth;
-  const y = (count) => margin.top + plotHeight - (count / maxOrganizations) * plotHeight;
-  // The score plot sits below the adoption plot and shares its x scale, which is
-  // the whole point: the two readings are only comparable if a vertical line
-  // through the chart means one date in both.
-  const scoreTop = margin.top + plotHeight + rugGap + rugHeight + bandGap;
+  const scoreTop = margin.top;
   // Better is always up. `direction` exists in the schema precisely so a metric
   // where lower wins (an edit distance, an error rate) does not render its
   // improvements as a downward slope; consulting it here is what makes the axis
   // mean "better" rather than "larger".
-  const scoreDescends = record?.direction === "lower_is_better";
+  const scoreDescends = record.direction === "lower_is_better";
   const scoreY = (value) => {
-    if (!band || band.high <= band.low) return scoreTop + scoreHeight / 2;
+    if (band.high <= band.low) return scoreTop + scoreHeight / 2;
     const fraction = (value - band.low) / (band.high - band.low);
     const fromFloor = scoreDescends ? 1 - fraction : fraction;
     return scoreTop + scoreHeight - fromFloor * scoreHeight;
   };
-  const advances = events.filter((event) => event.advances);
 
   const svg = svgElement("svg", {
     viewBox: `0 0 ${width} ${height}`,
@@ -4636,220 +4433,15 @@ function adoptionFrontierChart(entry, board, events, { sparse = false } = {}) {
     // accessibility tree, which would hide the interactive marker buttons.
     role: "group",
     "aria-label":
-      (events.length
-        ? `${entry.name} reporting adoption over time. ${advances.length} of ` +
-          `${board.organization_count} organizations have a dated report.`
-        : `${entry.name} readable scores over time. No mention of it carries a date, so no ` +
-          "adoption timeline is shown.") +
-      (record
-        ? ` ${events.length ? "Below it, " : ""}${metricLabel(
-            record.observation_count,
-            "readable score",
-          )} from ${formatDate(record.first_reported_at, { dateStyle: "medium" })} to ` +
-          `${formatDate(record.last_reported_at, { dateStyle: "medium" })}, best ` +
-          `${record.saturation.best_value}.`
-        : " No readable score for this benchmark."),
+      `${entry.name} readable scores over time. ${metricLabel(
+        record.observation_count,
+        "readable score",
+      )} from ${formatDate(record.first_reported_at, { dateStyle: "medium" })} to ` +
+      `${formatDate(record.last_reported_at, { dateStyle: "medium" })}, best ` +
+      `${record.saturation.best_value}.`,
   });
-  // The adoption plot. Skipped entirely when its stepper is rendered separately:
-  // a step line with fewer than two advances says nothing a reader can use.
-  if (!sparse) {
-    const tickStep = Math.max(1, Math.ceil(maxOrganizations / 5));
-    const tickValues = new Set([0, maxOrganizations]);
-    for (let count = tickStep; count < maxOrganizations; count += tickStep) {
-      tickValues.add(count);
-    }
-    for (const count of [...tickValues].sort((a, b) => a - b)) {
-      const yPosition = y(count);
-      svg.append(
-        svgElement("line", {
-          x1: margin.left,
-          y1: yPosition,
-          x2: width - margin.right,
-          y2: yPosition,
-          class: "frontier-grid",
-        }),
-      );
-      svg.append(
-        svgElement(
-          "text",
-          { x: margin.left - 12, y: yPosition + 4, "text-anchor": "end", class: "frontier-tick" },
-          count,
-        ),
-      );
-    }
 
-    let path = `M ${x(startText)} ${y(0)}`;
-    for (const event of advances) {
-      path += ` H ${x(event.published)} V ${y(event.organizationCount)}`;
-    }
-    path += ` H ${x(endText)}`;
-    svg.append(svgElement("path", { d: path, class: "frontier-line" }));
-
-    // Diamonds at the jumps, and only at the jumps. The marker number is gone: it
-    // restated the y-axis value the marker already sits at, and a digit inside a
-    // circle reads as a record id, so readers took the staircase for a numbered
-    // list of points rather than a cumulative count.
-    for (const event of advances) {
-      const pointX = x(event.published);
-      const pointY = y(event.organizationCount);
-      const group = svgElement("g", {
-        class: "frontier-point frontier-point-advance",
-        tabindex: "0",
-        role: "button",
-        "aria-pressed": "false",
-        "data-frontier-point": "",
-        "aria-label":
-          `${event.organization} first reported it ${formatDate(event.published, {
-            dateStyle: "medium",
-          })} with ${event.model}, taking the count to ${event.organizationCount}. ` +
-          "Click to pin record details.",
-      });
-      const r = 8;
-      const orgColor = organizationColor(event.organization);
-      group.append(
-        svgElement("circle", {
-          cx: pointX,
-          cy: pointY,
-          r,
-          style: `fill: ${orgColor}`,
-          class: "frontier-point-face",
-        }),
-      );
-      group.append(brandGlyph(event.organization, pointX, pointY, r * 1.6, "frontier-point-glyph"));
-      makeFrontierPointInteractive(group, {
-        kind: "New organization",
-        title: `${event.organization} · ${event.model}`,
-        rows: [
-          { label: "Organization", value: event.organization },
-          { label: "Model", value: event.model },
-          {
-            label: "Date",
-            value: formatDate(event.published, { dateStyle: "medium" }),
-          },
-          {
-            label: "Adoption",
-            value: `First report · cumulative count ${event.organizationCount}`,
-          },
-          {
-            label: "Source",
-            value: String(event.document_type || "model card").replaceAll("_", " "),
-          },
-        ],
-        url: event.url,
-      });
-      svg.append(group);
-    }
-  }
-
-  // The card rug. Every card gets exactly one tick, so a date carrying several
-  // cards shows several ticks side by side instead of a pile of circles on the
-  // staircase. Orange marks a first report, gray a later card from an
-  // organization already counted.
-  if (rugHeight) {
-    svg.append(
-      svgElement("line", {
-        x1: margin.left,
-        y1: rugTop + rugHeight / 2,
-        x2: width - margin.right,
-        y2: rugTop + rugHeight / 2,
-        class: "card-rug-baseline",
-      }),
-    );
-    // Tick positions are allocated across every card at once, not per date. Two
-    // earlier versions were wrong in the same way at different scales: x(date)
-    // alone overpainted cards sharing a date, and fanning each date independently
-    // then pushed those ticks into a *neighbouring* date's -- on shipped GPQA
-    // Diamond at the narrow viewBox a fanned 2026-02-11 tick landed 0.04 units
-    // from the 2026-02-16 tick, inside a 2.5-unit stroke, so one still vanished
-    // and swallowed the other's hover target. One-day-apart pairs collided at
-    // desktop width too.
-    //
-    // So this is a single left-to-right sweep that keeps every tick at least a
-    // stroke-width apart, then shifts the whole run back by half its total drift
-    // to keep the group centred on the dates it represents. Ticks stay in date
-    // order and no two can occupy the same pixel, which is the guarantee the rug
-    // exists to make; a tick may sit a fraction of a unit off its exact date, and
-    // that is the honest trade, since a hidden card is a lost observation while a
-    // 3px nudge is not.
-    const MIN_TICK_GAP = 3.5;
-    const positions = [];
-    let previous = -Infinity;
-    for (const event of events) {
-      const ideal = x(event.published);
-      const placed = Math.max(ideal, previous + MIN_TICK_GAP);
-      positions.push(placed);
-      previous = placed;
-    }
-    const drift = positions.length ? positions[positions.length - 1] - x(events[events.length - 1].published) : 0;
-    const shift = drift / 2;
-    for (const [index, event] of events.entries()) {
-      const tickX = positions[index] - shift;
-      const group = svgElement("g", {
-        class: `card-rug-tick${event.advances ? " card-rug-tick-first" : " card-rug-tick-repeat"}`,
-        tabindex: "0",
-        role: "button",
-        "aria-pressed": "false",
-        "data-frontier-point": "",
-        "aria-label":
-          `${event.organization}, ${event.model}, ${formatDate(event.published, {
-            dateStyle: "medium",
-          })}` +
-          (event.advances
-            ? ", first report from this organization"
-            : ", later card from an organization already counted"),
-      });
-      // A first report gets a full-height tick, a repeat a short one, so the two
-      // are distinguishable without relying on colour alone.
-      const halfHeight = event.advances ? rugHeight / 2 : rugHeight / 4;
-      group.append(
-        svgElement("line", {
-          x1: tickX,
-          y1: rugTop + rugHeight / 2 - halfHeight,
-          x2: tickX,
-          y2: rugTop + rugHeight / 2 + halfHeight,
-        }),
-      );
-      makeFrontierPointInteractive(group, {
-        kind: event.advances ? "First report card" : "Repeat report card",
-        title: `${event.organization} · ${event.model}`,
-        rows: [
-          { label: "Organization", value: event.organization },
-          { label: "Model", value: event.model },
-          {
-            label: "Date",
-            value: formatDate(event.published, { dateStyle: "medium" }),
-          },
-          {
-            label: "Adoption",
-            value: event.advances
-              ? `First report · cumulative count ${event.organizationCount}`
-              : `Later card · cumulative count unchanged at ${event.organizationCount}`,
-          },
-          {
-            label: "Source",
-            value: String(event.document_type || "model card").replaceAll("_", " "),
-          },
-        ],
-        url: event.url,
-      });
-      svg.append(group);
-    }
-    svg.append(
-      svgElement(
-        "text",
-        {
-          x: 17,
-          y: rugTop + rugHeight / 2,
-          transform: `rotate(-90 17 ${rugTop + rugHeight / 2})`,
-          "text-anchor": "middle",
-          class: "frontier-axis-label",
-        },
-        "cards",
-      ),
-    );
-  }
-
-  if (record) {
+  {
     // Band bounds, not 0-100: every value in this corpus sits in the upper part
     // of its scale, so the axis is zoomed and says so on both ticks.
     for (const value of [band.high, band.low]) {
@@ -5010,11 +4602,6 @@ function adoptionFrontierChart(entry, board, events, { sparse = false } = {}) {
     // that this benchmark went unread: shipped Arena-Hard and Aider Polyglot have
     // no adopter newer than their last score, so ending at the global date drew a
     // long gap that nothing about those benchmarks supported.
-    const lastMention = events
-      .map((event) => event.published)
-      .filter(Boolean)
-      .sort()
-      .at(-1);
     const lastScoreX = x(record.last_reported_at);
     const endX = x(
       lastMention && lastMention > record.last_reported_at ? lastMention : record.last_reported_at,
@@ -5043,13 +4630,20 @@ function adoptionFrontierChart(entry, board, events, { sparse = false } = {}) {
           }),
         );
       }
+      // Centred on the span, except when the span runs to the end of the axis:
+      // a centred label there puts half its width past the right gutter and the
+      // viewBox clips it, which on shipped GPQA Diamond left the reader with
+      // "NO READABLE SCORE IN THI". Anchoring to the span's right end instead
+      // keeps the whole string inside without measuring text, which is not
+      // available on a detached SVG and would differ per locale anyway.
+      const gapReachesAxisEnd = endX >= margin.left + plotWidth - 1;
       svg.append(
         svgElement(
           "text",
           {
-            x: (lastScoreX + endX) / 2,
+            x: gapReachesAxisEnd ? endX : (lastScoreX + endX) / 2,
             y: scoreTop + scoreHeight + 18,
-            "text-anchor": "middle",
+            "text-anchor": gapReachesAxisEnd ? "end" : "middle",
             class: "score-gap-label",
           },
           t("no readable score in this window"),
@@ -5078,29 +4672,6 @@ function adoptionFrontierChart(entry, board, events, { sparse = false } = {}) {
     );
   }
 
-  const releaseX = entry.released ? x(entry.released) : x(startText);
-  svg.append(
-    svgElement("line", {
-      x1: releaseX,
-      y1: margin.top,
-      // Spans both plots when a score band exists, so the release date reads as
-      // one moment in the benchmark's life rather than as two unrelated marks.
-      x2: releaseX,
-      y2: record ? scoreTop + scoreHeight : rugTop + rugHeight,
-      class: "frontier-release-line",
-    }),
-  );
-  svg.append(
-    svgElement(
-      "text",
-      { x: releaseX + 8, y: margin.top + 14, class: "frontier-release-label" },
-      entry.released
-        ? t("release")
-        : events.length
-          ? t("first dated mention")
-          : t("first readable score"),
-    ),
-  );
   for (const [date, anchor] of [
     [startText, "start"],
     [endText, "end"],
@@ -5113,51 +4684,15 @@ function adoptionFrontierChart(entry, board, events, { sparse = false } = {}) {
       ),
     );
   }
-  if (!sparse) {
-    svg.append(
-      svgElement(
-        "text",
-        {
-          x: 15,
-          y: margin.top + plotHeight / 2,
-          transform: `rotate(-90 15 ${margin.top + plotHeight / 2})`,
-          "text-anchor": "middle",
-          class: "frontier-axis-label",
-        },
-        // Named for what the axis counts. "Organizations reporting" invited the
-        // reading that a repeat card adds to it; "cumulative distinct" says in the
-        // label itself that a second card from a counted vendor moves nothing.
-        // Shortened on a narrow viewport, where the rotated full text is longer
-        // than the plot is tall and would be clipped at the viewBox edge.
-        narrow ? t("distinct orgs") : t("cumulative distinct organizations"),
-      ),
-    );
-  }
   svg.append(
     svgElement(
       "text",
       { x: margin.left + plotWidth / 2, y: height - 7, "text-anchor": "middle", class: "frontier-axis-label" },
-      t("publication time"),
+      t("document publication date"),
     ),
   );
   enableFrontierTouchTargets(svg);
   return svg;
-}
-
-// The score track alone, for a benchmark whose every mention is undated. Delegates
-// to the same renderer with no adoption events rather than duplicating the score
-// geometry: two implementations of one axis would be free to disagree about the
-// join rule, which is the one thing this chart must not do.
-function scoreOnlyChart(entry, board) {
-  return adoptionFrontierChart(
-    entry,
-    // `organization_count` is only read for the adoption axis, which is suppressed
-    // here. Keep the real card roster so score tooltips can resolve their source
-    // labels and links even when no dated adoption event can be drawn.
-    board,
-    [],
-    { sparse: true },
-  );
 }
 
 function clearAdoptionFrontier(message) {
@@ -5166,10 +4701,12 @@ function clearAdoptionFrontier(message) {
   // restored here rather than at each call site: an external selection that
   // hid it must not leave the next canonical render missing its chart blocks.
   setCanonicalFrontierChrome(true);
-  byId("frontier-eyebrow").textContent = t("Reporting over time");
-  byId("frontier-stage").textContent = "";
-  replaceChildren(byId("frontier-summary"), []);
-  replaceChildren(byId("frontier-milestones"), []);
+  byId("frontier-eyebrow").textContent = t("The saturation curve");
+  const stage = byId("frontier-stage");
+  stage.textContent = "";
+  // The badge only carries the source name on the external path; an empty one
+  // would render as a bare outline beside the picker.
+  stage.hidden = true;
   replaceChildren(byId("frontier-task-preview"), []);
   replaceChildren(byId("frontier-score-readout"), []);
   replaceChildren(byId("frontier-legend"), []);
@@ -5184,9 +4721,15 @@ function clearAdoptionFrontier(message) {
 
 function renderAdoptionFrontier(board) {
   const adopted = (board.entries || []).filter((entry) => entry.card_count > 0);
+  // The panel is the saturation curve now, so a benchmark enters the picker
+  // only when a score could be read verbatim from a cited document. 20 of the
+  // 79 adopted benchmarks carry card mentions without a single readable score;
+  // with the adoption staircase retired they would render an empty panel, so
+  // they are absent here and a permalink to one falls back to the default.
+  const scored = adopted.filter((entry) => scoreRecord(entry.benchmark_id));
   const defaultEntry = frontierDefaultEntry(board);
-  if (!adopted.length || !defaultEntry) {
-    clearAdoptionFrontier(t("No dated model-card mentions yet."));
+  if (!scored.length || !defaultEntry) {
+    clearAdoptionFrontier(t("No benchmark in this registry has a readable score yet."));
     return;
   }
   // Resolution order is the permalink contract (display plan step 6): an exact
@@ -5198,17 +4741,43 @@ function renderAdoptionFrontier(board) {
     : null;
   if (slugRecord) {
     renderBenchmarkNavigator(board);
-    renderExternalBenchmark(board, adopted, slugRecord);
+    renderExternalBenchmark(board, scored, slugRecord);
     return;
   }
-  let entry = adopted.find((candidate) => candidate.benchmark_id === state.lfrontier);
+  // A canonical id that the registry knows but the score layer does not. Before
+  // the panel became the score track this resolved and drew an adoption
+  // staircase, so links to these 20 benchmarks are already out there. Falling
+  // through to the default would show a different benchmark under the reader's
+  // own URL with nothing to say so, which is worse than an explicit refusal.
+  // The index is not consulted: a canonical id and an external slug are separate
+  // namespaces (every slug is source-prefixed), so no pending fetch can change
+  // this answer.
+  const unscoredEntry = state.lfrontier
+    ? adopted.find(
+        (candidate) =>
+          candidate.benchmark_id === state.lfrontier && !scoreRecord(candidate.benchmark_id),
+      )
+    : null;
+  if (unscoredEntry) {
+    renderBenchmarkNavigator(board);
+    renderExternalShell(board, scored, {
+      eyebrow: t("The saturation curve"),
+      heading: unscoredEntry.name,
+      badge: "",
+      message: t(
+        "No score for this benchmark could be read verbatim from the cited documents, so there is no track to draw. An absent value is not a zero and not a plateau.",
+      ),
+    });
+    return;
+  }
+  let entry = scored.find((candidate) => candidate.benchmark_id === state.lfrontier);
   if (!entry && state.lfrontier && !state.benchmarkIndexLoaded) {
     // A permalink whose index is still on the wire. Hold the selection and say
     // so: snapping to the default now would rewrite the reader's URL before
     // the slug could even be checked, and initBenchmarkSearch re-renders this
     // panel when the fetch settles.
     renderBenchmarkNavigator(board);
-    renderExternalShell(board, adopted, {
+    renderExternalShell(board, scored, {
       eyebrow: t("External catalog record"),
       heading: state.lfrontier,
       badge: "",
@@ -5220,7 +4789,7 @@ function renderAdoptionFrontier(board) {
     // The index fetch failed, so a slug can never resolve. The panel says so
     // outright; the selection and the URL stay as the reader wrote them.
     renderBenchmarkNavigator(board);
-    renderExternalShell(board, adopted, {
+    renderExternalShell(board, scored, {
       eyebrow: t("External catalog record"),
       heading: state.lfrontier,
       badge: "",
@@ -5234,9 +4803,15 @@ function renderAdoptionFrontier(board) {
     entry = defaultEntry;
   }
   setCanonicalFrontierChrome(true);
-  byId("frontier-eyebrow").textContent = t("Reporting over time");
+  byId("frontier-eyebrow").textContent = t("The saturation curve");
+  // The stage badge is an adoption reading ("Saturated reporting" is a judgement
+  // about who reports, not about scores), so the canonical path leaves it empty
+  // and hidden. The external path reuses the element for the source name.
+  const stageBadge = byId("frontier-stage");
+  stageBadge.textContent = "";
+  stageBadge.hidden = true;
   replaceChildren(byId("frontier-benchmark"), [
-    ...[...adopted]
+    ...[...scored]
       .sort((a, b) => a.name.localeCompare(b.name))
       .map((candidate) =>
         option(candidate.benchmark_id, candidate.name, candidate.benchmark_id === state.lfrontier),
@@ -5244,70 +4819,13 @@ function renderAdoptionFrontier(board) {
   ]);
   renderBenchmarkNavigator(board);
 
-  byId("frontier-heading").textContent = `${entry.name} ${t("adoption trajectory")}`;
-  const events = frontierEvents(entry);
-  if (!events.length) {
-    // No dated mention means no adoption timeline can be drawn. The score
-    // reading is independent of that, though: the registry permits a card
-    // without a `published` date, and clearing the panel outright would hide
-    // every readable score because the *other* layer had no usable date. So the
-    // score track still draws, on its own, with the points and comparable series
-    // intact rather than reduced to the aggregate readout.
-    clearAdoptionFrontier(t("This benchmark has no dated mentions."));
-    const record = scoreRecord(entry.benchmark_id);
-    renderFrontierLegend(entry, record, { sparse: true });
-    if (record) {
-      replaceChildren(byId("frontier-chart"), [scoreOnlyChart(entry, board), frontierTooltip()]);
-    }
-    renderScoreReadout(entry);
-    return;
-  }
-
-  const frontier = events.filter((event) => event.advances);
-  const lastAdvance = frontier.at(-1);
-  const stage = reportingStage(entry, board);
-  const stageElement = byId("frontier-stage");
-  stageElement.className = `frontier-stage frontier-stage-${stage.id}`;
-  stageElement.textContent = `${t("Reporting stage")} · ${stage.label}`;
-  replaceChildren(byId("frontier-summary"), [
-    element("strong", { text: entry.name }),
-    // "23 cards · 10 of 10 dated organizations" read as one ratio about a single
-    // quantity. They are two different counts, so they are now named separately.
-    //
-    // The organization count is qualified as "dated" when some card carries no
-    // publication date: `card_count` includes those cards but `frontier` cannot,
-    // so an unqualified "distinct organizations" beside the card total would imply
-    // the two were counted over the same set of documents.
-    element("span", {
-      text:
-        `${metricLabel(entry.card_count, "model card")} · ` +
-        `${metricLabel(frontier.length, "distinct organization")}` +
-        ((entry.adopters || []).some((adopter) => !adopter.published) ? ` ${t("with a dated card")}` : ""),
-    }),
-    element("span", {
-      text: `${t("last new organization")} ${formatDate(lastAdvance.published, { dateStyle: "medium" })}`,
-    }),
-    element("span", { className: "frontier-stage-description", text: stage.description }),
-  ]);
-  // A single-advance adoption step line says nothing visually, which is why the
-  // sparse stepper replaces it. The score track is a separate reading though, so
-  // when one exists it is still drawn: dropping it would hide real data because a
-  // *different* layer was thin.
-  const sparse = frontier.length < 2;
-  const scored = Boolean(scoreRecord(entry.benchmark_id));
-  renderFrontierLegend(entry, scoreRecord(entry.benchmark_id), { sparse });
-  renderFrontierOrgKey(entry, events);
+  byId("frontier-heading").textContent = `${entry.name} ${t("reported scores over time")}`;
+  const record = scoreRecord(entry.benchmark_id);
+  renderFrontierLegend(entry, record);
+  renderFrontierOrgKey(record);
   clearFrontierPointSelection();
-  replaceChildren(byId("frontier-chart"), [
-    sparse ? sparseFrontier(entry, events) : null,
-    sparse && !scored ? null : adoptionFrontierChart(entry, board, events, { sparse }),
-    sparse && !scored ? null : frontierTooltip(),
-  ]);
-  // Rendered for every benchmark, including those whose adoption is too sparse
-  // to plot: the score reading is a separate question from the adoption reading,
-  // and a benchmark with one adopter can still have a readable score.
+  replaceChildren(byId("frontier-chart"), [scoreTrackChart(entry, board), frontierTooltip()]);
   renderScoreReadout(entry);
-  renderFrontierMilestones(entry, events);
   renderFrontierTaskPreview(entry);
 }
 
@@ -5347,8 +4865,13 @@ function findingCard(finding, board) {
   ];
 
   // Corpus-scope findings carry no benchmark_id, so there is nothing to focus.
+  // A benchmark with no readable score is no longer focusable either: the panel
+  // is the score track now, so the jump would land on the default entry instead
+  // of the benchmark the finding is about.
   const target = finding.benchmark_id
-    ? (board.entries || []).find((entry) => entry.benchmark_id === finding.benchmark_id)
+    ? (board.entries || []).find(
+        (entry) => entry.benchmark_id === finding.benchmark_id && scoreRecord(entry.benchmark_id),
+      )
     : null;
   if (target) {
     const jump = element("button", {
@@ -5487,12 +5010,17 @@ function leaderboardRow(entry) {
     );
   }
 
-  const frontierButton = element("button", {
-    className: "secondary-link frontier-jump",
-    text: t("View adoption frontier ↑"),
-    attrs: { type: "button" },
-  });
-  frontierButton.addEventListener("click", () => {
+  // The jump targets the saturation curve, so it is only offered when a score
+  // could be read: for the 20 adopted benchmarks without one it would snap to
+  // the default entry and lie about what it opened.
+  const frontierButton = scoreRecord(entry.benchmark_id)
+    ? element("button", {
+        className: "secondary-link frontier-jump",
+        text: t("View score track ↑"),
+        attrs: { type: "button" },
+      })
+    : null;
+  frontierButton?.addEventListener("click", () => {
     selectFrontier(entry.benchmark_id);
     renderAdoptionFrontier(board);
     writeUrl();

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -394,13 +394,16 @@ const I18N = {
     "Registry overview": "总览",
     "What the two layers say": "两层信息说了什么",
     "Stated findings": "明确结论",
-    "Benchmarks to watch": "值得关注的基准",
-    "Choose a reporting story": "选择一个报告故事",
     "leaderboard.navigator.note":
-      "从能把新兴工具与成熟标准、饱和惯例区分开来的信号入手。",
+      "如果你还没有想好要看哪个基准,这里有几条可以直接打开。上面的搜索框可以检索登记册与抓取目录中的每一个基准。",
     "The saturation curve": "饱和曲线",
     "Benchmark reported scores over time": "基准报告分数随时间的变化",
     "All tracked benchmarks": "所有追踪的基准",
+    "Search every benchmark": "搜索全部基准",
+    "Search benchmarks, tasks, domains…": "搜索基准、任务、领域…",
+    "Worked examples": "示例记录",
+    "Famous benchmarks": "知名基准",
+    "{n} benchmarks": "{n} 个基准",
     "Curated registry": "精选登记册",
     "New instruments with scores": "有分数的新工具",
     "Deepest score records": "分数记录最全的基准",
@@ -3177,7 +3180,12 @@ function searchBenchmarkIndex(records, query) {
   const scored = [];
   for (const record of records) {
     const name = foldName(record.name);
-    if (!name.includes(needle)) continue;
+    // The crawled catalog carries no domain, so publisher and modality are the
+    // fields a "tasks, domains" query can land on here.
+    const named = name.includes(needle);
+    if (!named && !foldName(record.publisher).includes(needle) && !foldName(record.modality).includes(needle)) {
+      continue;
+    }
     // Prefix beats substring, then a record that can answer more of the
     // reader's questions beats one that cannot, then shorter names first so
     // "MMLU" outranks "MMLU-Pro-Extended" for the query "mmlu".
@@ -3186,7 +3194,10 @@ function searchBenchmarkIndex(records, query) {
       (record.openness !== "unknown" ? 1 : 0) +
       (record.has_size ? 1 : 0) +
       (record.score_count > 0 ? 1 : 0);
-    scored.push({ record, rank: [name.startsWith(needle) ? 0 : 1, -answers, name.length] });
+    scored.push({
+      record,
+      rank: [named ? (name.startsWith(needle) ? 0 : 1) : 2, -answers, name.length],
+    });
   }
   scored.sort(
     (a, b) =>
@@ -3275,9 +3286,13 @@ function searchCuratedEntries(board, query) {
   const scored = [];
   for (const entry of board?.entries || []) {
     if (!scoreRecord(entry.benchmark_id)) continue;
+    // Name and aliases identify the record; `domain` is what the placeholder
+    // means by tasks and domains, since the task shape shown in the panel is
+    // selected by domain. Matching it lets "agent" or "science" return a set
+    // rather than nothing.
     const names = [entry.name, ...(entry.aliases || [])].map(foldName);
     const hits = names.filter((name) => name.includes(needle));
-    if (!hits.length) continue;
+    if (!hits.length && !foldName(entry.domain).includes(needle)) continue;
     // Exact beats prefix beats substring, then the shortest matched string.
     // Ranking on the entry name alone put AutomationBench above Humanity's Last
     // Exam for the query "HLE": the registry really does record the alias
@@ -3285,8 +3300,12 @@ function searchCuratedEntries(board, query) {
     // won. What a reader means by "HLE" is the record that answers to it
     // exactly, so the matched alias is what gets ranked, not the entry name.
     const tier = (name) => (name === needle ? 0 : name.startsWith(needle) ? 1 : 2);
-    const best = Math.min(...hits.map(tier));
-    const shortest = Math.min(...hits.filter((name) => tier(name) === best).map((n) => n.length));
+    // A domain-only hit is a weaker answer than a name hit: the reader typed a
+    // field value, not an identity, so those rank below every named match.
+    const best = hits.length ? Math.min(...hits.map(tier)) : 3;
+    const shortest = hits.length
+      ? Math.min(...hits.filter((name) => tier(name) === best).map((name) => name.length))
+      : 0;
     scored.push({ entry, rank: [best, shortest, foldName(entry.name).length] });
   }
   scored.sort(
@@ -3357,10 +3376,17 @@ function renderBenchmarkSearch() {
   }
   if (!state.benchmarkQuery) {
     replaceChildren(container, []);
-    status.textContent = t("{n} benchmarks searchable").replace(
+    // Stated as reach, not as a boast: the number is what this box searches
+    // right now, so it drops when the crawled index fails to load rather than
+    // advertising records that cannot be returned. "Sources" counts the layers
+    // behind those records (the curated registry plus each crawl), not the
+    // radar's discovery connectors, which supply no benchmark to this index.
+    const sources = new Set((records || []).map((record) => record.source));
+    if (curatedCount) sources.add("curated");
+    status.textContent = `${t("{n} benchmarks").replace(
       "{n}",
       (curatedCount + (records?.length || 0)).toLocaleString(),
-    );
+    )} \u00b7 ${metricLabel(sources.size, "source")}`;
     return;
   }
   const curatedMatches = searchCuratedEntries(board, state.benchmarkQuery);

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -401,6 +401,7 @@ const I18N = {
     "The saturation curve": "饱和曲线",
     "Benchmark reported scores over time": "基准报告分数随时间的变化",
     "All tracked benchmarks": "所有追踪的基准",
+    "Curated registry": "精选登记册",
     "New instruments with scores": "有分数的新工具",
     "Deepest score records": "分数记录最全的基准",
     "No benchmark in this registry has a readable score yet.": "此登记册中还没有任何基准具有可读分数。",
@@ -3259,12 +3260,97 @@ function benchmarkResultRow(record) {
   return button;
 }
 
+// Search covers both layers. It used to read the crawled index only, so a
+// reader typing "GPQA" was shown crawled rows and not the curated GPQA Diamond
+// record that the panel actually charts, while the picker had the opposite
+// blind spot. Curated matches rank above crawled ones for the same reason the
+// picker lists them first: they are the layer with a protocol and a time axis.
+//
+// Matched on aliases as well as the name, because the registry records them
+// ("HLE" for Humanity's Last Exam) precisely so a reader does not have to know
+// the canonical spelling.
+function searchCuratedEntries(board, query) {
+  const needle = foldName(query);
+  if (!needle) return [];
+  const scored = [];
+  for (const entry of board?.entries || []) {
+    if (!scoreRecord(entry.benchmark_id)) continue;
+    const names = [entry.name, ...(entry.aliases || [])].map(foldName);
+    const hits = names.filter((name) => name.includes(needle));
+    if (!hits.length) continue;
+    // Exact beats prefix beats substring, then the shortest matched string.
+    // Ranking on the entry name alone put AutomationBench above Humanity's Last
+    // Exam for the query "HLE": the registry really does record the alias
+    // `HLEAutomationBench`, so both were prefix hits and the shorter entry name
+    // won. What a reader means by "HLE" is the record that answers to it
+    // exactly, so the matched alias is what gets ranked, not the entry name.
+    const tier = (name) => (name === needle ? 0 : name.startsWith(needle) ? 1 : 2);
+    const best = Math.min(...hits.map(tier));
+    const shortest = Math.min(...hits.filter((name) => tier(name) === best).map((n) => n.length));
+    scored.push({ entry, rank: [best, shortest, foldName(entry.name).length] });
+  }
+  scored.sort(
+    (a, b) =>
+      a.rank[0] - b.rank[0] ||
+      a.rank[1] - b.rank[1] ||
+      a.rank[2] - b.rank[2] ||
+      a.entry.name.localeCompare(b.entry.name),
+  );
+  return scored.map((item) => item.entry);
+}
+
+// A curated result states what the crawled rows cannot: how many values were
+// read verbatim, and that this record charts. The layer is named on the row
+// rather than left to the reader to infer from the absence of a source chip.
+function curatedResultRow(entry) {
+  const record = scoreRecord(entry.benchmark_id);
+  const facts = [];
+  if (entry.domain) facts.push(String(entry.domain).replaceAll("_", " "));
+  if (entry.released) facts.push(String(entry.released).slice(0, 4));
+  facts.push(metricLabel(entry.card_count, "model card"));
+  const button = element("button", {
+    className: "benchmark-result benchmark-result-curated",
+    attrs: {
+      type: "button",
+      "aria-pressed": entry.benchmark_id === state.lfrontier ? "true" : "false",
+    },
+  }, [
+    element("span", { className: "benchmark-result-name", text: entry.name }),
+    element("span", { className: "benchmark-result-facts", text: facts.join(" \u00b7 ") }),
+    element("span", { className: "benchmark-result-meta" }, [
+      element("span", {
+        className: "benchmark-result-source benchmark-result-source-curated",
+        text: t("Curated registry"),
+      }),
+      element("span", {
+        className: "benchmark-result-scores",
+        text: metricLabel(record.observation_count, "readable score"),
+      }),
+    ]),
+  ]);
+  button.addEventListener("click", () => {
+    selectFrontier(entry.benchmark_id);
+    renderBenchmarkSearch();
+    const board = state.data?.model_card_leaderboard;
+    if (board) renderAdoptionFrontier(board);
+    writeUrl();
+  });
+  return button;
+}
+
 function renderBenchmarkSearch() {
   const container = byId("benchmark-search-results");
   const status = byId("benchmark-search-status");
   if (!container || !status) return;
   const records = state.benchmarkIndex;
-  if (!records) {
+  const board = state.data?.model_card_leaderboard;
+  // The curated layer is in the dashboard payload, which is already loaded, so
+  // search still works over it while the crawled index is on the wire or after
+  // that fetch has failed. Only the crawled half degrades.
+  const curatedCount = (board?.entries || []).filter((entry) =>
+    scoreRecord(entry.benchmark_id),
+  ).length;
+  if (!records && !curatedCount) {
     replaceChildren(container, []);
     status.textContent = "";
     return;
@@ -3273,17 +3359,30 @@ function renderBenchmarkSearch() {
     replaceChildren(container, []);
     status.textContent = t("{n} benchmarks searchable").replace(
       "{n}",
-      String(records.length),
+      (curatedCount + (records?.length || 0)).toLocaleString(),
     );
     return;
   }
-  const matches = searchBenchmarkIndex(records, state.benchmarkQuery);
-  const shown = matches.slice(0, BENCHMARK_SEARCH_LIMIT);
-  replaceChildren(container, shown.map(benchmarkResultRow));
-  status.textContent = matches.length
+  const curatedMatches = searchCuratedEntries(board, state.benchmarkQuery);
+  const externalMatches = records
+    ? searchBenchmarkIndex(records, state.benchmarkQuery)
+    : [];
+  // Curated first, then crawled, and the cap applies across both so a common
+  // name cannot push every curated hit off the end of the list.
+  const shownCurated = curatedMatches.slice(0, BENCHMARK_SEARCH_LIMIT);
+  const shownExternal = externalMatches.slice(
+    0,
+    Math.max(0, BENCHMARK_SEARCH_LIMIT - shownCurated.length),
+  );
+  const total = curatedMatches.length + externalMatches.length;
+  replaceChildren(container, [
+    ...shownCurated.map(curatedResultRow),
+    ...shownExternal.map(benchmarkResultRow),
+  ]);
+  status.textContent = total
     ? t("{shown} of {total} matches")
-        .replace("{shown}", String(shown.length))
-        .replace("{total}", String(matches.length))
+        .replace("{shown}", String(shownCurated.length + shownExternal.length))
+        .replace("{total}", String(total))
     : t("No benchmark matches that name");
 }
 
@@ -3709,6 +3808,56 @@ function setCanonicalFrontierChrome(visible) {
 // heading, source badge where the curated path hides it, the curated picker
 // still offering every scored canonical benchmark, and the message or detail
 // in the external container.
+// --- The benchmark picker ----------------------------------------------------
+//
+// One <select> over both layers, grouped rather than interleaved. The curated
+// registry and the crawled catalog are separate namespaces (a `benchmark_id`
+// against a source-prefixed `slug`), and they answer to different standards: a
+// curated row carries an instrument, a protocol and a document publication
+// date, so it can be drawn on a time axis; a crawled row carries none of those
+// and renders as a table. A reader has to be able to tell which they are
+// looking at before they click, so the group label says it.
+//
+// A crawled record with no readable score is omitted for the same reason its
+// curated counterpart is: the panel would have nothing to show it.
+function frontierPickerGroups(scored) {
+  const groups = [
+    [
+      t("Curated registry"),
+      [...scored]
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .map((entry) => [entry.benchmark_id, entry.name]),
+    ],
+  ];
+  const external = (state.benchmarkIndex || []).filter((record) => record.score_count > 0);
+  for (const source of [...new Set(external.map((record) => record.source))].sort()) {
+    groups.push([
+      externalSourceMeta(source).name,
+      external
+        .filter((record) => record.source === source)
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .map((record) => [record.slug, record.name]),
+    ]);
+  }
+  return groups.filter(([, rows]) => rows.length);
+}
+
+function renderFrontierPicker(scored, selectedValue) {
+  replaceChildren(
+    byId("frontier-benchmark"),
+    frontierPickerGroups(scored).map(([label, rows]) =>
+      element(
+        "optgroup",
+        // The count is on the label because the groups are wildly uneven (59
+        // curated against several hundred crawled) and a reader scrolling a
+        // long list deserves to know how far the group runs.
+        { attrs: { label: `${label} (${rows.length.toLocaleString()})` } },
+        rows.map(([value, name]) => option(value, name, value === selectedValue)),
+      ),
+    ),
+  );
+}
+
 function renderExternalShell(board, scored, { eyebrow, heading, badge, message }) {
   clearFrontierPointSelection();
   setCanonicalFrontierChrome(false);
@@ -3718,11 +3867,7 @@ function renderExternalShell(board, scored, { eyebrow, heading, badge, message }
   stage.className = "frontier-stage";
   stage.hidden = false;
   stage.textContent = badge;
-  replaceChildren(byId("frontier-benchmark"), [
-    ...[...scored]
-      .sort((a, b) => a.name.localeCompare(b.name))
-      .map((entry) => option(entry.benchmark_id, entry.name, false)),
-  ]);
+  renderFrontierPicker(scored, state.lfrontier);
   replaceChildren(byId("frontier-external"), [
     element("p", { className: "empty-state", text: message }),
   ]);
@@ -3736,12 +3881,14 @@ function renderExternalBenchmark(board, scored, record) {
     badge: meta.name,
     message: t("Loading benchmark details…"),
   });
-  // The picker has no canonical option for a slug, so the selected record is
-  // prepended as its own option: a <select> that displays a different
-  // benchmark than the one rendered would be lying about the state.
-  byId("frontier-benchmark").prepend(
-    option(record.slug, `${record.name} · ${meta.name}`, true),
-  );
+  // Scored crawled records are in the picker already. An unscored one is not,
+  // and it is still reachable by search, so it is prepended as its own option:
+  // a <select> displaying a different benchmark than the one rendered would be
+  // lying about the state.
+  const picker = byId("frontier-benchmark");
+  const existing = [...picker.options].find((candidate) => candidate.value === record.slug);
+  if (existing) existing.selected = true;
+  else picker.prepend(option(record.slug, `${record.name} · ${meta.name}`, true));
   const container = byId("frontier-external");
   loadBenchmarkShard(record.slug).then((shard) => {
     // The reader may have moved on while the shard was on the wire; only paint
@@ -4792,13 +4939,7 @@ function renderAdoptionFrontier(board) {
   const stageBadge = byId("frontier-stage");
   stageBadge.textContent = "";
   stageBadge.hidden = true;
-  replaceChildren(byId("frontier-benchmark"), [
-    ...[...scored]
-      .sort((a, b) => a.name.localeCompare(b.name))
-      .map((candidate) =>
-        option(candidate.benchmark_id, candidate.name, candidate.benchmark_id === state.lfrontier),
-      ),
-  ]);
+  renderFrontierPicker(scored, state.lfrontier);
   renderBenchmarkNavigator(board);
 
   byId("frontier-heading").textContent = `${entry.name} ${t("reported scores over time")}`;

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -398,7 +398,7 @@ const I18N = {
     "Benchmark reported scores over time": "基准报告分数随时间的变化",
     "All tracked benchmarks": "所有追踪的基准",
     "Search every benchmark": "搜索全部基准",
-    "Try:": "试试:",
+    "Most reported": "报告最多",
     "Search benchmarks, tasks, domains…": "搜索基准、任务、领域…",
     "{n} benchmarks": "{n} 个基准",
     "Curated registry": "精选登记册",
@@ -3930,56 +3930,51 @@ function renderExternalBenchmark(board, scored, record) {
   });
 }
 
-// A handful of entry points for a reader who has nothing in mind to type, on
-// one line. This replaced a titled block with two computed subheadings and
-// eight cards: it outranked the search box it existed to support, and a reader
-// who wanted anything else read four suggestions before finding the field.
+// Entry points for a reader who has nothing in mind to type, ranked by how
+// many curated model cards report the benchmark. That ordering is the one
+// reading this registry is built to make, so the list needs no editorial
+// curation and no computed subheadings: "most reported" is both the rank and
+// the reason a name is worth trying.
 //
-// The list is editorial rather than computed, which is the point. MMLU carries
-// only 4 readable scores here and would never place in a "deepest records"
-// ranking, but it is the name a newcomer arrives with. Short labels are used
-// because these are prompts for the search box, not record titles; each chip
-// carries the registry's full name as its accessible name and tooltip, so the
-// abbreviation never hides what will open.
-const BENCHMARK_EXAMPLES = [
-  ["mmlu", "MMLU"],
-  ["gpqa_diamond", "GPQA"],
-  ["swe_bench_verified", "SWE-bench"],
-  ["terminal_bench", "Terminal-Bench"],
-];
+// Every row is a curated benchmark, because `card_count` is a curated fact:
+// the crawled catalog records scores, not who chose to report them. The
+// crawled layer is not hidden by this, it is reached from the search box and
+// the picker, both of which cover all 679 scored crawled records alongside
+// these.
+const BENCHMARK_EXAMPLE_LIMIT = 20;
 
 function renderBenchmarkNavigator(board) {
   const host = byId("benchmark-shortlist");
   if (host) {
-    const byBenchmarkId = new Map(
-      (board.entries || []).map((entry) => [entry.benchmark_id, entry]),
-    );
-    // Filtered against the live registry rather than trusted: an id that leaves
-    // the registry, or loses its last readable score, drops out of the line
-    // instead of rendering a chip that opens the refusal panel.
-    const chips = BENCHMARK_EXAMPLES.map(([benchmarkId, label]) => {
-      const entry = byBenchmarkId.get(benchmarkId);
-      if (!entry || !scoreRecord(benchmarkId)) return null;
-      const chip = element("button", {
-        className: "benchmark-example",
-        text: label,
-        attrs: {
-          type: "button",
-          title: entry.name,
-          "aria-label": entry.name,
-          "aria-pressed": benchmarkId === state.lfrontier ? "true" : "false",
-        },
-      });
-      chip.addEventListener("click", () => {
-        selectFrontier(benchmarkId);
-        renderAdoptionFrontier(board);
-        writeUrl();
-      });
-      return chip;
-    }).filter(Boolean);
+    const examples = (board.entries || [])
+      // Scored only, same rule as every other route into the panel: an example
+      // that opens the no-score refusal is not an example.
+      .filter((entry) => entry.card_count > 0 && scoreRecord(entry.benchmark_id))
+      .sort((a, b) => b.card_count - a.card_count || a.name.localeCompare(b.name))
+      .slice(0, BENCHMARK_EXAMPLE_LIMIT);
     replaceChildren(
       host,
-      chips.length ? [element("span", { className: "benchmark-example-lead", text: t("Try:") }), ...chips] : [],
+      examples.map((entry) => {
+        const card = element("button", {
+          className: "benchmark-example",
+          attrs: {
+            type: "button",
+            "aria-pressed": entry.benchmark_id === state.lfrontier ? "true" : "false",
+          },
+        }, [
+          element("span", { className: "benchmark-example-name", text: entry.name }),
+          element("small", {
+            className: "benchmark-example-meta",
+            text: metricLabel(entry.card_count, "model card"),
+          }),
+        ]);
+        card.addEventListener("click", () => {
+          selectFrontier(entry.benchmark_id);
+          renderAdoptionFrontier(board);
+          writeUrl();
+        });
+        return card;
+      }),
     );
   }
   // Binds the input and kicks off the crawled-index fetch on first call; a

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -2555,17 +2555,6 @@ td a {
   border-radius: 50%;
 }
 
-.legend-swatch-score-line,
-.legend-swatch-score-line-single-org {
-  width: 24px;
-  height: 0;
-  border-top: 3px solid #6ea8dc;
-}
-
-.legend-swatch-score-line-single-org {
-  border-top-style: dashed;
-}
-
 .frontier-tooltip {
   position: absolute;
   z-index: 4;
@@ -2733,22 +2722,6 @@ td a {
   margin-top: 1.2rem;
   padding-top: 1rem;
   border-top: 1px solid var(--line);
-}
-
-/* Score progression (issue #91). Sea green throughout, deliberately distinct
-   from the gold of an adoption advance: the two layers share an x axis and must
-   never share a colour, or a reader will connect a score point to a mention. */
-.score-line {
-  fill: none;
-  stroke: #6ea8dc;
-  stroke-width: 2.5;
-}
-
-/* A single-organization run is one vendor's own model line, which is weaker
-   evidence about the field. Dashed rather than a different hue: the dash says
-   "provisional" without implying a third measurement type. */
-.score-line-single-org {
-  stroke-dasharray: 7 4;
 }
 
 .score-point-face {

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -2305,6 +2305,8 @@ td a {
 .benchmark-navigator {
   position: sticky;
   top: 1rem;
+  max-height: calc(100vh - 2rem);
+  overflow-y: auto;
   padding: 1.25rem;
   border: 1px solid var(--ink);
   background: var(--panel);
@@ -3768,8 +3770,6 @@ footer {
   flex-direction: column;
   gap: 0.25rem;
   margin: 0;
-  max-height: 15rem;
-  overflow-y: auto;
 }
 
 /* Deliberately not `.eyebrow`: that class is accent blue, which plants a second

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -2316,7 +2316,15 @@ td a {
   font-size: 1.45rem;
 }
 
-.benchmark-navigator > p:not(.eyebrow) {
+/* The search label is the panel's leading heading, so it is an <h2> for the
+   document outline while keeping the small uppercase field-label treatment.
+   Its own rule below would otherwise lose the cascade to the h2 sizing. */
+.benchmark-navigator h2.benchmark-search-label {
+  margin-bottom: 0.4rem;
+  font-size: 0.78rem;
+}
+
+.benchmark-navigator p:not(.eyebrow):not(.benchmark-search-status) {
   color: var(--muted);
   font-size: 0.8rem;
 }
@@ -3820,9 +3828,15 @@ footer {
 }
 
 .benchmark-search {
-  margin-top: 1.25rem;
+  margin-top: 0;
+}
+
+/* The worked examples sit under the search box and are separated from it, so
+   the rule that used to head the search block heads this one instead. */
+.benchmark-shortlist-section {
+  margin-top: 1.5rem;
   border-top: 1px solid var(--border);
-  padding-top: 1rem;
+  padding-top: 1.1rem;
 }
 
 .benchmark-search-label {
@@ -3849,6 +3863,7 @@ footer {
   margin: 0.45rem 0 0.35rem;
   font-size: 0.78rem;
   color: var(--muted);
+  font-variant-numeric: tabular-nums;
 }
 
 #benchmark-search-results {

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -2418,16 +2418,6 @@ td a {
   gap: 0.65rem;
 }
 
-.frontier-stage-emerging {
-  border-color: #f4b65e;
-  color: #ffd99e;
-}
-
-.frontier-stage-saturated {
-  border-color: #91a0a7;
-  color: #c1cbd0;
-}
-
 .frontier-panel .eyebrow {
   color: #7fc7bc;
 }
@@ -2457,37 +2447,6 @@ td a {
   color: #f3f6f7;
 }
 
-.frontier-summary {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.45rem 1.2rem;
-  align-items: baseline;
-  padding: 0.75rem 0;
-  border-top: 1px solid #39464c;
-  border-bottom: 1px solid #39464c;
-  font-family: var(--utility);
-  font-size: 0.72rem;
-  text-transform: uppercase;
-}
-
-.frontier-summary strong {
-  color: white;
-  font-size: 0.82rem;
-}
-
-.frontier-summary span {
-  color: #aebcc1;
-}
-
-.frontier-summary .frontier-stage-description {
-  flex-basis: 100%;
-  color: #d6e0e3;
-  font-family: var(--body);
-  font-size: 0.8rem;
-  letter-spacing: normal;
-  text-transform: none;
-}
-
 .frontier-chart {
   position: relative;
   margin-top: 0.5rem;
@@ -2503,34 +2462,6 @@ td a {
   stroke: #344249;
   stroke-dasharray: 3 6;
   stroke-width: 1;
-}
-
-.frontier-line {
-  fill: none;
-  stroke: #7fc7bc;
-  stroke-width: 3;
-}
-
-/* A colored circle carrying the reporting organization's brand glyph. The circle
-   takes the organization's frontier color and the glyph sits dark on it, so the
-   mark reads at a glance which organization stepped the count up (issue #178,
-   HLE/harbor style). */
-.frontier-point-face {
-  stroke: #0d1519;
-  stroke-width: 2;
-  transition: stroke-width 120ms ease;
-}
-
-.frontier-point-glyph {
-  color: #0d1519;
-  pointer-events: none;
-  user-select: none;
-}
-
-.frontier-point:focus .frontier-point-face,
-.frontier-point:hover .frontier-point-face,
-.frontier-point.is-selected .frontier-point-face {
-  stroke-width: 4;
 }
 
 /* Color key under the chart: one circular chip per reporting organization, in
@@ -2573,63 +2504,17 @@ td a {
   letter-spacing: 0.04em;
 }
 
-.frontier-point,
 .score-point {
   cursor: pointer;
 }
 
-/* Card events live on their own band. A tick per card means several cards on one
-   date sit side by side instead of stacking into an unreadable pile on the
-   staircase, which is what made the old chart look like numbered records. */
-.card-rug-baseline {
-  stroke: #2c383e;
-  stroke-width: 1;
-}
-
-.card-rug-tick line {
-  stroke-linecap: butt;
-  transition: stroke-width 120ms ease;
-}
-
-.card-rug-tick-first line {
-  stroke: #f4b65e;
-  stroke-width: 2.5;
-}
-
-.card-rug-tick-repeat line {
-  stroke: #89969e;
-  stroke-width: 2;
-}
-
-.card-rug-tick:focus line,
-.card-rug-tick:hover line,
-.card-rug-tick.is-selected line {
-  stroke-width: 4;
-}
-
-.frontier-release-label,
 .frontier-tick,
 .frontier-axis-label {
   fill: #aebcc1;
   font-family: var(--utility);
-}
-
-.frontier-tick,
-.frontier-axis-label {
   font-size: 11px;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-}
-
-.frontier-release-line {
-  stroke: #dc633f;
-  stroke-dasharray: 5 5;
-  stroke-width: 1.5;
-}
-
-.frontier-release-label {
-  fill: #ee9b82;
-  font-size: 11px;
 }
 
 /* Legend, keyed to the marks on the chart and sitting directly above it rather
@@ -2661,30 +2546,6 @@ td a {
 .legend-swatch {
   flex: 0 0 auto;
   align-self: center;
-}
-
-.legend-swatch-point {
-  width: 13px;
-  height: 13px;
-  background: #f4b65e;
-  border: 2px solid #0d1519;
-  border-radius: 50%;
-  box-sizing: border-box;
-}
-
-.legend-swatch-tick-first,
-.legend-swatch-tick-repeat {
-  width: 3px;
-  background: #f4b65e;
-}
-
-.legend-swatch-tick-first {
-  height: 15px;
-}
-
-.legend-swatch-tick-repeat {
-  height: 8px;
-  background: #89969e;
 }
 
 .legend-swatch-score {
@@ -3053,7 +2914,6 @@ td a {
 
 .frontier-evidence {
   display: grid;
-  grid-template-columns: minmax(0, 1.05fr) minmax(260px, 0.95fr);
   gap: 1.5rem;
   margin-top: 1.2rem;
   padding-top: 1.5rem;
@@ -3066,76 +2926,8 @@ td a {
   font-size: 1.25rem;
 }
 
-.milestone-release,
-.milestone-repeat-note {
-  color: #aebcc1;
-  font-family: var(--utility);
-  font-size: 0.65rem;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-}
-
-.frontier-milestone-list {
-  display: grid;
-  gap: 0;
-  margin: 0 0 0.9rem;
-  padding: 0;
-  list-style: none;
-}
-
-.frontier-milestone-list li {
-  display: grid;
-  grid-template-columns: 30px minmax(0, 1fr);
-  gap: 0.65rem;
-  min-height: 58px;
-  padding: 0.55rem 0;
-  border-top: 1px solid #2d3b41;
-}
-
-.milestone-number {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 27px;
-  height: 27px;
-  border: 1px solid #f4b65e;
-  color: #f4b65e;
-  font-family: var(--utility);
-  font-size: 0.66rem;
-}
-
-.milestone-date {
-  margin: 0;
-  color: #aebcc1;
-  font-family: var(--utility);
-  font-size: 0.61rem;
-  text-transform: uppercase;
-}
-
-.milestone-source {
-  display: inline-flex;
-  align-items: center;
-  min-height: 28px;
-  color: white;
-  font-size: 0.8rem;
-  font-weight: 700;
-  text-decoration: none;
-}
-
-.milestone-source:hover,
-.milestone-source:focus-visible {
-  text-decoration: underline;
-}
-
-.milestone-model {
-  display: block;
-  color: #aebcc1;
-  font-size: 0.72rem;
-}
-
 .frontier-context {
-  padding-left: 1.5rem;
-  border-left: 1px solid #39464c;
+  padding-left: 0;
 }
 
 .task-shape {
@@ -3214,45 +3006,6 @@ td a {
   font-family: var(--utility);
   font-size: 0.65rem;
   text-transform: uppercase;
-}
-
-.frontier-sparse {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 1px;
-  margin: 1.5rem 0;
-  border: 1px solid #39464c;
-  background: #39464c;
-}
-
-.frontier-sparse-step {
-  display: grid;
-  align-content: start;
-  min-height: 150px;
-  padding: 1rem;
-  background: #162228;
-}
-
-.frontier-sparse-step > span {
-  color: #7fc7bc;
-  font-family: var(--utility);
-  font-size: 0.63rem;
-}
-
-.frontier-sparse-step strong {
-  margin-top: 1.4rem;
-  font-size: 0.85rem;
-}
-
-.frontier-sparse-step small {
-  margin-top: 0.45rem;
-  color: #aebcc1;
-  font-size: 0.72rem;
-}
-
-.frontier-sparse-step.is-awaiting {
-  border: 1px dashed #74848b;
-  background: #111c21;
 }
 
 .benchmark-new {
@@ -3914,16 +3667,6 @@ footer {
     border-right: 0;
   }
 
-  .frontier-evidence {
-    grid-template-columns: 1fr;
-  }
-
-  .frontier-context {
-    padding: 1.25rem 0 0;
-    border-top: 1px solid #39464c;
-    border-left: 0;
-  }
-
   .heading-note {
     text-align: left;
   }
@@ -4080,17 +3823,8 @@ footer {
     padding-inline: 1rem;
   }
 
-  .frontier-sparse {
-    grid-template-columns: 1fr;
-  }
-
-  .frontier-sparse-step {
-    min-height: 118px;
-  }
-
   .frontier-tick,
   .frontier-axis-label,
-  .frontier-release-label,
   .score-best-label,
   .score-gap-label {
     font-size: 20px;

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -2329,63 +2329,6 @@ td a {
   font-size: 0.8rem;
 }
 
-.benchmark-shortlist-group {
-  margin-top: 1rem;
-}
-
-.benchmark-shortlist-group h3 {
-  margin: 0 0 0.35rem;
-  color: var(--muted);
-  font-family: var(--utility);
-  font-size: 0.63rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.benchmark-shortlist-buttons {
-  display: grid;
-  gap: 0.3rem;
-}
-
-.benchmark-shortlist-button {
-  display: grid;
-  gap: 0.1rem;
-  min-height: 48px;
-  padding: 0.55rem 0.65rem;
-  border: 1px solid var(--line);
-  background: transparent;
-  text-align: left;
-}
-
-.benchmark-shortlist-button span {
-  overflow-wrap: anywhere;
-  font-size: 0.82rem;
-  font-weight: 650;
-}
-
-.benchmark-shortlist-button small {
-  color: var(--muted);
-  font-family: var(--utility);
-  font-size: 0.61rem;
-  text-transform: uppercase;
-}
-
-.benchmark-shortlist-button:hover,
-.benchmark-shortlist-button:focus-visible {
-  border-color: var(--blue);
-  background: var(--canvas);
-}
-
-.benchmark-shortlist-button[aria-pressed="true"] {
-  border-color: var(--ink);
-  background: var(--ink);
-  color: white;
-}
-
-.benchmark-shortlist-button[aria-pressed="true"] small {
-  color: #c7d1d5;
-}
-
 .frontier-panel {
   padding: clamp(1.25rem, 3vw, 2rem);
   border: 1px solid var(--ink);
@@ -3555,12 +3498,6 @@ footer {
     order: -1;
   }
 
-  #benchmark-shortlist {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 0 1rem;
-  }
-
   .health-panel {
     position: static;
   }
@@ -3796,10 +3733,6 @@ footer {
     white-space: normal;
   }
 
-  #benchmark-shortlist {
-    grid-template-columns: 1fr;
-  }
-
   .frontier-panel {
     padding-inline: 1rem;
   }
@@ -3827,16 +3760,44 @@ footer {
   }
 }
 
-.benchmark-search {
-  margin-top: 0;
+.benchmark-shortlist {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  align-items: baseline;
+  margin: 0 0 0.6rem;
 }
 
-/* The worked examples sit under the search box and are separated from it, so
-   the rule that used to head the search block heads this one instead. */
-.benchmark-shortlist-section {
-  margin-top: 1.5rem;
-  border-top: 1px solid var(--border);
-  padding-top: 1.1rem;
+.benchmark-example-lead {
+  font-size: 0.72rem;
+  color: var(--muted);
+}
+
+.benchmark-example {
+  padding: 0.1rem 0.4rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  font-size: 0.72rem;
+  cursor: pointer;
+}
+
+.benchmark-example:hover,
+.benchmark-example:focus-visible {
+  border-color: var(--ink);
+  color: var(--ink);
+}
+
+.benchmark-example[aria-pressed="true"] {
+  border-color: var(--ink);
+  background: var(--ink);
+  color: var(--panel);
+}
+
+.benchmark-search {
+  margin-top: 0;
 }
 
 .benchmark-search-label {

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -3760,40 +3760,75 @@ footer {
   }
 }
 
+/* Ranked entry points, sat below the results so the field and its output own
+   the top of the panel. Scrollable rather than 20 rows tall: the whole point of
+   this aside is that it must not out-weigh the chart beside it. */
 .benchmark-shortlist {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.3rem;
-  align-items: baseline;
-  margin: 0 0 0.6rem;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin: 0;
+  max-height: 15rem;
+  overflow-y: auto;
 }
 
+/* Deliberately not `.eyebrow`: that class is accent blue, which plants a second
+   strong anchor in a panel whose only anchor should be the search field. This
+   is the same quiet register as the reach line. */
 .benchmark-example-lead {
-  font-size: 0.72rem;
+  margin: 0.9rem 0 0.35rem;
+  font-size: 0.7rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
   color: var(--muted);
+  opacity: 0.75;
 }
 
 .benchmark-example {
-  padding: 0.1rem 0.4rem;
-  border: 1px solid var(--border);
-  border-radius: 999px;
+  display: flex;
+  gap: 0.5rem;
+  align-items: baseline;
+  justify-content: space-between;
+  width: 100%;
+  padding: 0.3rem 0.45rem;
+  border: 1px solid transparent;
+  border-radius: 5px;
   background: transparent;
-  color: var(--muted);
+  color: inherit;
   font: inherit;
-  font-size: 0.72rem;
+  text-align: left;
   cursor: pointer;
+}
+
+.benchmark-example-name {
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+/* The count is context, not a score, so it stays quieter than the name it
+   qualifies and never competes with it for the first read. */
+.benchmark-example-meta {
+  flex: 0 0 auto;
+  font-size: 0.68rem;
+  color: var(--muted);
+  opacity: 0.8;
 }
 
 .benchmark-example:hover,
 .benchmark-example:focus-visible {
-  border-color: var(--ink);
-  color: var(--ink);
+  border-color: var(--line);
+  background: var(--canvas);
 }
 
 .benchmark-example[aria-pressed="true"] {
   border-color: var(--ink);
   background: var(--ink);
   color: var(--panel);
+}
+
+.benchmark-example[aria-pressed="true"] .benchmark-example-meta {
+  color: var(--panel);
+  opacity: 0.7;
 }
 
 .benchmark-search {
@@ -3812,18 +3847,31 @@ footer {
 
 .benchmark-search-input {
   width: 100%;
-  padding: 0.5rem 0.65rem;
-  border: 1px solid var(--border);
+  padding: 0.6rem 0.7rem;
+  border: 2px solid var(--ink);
   border-radius: 6px;
-  background: var(--surface);
+  background: white;
   color: inherit;
   font: inherit;
+  font-size: 0.95rem;
+  box-shadow: inset 0 1px 3px rgb(21 36 42 / 8%);
+}
+
+.benchmark-search-input::placeholder {
+  color: var(--muted);
+  opacity: 0.75;
+}
+
+.benchmark-search-input:focus-visible {
+  outline: 2px solid var(--blue);
+  outline-offset: 1px;
 }
 
 .benchmark-search-status {
-  margin: 0.45rem 0 0.35rem;
-  font-size: 0.78rem;
+  margin: 0.4rem 0 0.35rem;
+  font-size: 0.7rem;
   color: var(--muted);
+  opacity: 0.75;
   font-variant-numeric: tabular-nums;
 }
 

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -3900,6 +3900,18 @@ footer {
   align-items: center;
 }
 
+/* Curated rows are marked in the search list rather than left to be told apart
+   by the absence of a source chip. The curated layer is the one with a protocol
+   and a time axis, so which layer a result came from is the first thing a
+   reader needs before clicking it. */
+.benchmark-result-source-curated {
+  border: 1px solid var(--accent);
+  border-radius: 999px;
+  padding: 0.05rem 0.45rem;
+  font-size: 0.72rem;
+  color: var(--accent);
+}
+
 /* Openness is a statement about what we know, so `unknown` is neutral rather
    than a warning. Only a positive verdict gets emphasis. */
 .benchmark-openness {

--- a/site/index.html
+++ b/site/index.html
@@ -371,25 +371,34 @@
         </details>
 
         <div class="benchmark-workbench">
-          <aside class="benchmark-navigator" aria-labelledby="benchmark-navigator-heading">
-            <p class="eyebrow" data-i18n="Benchmarks to watch">Benchmarks to watch</p>
-            <h2 id="benchmark-navigator-heading" data-i18n="Choose a reporting story">Choose a reporting story</h2>
-            <p data-i18n="leaderboard.navigator.note">
-              Start with signals that distinguish emerging instruments from established
-              standards and saturated conventions.
-            </p>
-            <div id="benchmark-shortlist"></div>
-
+          <aside class="benchmark-navigator" aria-labelledby="benchmark-search-heading">
+            <!-- Search leads the panel. The shortlist below it is a set of worked
+                 examples, and an example list placed first reads as the whole
+                 offer: a reader who wanted a benchmark not on it had to scroll
+                 past four suggestions to find the box that reaches all of them. -->
             <div class="benchmark-search">
-              <label class="benchmark-search-label" for="benchmark-search-input"
-                     data-i18n="Search every benchmark">Search every benchmark</label>
+              <h2 class="benchmark-search-label" id="benchmark-search-heading">
+                <label for="benchmark-search-input"
+                       data-i18n="Search every benchmark">Search every benchmark</label>
+              </h2>
               <input id="benchmark-search-input" type="search" autocomplete="off"
                      class="benchmark-search-input"
-                     data-i18n-placeholder="Name or alias"
-                     placeholder="Name or alias" />
+                     data-i18n-placeholder="Search benchmarks, tasks, domains…"
+                     placeholder="Search benchmarks, tasks, domains…" />
               <p id="benchmark-search-status" class="benchmark-search-status"></p>
               <div id="benchmark-search-results"></div>
             </div>
+
+            <section class="benchmark-shortlist-section"
+                     aria-labelledby="benchmark-navigator-heading">
+              <p class="eyebrow" data-i18n="Worked examples">Worked examples</p>
+              <h2 id="benchmark-navigator-heading" data-i18n="Famous benchmarks">Famous benchmarks</h2>
+              <p data-i18n="leaderboard.navigator.note">
+                A few records to open if you do not have one in mind. The search above
+                reaches every benchmark in the registry and the crawled catalog.
+              </p>
+              <div id="benchmark-shortlist"></div>
+            </section>
           </aside>
 
           <section class="frontier-panel" id="adoption-frontier" aria-labelledby="frontier-heading">

--- a/site/index.html
+++ b/site/index.html
@@ -371,11 +371,11 @@
         </details>
 
         <div class="benchmark-workbench">
+          <!-- A tool region, not a content section. The examples used to be a
+               titled block with two subheadings and eight cards, which outranked
+               the search box it was meant to support; they are now one line of
+               chips for a reader who has nothing in mind to type. -->
           <aside class="benchmark-navigator" aria-labelledby="benchmark-search-heading">
-            <!-- Search leads the panel. The shortlist below it is a set of worked
-                 examples, and an example list placed first reads as the whole
-                 offer: a reader who wanted a benchmark not on it had to scroll
-                 past four suggestions to find the box that reaches all of them. -->
             <div class="benchmark-search">
               <h2 class="benchmark-search-label" id="benchmark-search-heading">
                 <label for="benchmark-search-input"
@@ -386,19 +386,9 @@
                      data-i18n-placeholder="Search benchmarks, tasks, domains…"
                      placeholder="Search benchmarks, tasks, domains…" />
               <p id="benchmark-search-status" class="benchmark-search-status"></p>
+              <p id="benchmark-shortlist" class="benchmark-shortlist"></p>
               <div id="benchmark-search-results"></div>
             </div>
-
-            <section class="benchmark-shortlist-section"
-                     aria-labelledby="benchmark-navigator-heading">
-              <p class="eyebrow" data-i18n="Worked examples">Worked examples</p>
-              <h2 id="benchmark-navigator-heading" data-i18n="Famous benchmarks">Famous benchmarks</h2>
-              <p data-i18n="leaderboard.navigator.note">
-                A few records to open if you do not have one in mind. The search above
-                reaches every benchmark in the registry and the crawled catalog.
-              </p>
-              <div id="benchmark-shortlist"></div>
-            </section>
           </aside>
 
           <section class="frontier-panel" id="adoption-frontier" aria-labelledby="frontier-heading">

--- a/site/index.html
+++ b/site/index.html
@@ -386,8 +386,9 @@
                      data-i18n-placeholder="Search benchmarks, tasks, domains…"
                      placeholder="Search benchmarks, tasks, domains…" />
               <p id="benchmark-search-status" class="benchmark-search-status"></p>
-              <p id="benchmark-shortlist" class="benchmark-shortlist"></p>
               <div id="benchmark-search-results"></div>
+              <p class="benchmark-example-lead" data-i18n="Most reported">Most reported</p>
+              <div id="benchmark-shortlist" class="benchmark-shortlist"></div>
             </div>
           </aside>
 

--- a/site/index.html
+++ b/site/index.html
@@ -395,8 +395,8 @@
           <section class="frontier-panel" id="adoption-frontier" aria-labelledby="frontier-heading">
             <div class="frontier-heading-row">
               <div>
-                <p class="eyebrow" id="frontier-eyebrow" data-i18n="Reporting over time">Reporting over time</p>
-                <h2 id="frontier-heading" data-i18n="Benchmark adoption frontier">Benchmark adoption frontier</h2>
+                <p class="eyebrow" id="frontier-eyebrow" data-i18n="The saturation curve">The saturation curve</p>
+                <h2 id="frontier-heading" data-i18n="Benchmark reported scores over time">Benchmark reported scores over time</h2>
               </div>
               <div class="frontier-controls">
                 <span class="frontier-stage" id="frontier-stage"></span>
@@ -406,33 +406,20 @@
                 </label>
               </div>
             </div>
-            <p class="section-note" id="frontier-explainer" data-i18n="frontier.explainer.tl1">
-              Three readings on one time axis. Each orange diamond marks an organization's first
-              report of this benchmark, which is the only event that raises the cumulative count.
-              The rug beneath it puts one tick per dated model card, so later cards from an
-              organization already counted appear as gray ticks and leave the staircase flat. A card
-              with no publication date cannot be placed on the timeline and is absent from both
-              bands, though it is still counted in the totals above. A long flat run is
-              reporting saturation observed within this curated registry, not a claim about
-              benchmark score saturation.
-            </p>
             <p class="section-note frontier-explainer-sub" id="frontier-explainer-sub" data-i18n="frontier.explainer.sub">
-              The score track below it is a separate reading: every value that could be read
-              verbatim from a cited document, connected only where the instrument and protocol
-              are identical. A flat score tail usually means no newer number could be read, which
-              is why the gap is marked rather than drawn through.
+              Every value that could be read verbatim from a cited document, placed at the date
+              that document was published rather than at any evaluation date, and connected only
+              where the instrument and protocol are identical. A flat tail usually means no newer
+              number could be read, which is why the gap is marked rather than drawn through.
+              Whether a curve has saturated stays a reading you make, not a score this panel
+              prints.
             </p>
-            <div class="frontier-summary" id="frontier-summary" aria-live="polite"></div>
             <div class="frontier-external" id="frontier-external" hidden></div>
             <div class="frontier-legend" id="frontier-legend" aria-label="Chart legend"></div>
             <div class="frontier-chart" id="frontier-chart"></div>
             <div class="frontier-org-key" id="frontier-org-key" aria-label="Reporting organization color key"></div>
             <div class="score-readout" id="frontier-score-readout"></div>
             <div class="frontier-evidence" id="frontier-evidence">
-              <section aria-labelledby="frontier-milestones-heading">
-                <h3 id="frontier-milestones-heading" data-i18n="Frontier milestones">Frontier milestones</h3>
-                <div id="frontier-milestones"></div>
-              </section>
               <aside class="frontier-context" aria-labelledby="frontier-task-heading">
                 <div id="frontier-task-preview"></div>
                 <details class="pareto-readiness">

--- a/tests/test_leaderboard_workbench.py
+++ b/tests/test_leaderboard_workbench.py
@@ -134,7 +134,6 @@ def test_the_score_legend_keys_one_mark_and_promises_no_connection():
     assert ".legend-swatch-score-line" not in styles
 
 
-
 def test_task_preview_distinguishes_source_paraphrase_from_domain_fallback():
     html = source("site/index.html")
     script = source("site/assets/app.js")

--- a/tests/test_leaderboard_workbench.py
+++ b/tests/test_leaderboard_workbench.py
@@ -113,18 +113,26 @@ def test_trajectory_points_expose_and_pin_record_details():
     assert "`${observation.model} · ${observation.value} · ${observation.protocol}`" not in script
 
 
-def test_score_legend_explains_solid_and_dashed_connections():
+def test_the_score_legend_keys_one_mark_and_promises_no_connection():
+    # The legend used to explain a solid connection (same instrument and
+    # protocol across organizations) and a dashed one (same, within a single
+    # vendor). Neither is drawn any more: comparability is stated by the paired
+    # comparison readout, in words that can carry the caveat a line cannot.
     script = source("site/assets/app.js")
     styles = source("site/assets/styles.css")
 
-    assert '"legend-swatch-score-line",' in script
-    assert '"Solid score connection"' in script
-    assert '"same instrument and protocol across organizations"' in script
-    assert '"legend-swatch-score-line-single-org",' in script
-    assert '"Dashed score connection"' in script
-    assert '"same instrument and protocol, one organization only"' in script
-    assert ".legend-swatch-score-line-single-org" in styles
-    assert "border-top-style: dashed" in styles
+    assert '"legend-swatch-score",' in script
+    assert '"one value read verbatim from a cited document"' in script
+    for gone in (
+        "legend-swatch-score-line",
+        "Solid score connection",
+        "Dashed score connection",
+        "same instrument and protocol across organizations",
+        "same instrument and protocol, one organization only",
+    ):
+        assert gone not in script, f"{gone!r} survives in the legend"
+    assert ".legend-swatch-score-line" not in styles
+
 
 
 def test_task_preview_distinguishes_source_paraphrase_from_domain_fallback():

--- a/tests/test_leaderboard_workbench.py
+++ b/tests/test_leaderboard_workbench.py
@@ -5,39 +5,56 @@ def source(path: str) -> str:
     return Path(path).read_text(encoding="utf-8")
 
 
-def test_frontier_opens_on_a_new_signal_with_three_dated_organizations():
+def test_frontier_opens_on_a_new_signal_with_three_readable_scores():
+    # The panel is the score track, so the benchmark it opens on is chosen by the
+    # same reading: the newest instrument that already carries three or more
+    # dated values. A one-point plot is technically recent but says nothing.
     script = source("site/assets/app.js")
 
     default_entry = script.split("function frontierDefaultEntry(board)", 1)[1].split(
-        "function reportingStage", 1
+        "\nconst BENCHMARK_TASK_SHAPES", 1
     )[0]
     assert "isNewBenchmark(entry, board)" in default_entry
-    assert "frontierAdvances(entry).length >= 3" in default_entry
-    assert "sharedSignals.length ? sharedSignals : adopted" in default_entry
+    assert "datedCount(entry) >= 3" in default_entry
+    assert "sharedSignals.length ? sharedSignals : scored" in default_entry
+    # And every candidate has a score record, so the default can never be a
+    # benchmark the panel cannot draw.
+    assert "entry.card_count > 0 && scoreRecord(entry.benchmark_id)" in default_entry
 
 
-def test_one_organization_history_uses_milestones_instead_of_an_empty_plot():
+def test_a_thin_history_no_longer_falls_back_to_an_adoption_stepper():
+    # A benchmark with one dated reporting organization used to swap the chart
+    # for a three-step "released / first report / awaiting a second" list. That
+    # is an adoption reading, and the score track answers a different question:
+    # a benchmark with one adopter can still carry several readable scores, and
+    # one with none is not offered at all.
     html = source("site/index.html")
     script = source("site/assets/app.js")
 
-    assert 'id="frontier-milestones"' in html
-    assert "frontier.length < 2" in script
-    assert 'className: "frontier-sparse"' in script
-    assert 'text: t("Awaiting an independent second organization")' in script
-    assert "Too early to infer" in script
+    assert 'id="frontier-milestones"' not in html
+    assert "function sparseFrontier(" not in script
+    assert "frontier.length < 2" not in script
+    assert "frontier-sparse" not in script
+    assert "Awaiting an independent second organization" not in script
 
 
-def test_reporting_stages_are_explicitly_about_the_curated_registry():
+def test_the_panel_prints_no_reporting_stage_verdict():
+    # The stage badge graded a benchmark "Saturated reporting" from the share of
+    # registry organizations reporting it. Saturation stays an editorial
+    # judgement (see the header of data/benchmark_scores.yml), and the panel now
+    # shows reported values over time rather than scoring them.
+    html = source("site/index.html")
     script = source("site/assets/app.js")
 
-    stage = script.split("function reportingStage(entry, board)", 1)[1].split(
-        "const BENCHMARK_TASK_SHAPES", 1
-    )[0]
-    assert "advances / total >= 0.8" in stage
-    assert "isNewBenchmark(entry, board) && advances <= 4" in stage
-    assert 'label: t("Saturated reporting")' in stage
-    assert "curated registry" in stage
-    assert "convention, not quality" in stage
+    assert "function reportingStage(" not in script
+    assert "advances / total >= 0.8" not in script
+    assert 't("Saturated reporting")' not in script
+    assert '"Saturated reporting":' not in script, "no zh entry for a badge nothing renders"
+    assert "convention, not quality" not in script
+    # The element survives for the external path, which puts a source name in it,
+    # and the curated path hides it rather than leaving a bare outline.
+    assert 'id="frontier-stage"' in html
+    assert "stage.hidden = true;" in script or "stageBadge.hidden = true;" in script
 
 
 def test_frontier_svg_fits_the_viewport_without_horizontal_scrolling():
@@ -47,10 +64,11 @@ def test_frontier_svg_fits_the_viewport_without_horizontal_scrolling():
     assert "width: 100%" in rule
     assert "height: auto" in rule
     assert "min-width" not in rule
-    # The marker styling this used to check (`.frontier-point-number`) is gone with
-    # the numbers themselves; the advance marker is now a brand-colored circle
-    # carrying the reporting organization's glyph (issue #178).
-    assert ".frontier-point-face" in styles
+    # The marker styling this used to check belonged to the adoption advance
+    # diamond, which is gone with its band. The score point is the only marker
+    # the chart draws now, and it keeps the brand-glyph treatment (issue #178).
+    assert ".score-point-face" in styles
+    assert ".score-point-glyph" in styles
 
 
 def test_trajectory_points_expose_and_pin_record_details():
@@ -66,7 +84,6 @@ def test_trajectory_points_expose_and_pin_record_details():
     assert '"aria-pressed": "false"' in script
     assert 'label: t("Protocol")' in script
     assert 'label: t("Source")' in script
-    assert ".frontier-point.is-selected .frontier-point-face" in styles
     assert ".score-point.is-selected .score-point-face" in styles
     assert "pinned: selectedFrontierPoint === group" in script
     assert 'record.unit === "percent" ? "%" : ` ${record.unit}`' in script
@@ -85,12 +102,13 @@ def test_trajectory_points_expose_and_pin_record_details():
     assert "nearestDistance <= 22" in script
     assert 'window.addEventListener("resize", repositionFrontierTooltip)' in script
     assert 'window.addEventListener("scroll", repositionFrontierTooltip' in script
-    assert 'kind: event.advances ? "First report card" : "Repeat report card"' in script
-    assert ".card-rug-tick.is-selected line" in styles
     assert "pointer-events: none" in styles
     assert ".frontier-tooltip.is-pinned" in styles
-    assert "function scoreOnlyChart(entry, board)" in script
-    assert "scoreOnlyChart(entry, board)" in script
+    # Score points are now the only pinnable marks, so they carry the whole
+    # tooltip contract that the advance diamond and the rug ticks used to share.
+    assert 'kind: t("Readable score")' in script
+    assert "title: `${observation.organization} · ${observation.model}`" in script
+    assert "function scoreOnlyChart(" not in script
     assert "`${event.organization} · ${event.model} · first report · count" not in script
     assert "`${observation.model} · ${observation.value} · ${observation.protocol}`" not in script
 
@@ -225,7 +243,7 @@ def test_detail_panel_renders_for_any_selected_record():
     script = source("site/assets/app.js")
 
     for fn in (
-        "function renderExternalBenchmark(board, adopted, record)",
+        "function renderExternalBenchmark(board, scored, record)",
         "function externalIdentityBlock(detail)",
         "function externalOpennessBlock(detail)",
         "function externalSizesBlock(detail)",

--- a/tests/test_saturation_view.py
+++ b/tests/test_saturation_view.py
@@ -186,7 +186,12 @@ def test_only_a_benchmark_with_a_readable_score_can_be_selected():
     assert "const scored = adopted.filter((entry) => scoreRecord(entry.benchmark_id));" in render
     # The <select>, the resolution of a ?lfrontier= permalink, and the empty
     # state all read from `scored`, so none of them can surface an unscored one.
-    assert "...[...scored]" in render
+    assert "renderFrontierPicker(scored, state.lfrontier);" in render
+    # And the picker itself applies the same rule to the crawled layer.
+    picker = script.split("function frontierPickerGroups(scored)", 1)[1].split(
+        "\n}", 1
+    )[0]
+    assert "record.score_count > 0" in picker
     assert "scored.find((candidate) => candidate.benchmark_id === state.lfrontier)" in render
     assert "if (!scored.length || !defaultEntry)" in render
     # The default selection is drawn from the same set.
@@ -194,6 +199,59 @@ def test_only_a_benchmark_with_a_readable_score_can_be_selected():
         "\n}", 1
     )[0]
     assert "scoreRecord(entry.benchmark_id)" in default_entry
+
+
+def test_the_picker_and_the_search_both_cover_both_layers():
+    # The two layers used to have opposite blind spots: the <select> held only
+    # the 59 curated benchmarks, while the search box read only the crawled
+    # index, so typing "GPQA" surfaced crawled rows but not the curated GPQA
+    # Diamond record the panel actually charts. Both entry points now reach
+    # both layers.
+    script = source("site/assets/app.js")
+
+    picker = script.split("function frontierPickerGroups(scored)", 1)[1].split("\n}", 1)[0]
+    assert 't("Curated registry")' in picker
+    assert "state.benchmarkIndex || []" in picker
+    # Grouped, never interleaved: only the curated layer carries an instrument,
+    # a protocol and a publication date, so a reader must be able to tell which
+    # layer a row is from before selecting it.
+    assert '"optgroup"' in script
+    assert "externalSourceMeta(source).name" in picker
+
+    render = script.split("function renderBenchmarkSearch()", 1)[1].split("\nfunction ", 1)[0]
+    assert "searchCuratedEntries(board, state.benchmarkQuery)" in render
+    assert "searchBenchmarkIndex(records, state.benchmarkQuery)" in render
+    # Curated results come first, and the cap spans both lists so a common name
+    # cannot push every curated hit off the end.
+    assert render.index("shownCurated") < render.index("shownExternal")
+    assert "BENCHMARK_SEARCH_LIMIT - shownCurated.length" in render
+
+
+def test_curated_search_matches_aliases_and_ranks_the_exact_one_first():
+    # The registry records aliases so a reader need not know the canonical
+    # spelling. It also records `HLEAutomationBench`, which made AutomationBench
+    # a prefix hit for "HLE" and, ranked on entry-name length, beat the record
+    # literally named HLE. The matched alias is what gets ranked.
+    script = source("site/assets/app.js")
+    search = script.split("function searchCuratedEntries(board, query)", 1)[1].split(
+        "\n}", 1
+    )[0]
+
+    assert "entry.aliases || []" in search
+    assert "name === needle ? 0 : name.startsWith(needle) ? 1 : 2" in search
+    # Only scored benchmarks are offered, same rule as the picker.
+    assert "if (!scoreRecord(entry.benchmark_id)) continue;" in search
+
+
+def test_search_still_works_when_the_crawled_index_is_unavailable():
+    # The curated layer lives in the dashboard payload, which is already loaded,
+    # so a failed or pending index fetch must degrade only the crawled half
+    # rather than blanking search entirely.
+    script = source("site/assets/app.js")
+    render = script.split("function renderBenchmarkSearch()", 1)[1].split("\nfunction ", 1)[0]
+
+    assert "if (!records && !curatedCount)" in render
+    assert "records\n    ? searchBenchmarkIndex(records, state.benchmarkQuery)\n    : []" in render
 
 
 def test_a_link_to_an_unscored_benchmark_says_so_instead_of_swapping():

--- a/tests/test_saturation_view.py
+++ b/tests/test_saturation_view.py
@@ -36,24 +36,52 @@ def test_the_score_track_occupies_the_whole_plot():
     assert "x(observation.reported_at)" in chart
 
 
-def test_the_score_layer_only_draws_lines_the_join_rule_permits():
-    # Two values taken under unstated and possibly different conditions are not
-    # a measurement of change, so an unconnectable series must draw no line.
+def test_the_score_layer_draws_no_connecting_line_at_all():
+    # A shared instrument and protocol makes two numbers comparable; it does not
+    # make them a series, and a segment asserts the second. On shipped GPQA
+    # Diamond the old join rule connected DeepSeek-V4-Pro (90.1) to
+    # DeepSeek-V4-Flash (88.1) and drew a decline out of a smaller model, and
+    # connected two vendors' unrelated models into an apparent trajectory.
+    # Restricting which pairs may join does not fix that: the defect is in the
+    # segment. Comparability is still computed, and still stated in prose by the
+    # paired comparison readout.
     script = source("site/assets/app.js")
+    styles = source("site/assets/styles.css")
     chart = script.split("function scoreTrackChart(", 1)[1].split(
         "\nfunction clearAdoptionFrontier", 1
     )[0]
 
-    assert "if (!series.connectable) continue;" in chart
+    assert "polyline" not in chart
+    assert "if (!series.connectable) continue;" not in chart
+    assert "score-line" not in script
+    assert "score-line" not in styles
+    # The one horizontal rule that remains is the best-on-record reference,
+    # which is a fact about the corpus to date rather than a join between points.
+    assert "const bestY = scoreY(record.saturation.best_value);" in chart
 
 
-def test_a_single_vendor_run_is_drawn_as_weaker_evidence():
+def test_comparability_is_stated_in_prose_rather_than_drawn():
+    # A single-vendor comparable run used to be drawn as a dashed line, weaker
+    # evidence than a solid cross-vendor one. Both are gone. The distinction
+    # survives where it can carry its own caveat: the readout under the chart.
     script = source("site/assets/app.js")
-    styles = source("site/assets/styles.css")
 
-    assert "score-line-single-org" in script
-    assert ".score-line-single-org" in styles
-    assert "stroke-dasharray" in styles.split(".score-line-single-org", 1)[1][:120]
+    assert "single_organization" not in script.split("function scoreTrackChart(", 1)[1].split(
+        "\nfunction clearAdoptionFrontier", 1
+    )[0]
+    # The evidence box is untouched: it names what a pair supports and what it
+    # does not, which is the honesty a line could never carry. Its label and
+    # both sentences come from the score record, so the readout renders them
+    # rather than restating them here.
+    readout = script.split("function scoreReadout(entry, record)", 1)[1].split(
+        "\nfunction ", 1
+    )[0]
+    assert 'text: t("Supports: ")' in readout
+    assert 'text: t("Does not support: ")' in readout
+    assert "evidence.does_not_support" in readout
+    # And the comparable-run count is still surfaced, so comparability is
+    # reported as a number even though it is not drawn as a line.
+    assert '"comparable run"' in readout
 
 
 def test_a_third_party_citation_is_marked_on_the_chart():
@@ -323,9 +351,11 @@ def test_the_legend_keys_only_marks_that_are_on_the_chart():
         "the tick under the jump",
     ):
         assert gone not in script, f"{gone!r} still in the legend copy"
-    # The score entries are what the key is for now.
+    # One entry remains, keyed to the only mark the chart draws.
     assert "legend-swatch-score" in legend
-    assert "connected only at one instrument and protocol" in legend
+    assert "one value read verbatim from a cited document" in legend
+    for gone in ("Solid score connection", "Dashed score connection"):
+        assert gone not in script, f"{gone!r} keys a mark that is no longer drawn"
 
 
 def test_the_axis_and_header_name_the_score_reading():

--- a/tests/test_saturation_view.py
+++ b/tests/test_saturation_view.py
@@ -254,6 +254,67 @@ def test_search_still_works_when_the_crawled_index_is_unavailable():
     assert "records\n    ? searchBenchmarkIndex(records, state.benchmarkQuery)\n    : []" in render
 
 
+def test_search_is_the_first_interactive_element_in_the_navigator():
+    # The shortlist used to lead the panel, which made four worked examples read
+    # as the whole offer: a reader wanting anything else had to scroll past them
+    # to reach the box that covers all 1,207 records. Search leads now, and the
+    # examples are framed as examples.
+    html = source("site/index.html")
+    navigator = html.split('class="benchmark-navigator"', 1)[1].split("</aside>", 1)[0]
+
+    assert navigator.index('class="benchmark-search"') < navigator.index(
+        'class="benchmark-shortlist-section"'
+    )
+    # Results sit immediately under the box, with nothing between them but the
+    # line stating what the box reaches.
+    assert navigator.index('id="benchmark-search-status"') < navigator.index(
+        'id="benchmark-search-results"'
+    )
+    assert navigator.index('id="benchmark-search-results"') < navigator.index(
+        'id="benchmark-shortlist"'
+    )
+    assert 'data-i18n="Famous benchmarks"' in navigator
+    assert 'data-i18n-placeholder="Search benchmarks, tasks, domains…"' in navigator
+
+
+def test_the_search_reach_line_counts_only_what_it_can_return():
+    # A count that advertised records the box cannot return would be a boast
+    # rather than a statement of reach, so it is derived from the loaded layers
+    # and drops when the crawled index fails. "Sources" counts those layers, not
+    # the radar's discovery connectors, which contribute no benchmark here.
+    script = source("site/assets/app.js")
+    render = script.split("function renderBenchmarkSearch()", 1)[1].split("\nfunction ", 1)[0]
+
+    assert 't("{n} benchmarks")' in render
+    assert 'metricLabel(sources.size, "source")' in render
+    assert "const sources = new Set((records || []).map((record) => record.source));" in render
+    assert 'if (curatedCount) sources.add("curated");' in render
+    # No literal totals anywhere: the numbers are computed, never written down.
+    assert "4,861" not in script and "4861" not in script
+
+
+def test_search_matches_the_fields_the_placeholder_promises():
+    # The box says "benchmarks, tasks, domains". Name and alias cover the first,
+    # and `domain` covers the rest: the task shape rendered in the panel is
+    # selected by domain, so matching it is what makes "agent" or "science"
+    # return a set instead of nothing. The crawled catalog carries no domain, so
+    # publisher and modality are the equivalent there.
+    script = source("site/assets/app.js")
+
+    curated = script.split("function searchCuratedEntries(board, query)", 1)[1].split(
+        "\n}", 1
+    )[0]
+    assert "foldName(entry.domain).includes(needle)" in curated
+    # A field hit is a weaker answer than a name hit and ranks below every one.
+    assert "const best = hits.length ? Math.min(...hits.map(tier)) : 3;" in curated
+
+    external = script.split("function searchBenchmarkIndex(records, query)", 1)[1].split(
+        "\n}", 1
+    )[0]
+    assert "foldName(record.publisher).includes(needle)" in external
+    assert "foldName(record.modality).includes(needle)" in external
+
+
 def test_a_link_to_an_unscored_benchmark_says_so_instead_of_swapping():
     # These 20 benchmarks resolved and drew an adoption staircase before this
     # change, so links to them are already out there. Falling through to the

--- a/tests/test_saturation_view.py
+++ b/tests/test_saturation_view.py
@@ -17,18 +17,21 @@ def source(path: str) -> str:
     return Path(path).read_text(encoding="utf-8")
 
 
-def test_both_readings_share_one_time_axis():
-    # The point of the panel. Two charts with independent x scales would not let
-    # a reader compare adoption against score at a given date, which is the
-    # comparison the issue asked for.
+def test_the_score_track_occupies_the_whole_plot():
+    # The panel used to lead with an adoption staircase and give the scores a
+    # short strip underneath. The staircase answered a different question, so the
+    # score band now starts at the top margin and takes the height the staircase,
+    # the card rug and the inter-band gaps vacated. The y-axis is zoomed to the
+    # observed range, so that height is vertical resolution on the one reading a
+    # reader must not misjudge.
     script = source("site/assets/app.js")
-    chart = script.split("function adoptionFrontierChart(", 1)[1].split(
+    chart = script.split("function scoreTrackChart(", 1)[1].split(
         "\nfunction clearAdoptionFrontier", 1
     )[0]
 
-    # One x() for both plots, and a score y that offsets below the adoption plot
-    # and the card rug that now sits between them (issue #91 legibility pass).
-    assert "const scoreTop = margin.top + plotHeight + rugGap + rugHeight + bandGap" in chart
+    assert "const scoreTop = margin.top;" in chart
+    assert "const scoreHeight = 480;" in chart
+    assert "const height = margin.top + scoreHeight + margin.bottom;" in chart
     assert "scoreY(observation.value)" in chart
     assert "x(observation.reported_at)" in chart
 
@@ -37,7 +40,7 @@ def test_the_score_layer_only_draws_lines_the_join_rule_permits():
     # Two values taken under unstated and possibly different conditions are not
     # a measurement of change, so an unconnectable series must draw no line.
     script = source("site/assets/app.js")
-    chart = script.split("function adoptionFrontierChart(", 1)[1].split(
+    chart = script.split("function scoreTrackChart(", 1)[1].split(
         "\nfunction clearAdoptionFrontier", 1
     )[0]
 
@@ -69,7 +72,7 @@ def test_score_points_carry_recognizable_model_family_marks():
     """Issue #195: saturation points identify models before interaction."""
     script = source("site/assets/app.js")
     styles = source("site/assets/styles.css")
-    chart = script.split("function adoptionFrontierChart(", 1)[1].split(
+    chart = script.split("function scoreTrackChart(", 1)[1].split(
         "\nfunction clearAdoptionFrontier", 1
     )[0]
 
@@ -125,11 +128,11 @@ def test_better_is_up_even_when_lower_is_the_better_score():
     # Codex P2. `direction` exists in the schema so an error-rate metric does not
     # render its improvements as a downward slope. The renderer has to consult it.
     script = source("site/assets/app.js")
-    chart = script.split("function adoptionFrontierChart(", 1)[1].split(
+    chart = script.split("function scoreTrackChart(", 1)[1].split(
         "\nfunction clearAdoptionFrontier", 1
     )[0]
 
-    assert 'record?.direction === "lower_is_better"' in chart
+    assert 'record.direction === "lower_is_better"' in chart
     assert "scoreDescends ? 1 - fraction : fraction" in chart
 
 
@@ -142,20 +145,60 @@ def test_lower_is_better_headroom_is_described_against_zero():
     assert "points to zero, the floor of this metric" in script
 
 
-def test_a_sparse_adoption_layer_does_not_hide_a_readable_score():
-    # Codex P2. The sparse stepper replaces a one-advance step line because that
-    # line says nothing visually. The score track is a separate reading, so
-    # dropping it would hide real data because a different layer was thin.
+def test_only_a_benchmark_with_a_readable_score_can_be_selected():
+    # The panel is the score track now, so a benchmark with no readable value has
+    # nothing to draw. It is filtered out of the picker rather than opening an
+    # empty chart, which would read as "scores went to zero here". 20 of the 79
+    # adopted registry benchmarks take this path.
     script = source("site/assets/app.js")
-    render = script.split("const sparse = frontier.length < 2;", 1)[1].split(
-        "renderScoreReadout(entry)", 1
+    render = script.split("function renderAdoptionFrontier(board)", 1)[1].split(
+        "\nfunction ", 1
     )[0]
 
-    assert "scoreRecord(entry.benchmark_id)" in render
-    assert "sparse && !scored ? null : adoptionFrontierChart" in render
-    # And the chart collapses the empty adoption band rather than padding with it.
-    chart = script.split("function adoptionFrontierChart(", 1)[1]
-    assert "const plotHeight = sparse ? 0 : 370 - margin.top - margin.bottom;" in chart
+    assert "const scored = adopted.filter((entry) => scoreRecord(entry.benchmark_id));" in render
+    # The <select>, the resolution of a ?lfrontier= permalink, and the empty
+    # state all read from `scored`, so none of them can surface an unscored one.
+    assert "...[...scored]" in render
+    assert "scored.find((candidate) => candidate.benchmark_id === state.lfrontier)" in render
+    assert "if (!scored.length || !defaultEntry)" in render
+    # The default selection is drawn from the same set.
+    default_entry = script.split("function frontierDefaultEntry(board)", 1)[1].split(
+        "\n}", 1
+    )[0]
+    assert "scoreRecord(entry.benchmark_id)" in default_entry
+
+
+def test_a_link_to_an_unscored_benchmark_says_so_instead_of_swapping():
+    # These 20 benchmarks resolved and drew an adoption staircase before this
+    # change, so links to them are already out there. Falling through to the
+    # default entry would show a different benchmark under the reader's own URL
+    # with nothing to say so, which is a worse failure than an explicit refusal.
+    script = source("site/assets/app.js")
+    render = script.split("function renderAdoptionFrontier(board)", 1)[1].split(
+        "\nfunction ", 1
+    )[0]
+
+    assert "const unscoredEntry = state.lfrontier" in render
+    assert "&& !scoreRecord(candidate.benchmark_id)" in render
+    assert "so there is no track to draw" in render
+    # It resolves before the default-entry fallback, or the fallback wins.
+    assert render.index("const unscoredEntry") < render.index("state.lfrontier = defaultEntry.benchmark_id")
+    # And the reader's URL is left alone: the panel names the benchmark they
+    # asked for rather than rewriting the address to one they did not.
+    assert "heading: unscoredEntry.name" in render
+
+
+def test_no_route_into_the_panel_can_land_on_an_unscored_benchmark():
+    # The picker is not the only way in: a leaderboard row and a finding card
+    # both jump here. Either would snap to the default entry for an unscored
+    # benchmark and lie about what it opened, so neither offers the jump.
+    script = source("site/assets/app.js")
+
+    row = script.split("function leaderboardRow(entry)", 1)[1]
+    assert "const frontierButton = scoreRecord(entry.benchmark_id)" in row
+
+    finding = script.split("function findingCard(finding, board)", 1)[1]
+    assert "entry.benchmark_id === finding.benchmark_id && scoreRecord(entry.benchmark_id)" in finding
 
 
 def test_the_time_range_covers_the_score_track_at_both_ends():
@@ -164,38 +207,51 @@ def test_the_time_range_covers_the_score_track_at_both_ends():
     # every card -- reachable when a card carries a later `revised` date -- landed
     # outside the viewBox and was silently clipped.
     script = source("site/assets/app.js")
-    chart = script.split("function adoptionFrontierChart(", 1)[1]
+    chart = script.split("function scoreTrackChart(", 1)[1]
     range_block = chart.split("const start = new Date(", 1)[0]
 
-    assert "record?.first_reported_at" in range_block
-    assert "record?.last_reported_at" in range_block
+    assert "const startText = record.first_reported_at;" in range_block
+    assert "record.last_reported_at" in range_block
 
 
-def test_scores_still_render_when_no_mention_carries_a_date():
-    # Codex P2, second and third pass. The registry permits a card without
-    # `published`, so a scored benchmark can have zero dated adoption events.
-    # Clearing the panel hid every readable score because the *other* layer had no
-    # date -- and restoring only the aggregate readout still hid the individual
-    # points and comparable series, so a real chart is drawn.
+def test_scores_render_whether_or_not_any_mention_carries_a_date():
+    # The registry permits a card without `published`. When the adoption band led
+    # the panel, a benchmark with no dated mention was routed through a separate
+    # early return and a second entry point into the chart. The score track needs
+    # no dated mention at all: its own axis is bounded by the score record, and
+    # `lastMention` is consulted only to bound the reading-gap marker.
     script = source("site/assets/app.js")
-    guard = script.split("if (!events.length) {", 1)[1].split("\n  }", 1)[0]
 
-    # Ordering matters: clearAdoptionFrontier empties the readout, so the score
-    # render has to come after it.
-    assert guard.index("clearAdoptionFrontier") < guard.index("renderScoreReadout(entry)")
-    assert "renderFrontierLegend(entry, record, { sparse: true })" in guard
-    assert "scoreOnlyChart(entry, board)" in guard
+    assert "if (!events.length) {" not in script
+    render = script.split("function renderAdoptionFrontier(board)", 1)[1].split(
+        "\nfunction ", 1
+    )[0]
+    assert 'replaceChildren(byId("frontier-chart"), [scoreTrackChart(entry, board), frontierTooltip()])' in render
+
+    chart = script.split("function scoreTrackChart(", 1)[1].split(
+        "\nfunction clearAdoptionFrontier", 1
+    )[0]
+    assert "const startText = record.first_reported_at;" in chart
+    # The only adoption field the renderer touches is the mention date, and only
+    # to bound the reading gap. It reads no advance flag and no running count.
+    assert "const lastMention = frontierEvents(entry).at(-1)?.published;" in chart
+    assert ".advances" not in chart
+    assert "organizationCount" not in chart
 
 
-def test_the_score_only_chart_reuses_the_one_score_renderer():
+def test_there_is_exactly_one_score_renderer():
     # Two implementations of one axis would be free to disagree about the join
-    # rule, which is the single thing this chart must not do.
+    # rule, which is the single thing this chart must not do. The second entry
+    # point (`scoreOnlyChart`, for a benchmark with no dated mention) existed only
+    # to suppress the adoption bands and went with them.
     script = source("site/assets/app.js")
-    helper = script.split("function scoreOnlyChart(entry, board)", 1)[1].split("\n}", 1)[0]
 
-    assert "adoptionFrontierChart(" in helper
-    assert "board," in helper
-    assert "sparse: true" in helper
+    assert script.count("function scoreTrackChart(") == 1
+    assert "function scoreOnlyChart(" not in script
+    assert "function adoptionFrontierChart(" not in script
+    # And no permanently-false flag left behind in its place: a switch nobody can
+    # turn on is worse than no switch.
+    assert "sparse" not in script
 
 
 def test_the_reading_gap_ends_at_this_benchmarks_own_latest_mention():
@@ -203,7 +259,7 @@ def test_the_reading_gap_ends_at_this_benchmarks_own_latest_mention():
     # registry, so shipped Arena-Hard and Aider Polyglot -- which have no adopter
     # newer than their last score -- drew a long gap nothing supported.
     script = source("site/assets/app.js")
-    gap = script.split("const lastMention = events", 1)[1].split(
+    gap = script.split("const lastMention = frontierEvents(entry)", 1)[1].split(
         "no readable score in this window", 1
     )[0]
 
@@ -211,68 +267,90 @@ def test_the_reading_gap_ends_at_this_benchmarks_own_latest_mention():
     assert "x(endText)" not in gap, "the gap must not extend to the registry-wide end date"
 
 
-def test_card_events_live_on_their_own_band_not_the_count_axis():
-    # Issue #91 legibility pass. Repeat cards were plotted at `y(organizationCount)`,
-    # putting a marker at a height the card did not cause: a card that changed
-    # nothing sat at the same y as the advance that did, and several cards sharing
-    # a date stacked into each other. Card events now get their own rug band.
-    script = source("site/assets/app.js")
-    chart = script.split("function adoptionFrontierChart(", 1)[1].split(
-        "\nfunction clearAdoptionFrontier", 1
-    )[0]
-
-    assert "const rugTop = margin.top + plotHeight + rugGap" in chart
-    assert "card-rug-tick" in chart
-    # The staircase loop iterates advances only; nothing else may touch y().
-    staircase = chart.split("for (const event of advances) {", 1)[1].split("\n  }", 1)[0]
-    assert "for (const event of events)" not in staircase
-
-
-def test_the_advance_marker_carries_no_number():
-    # The digit inside the circle restated the y-axis value the marker already sat
-    # at, and a number in a circle reads as a record id, so readers took the
-    # staircase for a numbered list rather than a cumulative count.
+def test_the_adoption_marks_are_gone_from_the_chart():
+    # The staircase, its orange advance diamonds, the release marker and the card
+    # rug all answered "who reported this, and when" rather than "what did it
+    # score". They are removed rather than hidden behind a flag: the geometry
+    # that kept them legible (the count axis, the rug's collision sweep, the
+    # release line spanning both plots) is dead weight the moment nothing draws
+    # them, and it would drift out of agreement with the score band it no longer
+    # shares a viewBox with.
     script = source("site/assets/app.js")
     styles = source("site/assets/styles.css")
 
-    assert "frontier-point-number" not in script
-    assert "frontier-point-number" not in styles
-    assert "advanceIndex" not in script
-    # A brand-colored circle carrying the reporting organization's glyph: the
-    # glyph names the organization that stepped the count up (issue #178).
-    assert "frontier-point-advance" in script
-    assert ".frontier-point-face" in styles
+    for mark in (
+        "frontier-point-advance",
+        "frontier-point-face",
+        "frontier-point-number",
+        "card-rug-tick",
+        "card-rug-baseline",
+        "frontier-release-line",
+        "frontier-line",
+        "MIN_TICK_GAP",
+        "organizationCount",
+        "maxOrganizations",
+        "frontier-sparse",
+    ):
+        assert mark not in script, f"{mark} still drawn"
+        assert mark not in styles, f"{mark} still styled"
+
+    # The score marks are untouched. They carry their own classes, so a check
+    # that the adoption ones are absent cannot pass by emptying the chart.
+    chart = script.split("function scoreTrackChart(", 1)[1].split(
+        "\nfunction clearAdoptionFrontier", 1
+    )[0]
+    assert "score-point-face" in chart
+    assert ".score-point-face" in styles
 
 
-def test_a_legend_names_each_mark_and_its_effect_on_the_count():
-    # "New organization" alone does not say that the other kind leaves the
-    # staircase flat, so each entry states the mark AND what it does to the count.
+def test_the_legend_keys_only_marks_that_are_on_the_chart():
+    # A key describing marks that are not on screen is worse than no key. The
+    # four adoption entries (the advance diamond, the two rug ticks and their
+    # effect on the count) named marks the chart no longer draws, so they went
+    # with the bands; what remains is keyed to the score marks.
+    html = source("site/index.html")
+    script = source("site/assets/app.js")
+    legend = script.split("function renderFrontierLegend(", 1)[1].split("\n}", 1)[0]
+
+    assert 'id="frontier-legend"' in html
+    assert "const items = [];" in legend
+    for gone in (
+        "New organization",
+        "First card from that organization",
+        "Later card, organization already counted",
+        "cumulative count increases",
+        "count unchanged",
+        "the tick under the jump",
+    ):
+        assert gone not in script, f"{gone!r} still in the legend copy"
+    # The score entries are what the key is for now.
+    assert "legend-swatch-score" in legend
+    assert "connected only at one instrument and protocol" in legend
+
+
+def test_the_axis_and_header_name_the_score_reading():
+    # The header said "ADOPTION TRAJECTORY" over a chart that no longer plots
+    # adoption, and the counts line under it ("26 model cards, 10 distinct
+    # organizations, last new organization ...") was an adoption reading in
+    # prose. Both are replaced by what the panel actually shows.
     html = source("site/index.html")
     script = source("site/assets/app.js")
 
-    assert 'id="frontier-legend"' in html
-    assert "function renderFrontierLegend(" in script
-    assert "cumulative count increases" in script
-    assert "count unchanged" in script
+    assert 't("reported scores over time")' in script
+    assert "adoption trajectory" not in script
+    # The counts line and the reporting-stage sentence are gone from the markup,
+    # so nothing can repopulate them.
+    assert 'id="frontier-summary"' not in html
+    assert "frontier-summary" not in script
+    assert "function reportingStage(" not in script
 
-
-def test_the_axis_and_header_name_distinct_organizations():
-    # "Organizations reporting" invited the reading that a repeat card adds to it,
-    # and "23 cards · 10 of 10 dated organizations" read as one ratio about a
-    # single quantity rather than two different counts.
-    script = source("site/assets/app.js")
-
-    assert "cumulative distinct organizations" in script
-    assert '"distinct organization"' in script
-    # Asserted on the strings that actually render, not on a source slice: "dated
-    # organizations" legitimately survives in comments (including the one
-    # documenting this very change) and in the navigator copy, so a
-    # substring-absence check over source text tests the wrong thing.
-    assert 'metricLabel(entry.card_count, "model card")' in script
-    assert 'metricLabel(frontier.length, "distinct organization")' in script
-    # And the organization count is qualified when some card carries no date, since
-    # card_count includes those while the plotted count cannot.
-    assert 't("with a dated card")' in script
+    # The x axis names the date each point actually carries. 5,522 of the 5,544
+    # crawled rows carry a model release date and none carries an evaluation
+    # date, so an unqualified "time" invites the wrong reading; the curated
+    # points here sit at the date their citing document was published, and the
+    # label says which.
+    assert 't("document publication date")' in script
+    assert '"document publication date": ' in script
 
 
 def test_the_chart_does_not_collapse_on_a_narrow_viewport():
@@ -295,22 +373,22 @@ def test_the_chart_does_not_collapse_on_a_narrow_viewport():
     assert "if (isNarrow === wasNarrow) return;" in script
 
 
-def test_rug_ticks_never_overpaint_each_other():
-    # Codex P1, twice. Two earlier versions were wrong the same way at different
-    # scales: x(date) alone overpainted cards sharing a date, and fanning each date
-    # independently then pushed those ticks into a *neighbouring* date's -- 0.04
-    # units apart on shipped GPQA Diamond at the narrow viewBox, inside a 2.5-unit
-    # stroke. Positions are therefore allocated across every card at once.
+def test_the_rug_collision_sweep_went_with_the_rug():
+    # The rug's one-pass tick allocation existed because several cards sharing a
+    # date overpainted each other. With the rug removed there is nothing left to
+    # allocate, and a nudging sweep that still ran would move score points off
+    # the dates they were reported on -- the opposite of what it was for.
     script = source("site/assets/app.js")
-    rug = script.split("const MIN_TICK_GAP", 1)[1].split("\n  }", 1)[0]
 
-    # A single sweep enforcing a minimum gap, not a per-date fan.
-    assert "Math.max(ideal, previous + MIN_TICK_GAP)" in rug
-    # Recentred afterwards so the run still sits on the dates it represents.
-    assert "const shift = drift / 2;" in rug
-    # The gap has to exceed the widest tick stroke (2.5) or ticks still touch.
-    gap = float(script.split("const MIN_TICK_GAP = ", 1)[1].split(";", 1)[0])
-    assert gap > 2.5, "the minimum gap must exceed the tick stroke width"
+    assert "MIN_TICK_GAP" not in script
+    # Score points sit at x(reported_at) and nowhere else. Several scores may
+    # share a date; they are separated by their y value, which is the reading,
+    # rather than nudged along the axis, which would falsify it.
+    chart = script.split("function scoreTrackChart(", 1)[1].split(
+        "\nfunction clearAdoptionFrontier", 1
+    )[0]
+    assert "x(observation.reported_at)" in chart
+    assert "previous + " not in chart
 
 
 def test_the_zoom_marker_survives_a_narrow_viewport():
@@ -323,17 +401,6 @@ def test_the_zoom_marker_survives_a_narrow_viewport():
     assert "(zoomed)" in script
 
 
-def test_the_legend_omits_marks_that_sparse_mode_suppresses():
-    # Codex P2. `sparse` replaces the staircase and rug with the step list, so a
-    # key describing diamonds and ticks that are not on screen is worse than none.
-    script = source("site/assets/app.js")
-    legend = script.split("function renderFrontierLegend(", 1)[1].split("\n}", 1)[0]
-
-    assert "sparse" in legend
-    assert "const items = sparse" in legend
-    assert "renderFrontierLegend(entry, scoreRecord(entry.benchmark_id), { sparse })" in script
-
-
 def test_the_score_axis_says_it_is_zoomed():
     # Every value in this corpus sits in the upper part of its scale, so the
     # band is padded around the observed range instead of running 0-100. A
@@ -344,16 +411,27 @@ def test_the_score_axis_says_it_is_zoomed():
     assert "(zoomed)" in script
 
 
-def test_a_benchmark_with_no_readable_score_says_so_instead_of_plotting_zero():
+def test_a_benchmark_with_no_readable_score_draws_no_chart_at_all():
+    # Previously the panel opened on the adoption staircase and said in the
+    # readout that no score could be read. With the staircase retired there is
+    # nothing left to draw, so the renderer refuses rather than emitting an empty
+    # band, which a reader would take for a drop to zero.
     script = source("site/assets/app.js")
 
+    chart = script.split("function scoreTrackChart(", 1)[1].split(
+        "\nfunction clearAdoptionFrontier", 1
+    )[0]
+    assert "if (!record) return null;" in chart
+    # No conditional band height survives: the band is unconditionally full.
+    assert "record ? 132 : 0" not in chart
+
+    # The readout keeps the honest sentence for the defensive case, minus the
+    # clause promising an adoption chart that no longer exists.
     readout = script.split("function renderScoreReadout(entry)", 1)[1].split(
-        "\nfunction adoptionFrontierChart", 1
+        "\nfunction ", 1
     )[0]
     assert "not a zero and not a plateau" in readout
-    # And the chart reserves no empty band for it, which would read as a drop.
-    chart = script.split("function adoptionFrontierChart(", 1)[1]
-    assert "const scoreHeight = record ? 132 : 0;" in chart
+    assert "the chart shows adoption only" not in script
 
 
 def test_the_evidence_grade_is_printed_not_hidden():
@@ -409,15 +487,21 @@ def test_a_finding_can_move_the_chart_to_the_benchmark_it_is_about():
     assert "finding.benchmark_id" in card
 
 
-def test_the_explainer_still_separates_reporting_from_score_saturation():
-    # The guarantee that predates this change and must survive it: a flat
-    # adoption run is reporting saturation within a curated registry, and is not
-    # a claim about the benchmark's scores.
+def test_the_explainer_leaves_saturation_as_the_readers_judgement():
+    # The predecessor of this guarantee said a flat adoption run was reporting
+    # saturation and not a claim about scores. The adoption run is gone, so the
+    # confusion it guarded against is now the inverse one: a flat score tail read
+    # as a saturated benchmark. The preamble has to name the gap for what it is
+    # and must not print a saturation verdict of its own.
     html = " ".join(source("site/index.html").split())
 
-    assert "A long flat run is reporting saturation" in html
-    assert "not a claim about benchmark score saturation" in html
+    assert "no newer number could be read" in html
+    assert "the gap is marked rather than drawn through" in html
+    assert "stays a reading you make, not a score this panel prints" in html
     assert "connected only where the instrument and protocol" in html
+    # And it names the date the x axis carries, rather than leaving "time" to be
+    # read as an evaluation date.
+    assert "placed at the date that document was published rather than at any evaluation date" in html
 
 
 def test_the_score_layer_is_keyed_by_the_same_benchmark_id_as_adoption():

--- a/tests/test_saturation_view.py
+++ b/tests/test_saturation_view.py
@@ -320,11 +320,14 @@ def test_the_examples_are_ranked_by_how_many_cards_report_them():
     assert "entry.card_count > 0 && scoreRecord(entry.benchmark_id)" in navigator
     assert "BENCHMARK_EXAMPLE_LIMIT" in navigator
     assert 'metricLabel(entry.card_count, "model card")' in navigator
-    # Bounded height rather than twenty rows tall: this aside must not out-weigh
-    # the chart beside it.
+    # Every example is on the page: an inner scroller hid ranks 8-20 behind a
+    # scrollbar that read as the end of the list. The sticky aside is what gets
+    # bounded to the viewport instead.
     shortlist = styles.split(".benchmark-shortlist {", 1)[1].split("}", 1)[0]
-    assert "max-height" in shortlist
-    assert "overflow-y: auto" in shortlist
+    assert "max-height" not in shortlist
+    aside = styles.split(".benchmark-navigator {", 1)[1].split("}", 1)[0]
+    assert "max-height: calc(100vh - 2rem)" in aside
+    assert "overflow-y: auto" in aside
 
 
 def test_the_navigator_still_starts_the_crawled_index_fetch():

--- a/tests/test_saturation_view.py
+++ b/tests/test_saturation_view.py
@@ -66,16 +66,17 @@ def test_comparability_is_stated_in_prose_rather_than_drawn():
     # survives where it can carry its own caveat: the readout under the chart.
     script = source("site/assets/app.js")
 
-    assert "single_organization" not in script.split("function scoreTrackChart(", 1)[1].split(
-        "\nfunction clearAdoptionFrontier", 1
-    )[0]
+    assert (
+        "single_organization"
+        not in script.split("function scoreTrackChart(", 1)[1].split(
+            "\nfunction clearAdoptionFrontier", 1
+        )[0]
+    )
     # The evidence box is untouched: it names what a pair supports and what it
     # does not, which is the honesty a line could never carry. Its label and
     # both sentences come from the score record, so the readout renders them
     # rather than restating them here.
-    readout = script.split("function scoreReadout(entry, record)", 1)[1].split(
-        "\nfunction ", 1
-    )[0]
+    readout = script.split("function scoreReadout(entry, record)", 1)[1].split("\nfunction ", 1)[0]
     assert 'text: t("Supports: ")' in readout
     assert 'text: t("Does not support: ")' in readout
     assert "evidence.does_not_support" in readout
@@ -179,25 +180,19 @@ def test_only_a_benchmark_with_a_readable_score_can_be_selected():
     # empty chart, which would read as "scores went to zero here". 20 of the 79
     # adopted registry benchmarks take this path.
     script = source("site/assets/app.js")
-    render = script.split("function renderAdoptionFrontier(board)", 1)[1].split(
-        "\nfunction ", 1
-    )[0]
+    render = script.split("function renderAdoptionFrontier(board)", 1)[1].split("\nfunction ", 1)[0]
 
     assert "const scored = adopted.filter((entry) => scoreRecord(entry.benchmark_id));" in render
     # The <select>, the resolution of a ?lfrontier= permalink, and the empty
     # state all read from `scored`, so none of them can surface an unscored one.
     assert "renderFrontierPicker(scored, state.lfrontier);" in render
     # And the picker itself applies the same rule to the crawled layer.
-    picker = script.split("function frontierPickerGroups(scored)", 1)[1].split(
-        "\n}", 1
-    )[0]
+    picker = script.split("function frontierPickerGroups(scored)", 1)[1].split("\n}", 1)[0]
     assert "record.score_count > 0" in picker
     assert "scored.find((candidate) => candidate.benchmark_id === state.lfrontier)" in render
     assert "if (!scored.length || !defaultEntry)" in render
     # The default selection is drawn from the same set.
-    default_entry = script.split("function frontierDefaultEntry(board)", 1)[1].split(
-        "\n}", 1
-    )[0]
+    default_entry = script.split("function frontierDefaultEntry(board)", 1)[1].split("\n}", 1)[0]
     assert "scoreRecord(entry.benchmark_id)" in default_entry
 
 
@@ -233,9 +228,7 @@ def test_curated_search_matches_aliases_and_ranks_the_exact_one_first():
     # a prefix hit for "HLE" and, ranked on entry-name length, beat the record
     # literally named HLE. The matched alias is what gets ranked.
     script = source("site/assets/app.js")
-    search = script.split("function searchCuratedEntries(board, query)", 1)[1].split(
-        "\n}", 1
-    )[0]
+    search = script.split("function searchCuratedEntries(board, query)", 1)[1].split("\n}", 1)[0]
 
     assert "entry.aliases || []" in search
     assert "name === needle ? 0 : name.startsWith(needle) ? 1 : 2" in search
@@ -369,16 +362,14 @@ def test_search_matches_the_fields_the_placeholder_promises():
     # publisher and modality are the equivalent there.
     script = source("site/assets/app.js")
 
-    curated = script.split("function searchCuratedEntries(board, query)", 1)[1].split(
-        "\n}", 1
-    )[0]
+    curated = script.split("function searchCuratedEntries(board, query)", 1)[1].split("\n}", 1)[0]
     assert "foldName(entry.domain).includes(needle)" in curated
     # A field hit is a weaker answer than a name hit and ranks below every one.
     assert "const best = hits.length ? Math.min(...hits.map(tier)) : 3;" in curated
 
-    external = script.split("function searchBenchmarkIndex(records, query)", 1)[1].split(
-        "\n}", 1
-    )[0]
+    external = script.split("function searchBenchmarkIndex(records, query)", 1)[1].split("\n}", 1)[
+        0
+    ]
     assert "foldName(record.publisher).includes(needle)" in external
     assert "foldName(record.modality).includes(needle)" in external
 
@@ -389,15 +380,14 @@ def test_a_link_to_an_unscored_benchmark_says_so_instead_of_swapping():
     # default entry would show a different benchmark under the reader's own URL
     # with nothing to say so, which is a worse failure than an explicit refusal.
     script = source("site/assets/app.js")
-    render = script.split("function renderAdoptionFrontier(board)", 1)[1].split(
-        "\nfunction ", 1
-    )[0]
+    render = script.split("function renderAdoptionFrontier(board)", 1)[1].split("\nfunction ", 1)[0]
 
     assert "const unscoredEntry = state.lfrontier" in render
     assert "&& !scoreRecord(candidate.benchmark_id)" in render
     assert "so there is no track to draw" in render
     # It resolves before the default-entry fallback, or the fallback wins.
-    assert render.index("const unscoredEntry") < render.index("state.lfrontier = defaultEntry.benchmark_id")
+    fallback = "state.lfrontier = defaultEntry.benchmark_id"
+    assert render.index("const unscoredEntry") < render.index(fallback)
     # And the reader's URL is left alone: the panel names the benchmark they
     # asked for rather than rewriting the address to one they did not.
     assert "heading: unscoredEntry.name" in render
@@ -413,7 +403,8 @@ def test_no_route_into_the_panel_can_land_on_an_unscored_benchmark():
     assert "const frontierButton = scoreRecord(entry.benchmark_id)" in row
 
     finding = script.split("function findingCard(finding, board)", 1)[1]
-    assert "entry.benchmark_id === finding.benchmark_id && scoreRecord(entry.benchmark_id)" in finding
+    guard = "entry.benchmark_id === finding.benchmark_id && scoreRecord(entry.benchmark_id)"
+    assert guard in finding
 
 
 def test_the_time_range_covers_the_score_track_at_both_ends():
@@ -438,10 +429,12 @@ def test_scores_render_whether_or_not_any_mention_carries_a_date():
     script = source("site/assets/app.js")
 
     assert "if (!events.length) {" not in script
-    render = script.split("function renderAdoptionFrontier(board)", 1)[1].split(
-        "\nfunction ", 1
-    )[0]
-    assert 'replaceChildren(byId("frontier-chart"), [scoreTrackChart(entry, board), frontierTooltip()])' in render
+    render = script.split("function renderAdoptionFrontier(board)", 1)[1].split("\nfunction ", 1)[0]
+    paint = (
+        'replaceChildren(byId("frontier-chart"), '
+        "[scoreTrackChart(entry, board), frontierTooltip()])"
+    )
+    assert paint in render
 
     chart = script.split("function scoreTrackChart(", 1)[1].split(
         "\nfunction clearAdoptionFrontier", 1
@@ -644,9 +637,7 @@ def test_a_benchmark_with_no_readable_score_draws_no_chart_at_all():
 
     # The readout keeps the honest sentence for the defensive case, minus the
     # clause promising an adoption chart that no longer exists.
-    readout = script.split("function renderScoreReadout(entry)", 1)[1].split(
-        "\nfunction ", 1
-    )[0]
+    readout = script.split("function renderScoreReadout(entry)", 1)[1].split("\nfunction ", 1)[0]
     assert "not a zero and not a plateau" in readout
     assert "the chart shows adoption only" not in script
 
@@ -718,7 +709,8 @@ def test_the_explainer_leaves_saturation_as_the_readers_judgement():
     assert "connected only where the instrument and protocol" in html
     # And it names the date the x axis carries, rather than leaving "time" to be
     # read as an evaluation date.
-    assert "placed at the date that document was published rather than at any evaluation date" in html
+    dateline = "placed at the date that document was published rather than at any evaluation date"
+    assert dateline in html
 
 
 def test_the_score_layer_is_keyed_by_the_same_benchmark_id_as_adoption():

--- a/tests/test_saturation_view.py
+++ b/tests/test_saturation_view.py
@@ -256,10 +256,9 @@ def test_search_still_works_when_the_crawled_index_is_unavailable():
 
 def test_the_navigator_is_a_tool_region_not_a_content_section():
     # The examples were a titled block with an eyebrow, a heading, a paragraph
-    # and two computed subheadings over eight cards. That outranked the search
-    # box it existed to support. Search leads, and the examples are one line of
-    # chips inside the same block, with nothing between the field and its
-    # results but the reach line and that line.
+    # and two computed subheadings. That outranked the search box it existed to
+    # support, and the paragraph restated the heading. The panel is now a field,
+    # its reach line, its results, and a quiet ranked list.
     html = source("site/index.html")
     navigator = html.split('class="benchmark-navigator"', 1)[1].split("</aside>", 1)[0]
 
@@ -270,48 +269,62 @@ def test_the_navigator_is_a_tool_region_not_a_content_section():
         "benchmark-shortlist-section",
     ):
         assert gone not in navigator, f"{gone} still occupies the navigator"
-    # The heading is the only one left, so it is the panel's label.
+    # The search label is the only heading, so it is the panel's one anchor.
     assert navigator.count("<h2") == 1
     assert 'data-i18n="Search every benchmark"' in navigator
+    # And the examples label is not `.eyebrow`, whose accent blue would plant a
+    # second anchor competing with the field.
+    assert 'class="eyebrow"' not in navigator
+    assert 'class="benchmark-example-lead"' in navigator
 
     order = [
         navigator.index('id="benchmark-search-input"'),
         navigator.index('id="benchmark-search-status"'),
-        navigator.index('id="benchmark-shortlist"'),
         navigator.index('id="benchmark-search-results"'),
+        navigator.index('id="benchmark-shortlist"'),
     ]
-    assert order == sorted(order), "field, reach line, examples, then results"
+    assert order == sorted(order), "field, reach line, results, then examples"
 
 
-def test_the_examples_are_one_line_of_verified_chips():
-    # An editorial list, not a computed one: MMLU carries 4 readable scores and
-    # would never place in a "deepest records" ranking, but it is the name a
-    # newcomer arrives with. Each id is still checked against the live registry,
-    # so a chip can never open the no-score refusal panel.
+def test_the_search_field_carries_the_panel_weight_through_affordance():
+    # The importance of this panel is expressed by the control, not by a large
+    # heading or a paragraph of prose. The label stays small; the field gets the
+    # emphasis, and the reach line drops a size and a step of contrast so it
+    # reads as a footnote to the field rather than as a headline.
+    styles = source("site/assets/styles.css")
+
+    field = styles.split(".benchmark-search-input {", 1)[1].split("}", 1)[0]
+    assert "border: 2px solid var(--ink)" in field
+    assert "background: white" in field
+
+    label = styles.split(".benchmark-search-label {", 1)[1].split("}", 1)[0]
+    assert "font-size: 0.78rem" in label, "the label must not grow"
+
+    status = styles.split(".benchmark-search-status {", 1)[1].split("}", 1)[0]
+    assert "font-size: 0.7rem" in status
+    assert "opacity: 0.75" in status
+
+
+def test_the_examples_are_ranked_by_how_many_cards_report_them():
+    # No editorial list and no computed subheadings: "most reported" is both the
+    # rank and the reason a name is worth trying, which is the one reading this
+    # registry exists to make. Curated only, because `card_count` is a curated
+    # fact; the crawled layer is reached from the field and the picker instead.
     script = source("site/assets/app.js")
     styles = source("site/assets/styles.css")
 
-    assert "const BENCHMARK_EXAMPLES = [" in script
-    for benchmark_id, label in (
-        ("mmlu", "MMLU"),
-        ("gpqa_diamond", "GPQA"),
-        ("swe_bench_verified", "SWE-bench"),
-        ("terminal_bench", "Terminal-Bench"),
-    ):
-        assert f'["{benchmark_id}", "{label}"]' in script
-
     navigator = script.split("function renderBenchmarkNavigator(board)", 1)[1].split(
-        "\n}", 1
+        "\nfunction ", 1
     )[0]
-    assert "if (!entry || !scoreRecord(benchmarkId)) return null;" in navigator
-    # A short label is a prompt for the search box, not a record title, so the
-    # full registry name rides along rather than being hidden by the shorthand.
-    assert "title: entry.name," in navigator
-    assert '"aria-label": entry.name,' in navigator
-    # Chips, not cards: the old grid of two-line buttons is gone.
-    assert "benchmark-shortlist-button" not in script
-    assert "benchmark-shortlist-button" not in styles
-    assert ".benchmark-example {" in styles
+    assert "b.card_count - a.card_count || a.name.localeCompare(b.name)" in navigator
+    assert "entry.card_count > 0 && scoreRecord(entry.benchmark_id)" in navigator
+    assert "BENCHMARK_EXAMPLE_LIMIT" in navigator
+    assert 'metricLabel(entry.card_count, "model card")' in navigator
+    # Bounded height rather than twenty rows tall: this aside must not out-weigh
+    # the chart beside it.
+    shortlist = styles.split(".benchmark-shortlist {", 1)[1].split("}", 1)[0]
+    assert "max-height" in shortlist
+    assert "overflow-y: auto" in shortlist
 
 
 def test_the_navigator_still_starts_the_crawled_index_fetch():

--- a/tests/test_saturation_view.py
+++ b/tests/test_saturation_view.py
@@ -254,27 +254,79 @@ def test_search_still_works_when_the_crawled_index_is_unavailable():
     assert "records\n    ? searchBenchmarkIndex(records, state.benchmarkQuery)\n    : []" in render
 
 
-def test_search_is_the_first_interactive_element_in_the_navigator():
-    # The shortlist used to lead the panel, which made four worked examples read
-    # as the whole offer: a reader wanting anything else had to scroll past them
-    # to reach the box that covers all 1,207 records. Search leads now, and the
-    # examples are framed as examples.
+def test_the_navigator_is_a_tool_region_not_a_content_section():
+    # The examples were a titled block with an eyebrow, a heading, a paragraph
+    # and two computed subheadings over eight cards. That outranked the search
+    # box it existed to support. Search leads, and the examples are one line of
+    # chips inside the same block, with nothing between the field and its
+    # results but the reach line and that line.
     html = source("site/index.html")
     navigator = html.split('class="benchmark-navigator"', 1)[1].split("</aside>", 1)[0]
 
-    assert navigator.index('class="benchmark-search"') < navigator.index(
-        'class="benchmark-shortlist-section"'
-    )
-    # Results sit immediately under the box, with nothing between them but the
-    # line stating what the box reaches.
-    assert navigator.index('id="benchmark-search-status"') < navigator.index(
-        'id="benchmark-search-results"'
-    )
-    assert navigator.index('id="benchmark-search-results"') < navigator.index(
-        'id="benchmark-shortlist"'
-    )
-    assert 'data-i18n="Famous benchmarks"' in navigator
-    assert 'data-i18n-placeholder="Search benchmarks, tasks, domains…"' in navigator
+    for gone in (
+        'data-i18n="Famous benchmarks"',
+        'data-i18n="Worked examples"',
+        'data-i18n="leaderboard.navigator.note"',
+        "benchmark-shortlist-section",
+    ):
+        assert gone not in navigator, f"{gone} still occupies the navigator"
+    # The heading is the only one left, so it is the panel's label.
+    assert navigator.count("<h2") == 1
+    assert 'data-i18n="Search every benchmark"' in navigator
+
+    order = [
+        navigator.index('id="benchmark-search-input"'),
+        navigator.index('id="benchmark-search-status"'),
+        navigator.index('id="benchmark-shortlist"'),
+        navigator.index('id="benchmark-search-results"'),
+    ]
+    assert order == sorted(order), "field, reach line, examples, then results"
+
+
+def test_the_examples_are_one_line_of_verified_chips():
+    # An editorial list, not a computed one: MMLU carries 4 readable scores and
+    # would never place in a "deepest records" ranking, but it is the name a
+    # newcomer arrives with. Each id is still checked against the live registry,
+    # so a chip can never open the no-score refusal panel.
+    script = source("site/assets/app.js")
+    styles = source("site/assets/styles.css")
+
+    assert "const BENCHMARK_EXAMPLES = [" in script
+    for benchmark_id, label in (
+        ("mmlu", "MMLU"),
+        ("gpqa_diamond", "GPQA"),
+        ("swe_bench_verified", "SWE-bench"),
+        ("terminal_bench", "Terminal-Bench"),
+    ):
+        assert f'["{benchmark_id}", "{label}"]' in script
+
+    navigator = script.split("function renderBenchmarkNavigator(board)", 1)[1].split(
+        "\n}", 1
+    )[0]
+    assert "if (!entry || !scoreRecord(benchmarkId)) return null;" in navigator
+    # A short label is a prompt for the search box, not a record title, so the
+    # full registry name rides along rather than being hidden by the shorthand.
+    assert "title: entry.name," in navigator
+    assert '"aria-label": entry.name,' in navigator
+    # Chips, not cards: the old grid of two-line buttons is gone.
+    assert "benchmark-shortlist-button" not in script
+    assert "benchmark-shortlist-button" not in styles
+    assert ".benchmark-example {" in styles
+
+
+def test_the_navigator_still_starts_the_crawled_index_fetch():
+    # Regression guard. `initBenchmarkSearch` binds the input and kicks off the
+    # index fetch, and it lived at the end of the shortlist renderer. Rewriting
+    # that renderer dropped it, so the index was never requested: search fell
+    # back to the curated layer alone and the reach line read "59 benchmarks,
+    # 1 source" instead of "1,207 benchmarks, 3 sources".
+    script = source("site/assets/app.js")
+    navigator = script.split("function renderBenchmarkNavigator(board)", 1)[1].split(
+        "\nfunction ", 1
+    )[0]
+
+    assert "initBenchmarkSearch();" in navigator
+    assert navigator.index("initBenchmarkSearch();") < navigator.index("renderBenchmarkSearch();")
 
 
 def test_the_search_reach_line_counts_only_what_it_can_return():

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -399,10 +399,11 @@ def test_dashboard_links_are_validated_escaped_and_non_swallowing():
     assert "function safeHttpUrl(" in script
     # Both interactive charts are role="group" (image descendants are
     # presentational in ARIA, which would hide their focusable marker buttons).
-    # role="img" is allowed only on the two decorative non-interactive widgets
-    # (the adoption bar and the sparse-frontier step diagram).
+    # role="img" is allowed only on the decorative non-interactive widget that
+    # is left: the adoption bar. The sparse-frontier step diagram that was the
+    # other one went with the adoption reading.
     assert 'role: "group"' in script
-    assert script.count('role: "img"') == 2
+    assert script.count('role: "img"') == 1
     assert "/^[=+\\-@]/" in script
     assert 'document.querySelector("dialog[open]")' in script
     assert "Do not swallow Escape" in script
@@ -754,7 +755,7 @@ def test_a_zero_adoption_bar_has_no_visible_width():
     assert "maxCount && entry.card_count" in script
 
 
-def test_leaderboard_has_an_honest_time_based_adoption_frontier():
+def test_leaderboard_has_an_honest_time_based_score_track():
     html = Path("site/index.html").read_text(encoding="utf-8")
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
     # Whitespace-normalized: these are prose guarantees, and HTML collapses the
@@ -764,10 +765,17 @@ def test_leaderboard_has_an_honest_time_based_adoption_frontier():
     assert 'id="adoption-frontier"' in html
     assert 'id="frontier-benchmark"' in html
     assert 'id="frontier-chart"' in html
+    # `frontierEvents` outlives the staircase it was written for: the leaderboard
+    # still counts first reports, and the score chart still reads the newest
+    # mention date to bound its reading gap.
     assert "function frontierEvents(entry)" in script
     assert "const advances = !seenOrganizations.has(adopter.organization)" in script
-    assert "A long flat run is reporting saturation" in prose
-    assert "not a claim about benchmark score saturation" in prose
+    # The disclaimer this replaces separated reporting saturation from score
+    # saturation, which mattered while a staircase led the panel. The panel now
+    # shows only scores, so the guarantee is that it still declines to grade
+    # them: saturation stays an editorial judgement, never a printed number.
+    assert "no newer number could be read" in prose
+    assert "stays a reading you make, not a score this panel prints" in prose
 
 
 def test_new_benchmarks_are_visually_prioritized_without_changing_the_rank():


### PR DESCRIPTION
## What changed

**The panel is the saturation curve now.** The adoption staircase, its
advance diamonds, the card rug, the release marker, the reporting-stage
badge, the counts line and the "Frontier milestones" column are all
removed. The score band takes the full height they vacated. Deleted
rather than hidden behind a flag: a switch nobody can turn on is worse
than no switch.

**No line joins any two score points.** A shared instrument and protocol
makes two numbers comparable; it does not make them a series, and a
segment asserts the second. On GPQA Diamond the old join rule connected
DeepSeek-V4-Pro (90.1) to V4-Flash (88.1) and drew a decline out of a
smaller model. `THE JOIN RULE` in `data/benchmark_scores.yml` is renamed
`THE COMPARABILITY RULE` so the doc and the chart agree; no data row
changed. Comparability is still computed and still stated, by the paired
comparison readout, in prose that can carry the caveat a line cannot.

**Both benchmark layers are reachable from both entry points.** The
picker used to hold only 59 curated benchmarks and search read only the
crawled index, so "GPQA" surfaced crawled rows but never the curated
record the panel charts. The picker now carries 738 options in labelled
groups (`Curated registry (59)`, `LLM Stats (679)`) and the field
searches all 1,207, curated first.

**A benchmark with no readable score is not offered anywhere**, since
the panel would have nothing to draw. That is 20 of 79 curated
benchmarks and every OpenCompass record, whose crawl is a catalog of
identity and openness rather than of scores. A permalink to one names
the benchmark and says why, instead of silently showing the default.

**The sidebar is a tool region.** Search leads with the visual weight on
the field rather than on a heading or a paragraph; the examples are the
20 most-reported benchmarks by `card_count`.

## Bugs found while verifying

- The reading-gap label was centred on its span, so a gap running to the
  end of the axis was clipped: shipped GPQA Diamond read `NO READABLE
  SCORE IN THI`.
- `initBenchmarkSearch` was dropped while rewriting the navigator, so the
  crawled index was never fetched. Search silently fell back to 59
  records with no console error.
- Curated search ranked on entry name, so the registry alias
  `HLEAutomationBench` put AutomationBench above the record literally
  named HLE.

## Verification

803 tests pass. Checked in a real browser at 1440px and 390px, in both
languages, with no console errors: gpqa_diamond, mmlu, a crawled-only
record, and a permalink to an unscored benchmark.