### PR TITLE
Ask for a screenshot when something looks wrong

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,56 @@
+name: Report a bug
+description: Something on the site does not work. For data that disagrees with its source, use "Report a data error" instead.
+title: "Bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        If the problem is with how something looks (a chart, a logo, a label, a
+        layout), please use "Report something that looks wrong" instead. It asks
+        for the few extra details that make a visual problem fixable.
+
+  - type: textarea
+    id: what_happened
+    attributes:
+      label: What happened
+      description: What you did, and what the site did instead of what you expected.
+      placeholder: |
+        I clicked the source filter and picked one source. The table went empty.
+        I expected it to show the rows from that source.
+    validations:
+      required: true
+
+  - type: input
+    id: page
+    attributes:
+      label: Page address
+      description: Copy the address bar from the page where it happened.
+      placeholder: https://ktwu01.github.io/benchmark-radar/
+    validations:
+      required: true
+
+  - type: dropdown
+    id: viewport
+    attributes:
+      label: Screen you were on
+      options:
+        - Desktop or laptop
+        - Phone
+        - Tablet
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: visual
+    attributes:
+      label: Screenshot or screen recording
+      description: |
+        Strongly wanted, and usually the fastest way to get this fixed. Drag the
+        image or video file straight into this box and GitHub will upload it.
+        Please crop out anything private first. If you cannot take one, leave
+        this empty and file anyway.
+      placeholder: Drop your screenshot here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/data-error.yml
+++ b/.github/ISSUE_TEMPLATE/data-error.yml
@@ -33,3 +33,15 @@ body:
       description: Quote it if you can, so the correction is checkable without re-reading the whole document.
     validations:
       required: true
