### PR TITLE
Show the sources that found nothing, and say which kind of nothing

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -29,6 +29,46 @@ const LEGACY_SOURCE_COLLECTION_METHODS = {
   brave: "API",
 };
 
+// Fetch health records a run under its internal key ("first_party_feeds"),
+// while the source mix counts finished evidence under the label a reader sees
+// ("First-party feed"). Without this bridge a source that returned nothing is
+// simply missing from the mix, and a reader cannot tell "this source looked
+// and found nothing" apart from "this source does not exist" (issue #260).
+const SOURCE_DISPLAY_NAMES = {
+  arxiv: "arXiv",
+  huggingface: "Hugging Face",
+  github: "GitHub",
+  openreview: "OpenReview",
+  semantic_scholar: "Semantic Scholar",
+  github_releases: "GitHub Release",
+  first_party_feeds: "First-party feed",
+  openalex: "OpenAlex",
+  brave: "Brave Web",
+};
+
+const sourceDisplayName = (key) =>
+  SOURCE_DISPLAY_NAMES[key] || String(key).replaceAll("_", " ");
+
+// Sources that ran for this day but put nothing into the ranked evidence, kept
+// in the order fetch health reports them so the ledger reads the same way every
+// day. A failed fetch is already reported by the Fetch health column, so this
+// covers both: a source that errored and one that succeeded with nothing to
+// show are equally invisible in the source mix, and equally worth flagging
+// because a silent zero can mean a broken source (issue #254).
+function zeroItemSources(day) {
+  const counts = day.source_counts || {};
+  const seen = new Set();
+  return (day.ingest_health || [])
+    .filter((entry) => entry.kind !== "attention")
+    .map((entry) => ({ ...entry, name: sourceDisplayName(entry.source) }))
+    .filter((entry) => {
+      if (Number(counts[entry.name] || 0) > 0) return false;
+      if (seen.has(entry.name)) return false;
+      seen.add(entry.name);
+      return true;
+    });
+}
+
 const byId = (id) => document.getElementById(id);
 
 // Interface language. English is the truth inside this file: every UI string
