### PR TITLE
Say why the list is empty, not whose fault it is

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -91,6 +91,40 @@ function zeroItemSources(day) {
   }));
 }
 
+// Why the Today list is empty, when a source filter is what emptied it.
+//
+// "No observations match these filters. Clear one or more filters" is right
+// when the filters are too narrow and wrong when the source simply had a
+// quiet day: clearing filters cannot conjure evidence that was never
+// collected, so the advice sends the reader looking for a mistake they did
+// not make. Filtering to First-party feed on Aug 18 2026 is exactly that
+// case, and it read as a broken filter (issue #254).
+//
+// Only speaks when the source filter alone is active. With a second filter
+// on, the source's own zero is no longer the whole story, and guessing which
+// of the two emptied the list would be a worse answer than the general one.
+function emptyTodayMessage(day) {
+  const others = [state.q.trim(), state.kind, state.category, state.event].filter(Boolean);
+  if (!state.source || others.length) {
+    return t("No observations match these filters. Clear one or more filters to widen the view.");
+  }
+  const wanted = state.source.trim().toLowerCase();
+  const gap = zeroItemSources(day).find((entry) => entry.name.toLowerCase() === wanted);
+  if (!gap) {
+    return t("No observations match these filters. Clear one or more filters to widen the view.");
+  }
+  // The three states from issue #260, said in the second person because the
+  // reader is standing in front of the empty list asking about this source.
+  const reason = {
+    unreachable: t("{source} could not be reached on this day, so nothing was collected from it."),
+    empty: t("{source} was checked on this day and had nothing new. The filter is working."),
+    unranked: t(
+      "{source} returned something on this day, but none of it scored high enough to be listed.",
+    ),
+  }[gap.state];
+  return `${reason.replace("{source}", state.source)} ${t("Try another date, or clear the filter.")}`;
+}
+
 const byId = (id) => document.getElementById(id);
 
 // Interface language. English is the truth inside this file: every UI string
@@ -732,6 +766,16 @@ const I18N = {
     "here is a third party": "有第三方",
     listed: "已列出",
     "no readable score in this window": "此窗口中无可读分数",
+    // Issue #254: why the Today list is empty, when a source filter emptied it.
+    "No observations match these filters. Clear one or more filters to widen the view.":
+      "没有符合这些筛选条件的结果。请清除一个或多个筛选条件以扩大范围。",
+    "{source} could not be reached on this day, so nothing was collected from it.":
+      "{source} 在这一天无法访问，因此未从中收集到任何内容。",
+    "{source} was checked on this day and had nothing new. The filter is working.":
+      "{source} 在这一天已检查过，没有新内容。筛选功能正常。",
+    "{source} returned something on this day, but none of it scored high enough to be listed.":
+      "{source} 在这一天有返回内容，但都未达到列入所需的分数。",
+    "Try another date, or clear the filter.": "请尝试其他日期，或清除筛选条件。",
     "one value read verbatim from a cited document": "一个从引文文档中逐字读到的数值",
     "not yet reported": "尚未报告",
     "points to zero, the floor of this metric": "指向零,该指标的底线",
@@ -1650,7 +1694,7 @@ function renderToday({ resultsOnly = false } = {}) {
       : [
           element("p", {
             className: "empty-state",
-            text: "No observations match these filters. Clear one or more filters to widen the view.",
+            text: emptyTodayMessage(day),
           }),
         ],
   );

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1550,3 +1550,38 @@ def test_jargon_audit_reads_only_user_facing_text():
         _term, _where, text = line.split("\t", 2)
         assert not text.startswith(("data-", "aria-")), text
         assert " " in text, f"lookup key, not prose: {text}"
+
+
+def test_an_empty_source_filter_says_why_instead_of_blaming_the_filter():
+    """Issue #254: filtering to a source that had a quiet day is not a filter bug.
+
+    "Clear one or more filters to widen the view" is right when the filters are
+    too narrow and wrong when the source simply collected nothing: clearing
+    filters cannot conjure evidence that was never there, so the advice sends
+    the reader hunting for a mistake they did not make. First-party feed on
+    Aug 18 2026 is exactly that case, and it read as a broken filter.
+    """
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    # The empty list asks the helper rather than hardcoding one sentence.
+    assert "text: emptyTodayMessage(day)," in script
+    assert "function emptyTodayMessage(day)" in script
+
+    # It reuses issue #260's three states rather than inventing a fourth
+    # answer that could disagree with the ledger on the same day.
+    helper = script.split("function emptyTodayMessage(day)", 1)[1][:1400]
+    assert "zeroItemSources(day)" in helper
+    for state in ("unreachable", "empty", "unranked"):
+        assert state in helper, state
+
+    # And it only speaks when the source filter alone emptied the list: with a
+    # second filter on, which one did it is a guess.
+    assert "others.length" in helper
+
+    # Every sentence it can print is translated, including the general one,
+    # which shipped untranslated before this change.
+    for phrase in (
+        "No observations match these filters. Clear one or more filters to widen the view.",
+        "Try another date, or clear the filter.",
+    ):
+        assert script.count(f'"{phrase}"') >= 2, phrase


### PR DESCRIPTION
Refs #254. Finishes the half that #274 left open.

## What you reported

> Users clicking `/?source=First-party+feed` or `/?source=GitHub+Release` on Aug 18 see an empty results page. The filter itself is working correctly, it's a data availability issue, not a filter bug.

> Consider documenting this as a known limitation or adding a "no results" message when a source filter yields empty results.

The page said: *"No observations match these filters. Clear one or more filters to widen the view."* Clearing filters cannot conjure evidence that was never collected, so it sent the reader hunting for a mistake they did not make.

## What it says now

| URL | Before | After |
|---|---|---|
| `?date=2026-08-18&source=First-party+feed` | No observations match these filters. Clear one or more filters... | **First-party feed was checked on this day and had nothing new. The filter is working.** Try another date, or clear the filter. |
| `?date=2026-08-18&source=GitHub+Release` | (same) | **GitHub Release returned something on this day, but none of it scored high enough to be listed.** Try another date, or clear the filter. |

Those two are different, which is the point of doing it this way. First-party feed collected nothing; GitHub Release collected records that did not rank. A single generic "this source had no results" line would have flattened them back together, and only one of them is worth investigating.

## How it decides

Reuses `zeroItemSources()` from #274 rather than inventing a fourth answer that could disagree with the Trends ledger on the same day. Same three states: `unreachable`, `empty`, `unranked`.

It speaks **only when the source filter alone** emptied the list. With a second filter also on, which of the two did it is a guess, so the general message stays.

## Also fixed

The original sentence shipped as a raw string with no Chinese entry, while every string around it went through `t()`. Now translated, along with the four new ones.

## Verified in a browser, Aug 18 2026

- Both reported sources explain themselves, each with the correct reason
- `?source=GitHub` still renders its 51 items, unaffected
- Adding `&q=zzzznomatch` correctly falls back to the general message
- `&lang=zh` renders with the source name interpolated
- No console errors

840 tests pass (one new regression test), ruff clean, and the new copy passes the jargon auditor from #271.
