### PR TITLE
Write the issue forms for people who did not build this

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-model-card.yml
+++ b/.github/ISSUE_TEMPLATE/add-model-card.yml
@@ -1,5 +1,5 @@
-name: Add a model card to the adoption registry
-description: Report a model card, system card, technical report, or release post the Model Card Adoption Rank has not read yet.
+name: Tell us about a model card we missed
+description: Name a model card, system card, technical report, or release post the site has not read yet.
 title: "Add model card: "
 labels: ["model-card", "good first issue"]
 body:
@@ -7,18 +7,19 @@ body:
     attributes:
       value: |
         The [Model Card Adoption Rank](https://github.com/ktwu01/benchmark-radar#model-card-adoption-rank)
-        is curated by hand, so its coverage is exactly the set of documents
-        someone has read. Naming one it is missing is a useful contribution on
-        its own; you do not have to open the pull request yourself.
+        counts how many companies report each benchmark when they launch a
+        model. Every document in it was read by a person, so the site only
+        knows about the ones somebody has pointed at.
 
-        If you would like to add it directly, see
+        Naming one we missed is a real contribution on its own. You do not
+        have to make the change yourself. If you would like to, see
         [CONTRIBUTING.md](https://github.com/ktwu01/benchmark-radar/blob/main/CONTRIBUTING.md).
 
   - type: input
     id: url
     attributes:
-      label: Document URL
-      description: The card, report, or post the benchmarks are read from. This is what makes the row checkable.
+      label: Link to the document
+      description: Where the scores are published. This is what lets anyone check the numbers later.
       placeholder: https://example.com/frontier-1-model-card
     validations:
       required: true
@@ -26,7 +27,7 @@ body:
   - type: input
     id: organization
     attributes:
-      label: Organization
+      label: Who released the model
       placeholder: Acme
     validations:
       required: true
@@ -34,7 +35,7 @@ body:
   - type: input
     id: model
     attributes:
-      label: Model
+      label: Model name
       placeholder: Frontier-1
     validations:
       required: true
@@ -42,20 +43,20 @@ body:
   - type: dropdown
     id: document_type
     attributes:
-      label: Document type
+      label: What kind of document is it
       options:
-        - model_card
-        - system_card
-        - technical_report
-        - release_post
+        - Model card
+        - System card
+        - Technical report
+        - Release post or blog
     validations:
       required: true
 
   - type: input
     id: published
     attributes:
-      label: Publication date (YYYY-MM-DD)
-      description: The document's date, not the model's announcement date, if they differ.
+      label: Date it was published (YYYY-MM-DD)
+      description: The date on the document itself. If the model was announced on a different day, use the document's date.
       placeholder: "2026-05-14"
     validations:
       required: true
@@ -63,14 +64,14 @@ body:
   - type: textarea
     id: benchmarks
     attributes:
-      label: Benchmarks the document reports
+      label: Which benchmarks does it report scores for
       description: |
-        One per line. Names as the document writes them are fine; they will be
-        mapped to registry ids.
+        One per line. Write the names however the document writes them. We
+        will match them to the names the site uses.
 
-        Record what the document reports, not what the model can do. The
-        counted unit is the document: a card reporting AIME in three
-        configurations still counts once.
+        List what the document actually publishes a score for, not everything
+        the model can do. A document that reports one benchmark three
+        different ways still counts as reporting it once.
       placeholder: |
         GPQA Diamond
         SWE-bench Verified
@@ -81,10 +82,10 @@ body:
   - type: textarea
     id: notes
     attributes:
-      label: Anything unusual about this document
+      label: Anything unusual about it
       description: |
-        Optional. Useful cases: the document was revised after publication and
-        gained benchmarks later, it reports a benchmark under a name nobody else
-        uses, or it describes an evaluation in prose without scoring it.
+        Optional. Worth mentioning if the document was edited after it went up
+        and gained scores later, if it calls a benchmark by a name nobody else
+        uses, or if it talks about a test without giving a score.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Model Card Adoption Rank
+  - name: See the ranking first
     url: https://ktwu01.github.io/benchmark-radar/?view=leaderboard
-    about: The live ranking, before you report a row as missing or wrong.
+    about: The live ranking. Worth a look before reporting something as missing or wrong.
   - name: How the ranking is built
     url: https://github.com/ktwu01/benchmark-radar/blob/main/CONTRIBUTING.md
-    about: What is counted, what is deliberately out of scope, and how to add a document.
+    about: What gets counted, what is left out on purpose, and how to add a document.

--- a/.github/ISSUE_TEMPLATE/data-error.yml
+++ b/.github/ISSUE_TEMPLATE/data-error.yml
@@ -1,35 +1,39 @@
-name: Report a data error
-description: A row in the adoption ranking or the daily radar does not match its source.
+name: Report a wrong number
+description: A number on the site does not match the document it came from.
 title: "Data error: "
 labels: ["data-error"]
 body:
   - type: markdown
     attributes:
       value: |
-        A wrong row is a real bug, not a nitpick. This project's only claim is
-        that every entry can be checked against the record it came from, so a
-        row that does not match its source breaks the one guarantee it makes.
+        A wrong number is a real bug, not a nitpick. This site makes one
+        promise: every number on it can be checked against the document it
+        was taken from. A number that does not match breaks that promise.
 
   - type: input
     id: source_url
     attributes:
-      label: Source document URL
-      description: The record the entry claims to be derived from.
+      label: Link to the document
+      description: The paper, model card, or post the number was supposed to come from.
     validations:
       required: true
 
   - type: textarea
     id: claimed
     attributes:
-      label: What the radar currently shows
-      description: The benchmark id, ranking row, or daily entry as published.
+      label: What the site says
+      description: |
+        Paste the line as it appears, or link to the page it is on. If you
+        know the benchmark's name, include it.
     validations:
       required: true
 
   - type: textarea
     id: actual
     attributes:
-      label: What the source actually says
-      description: Quote it if you can, so the correction is checkable without re-reading the whole document.
+      label: What the document says
+      description: |
+        Quote it if you can. A quote means the fix can be checked without
+        anyone having to read the whole document again.
     validations:
       required: true


### PR DESCRIPTION
Refs #241. Does **not** close it.

You said the issue templates are too jargon-heavy. They were. This rewrites them for someone who did not build this project.

## What a reporter used to read

| Before | After |
|---|---|
| "A **row** in the adoption ranking or the daily radar does not match its source." | "A number on the site does not match the document it came from." |
| "The record the entry claims to be **derived from**." | "The paper, model card, or post the number was supposed to come from." |
| "The **benchmark id**, ranking row, or daily entry as published." | "Paste the line as it appears, or link to the page it is on." |
| "Add a model card to the **adoption registry**" | "Tell us about a model card we missed" |
| "they will be **mapped to registry ids**" | "We will match them to the names the site uses" |
| "The **counted unit is the document**: a card reporting AIME in three configurations still counts once." | "A document that reports one benchmark three different ways still counts as reporting it once." |

## Also fixed

The document-type dropdown showed the pipeline's raw internal values to a human: `model_card`, `system_card`, `technical_report`, `release_post`. Now "Model card", "System card", "Technical report", "Release post or blog".

Label descriptions were jargon too, and I changed those in the GitHub UI (they do not live in the repo):
- `data-error`: "A published row does not match the source it cites" is now "A number on the site does not match the document it came from"
- `model-card`: dropped "Model Card Adoption Rank registry" for "Adds or fixes a model card the site tracks"

## Unchanged on purpose

Same fields, same required/optional flags, same labels applied. This is a wording pass only, so nothing about how reports get triaged changes.

All three YAML files validate (`name`, `description`, `body` present; every body item has `type` and `attributes`). No em dashes. 835 tests pass.

## Note on overlap

PR #272 adds three new forms (ui-bug, bug, logo) and touches `data-error.yml` to add an optional screenshot box. That PR and this one both edit `data-error.yml`, so whichever merges second will need a small conflict resolution. Happy to rebase this one on top of that if you merge #272 first.