@@ -489,6 +529,16 @@ const I18N = {
     Events: "事件",
     Attention: "关注度",
     "Fetch health": "抓取状态",
+    // Sources that found nothing on a day (issue #260). The two sentence
+    // templates carry {sources} and {date} so zh can order them its own way.
+    "On {date} these sources ran but found nothing: {sources}.":
+      "{date},这些来源运行了但没有找到任何内容:{sources}。",
+    "On {date} these sources could not be reached: {sources}.":
+      "{date},这些来源无法访问:{sources}。",
+    "A source that stays at zero for several days is usually broken, not quiet.":
+      "一个来源连续几天都是零,通常说明它出了问题,而不是没有新内容。",
+    "This source ran and found nothing on this day.": "这个来源当天运行了,但没有找到任何内容。",
+    "This source could not be reached on this day.": "这个来源当天无法访问。",
     // --- Map ----------------------------------------------------------------
     "Big picture": "整体概览",
     "What we found": "我们发现了什么",
@@ -1892,6 +1942,7 @@ function renderTrends() {
   );
   hideDayTooltip();
   byId("snapshot-count").textContent = `${state.data.snapshot_count} ${t("snapshots")}`;
+  renderSourceGapNote(state.data.days[dayCount - 1]);
   replaceChildren(
     byId("trend-table"),
     [...state.data.days].reverse().map((day) => {
@@ -1908,7 +1959,7 @@ function renderTrends() {
           text: `${formatDate(day.since, { dateStyle: "short", timeStyle: "short" })} → ${formatDate(day.generated_at, { dateStyle: "short", timeStyle: "short" })}`,
         }),
         element("td", { text: day.evidence_count }),
-        element("td", { text: countMapText(day.source_counts) }),
+        element("td", {}, sourceMixCell(day)),
         element("td", {
           text: countMapText(day.category_counts),
         }),
@@ -2151,6 +2202,72 @@ function metricLabel(value, singular, plural = `${singular}s`) {
   const count = Number(value || 0);
   const noun = count === 1 ? t(singular) : t(plural);
   return `${count.toLocaleString()} ${noun}`;
+}
+
+// The ledger is long and the newest day sits at the top of it, so the gaps for
+// that day are stated once in plain words above the table. Naming the sources
+// is the point: "2 sources found nothing" tells a reader there is a problem but
+// not where to look, and the two answers (a source that ran and found nothing
+// versus one that could not be reached) call for different follow-up.
+function renderSourceGapNote(day) {
+  const note = byId("source-gap-note");
+  if (!note) return;
+  const gaps = day ? zeroItemSources(day) : [];
+  if (!gaps.length) {
+    note.hidden = true;
+    note.textContent = "";
+    return;
+  }
+  const unreachable = gaps.filter((entry) => !entry.ok).map((entry) => entry.name);
+  const empty = gaps.filter((entry) => entry.ok).map((entry) => entry.name);
+  const sentence = (template, names) =>
+    t(template, { date: formatDate(day.date), sources: names.join(", ") });
+  const sentences = [];
+  if (empty.length) {
+    sentences.push(sentence("On {date} these sources ran but found nothing: {sources}.", empty));
+  }
+  if (unreachable.length) {
+    sentences.push(
+      sentence("On {date} these sources could not be reached: {sources}.", unreachable),
+    );
+  }
+  note.textContent = `${sentences.join(" ")} ${t("A source that stays at zero for several days is usually broken, not quiet.")}`;
+  note.hidden = false;
+}
+
+// The source mix used to list only sources that found something, so a day on
+// which a source found nothing looked identical to a day on which that source
+// did not exist. The zeros are the interesting half: a source that quietly
+// returns nothing several days running is usually broken, not idle, so they are
+// spelled out here rather than left to be inferred from an absence (issue #260).
+function sourceMixCell(day) {
+  const found = Object.entries(day.source_counts || {});
+  const gaps = zeroItemSources(day);
+  const parts = [];
+  parts.push(
+    element("span", {
+      text: found.length
+        ? found.map(([name, count]) => `${name.replaceAll("_", " ")} ${count}`).join(" · ")
+        : t("none"),
+    }),
+  );
+  gaps.forEach((entry) => {
+    parts.push(
+      element("span", {
+        className: "source-gap",
+        text: `${entry.name} 0`,
+        attrs: {
+          // Why it is zero is the reader's next question, and the two answers
+          // mean different things: an error is a fault to chase, an empty run
+          // is a source that looked and found nothing worth keeping.
+          title: entry.ok
+            ? t("This source ran and found nothing on this day.")
+            : t("This source could not be reached on this day."),
+        },
+      }),
+    );
+  });
+  return parts;
 }
 
 function countMapText(values) {

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -49,24 +49,46 @@ const SOURCE_DISPLAY_NAMES = {
 const sourceDisplayName = (key) =>
   SOURCE_DISPLAY_NAMES[key] || String(key).replaceAll("_", " ");
 
+// One sentence per kind of zero, so hovering a zero answers the question it
+// raises instead of only restating that the number is zero.
+const SOURCE_GAP_REASONS = {
+  unreachable: "This source could not be reached on this day.",
+  empty: "This source was checked and found nothing at all on this day.",
+  unranked: "This source returned something, but none of it scored high enough to be listed.",
+};
+
 // Sources that ran for this day but put nothing into the ranked evidence, kept
 // in the order fetch health reports them so the ledger reads the same way every
-// day. A failed fetch is already reported by the Fetch health column, so this
-// covers both: a source that errored and one that succeeded with nothing to
-// show are equally invisible in the source mix, and equally worth flagging
-// because a silent zero can mean a broken source (issue #254).
+// day. Why a source is at zero decides what the reader should do about it, and
+// the source mix counts ranked evidence while fetch health counts raw records,
+// so there are three different zeros and only one of them is "nothing arrived":
+//   unreachable  the fetch failed, so nothing could arrive
+//   empty        the fetch worked and returned no records at all
+//   unranked     records arrived but none scored high enough to be listed
+// Calling the third one "found nothing" would be wrong: GitHub returning 300
+// records that all scored too low is a scoring outcome, not a broken source.
 function zeroItemSources(day) {
   const counts = day.source_counts || {};
-  const seen = new Set();
-  return (day.ingest_health || [])
+  const merged = new Map();
+  (day.ingest_health || [])
     .filter((entry) => entry.kind !== "attention")
-    .map((entry) => ({ ...entry, name: sourceDisplayName(entry.source) }))
-    .filter((entry) => {
-      if (Number(counts[entry.name] || 0) > 0) return false;
-      if (seen.has(entry.name)) return false;
-      seen.add(entry.name);
-      return true;
+    .forEach((entry) => {
+      const name = sourceDisplayName(entry.source);
+      if (Number(counts[name] || 0) > 0) return;
+      // One source can be reported by more than one row (a connector retried
+      // under a second method). A failure anywhere is the answer worth showing,
+      // and the raw counts add up across the rows that did return something.
+      const previous = merged.get(name);
+      merged.set(name, {
+        name,
+        ok: previous ? previous.ok && entry.ok : entry.ok,
+        fetched: (previous?.fetched || 0) + Number(entry.item_count || 0),
+      });
     });
+  return [...merged.values()].map((entry) => ({
+    ...entry,
+    state: !entry.ok ? "unreachable" : entry.fetched > 0 ? "unranked" : "empty",
+  }));
 }
 
 const byId = (id) => document.getElementById(id);
@@ -529,16 +551,21 @@ const I18N = {
     Events: "事件",
     Attention: "关注度",
     "Fetch health": "抓取状态",
-    // Sources that found nothing on a day (issue #260). The two sentence
-    // templates carry {sources} and {date} so zh can order them its own way.
-    "On {date} these sources ran but found nothing: {sources}.":
-      "{date},这些来源运行了但没有找到任何内容:{sources}。",
+    // Sources at zero on a day (issue #260). The sentence templates carry
+    // {sources} and {date} so zh can order them its own way.
+    "On {date} these sources found nothing at all: {sources}.":
+      "{date},这些来源什么都没有找到:{sources}。",
     "On {date} these sources could not be reached: {sources}.":
       "{date},这些来源无法访问:{sources}。",
+    "On {date} these sources returned something, but none of it scored high enough to be listed: {sources}.":
+      "{date},这些来源有返回内容,但都没有达到上榜所需的分数:{sources}。",
     "A source that stays at zero for several days is usually broken, not quiet.":
       "一个来源连续几天都是零,通常说明它出了问题,而不是没有新内容。",
-    "This source ran and found nothing on this day.": "这个来源当天运行了,但没有找到任何内容。",
+    "This source was checked and found nothing at all on this day.":
+      "这个来源当天检查过了,但什么都没有找到。",
     "This source could not be reached on this day.": "这个来源当天无法访问。",
+    "This source returned something, but none of it scored high enough to be listed.":
+      "这个来源有返回内容,但都没有达到上榜所需的分数。",
     // --- Map ----------------------------------------------------------------
     "Big picture": "整体概览",
     "What we found": "我们发现了什么",
@@ -2206,9 +2233,9 @@ function metricLabel(value, singular, plural = `${singular}s`) {
 
 // The ledger is long and the newest day sits at the top of it, so the gaps for
 // that day are stated once in plain words above the table. Naming the sources
-// is the point: "2 sources found nothing" tells a reader there is a problem but
-// not where to look, and the two answers (a source that ran and found nothing
-// versus one that could not be reached) call for different follow-up.
+// is the point: "3 sources are at zero" tells a reader there is a problem but
+// not where to look, and each of the three reasons calls for different
+// follow-up (fix the fetch, wait, or look at the scoring).
 function renderSourceGapNote(day) {
   const note = byId("source-gap-note");
   if (!note) return;
@@ -2218,20 +2245,26 @@ function renderSourceGapNote(day) {
     note.textContent = "";
     return;
   }
-  const unreachable = gaps.filter((entry) => !entry.ok).map((entry) => entry.name);
-  const empty = gaps.filter((entry) => entry.ok).map((entry) => entry.name);
+  const named = (state) =>
+    gaps.filter((entry) => entry.state === state).map((entry) => entry.name);
   const sentence = (template, names) =>
-    t(template, { date: formatDate(day.date), sources: names.join(", ") });
-  const sentences = [];
-  if (empty.length) {
-    sentences.push(sentence("On {date} these sources ran but found nothing: {sources}.", empty));
-  }
-  if (unreachable.length) {
-    sentences.push(
-      sentence("On {date} these sources could not be reached: {sources}.", unreachable),
-    );
-  }
-  note.textContent = `${sentences.join(" ")} ${t("A source that stays at zero for several days is usually broken, not quiet.")}`;
+    names.length ? t(template, { date: formatDate(day.date), sources: names.join(", ") }) : "";
+  const sentences = [
+    sentence("On {date} these sources found nothing at all: {sources}.", named("empty")),
+    sentence("On {date} these sources could not be reached: {sources}.", named("unreachable")),
+    sentence(
+      "On {date} these sources returned something, but none of it scored high enough to be listed: {sources}.",
+      named("unranked"),
+    ),
+  ].filter(Boolean);
+  // Only the first two sentences are a reason to go and check something. A
+  // source whose records all scored too low is the ranking doing its job, so
+  // adding the warning there would cry wolf on a normal day.
+  const worrying = named("empty").length + named("unreachable").length;
+  note.textContent = worrying
+    ? `${sentences.join(" ")} ${t("A source that stays at zero for several days is usually broken, not quiet.")}`
+    : sentences.join(" ");
+  note.classList.toggle("is-warning", worrying > 0);
   note.hidden = false;
 }
 
@@ -2244,26 +2277,26 @@ function sourceMixCell(day) {
   const found = Object.entries(day.source_counts || {});
   const gaps = zeroItemSources(day);
   const parts = [];
-  parts.push(
-    element("span", {
-      text: found.length
-        ? found.map(([name, count]) => `${name.replaceAll("_", " ")} ${count}`).join(" · ")
-        : t("none"),
-    }),
-  );
+  // "none" contradicts a row that goes on to name three sources at zero, so it
+  // is only printed when the day has nothing at all to say about its sources.
+  if (found.length || !gaps.length) {
+    parts.push(
+      element("span", {
+        text: found.length
+          ? found.map(([name, count]) => `${name.replaceAll("_", " ")} ${count}`).join(" · ")
+          : t("none"),
+      }),
+    );
+  }
   gaps.forEach((entry) => {
     parts.push(
       element("span", {
-        className: "source-gap",
+        // Why it is zero is the reader's next question, and an unranked source
+        // is the ranking working as intended rather than a fault to chase, so
+        // it is not dressed up in the same alarm colour as the other two.
+        className: entry.state === "unranked" ? "source-gap is-unranked" : "source-gap",
         text: `${entry.name} 0`,
-        attrs: {
-          // Why it is zero is the reader's next question, and the two answers
-          // mean different things: an error is a fault to chase, an empty run
-          // is a source that looked and found nothing worth keeping.
-          title: entry.ok
-            ? t("This source ran and found nothing on this day.")
-            : t("This source could not be reached on this day."),
-        },
+        attrs: { title: t(SOURCE_GAP_REASONS[entry.state]) },
       }),
     );
   });

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -1530,6 +1530,29 @@ input {
   cursor: default;
 }
 
+/* A source that found nothing is printed in the mix rather than left out, so
+   it needs to read as a gap and not as another count (issue #260). */
+.source-gap {
+  display: inline-block;
+  margin-left: 0.4rem;
+  padding: 0.05rem 0.4rem;
+  border: 1px solid var(--danger);
+  border-radius: 999px;
+  color: var(--danger);
+  font-family: var(--utility);
+  font-size: 0.68rem;
+  white-space: nowrap;
+}
+
+.source-gap-note {
+  margin: 0 0 1rem;
+  padding: 0.7rem 0.9rem;
+  border-left: 3px solid var(--danger);
+  background: var(--panel);
+  color: var(--ink);
+  font-size: 0.85rem;
+}
+
 .trend-message {
   margin: 1.25rem 0 0;
   padding: 0.9rem 1rem;

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -1544,13 +1544,25 @@ input {
   white-space: nowrap;
 }
 
+/* Records arrived but none scored high enough to list. That is the ranking
+   working, not a source to go and check, so it reads as a quiet note rather
+   than sharing the alarm colour with a source that returned nothing. */
+.source-gap.is-unranked {
+  border-color: var(--line);
+  color: var(--muted);
+}
+
 .source-gap-note {
   margin: 0 0 1rem;
   padding: 0.7rem 0.9rem;
-  border-left: 3px solid var(--danger);
+  border-left: 3px solid var(--line);
   background: var(--panel);
   color: var(--ink);
   font-size: 0.85rem;
+}
+
+.source-gap-note.is-warning {
+  border-left-color: var(--danger);
 }
 
 .trend-message {

--- a/site/index.html
+++ b/site/index.html
@@ -612,6 +612,11 @@
             Source mix counts ranked evidence after scoring. Fetch health counts raw records
             returned before scoring, so a source can be ok and still empty.
           </p>
+          <!-- Sources that found nothing are the ones worth reading first: a
+               source that quietly returns nothing day after day is usually
+               broken rather than idle (issue #260). role="status" so a screen
+               reader hears it when the day's numbers are re-rendered. -->
+          <p class="source-gap-note" id="source-gap-note" role="status" hidden></p>
           <div class="table-wrap">
             <table>
               <thead>

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1476,14 +1476,39 @@ def test_source_mix_names_the_sources_that_found_nothing():
 
     # The mix cell is built from nodes now, so a zero can carry its own styling.
     assert 'element("td", {}, sourceMixCell(day))' in script
-    assert 'className: "source-gap"' in script
+    assert '"source-gap"' in script
     assert ".source-gap {" in styles
 
-    # And the newest day's gaps are stated in words above the table, separating
-    # a source that ran and found nothing from one that could not be reached.
+    # And the newest day's gaps are stated in words above the table.
     assert 'id="source-gap-note"' in html
-    assert "On {date} these sources ran but found nothing: {sources}." in script
-    assert "On {date} these sources could not be reached: {sources}." in script
+
+
+def test_source_mix_separates_the_three_reasons_a_source_shows_zero():
+    """Issue #260: the source mix counts ranked evidence, fetch health counts
+    raw records, so a zero has three different meanings and only two of them
+    are a reason to go and check something.
+
+    Calling all three "found nothing" would be wrong: GitHub returning 300
+    records that all scored too low is the ranking working as intended, and
+    dressing that as a fault teaches the reader to ignore the real gaps.
+    """
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+    styles = Path("site/assets/styles.css").read_text(encoding="utf-8")
+
+    # The state is derived from both signals, not from `ok` alone.
+    assert 'state: !entry.ok ? "unreachable" : entry.fetched > 0 ? "unranked" : "empty"' in script
+    # A source reported by two health rows must not take an arbitrary one of
+    # them: a failure anywhere is the answer worth showing.
+    assert "ok: previous ? previous.ok && entry.ok : entry.ok" in script
+
+    # An unranked source is not dressed in the alarm colour, and the summary
+    # warning is withheld when nothing worrying happened.
+    assert '"source-gap is-unranked"' in script
+    assert ".source-gap.is-unranked {" in styles
+    assert 'note.classList.toggle("is-warning", worrying > 0)' in script
+
+    # A row that names its zeros must not also claim "none".
+    assert "if (found.length || !gaps.length) {" in script
 
 
 def test_every_new_source_gap_string_has_a_chinese_rendering():
@@ -1491,10 +1516,13 @@ def test_every_new_source_gap_string_has_a_chinese_rendering():
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
     zh = script.split("  zh: {", 1)[1]
     for phrase in (
-        "On {date} these sources ran but found nothing: {sources}.",
+        "On {date} these sources found nothing at all: {sources}.",
         "On {date} these sources could not be reached: {sources}.",
+        "On {date} these sources returned something, but none of it scored "
+        "high enough to be listed: {sources}.",
         "A source that stays at zero for several days is usually broken, not quiet.",
-        "This source ran and found nothing on this day.",
+        "This source was checked and found nothing at all on this day.",
         "This source could not be reached on this day.",
+        "This source returned something, but none of it scored high enough to be listed.",
     ):
         assert f'"{phrase}":' in zh, phrase

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1447,3 +1447,54 @@ def test_connector_failure_marks_the_summary_without_force_opening_the_panel():
     # No code path opens the panel's body.
     assert 'health-panel-details").open' not in script
     assert 'health-panel-details" ].open' not in script
+
+
+def test_source_mix_names_the_sources_that_found_nothing():
+    """Issue #260: a source that found nothing must be printed as a gap.
+
+    The ledger used to list only sources that returned something, so a day on
+    which First-party feed found nothing looked exactly like a day on which
+    First-party feed did not exist (issue #254). The zeros carry the signal: a
+    source stuck at zero for days is usually broken rather than idle.
+    """
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+    html = Path("site/index.html").read_text(encoding="utf-8")
+    styles = Path("site/assets/styles.css").read_text(encoding="utf-8")
+
+    # Fetch health names a run by its internal key, the source mix by the label
+    # a reader sees. Without the bridge the zeros cannot be matched at all.
+    assert 'first_party_feeds: "First-party feed"' in script
+    assert 'github_releases: "GitHub Release"' in script
+    # Every fetcher in the pipeline needs a reader-facing name, or its zero day
+    # would print a bare internal key.
+    fetchers = Path("src/benchmark_radar/sources.py").read_text(encoding="utf-8")
+    registry = fetchers.split("SOURCE_FETCHERS = {", 1)[1].split("}", 1)[0]
+    for line in registry.splitlines():
+        key = line.strip().split(":", 1)[0].strip('", ')
+        if key:
+            assert f"{key}:" in script.split("SOURCE_DISPLAY_NAMES = {", 1)[1], key
+
+    # The mix cell is built from nodes now, so a zero can carry its own styling.
+    assert 'element("td", {}, sourceMixCell(day))' in script
+    assert 'className: "source-gap"' in script
+    assert ".source-gap {" in styles
+
+    # And the newest day's gaps are stated in words above the table, separating
+    # a source that ran and found nothing from one that could not be reached.
+    assert 'id="source-gap-note"' in html
+    assert "On {date} these sources ran but found nothing: {sources}." in script
+    assert "On {date} these sources could not be reached: {sources}." in script
+
+
+def test_every_new_source_gap_string_has_a_chinese_rendering():
+    """Issue #260 strings are user-facing, so the zh table must carry them."""
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+    zh = script.split("  zh: {", 1)[1]
+    for phrase in (
+        "On {date} these sources ran but found nothing: {sources}.",
+        "On {date} these sources could not be reached: {sources}.",
+        "A source that stays at zero for several days is usually broken, not quiet.",
+        "This source ran and found nothing on this day.",
+        "This source could not be reached on this day.",
+    ):
+        assert f'"{phrase}":' in zh, phrase


### PR DESCRIPTION
Refs #260. Refs #254.

## The problem

On `/?view=trends`, the Daily ledger's **Source mix** column listed only the sources that returned something. A source that came back with nothing simply was not in the row, so a reader could not tell these two apart:

- this source looked and found nothing today
- this source does not exist

That distinction is the whole point. Issue #254 recorded First-party feed and GitHub Release sitting at 0 on Aug 18, 2026, and a source that quietly stays at zero for several days is usually a broken source, not a quiet one. Nothing on the page said so.

## What changed

**The zeros are printed.** Each ledger row now names the sources that ended the day at zero, as small labelled chips after the counts. Fetch health records a run under its internal key (`first_party_feeds`) while the source mix counts finished evidence under the reader-facing label (`First-party feed`), so a small mapping bridges the two.

**A zero has three meanings, and only two are a problem.** The source mix counts ranked evidence after scoring; fetch health counts raw records before it. The ledger's own note already says a source "can be ok and still empty". So the reason a source is at zero is read from both signals:

| state | meaning | shown as |
|---|---|---|
| unreachable | the fetch failed, nothing could arrive | red chip |
| empty | the fetch worked and returned no records | red chip |
| unranked | records arrived, none scored high enough to list | grey chip |

Calling the third one "found nothing" would be wrong. GitHub returning 300 records that all score too low is the ranking working as intended, and dressing that as a fault teaches the reader to skim past the real gaps. On the current local data, 13 of 115 zeros are of that third kind.

**One sentence above the table** names the newest day's gaps in plain words, since the ledger is long and "3 sources are at zero" tells a reader there is a problem but not where to look. Each of the three reasons calls for different follow-up. The "usually broken, not quiet" warning and the red left border are withheld when the only zeros are unranked ones, so a normal day does not cry wolf.

Two smaller fixes that came out of review:

- A source reported by more than one fetch-health row now takes the failure rather than whichever row happened to come first.
- A row that goes on to name its zeros no longer also claims "none".

## User-facing wording

No internal vocabulary. The UI says "source", never "connector". Every new English string has a Chinese entry in the i18n table, and the two sentence templates carry `{date}` and `{sources}` so Chinese can order them its own way.

## Checks

- `uv run pytest -q`: **838 passed** (835 on `main` plus 3 new tests). One of the new tests walks `SOURCE_FETCHERS` in `sources.py` rather than a hand-kept list, so adding a tenth source without a reader-facing name fails here instead of printing a bare internal key in the ledger.
- `uv run ruff check .` and `uv run ruff format --check .`: unchanged from `main` (the same 4 pre-existing errors and 5 pre-existing format diffs, all in files this PR does not touch).
- Browser check at `/?view=trends`, English and Chinese, no console errors. Verified the red and grey chips render on every row, the summary sentence names the right sources for the newest day, and the `is-warning` border appears only when a real gap exists.

## Not done

- No Python or pipeline change. The zeros are derived on the page from data the snapshots already carry, so this works on every historical snapshot rather than only on days generated after the change.
- The `Fetch health` column is left alone. It already reports failures and empty runs; this PR is about the source mix not showing them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PuehBQFtLfJ81UWGv6EGCg
