### PR TITLE
Check user-facing text for project vocabulary every Monday

### DIFF
--- a/.github/workflows/weekly-jargon.yml
+++ b/.github/workflows/weekly-jargon.yml
@@ -1,0 +1,47 @@
+name: Weekly Jargon Audit
+
+on:
+  schedule:
+    # Mondays 02:00 UTC = 10:00 Asia/Singapore, an hour after the daily radar
+    # so the two never contend for the same runner. Weekly rather than daily
+    # because the copy changes slowly and a report nobody has had time to act
+    # on is a report that gets skimmed (issue #241).
+    - cron: "0 2 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    permissions:
+      contents: read
+      issues: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - name: Scan user-facing text for project vocabulary
+        run: python scripts/audit_jargon.py --markdown > body.md
+      - name: Open or update the tracking issue
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          title="Jargon in user-facing text — week of $(date -u +%Y-%m-%d)"
+          # One rolling issue, not one per week: the finding list is a
+          # standing state of the copy, so a new issue every Monday would
+          # bury the discussion that happened on the last one. The title
+          # carries the date so it is obvious when it was last refreshed.
+          existing=$(gh issue list --state open --label jargon \
+            --json number --jq '.[0].number // empty')
+          if [[ -n "${existing}" ]]; then
+            gh issue edit "${existing}" --title "${title}" --body-file body.md
+            echo "Updated issue #${existing}"
+          else
+            gh issue create --title "${title}" --body-file body.md \
+              --label jargon --label automated
+          fi

--- a/.github/workflows/weekly-jargon.yml
+++ b/.github/workflows/weekly-jargon.yml
@@ -31,7 +31,17 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          title="Jargon in user-facing text — week of $(date -u +%Y-%m-%d)"
+          # No findings, no issue. The script prints nothing when the copy is
+          # clean, and a weekly "nothing to report" is the kind of non-news
+          # that teaches a reader to skip the notification. Then the week with
+          # real findings gets skipped too. An already-open issue is left
+          # alone rather than edited to say it is empty, so whoever is working
+          # through the list does not lose it mid-week.
+          if [[ ! -s body.md ]]; then
+            echo "No flagged terms. Nothing filed."
+            exit 0
+          fi
+          title="Jargon in user-facing text, week of $(date -u +%Y-%m-%d)"
           # One rolling issue, not one per week: the finding list is a
           # standing state of the copy, so a new issue every Monday would
           # bury the discussion that happened on the last one. The title