+
+  - type: textarea
+    id: visual
+    attributes:
+      label: Screenshot of the row as published
+      description: |
+        Optional but helpful. Drag the image straight into this box and GitHub
+        will upload it. It shows exactly what you were looking at, which settles
+        questions the text version cannot.
+      placeholder: Drop your screenshot here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/logo.yml
+++ b/.github/ISSUE_TEMPLATE/logo.yml
@@ -1,0 +1,61 @@
+name: Report a wrong or unreadable logo
+description: A brand mark is the wrong one, missing, or too hard to read at the size a chart draws it.
+title: "Logo: "
+labels: ["logo"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Logos are drawn small, so one that reads fine on its own can turn into a
+        smudge on a chart. A screenshot of it at the size you actually saw it is
+        the most useful thing you can attach.
+
+  - type: input
+    id: organization
+    attributes:
+      label: Whose logo is it
+      placeholder: Acme
+    validations:
+      required: true
+
+  - type: dropdown
+    id: problem
+    attributes:
+      label: What is wrong with it
+      options:
+        - It is the wrong logo
+        - It is missing
+        - It is too hard to read at chart size
+        - It is out of date
+    validations:
+      required: true
+
+  - type: textarea
+    id: visual
+    attributes:
+      label: Screenshot
+      description: |
+        Drag the image straight into this box and GitHub will upload it. Please
+        show it at the size it appears on the page, not zoomed in, so the
+        readability problem is visible.
+      placeholder: Drop your screenshot here.
+    validations:
+      required: false
+
+  - type: input
+    id: page
+    attributes:
+      label: Page address
+      description: Where you saw it.
+      placeholder: https://ktwu01.github.io/benchmark-radar/
+    validations:
+      required: true
+
+  - type: input
+    id: correct_source
+    attributes:
+      label: Where the correct logo can be found
+      description: Optional. A press kit or brand page is ideal.
+      placeholder: https://example.com/brand
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/ui-bug.yml
+++ b/.github/ISSUE_TEMPLATE/ui-bug.yml
@@ -1,0 +1,69 @@
+name: Report something that looks wrong
+description: A chart, logo, label, or page renders badly, is unreadable, or is cut off.
+title: "Looks wrong: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        How the site looks is part of whether it works. A chart nobody can read
+        is a broken chart.
+
+        A picture settles this faster than any description. Please drag a
+        screenshot or a short screen recording into the box below. If you cannot
+        take one right now, file anyway and describe what you see.
+
+  - type: textarea
+    id: visual
+    attributes:
+      label: Screenshot or screen recording
+      description: |
+        Drag the image or video file straight into this box and GitHub will
+        upload it. A recording helps most when the problem only shows up while
+        you scroll, hover, or resize.
+
+        Please crop out anything private before you upload.
+      placeholder: Drop your screenshot here.
+    validations:
+      required: false
+
+  - type: input
+    id: page
+    attributes:
+      label: Page address
+      description: Copy the address bar from the page where you saw it.
+      placeholder: https://ktwu01.github.io/benchmark-radar/?view=leaderboard
+    validations:
+      required: true
+
+  - type: dropdown
+    id: viewport
+    attributes:
+      label: Screen you were on
+      options:
+        - Desktop or laptop
+        - Phone
+        - Tablet
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What looks wrong, and what you expected instead
+      description: One or two sentences is plenty.
+      placeholder: |
+        The bar labels run into each other, so I cannot tell which model each bar belongs to.
+        I expected each bar to be labelled clearly.
+    validations:
+      required: true
+
+  - type: input
+    id: browser
+    attributes:
+      label: Browser
+      description: Optional, but it helps if the problem only happens in one of them.
+      placeholder: Chrome, Safari, Firefox
+    validations:
+      required: false


### PR DESCRIPTION
Refs #257

UI quality matters a lot here, and bug reports about the UI keep arriving with no picture. These forms make a screenshot the normal thing to include.

## What was already there

`.github/ISSUE_TEMPLATE/` had `add-model-card.yml`, `data-error.yml`, and `config.yml`. There was no bug form at all. Anyone reporting that the site looked broken was filing a blank issue, which is exactly the path that produces a report with no screenshot, no page address, and no screen size. That gap is most of the problem.

## Separate template, or a field on a generic bug form

Both, and deliberately.

A visual bug and a logic bug need different things. For a visual bug the picture is close to the whole report: what "wrong" means is often impossible to write down but obvious in one image, and it also depends on the screen it was seen on. For a logic bug, the steps are load-bearing and a screenshot is supporting evidence.

Folding both into one form means either asking everyone for screen size and viewport details they do not need, or burying the visual questions so far down that the people who most need them skip them. GitHub's template picker is cheap: a reporter who thinks "this looks wrong" picks the form that says that. So the visual report gets its own form with the screenshot box first, and the general bug form carries the same box lower down, optional.

## Files

Added `ui-bug.yml`, "Report something that looks wrong". Screenshot or recording box first, then page address, then which screen they were on (a plain dropdown, not device widths), then what looks wrong, then browser as optional.

Added `bug.yml`, the general bug form. Points visual problems at the form built for them, and still offers the screenshot box.

Added `logo.yml`, wired to the new `logo` label, which had nothing routing reports to it. Readability at chart size is the failure the label describes, so it asks for the logo shown at the size it actually appears rather than zoomed in.

Changed `data-error.yml`, adding an optional screenshot of the published row. The source quote is still the part that decides the issue, so this stays at the bottom and stays optional.

## Choices worth flagging

The screenshot field is never required. A required attachment is a wall: someone on a locked-down machine, or reporting from a phone, simply cannot file, and a described bug beats a lost one. The forms lean on wording instead, asking for the picture first and saying plainly that it is the fastest route to a fix.

Every form asks for the page address and screen, because those are the two facts that make a visual bug reproducible and the two people most often forget.

Wording follows #241, plain English throughout: "Screen you were on" rather than viewport, "Page address" rather than URL. Each form is five or six fields, since a long form suppresses reports.

Labels are all existing ones: `bug` for the two bug forms, `logo` for the logo form.

## Checks

Every file parses under `yaml.safe_load`, and each form has `name`, `description`, and `body`, with `type` and `attributes` on every body item and `options` present on every dropdown.

`uv run pytest -q`: 835 passed. That matches the count on `origin/main` exactly, so nothing regressed. (The 836 figure in the brief came from a commit on another local branch that adds one test and is not part of this base.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PuehBQFtLfJ81UWGv6EGCg