--- a/scripts/audit_jargon.py
+++ b/scripts/audit_jargon.py
@@ -1,0 +1,121 @@
+"""Find project vocabulary that leaked into user-facing text.
+
+Issue #241 asks that the site read to a 16-year-old. The failure it names is
+specific and recurring: a word that is precise inside this codebase gets
+printed to a reader who has never seen the codebase. "Comparable run" meant
+a group of scores sharing an instrument and a protocol, which is exactly
+right internally and meaningless on a chart (issue #261).
+
+This scans the strings a reader actually sees -- the i18n keys in app.js and
+the copy in the HTML -- and reports the terms below. It is deliberately a
+small hand-written list rather than a readability score: Flesch-Kincaid
+rewards short words, and "run", "row" and "shard" are short. The problem is
+unexplained vocabulary, not long sentences.
+
+    python scripts/audit_jargon.py            # human-readable
+    python scripts/audit_jargon.py --markdown # issue body
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# term -> why a reader outside this project cannot be expected to know it.
+JARGON = {
+    "comparable run": "internal name for scores sharing an instrument and protocol",
+    "comparable group": "internal join key; means nothing to a reader",
+    "instrument": "used here to mean the exact test variant, not its dictionary sense",
+    "protocol": "used here to mean the run conditions, not its dictionary sense",
+    "shard": "storage detail; a reader does not load files",
+    "corpus": "means 'everything collected'; say that instead",
+    "donor": "internal term for a record lending its identity",
+    "connector": "internal name for a data source adapter",
+    "provenance": "means 'where this came from'; say that instead",
+    "normalization": "pipeline step; invisible to a reader",
+    "schema": "developer word for the shape of a file",
+    "observation count": "means 'how many scores'; say that instead",
+    "saturation": "jargon unless the page explains it on the spot",
+    "frontier": "used here as a section name, not a plain-English word",
+    "readable score": "project term of art; explained on some pages, not all",
+}
+
+# Text a reader sees. Comments and code identifiers are exempt: naming a
+# concept precisely in source is the point, and only printed strings are read.
+I18N_KEY = re.compile(r'^\s*"([^"]{4,})":\s*"', re.M)
+HTML_TEXT = re.compile(r">([^<>{}]{12,})<", re.S)
+
+
+# An i18n key is English prose; a lookup key like "frontier.explainer.sub" or a
+# DOM attribute like "data-frontier-point" is not, and flagging those would
+# bury the real hits under noise the reader never sees.
+NOT_PROSE = re.compile(r"^[a-z0-9_.-]+$|^data-|^aria-")
+
+
+def user_facing_strings(root: Path) -> list[tuple[str, str]]:
+    out: list[tuple[str, str]] = []
+    app = root / "site/assets/app.js"
+    if app.exists():
+        # The i18n table's keys are the English the site prints.
+        for m in I18N_KEY.finditer(app.read_text(encoding="utf-8")):
+            key = m.group(1)
+            if not NOT_PROSE.match(key) and " " in key:
+                out.append((str(app.relative_to(root)), key))
+    for html in sorted((root / "site").glob("*.html")):
+        for m in HTML_TEXT.finditer(html.read_text(encoding="utf-8")):
+            text = " ".join(m.group(1).split())
+            if text and not text.startswith(("//", "/*")):
+                out.append((str(html.relative_to(root)), text))
+    return out
+
+
+def findings(root: Path) -> list[tuple[str, str, str, str]]:
+    hits = []
+    for where, text in user_facing_strings(root):
+        low = text.lower()
+        for term, why in JARGON.items():
+            if re.search(rf"\b{re.escape(term)}s?\b", low):
+                hits.append((term, where, text, why))
+    hits.sort(key=lambda h: (h[0], h[1]))
+    return hits
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--markdown", action="store_true")
+    ap.add_argument("--root", type=Path, default=Path("."))
+    args = ap.parse_args()
+    hits = findings(args.root)
+
+    if args.markdown:
+        print("## Jargon in user-facing text\n")
+        if not hits:
+            print("No flagged terms this week. Nothing to do.")
+            return 0
+        print(
+            f"{len(hits)} place(s) print a word that only makes sense inside this "
+            "project. Each line is the text a reader sees.\n"
+        )
+        current = None
+        for term, where, text, why in hits:
+            if term != current:
+                current = term
+                print(f"\n### `{term}`\n\n_{why}_\n")
+            snippet = text if len(text) <= 160 else text[:157] + "..."
+            print(f"- `{where}` — {snippet}")
+        print(
+            "\n---\nNot every hit is a bug: a term the surrounding sentence "
+            "defines is fine. Rewrite the ones that assume the reader already "
+            "knows. Refs #241."
+        )
+    else:
+        for term, where, text, _ in hits:
+            print(f"{term}\t{where}\t{text[:90]}")
+        print(f"\n{len(hits)} hit(s)", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit_jargon.py
+++ b/scripts/audit_jargon.py
@@ -90,10 +90,14 @@ def main() -> int:
     hits = findings(args.root)
 
     if args.markdown:
-        print("## Jargon in user-facing text\n")
+        # Nothing to print when nothing is wrong. The workflow keys on empty
+        # output to stay silent rather than filing "no findings" every Monday,
+        # which is the kind of recurring non-news that teaches a reader to
+        # skip the notification, and then the week with real findings is
+        # skipped too.
         if not hits:
-            print("No flagged terms this week. Nothing to do.")
             return 0
+        print("## Jargon in user-facing text\n")
         print(
             f"{len(hits)} place(s) print a word that only makes sense inside this "
             "project. Each line is the text a reader sees.\n"
@@ -104,7 +108,7 @@ def main() -> int:
                 current = term
                 print(f"\n### `{term}`\n\n_{why}_\n")
             snippet = text if len(text) <= 160 else text[:157] + "..."
-            print(f"- `{where}` — {snippet}")
+            print(f"- `{where}`: {snippet}")
         print(
             "\n---\nNot every hit is a bug: a term the surrounding sentence "
             "defines is fine. Rewrite the ones that assume the reader already "

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1526,3 +1526,27 @@ def test_every_new_source_gap_string_has_a_chinese_rendering():
         "This source returned something, but none of it scored high enough to be listed.",
     ):
         assert f'"{phrase}":' in zh, phrase
+
+
+def test_jargon_audit_reads_only_user_facing_text():
+    """The weekly jargon audit (issue #241) must not flag code identifiers.
+
+    Its value depends on every hit being text a reader actually sees. A run
+    that reports `data-frontier-point` teaches the reader to skim past it,
+    and then the real hits go unread too.
+    """
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [sys.executable, "scripts/audit_jargon.py"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    for line in result.stdout.splitlines():
+        if not line.strip():
+            continue
+        _term, _where, text = line.split("\t", 2)
+        assert not text.startswith(("data-", "aria-")), text
+        assert " " in text, f"lookup key, not prose: {text}"


### PR DESCRIPTION
Refs #241. Does **not** close it: #241 is a standing quality bar, and the point of this is that it keeps applying.

## What this adds

`scripts/audit_jargon.py` scans the strings a reader actually sees (the i18n keys in `app.js`, the copy in the HTML) for 15 terms that are precise inside this project and opaque outside it. A workflow runs it Mondays 02:00 UTC.

Deliberately **not** a readability score. Flesch-Kincaid rewards short words, and "run", "row" and "shard" are short. The failure #241 describes is unexplained vocabulary, not long sentences.

## What it finds today

25 hits: `readable score` (5), `connector` (4), `protocol` (4), `frontier` (4), `instrument` (3), `corpus` (3), `saturation` (2).

Sample of what a reader currently sees:

- "Which of that movement is corroborated by more than one **connector**?"
- "**Corpus** coverage"
- "Two snapshots are available, but their **connector** coverage or report limit differs..."

## Design choices worth reviewing

- **One rolling issue, not one per week.** A new issue every Monday buries the discussion on the previous one. The workflow edits the open `jargon`-labelled issue if there is one, and the title carries the date so staleness is visible.
- **It never closes anything**, per your instruction that fixes get manually verified.
- **Lookup keys and DOM attributes are filtered out**, with a test pinning it. A report containing `data-frontier-point` teaches the reader to skim, and then the real hits go unread too.
- **The term list is hand-written** and lives at the top of the script, so adding or retiring a word is a one-line edit.

## Not done here

The 25 hits are reported, not fixed. Rewriting them is a copy decision per string, and some are fine as-is where the surrounding sentence defines the term. Worth its own PR once you have looked at the list.

836 tests pass; ruff clean.
