### PR TITLE
Let a benchmark name find the benchmark

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -1674,6 +1674,8 @@ function renderBuildMeta() {
 // benchmarks rather than mixed into a list sorted by daily priority. A prose
 // mention inside an abstract and a registry record are different kinds of
 // answer, and collapsing them is what produced the arXiv result.
+let benchmarkIndexRerenderQueued = false;
+
 function renderTodayBenchmarks() {
   const section = byId("today-benchmarks");
   if (!section) return 0;
@@ -1685,7 +1687,13 @@ function renderTodayBenchmarks() {
   }
   // Only fetched when someone actually searches, so the dashboard's first
   // paint never waits on a catalog most visits do not open.
-  if (!state.benchmarkIndexLoaded) {
+  //
+  // Attached once, not once per keystroke. loadBenchmarkIndex() caches its
+  // promise, so on a slow connection every debounced keystroke would hang
+  // another handler on the same fetch and they would all fire together when it
+  // landed, each one re-filtering the observations and rebuilding the list.
+  if (!state.benchmarkIndexLoaded && !benchmarkIndexRerenderQueued) {
+    benchmarkIndexRerenderQueued = true;
     loadBenchmarkIndex().then((records) => {
       state.benchmarkIndex = records;
       state.benchmarkIndexLoaded = true;

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -121,6 +121,9 @@ function emptyTodayMessage(day, benchmarkMatches = 0) {
     !state.source &&
     !state.organization &&
     !state.event;
+  if (queryOnly && benchmarkMatches === "pending") {
+    return t("Still checking the benchmark registry\u2026");
+  }
   if (queryOnly && benchmarkMatches) {
     return t(
       state.todayDate === "all"
@@ -433,6 +436,7 @@ const I18N = {
       "这是计算排名的精选来源列表。展开任意一张卡可看到其报告的全部基准,并按源文档的分组方式分组,以便我们的数据能逐行对照原文核查。",
     "Benchmarks with this name": "同名的基准",
     "no score read from a document yet": "尚无从文档中读到的分数",
+    "Still checking the benchmark registry\u2026": "正在查询基准登记册\u2026",
     "The crawled benchmark catalog could not be loaded, so these results may be incomplete.":
       "无法加载抓取的基准目录,因此这些结果可能不完整。",
     "The benchmark registry could not be loaded, so this search covered collected observations only.":
@@ -1711,7 +1715,13 @@ function renderTodayBenchmarks() {
     ...curatedShown.map((entry) => curatedResultRow(entry, { navigate, inert: !navigate })),
     ...externalShown.map((record) => benchmarkResultRow(record, { navigate, inert: !navigate })),
   ];
-  if (!rows.length && !indexFailed) {
+  // Still on the wire. Zero matches is not yet a fact, so the empty list must
+  // not print the sentence this whole change exists to stop printing: on a
+  // cold search for a crawled-only benchmark the catalog has not arrived, and
+  // a slow request would leave "clear one or more filters" on screen for as
+  // long as it takes. Reported as pending until it settles.
+  const indexPending = !state.benchmarkIndexLoaded;
+  if (!rows.length && !indexFailed && !indexPending) {
     section.hidden = true;
     replaceChildren(byId("today-benchmarks-results"), []);
     return 0;
@@ -1725,10 +1735,12 @@ function renderTodayBenchmarks() {
     : "";
   const warning = indexFailed
     ? t("The crawled benchmark catalog could not be loaded, so these results may be incomplete.")
-    : "";
+    : indexPending
+      ? t("Still checking the benchmark registry\u2026")
+      : "";
   byId("today-benchmarks-note").textContent = [note, warning].filter(Boolean).join(" ");
   replaceChildren(byId("today-benchmarks-results"), rows);
-  return total;
+  return !total && indexPending ? "pending" : total;
 }
 
 function renderToday({ resultsOnly = false } = {}) {

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -432,6 +432,9 @@ const I18N = {
     "leaderboard.ledger.note":
       "这是计算排名的精选来源列表。展开任意一张卡可看到其报告的全部基准,并按源文档的分组方式分组,以便我们的数据能逐行对照原文核查。",
     "Benchmarks with this name": "同名的基准",
+    "no score read from a document yet": "尚无从文档中读到的分数",
+    "The benchmark registry could not be loaded, so this search covered collected observations only.":
+      "无法加载基准登记册,因此本次搜索只覆盖了已收集的内容。",
     "No collected observation mentions \u201c{q}\u201d, but it is in the benchmark registry. The matches are listed above.":
       "收集到的内容中没有提到\u201c{q}\u201d,但它在基准登记册中。匹配结果列在上方。",
     "Registry records matching \u201c{q}\u201d. These are benchmarks the radar tracks, not things collected on a date.":
@@ -1682,15 +1685,29 @@ function renderTodayBenchmarks() {
     });
   }
   const board = state.data?.model_card_leaderboard;
-  const curated = searchCuratedEntries(board, query);
+  const curated = searchCuratedEntries(board, query, { includeUnscored: true });
   const external = searchBenchmarkIndex(state.benchmarkIndex || [], query);
-  // The curated layer has a protocol and a time axis; the crawled layer is a
-  // name and a count. Same order the leaderboard's own picker uses.
+  // A row is only worth clicking if the panel it leads to can draw. Without a
+  // curated leaderboard renderLeaderboard() returns early, so navigating would
+  // land the reader on a blank view: show the match, do not offer the trip.
+  const navigate = Boolean(board?.entries?.length);
   const rows = [
-    ...curated.map((entry) => curatedResultRow(entry, { navigate: true })),
-    ...external.map((record) => benchmarkResultRow(record, { navigate: true })),
+    ...curated.map((entry) => curatedResultRow(entry, { navigate })),
+    ...external.map((record) => benchmarkResultRow(record, { navigate })),
   ].slice(0, BENCHMARK_SEARCH_LIMIT);
   if (!rows.length) {
+    // A failed catalog fetch is not the same answer as a search that found
+    // nothing, and silently treating it as one puts the reader back in front
+    // of "clear one or more filters" with no way to know the registry was
+    // never consulted. loadBenchmarkIndex() resolves null only on failure.
+    if (state.benchmarkIndexLoaded && state.benchmarkIndex === null) {
+      section.hidden = false;
+      byId("today-benchmarks-note").textContent = t(
+        "The benchmark registry could not be loaded, so this search covered collected observations only.",
+      );
+      replaceChildren(byId("today-benchmarks-results"), []);
+      return 0;
+    }
     section.hidden = true;
     replaceChildren(byId("today-benchmarks-results"), []);
     return 0;
@@ -3483,12 +3500,19 @@ function benchmarkResultRow(record, { navigate = false } = {}) {
 // Matched on aliases as well as the name, because the registry records them
 // ("HLE" for Humanity's Last Exam) precisely so a reader does not have to know
 // the canonical spelling.
-function searchCuratedEntries(board, query) {
+// `includeUnscored` exists for callers that are answering "does the radar
+// track this?" rather than "can this be charted?". The leaderboard picker
+// needs a score record because it drives a chart, but 20 of the 79 curated
+// entries have no score progression, and 5 of those are in no crawled index
+// either: CVE-Bench, Chatbot Arena, CursorBench, MTOB and ViBench were tracked
+// benchmarks that name search could not find, which is issue #245 again with a
+// different benchmark in it.
+function searchCuratedEntries(board, query, { includeUnscored = false } = {}) {
   const needle = foldName(query);
   if (!needle) return [];
   const scored = [];
   for (const entry of board?.entries || []) {
-    if (!scoreRecord(entry.benchmark_id)) continue;
+    if (!includeUnscored && !scoreRecord(entry.benchmark_id)) continue;
     // Name and aliases identify the record; `domain` is what the placeholder
     // means by tasks and domains, since the task shape shown in the panel is
     // selected by domain. Matching it lets "agent" or "science" return a set
@@ -3529,6 +3553,8 @@ function searchCuratedEntries(board, query) {
 // register as nothing happening. Carrying them to the panel is the only
 // behaviour that matches what the row looks like it promises.
 function curatedResultRow(entry, { navigate = false } = {}) {
+  // May be absent: a curated entry is a benchmark model cards report, which is
+  // a separate fact from whether any score was read from a document for it.
   const record = scoreRecord(entry.benchmark_id);
   const facts = [];
   if (entry.domain) facts.push(String(entry.domain).replaceAll("_", " "));
@@ -3550,7 +3576,13 @@ function curatedResultRow(entry, { navigate = false } = {}) {
       }),
       element("span", {
         className: "benchmark-result-scores",
-        text: metricLabel(record.observation_count, "score read from a document", "scores read from a document"),
+        text: record
+          ? metricLabel(
+              record.observation_count,
+              "score read from a document",
+              "scores read from a document",
+            )
+          : t("no score read from a document yet"),
       }),
     ]),
   ]);

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -436,6 +436,8 @@ const I18N = {
       "这是计算排名的精选来源列表。展开任意一张卡可看到其报告的全部基准,并按源文档的分组方式分组,以便我们的数据能逐行对照原文核查。",
     "Benchmarks with this name": "同名的基准",
     "no score read from a document yet": "尚无从文档中读到的分数",
+    "Showing {shown} of {total} registry records matching \u201c{q}\u201d. Narrow the search to see the rest.":
+      "显示与\u201c{q}\u201d匹配的 {total} 条登记册记录中的 {shown} 条。缩小搜索范围可查看其余记录。",
     "Still checking the benchmark registry\u2026": "正在查询基准登记册\u2026",
     "The crawled benchmark catalog could not be loaded, so these results may be incomplete.":
       "无法加载抓取的基准目录,因此这些结果可能不完整。",
@@ -1693,11 +1695,17 @@ function renderTodayBenchmarks() {
   const board = state.data?.model_card_leaderboard;
   const curated = searchCuratedEntries(board, query, { includeUnscored: true });
   const external = searchBenchmarkIndex(state.benchmarkIndex || [], query);
-  // A row is only worth clicking if the panel it leads to can draw. Without a
-  // curated leaderboard renderLeaderboard() returns early, so navigating would
-  // land the reader on a blank view. A button that goes nowhere is worse than
-  // no button, so the rows render as plain records instead.
-  const navigate = Boolean(board?.entries?.length);
+  // A row is only worth clicking if the panel it leads to can draw. That needs
+  // more than a non-empty board: renderAdoptionFrontier() gives up unless some
+  // adopted entry has a readable score record and a default entry resolves, so
+  // a registry of card mentions with no scores yet renders the same empty panel
+  // as no registry at all. A button that goes nowhere is worse than no button,
+  // so those rows render as plain records instead.
+  const navigate = Boolean(
+    (board?.entries || []).some(
+      (item) => item.card_count > 0 && scoreRecord(item.benchmark_id),
+    ) && frontierDefaultEntry(board),
+  );
   // loadBenchmarkIndex() resolves null only on failure. That is a different
   // answer from a search that matched nothing, and it stays true whether or
   // not the curated layer had a hit: reporting it only on an empty result
@@ -1728,10 +1736,21 @@ function renderTodayBenchmarks() {
   }
   section.hidden = false;
   const total = curated.length + external.length;
+  // Saying "matching X" over a truncated list invites the reader to conclude a
+  // benchmark that is present but past row 50 does not exist, which is the
+  // reading this whole change is trying to prevent. Show the arithmetic.
+  const truncated = total > rows.length;
   const note = rows.length
-    ? t(
-        "Registry records matching \u201c{q}\u201d. These are benchmarks the radar tracks, not things collected on a date.",
-      ).replace("{q}", query)
+    ? truncated
+      ? t(
+          "Showing {shown} of {total} registry records matching \u201c{q}\u201d. Narrow the search to see the rest.",
+        )
+          .replace("{shown}", rows.length)
+          .replace("{total}", total)
+          .replace("{q}", query)
+      : t(
+          "Registry records matching \u201c{q}\u201d. These are benchmarks the radar tracks, not things collected on a date.",
+        ).replace("{q}", query)
     : "";
   const warning = indexFailed
     ? t("The crawled benchmark catalog could not be loaded, so these results may be incomplete.")

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -433,6 +433,8 @@ const I18N = {
       "这是计算排名的精选来源列表。展开任意一张卡可看到其报告的全部基准,并按源文档的分组方式分组,以便我们的数据能逐行对照原文核查。",
     "Benchmarks with this name": "同名的基准",
     "no score read from a document yet": "尚无从文档中读到的分数",
+    "The crawled benchmark catalog could not be loaded, so these results may be incomplete.":
+      "无法加载抓取的基准目录,因此这些结果可能不完整。",
     "The benchmark registry could not be loaded, so this search covered collected observations only.":
       "无法加载基准登记册,因此本次搜索只覆盖了已收集的内容。",
     "No collected observation mentions \u201c{q}\u201d, but it is in the benchmark registry. The matches are listed above.":
@@ -1689,34 +1691,42 @@ function renderTodayBenchmarks() {
   const external = searchBenchmarkIndex(state.benchmarkIndex || [], query);
   // A row is only worth clicking if the panel it leads to can draw. Without a
   // curated leaderboard renderLeaderboard() returns early, so navigating would
-  // land the reader on a blank view: show the match, do not offer the trip.
+  // land the reader on a blank view. A button that goes nowhere is worse than
+  // no button, so the rows render as plain records instead.
   const navigate = Boolean(board?.entries?.length);
+  // loadBenchmarkIndex() resolves null only on failure. That is a different
+  // answer from a search that matched nothing, and it stays true whether or
+  // not the curated layer had a hit: reporting it only on an empty result
+  // would present half a registry search as a whole one.
+  const indexFailed = state.benchmarkIndexLoaded && state.benchmarkIndex === null;
+  // Sliced before the rows are built, not after. "bench" matches 355 of the
+  // 1,148 crawled records, and building every one of them into a DOM subtree
+  // with a listener to then discard all but 50 is work done on each keystroke.
+  const curatedShown = curated.slice(0, BENCHMARK_SEARCH_LIMIT);
+  const externalShown = external.slice(
+    0,
+    Math.max(0, BENCHMARK_SEARCH_LIMIT - curatedShown.length),
+  );
   const rows = [
-    ...curated.map((entry) => curatedResultRow(entry, { navigate })),
-    ...external.map((record) => benchmarkResultRow(record, { navigate })),
-  ].slice(0, BENCHMARK_SEARCH_LIMIT);
-  if (!rows.length) {
-    // A failed catalog fetch is not the same answer as a search that found
-    // nothing, and silently treating it as one puts the reader back in front
-    // of "clear one or more filters" with no way to know the registry was
-    // never consulted. loadBenchmarkIndex() resolves null only on failure.
-    if (state.benchmarkIndexLoaded && state.benchmarkIndex === null) {
-      section.hidden = false;
-      byId("today-benchmarks-note").textContent = t(
-        "The benchmark registry could not be loaded, so this search covered collected observations only.",
-      );
-      replaceChildren(byId("today-benchmarks-results"), []);
-      return 0;
-    }
+    ...curatedShown.map((entry) => curatedResultRow(entry, { navigate, inert: !navigate })),
+    ...externalShown.map((record) => benchmarkResultRow(record, { navigate, inert: !navigate })),
+  ];
+  if (!rows.length && !indexFailed) {
     section.hidden = true;
     replaceChildren(byId("today-benchmarks-results"), []);
     return 0;
   }
   section.hidden = false;
   const total = curated.length + external.length;
-  byId("today-benchmarks-note").textContent = t(
-    "Registry records matching \u201c{q}\u201d. These are benchmarks the radar tracks, not things collected on a date.",
-  ).replace("{q}", query);
+  const note = rows.length
+    ? t(
+        "Registry records matching \u201c{q}\u201d. These are benchmarks the radar tracks, not things collected on a date.",
+      ).replace("{q}", query)
+    : "";
+  const warning = indexFailed
+    ? t("The crawled benchmark catalog could not be loaded, so these results may be incomplete.")
+    : "";
+  byId("today-benchmarks-note").textContent = [note, warning].filter(Boolean).join(" ");
   replaceChildren(byId("today-benchmarks-results"), rows);
   return total;
 }
@@ -3436,7 +3446,7 @@ function opennessChip(status) {
   });
 }
 
-function benchmarkResultRow(record, { navigate = false } = {}) {
+function benchmarkResultRow(record, { navigate = false, inert = false } = {}) {
   const facts = [];
   // Every one of these renders an explicit "not established" rather than being
   // hidden. Hiding an empty field reads as "not applicable", and whether these
@@ -3473,6 +3483,10 @@ function benchmarkResultRow(record, { navigate = false } = {}) {
       }),
     ]),
   ]);
+  if (inert) {
+    button.disabled = true;
+    return button;
+  }
   button.addEventListener("click", () => {
     selectFrontier(record.slug);
     if (navigate) {
@@ -3552,7 +3566,7 @@ function searchCuratedEntries(board, query, { includeUnscored = false } = {}) {
 // benchmark updates a panel the reader is not looking at, so the click would
 // register as nothing happening. Carrying them to the panel is the only
 // behaviour that matches what the row looks like it promises.
-function curatedResultRow(entry, { navigate = false } = {}) {
+function curatedResultRow(entry, { navigate = false, inert = false } = {}) {
   // May be absent: a curated entry is a benchmark model cards report, which is
   // a separate fact from whether any score was read from a document for it.
   const record = scoreRecord(entry.benchmark_id);
@@ -3586,6 +3600,13 @@ function curatedResultRow(entry, { navigate = false } = {}) {
       }),
     ]),
   ]);
+  // Nothing to navigate to and no panel on screen to update: an enabled
+  // control whose click does nothing visible is a worse answer than a row that
+  // does not look clickable.
+  if (inert) {
+    button.disabled = true;
+    return button;
+  }
   button.addEventListener("click", () => {
     selectFrontier(entry.benchmark_id);
     if (navigate) {

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -108,9 +108,24 @@ function emptyTodayMessage(day, benchmarkMatches = 0) {
   // filter that is set too narrow, and telling the reader to widen it sends
   // them adjusting controls that cannot produce the rows they want. Name what
   // was found instead, and point at it (issue #245).
-  if (state.q.trim() && benchmarkMatches) {
+  //
+  // Only when the query is the sole filter. With a second one active, a
+  // matching observation may exist and have been removed by that filter, so
+  // "nothing was collected" would be a claim this function cannot check. And
+  // the two date modes need different sentences: "on this date" is false in
+  // All dates mode, where the search already covered the whole archive.
+  const queryOnly =
+    state.q.trim() &&
+    !state.kind &&
+    !state.category &&
+    !state.source &&
+    !state.organization &&
+    !state.event;
+  if (queryOnly && benchmarkMatches) {
     return t(
-      "Nothing was collected about \u201c{q}\u201d on this date, but it is in the benchmark registry. The matches are listed above.",
+      state.todayDate === "all"
+        ? "No collected observation mentions \u201c{q}\u201d, but it is in the benchmark registry. The matches are listed above."
+        : "Nothing was collected about \u201c{q}\u201d on this date, but it is in the benchmark registry. The matches are listed above.",
     ).replace("{q}", state.q.trim());
   }
   const others = [state.q.trim(), state.kind, state.category, state.event].filter(Boolean);
@@ -417,6 +432,8 @@ const I18N = {
     "leaderboard.ledger.note":
       "这是计算排名的精选来源列表。展开任意一张卡可看到其报告的全部基准,并按源文档的分组方式分组,以便我们的数据能逐行对照原文核查。",
     "Benchmarks with this name": "同名的基准",
+    "No collected observation mentions \u201c{q}\u201d, but it is in the benchmark registry. The matches are listed above.":
+      "收集到的内容中没有提到\u201c{q}\u201d,但它在基准登记册中。匹配结果列在上方。",
     "Registry records matching \u201c{q}\u201d. These are benchmarks the radar tracks, not things collected on a date.":
       "登记册中与\u201c{q}\u201d匹配的记录。这些是雷达追踪的基准,而不是某一天收集到的内容。",
     "Nothing was collected about \u201c{q}\u201d on this date, but it is in the benchmark registry. The matches are listed above.":
@@ -3442,7 +3459,11 @@ function benchmarkResultRow(record, { navigate = false } = {}) {
   button.addEventListener("click", () => {
     selectFrontier(record.slug);
     if (navigate) {
+      // setView toggles visibility and the URL; it does not draw. On a first
+      // visit the leaderboard has never rendered, so switching to it without
+      // this leaves the reader on an empty panel.
       setView("leaderboard");
+      renderLeaderboard();
       return;
     }
     renderBenchmarkSearch();
@@ -3536,7 +3557,11 @@ function curatedResultRow(entry, { navigate = false } = {}) {
   button.addEventListener("click", () => {
     selectFrontier(entry.benchmark_id);
     if (navigate) {
+      // setView toggles visibility and the URL; it does not draw. On a first
+      // visit the leaderboard has never rendered, so switching to it without
+      // this leaves the reader on an empty panel.
       setView("leaderboard");
+      renderLeaderboard();
       return;
     }
     renderBenchmarkSearch();

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -103,7 +103,16 @@ function zeroItemSources(day) {
 // Only speaks when the source filter alone is active. With a second filter
 // on, the source's own zero is no longer the whole story, and guessing which
 // of the two emptied the list would be a worse answer than the general one.
-function emptyTodayMessage(day) {
+function emptyTodayMessage(day, benchmarkMatches = 0) {
+  // A search that found the benchmark but no daily coverage of it is not a
+  // filter that is set too narrow, and telling the reader to widen it sends
+  // them adjusting controls that cannot produce the rows they want. Name what
+  // was found instead, and point at it (issue #245).
+  if (state.q.trim() && benchmarkMatches) {
+    return t(
+      "Nothing was collected about \u201c{q}\u201d on this date, but it is in the benchmark registry. The matches are listed above.",
+    ).replace("{q}", state.q.trim());
+  }
   const others = [state.q.trim(), state.kind, state.category, state.event].filter(Boolean);
   if (!state.source || others.length) {
     return t("No observations match these filters. Clear one or more filters to widen the view.");
@@ -407,6 +416,11 @@ const I18N = {
       "每张模型卡对同一基准只计一次。一张在四个配置中报告 AIME 的卡,与只报告一次的卡计数相同,因此冗长的附录不能压过不同的供应商。机构可以打破平局:六个供应商报告同一计数是共同标准,只有一个供应商报告则是自家风格。",
     "leaderboard.ledger.note":
       "这是计算排名的精选来源列表。展开任意一张卡可看到其报告的全部基准,并按源文档的分组方式分组,以便我们的数据能逐行对照原文核查。",
+    "Benchmarks with this name": "同名的基准",
+    "Registry records matching \u201c{q}\u201d. These are benchmarks the radar tracks, not things collected on a date.":
+      "登记册中与\u201c{q}\u201d匹配的记录。这些是雷达追踪的基准,而不是某一天收集到的内容。",
+    "Nothing was collected about \u201c{q}\u201d on this date, but it is in the benchmark registry. The matches are listed above.":
+      "这一天没有收集到关于\u201c{q}\u201d的内容,但它在基准登记册中。匹配结果列在上方。",
     "pareto.readiness.summary": "要把最高分数和最低成本画在一张图上,还差什么?",
     "pareto.readiness.note1":
       "两个分数只有在各自都记录了以下信息时才能比较:测的是哪个版本、取的是哪一部分、数值高好还是低好、用的哪个模型、由什么软件运行、给了多少思考时间、花了多少钱、用了多长时间、何时发布,以及这个数字出自哪里。其中测试本身和运行方式必须一致,而模型、成本、耗时和日期可以不同,因为它们正是图表要对比的内容。本站记录的是某张模型卡提到了某个基准,还没有记录这些测量值。",
@@ -1617,6 +1631,62 @@ function renderBuildMeta() {
   )} UTC`;
 }
 
+// The search box reads the daily feed: titles, summaries and source names of
+// what the crawl collected on a date. The benchmark registry is a different
+// dataset, and until issue #245 nothing joined them, so a reader searching for
+// a benchmark by name got one of two wrong answers. "researchclawbench"
+// returned "No observations match these filters", advice that cannot work
+// because clearing a filter does not add a dataset. "terminal-bench" was worse:
+// it returned an arXiv paper on uncertainty propagation, which ranked because
+// the string "Terminal-Bench-2" appears in its abstract. Both benchmarks are in
+// the registry with scores, and both were unreachable from the box that looks
+// like the way to find them.
+//
+// So the query runs against the registry too, and its matches are named as
+// benchmarks rather than mixed into a list sorted by daily priority. A prose
+// mention inside an abstract and a registry record are different kinds of
+// answer, and collapsing them is what produced the arXiv result.
+function renderTodayBenchmarks() {
+  const section = byId("today-benchmarks");
+  if (!section) return 0;
+  const query = state.q.trim();
+  if (!query) {
+    section.hidden = true;
+    replaceChildren(byId("today-benchmarks-results"), []);
+    return 0;
+  }
+  // Only fetched when someone actually searches, so the dashboard's first
+  // paint never waits on a catalog most visits do not open.
+  if (!state.benchmarkIndexLoaded) {
+    loadBenchmarkIndex().then((records) => {
+      state.benchmarkIndex = records;
+      state.benchmarkIndexLoaded = true;
+      if (state.q.trim()) renderToday({ resultsOnly: true });
+    });
+  }
+  const board = state.data?.model_card_leaderboard;
+  const curated = searchCuratedEntries(board, query);
+  const external = searchBenchmarkIndex(state.benchmarkIndex || [], query);
+  // The curated layer has a protocol and a time axis; the crawled layer is a
+  // name and a count. Same order the leaderboard's own picker uses.
+  const rows = [
+    ...curated.map((entry) => curatedResultRow(entry, { navigate: true })),
+    ...external.map((record) => benchmarkResultRow(record, { navigate: true })),
+  ].slice(0, BENCHMARK_SEARCH_LIMIT);
+  if (!rows.length) {
+    section.hidden = true;
+    replaceChildren(byId("today-benchmarks-results"), []);
+    return 0;
+  }
+  section.hidden = false;
+  const total = curated.length + external.length;
+  byId("today-benchmarks-note").textContent = t(
+    "Registry records matching \u201c{q}\u201d. These are benchmarks the radar tracks, not things collected on a date.",
+  ).replace("{q}", query);
+  replaceChildren(byId("today-benchmarks-results"), rows);
+  return total;
+}
+
 function renderToday({ resultsOnly = false } = {}) {
   // Events are bound before the data file resolves (initialize), so a nav
   // click or filter keystroke in the load window must no-op, not throw.
@@ -1642,6 +1712,7 @@ function renderToday({ resultsOnly = false } = {}) {
   // resultsOnly re-renders that follow each drawer interaction.
   updateFiltersCount();
   const observations = filteredObservations();
+  const benchmarkMatches = renderTodayBenchmarks();
   const resultsKey = [
     state.todayDate,
     state.q,
@@ -1693,7 +1764,7 @@ function renderToday({ resultsOnly = false } = {}) {
       : [
           element("p", {
             className: "empty-state",
-            text: emptyTodayMessage(day),
+            text: emptyTodayMessage(day, benchmarkMatches),
           }),
         ],
   );
@@ -3331,7 +3402,7 @@ function opennessChip(status) {
   });
 }
 
-function benchmarkResultRow(record) {
+function benchmarkResultRow(record, { navigate = false } = {}) {
   const facts = [];
   // Every one of these renders an explicit "not established" rather than being
   // hidden. Hiding an empty field reads as "not applicable", and whether these
@@ -3370,6 +3441,10 @@ function benchmarkResultRow(record) {
   ]);
   button.addEventListener("click", () => {
     selectFrontier(record.slug);
+    if (navigate) {
+      setView("leaderboard");
+      return;
+    }
     renderBenchmarkSearch();
     const board = state.data?.model_card_leaderboard;
     if (board) renderAdoptionFrontier(board);
@@ -3428,7 +3503,11 @@ function searchCuratedEntries(board, query) {
 // A curated result states what the crawled rows cannot: how many values were
 // read verbatim, and that this record charts. The layer is named on the row
 // rather than left to the reader to infer from the absence of a source chip.
-function curatedResultRow(entry) {
+// `navigate` is for rows rendered outside the leaderboard. There, selecting a
+// benchmark updates a panel the reader is not looking at, so the click would
+// register as nothing happening. Carrying them to the panel is the only
+// behaviour that matches what the row looks like it promises.
+function curatedResultRow(entry, { navigate = false } = {}) {
   const record = scoreRecord(entry.benchmark_id);
   const facts = [];
   if (entry.domain) facts.push(String(entry.domain).replaceAll("_", " "));
@@ -3456,6 +3535,10 @@ function curatedResultRow(entry) {
   ]);
   button.addEventListener("click", () => {
     selectFrontier(entry.benchmark_id);
+    if (navigate) {
+      setView("leaderboard");
+      return;
+    }
     renderBenchmarkSearch();
     const board = state.data?.model_card_leaderboard;
     if (board) renderAdoptionFrontier(board);

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -3974,12 +3974,36 @@ footer {
   font-variant-numeric: tabular-nums;
 }
 
-#benchmark-search-results {
+#benchmark-search-results,
+#today-benchmarks-results {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
   max-height: 22rem;
   overflow-y: auto;
+}
+
+/* Registry matches sit above the day's list and answer a different question
+   than it does, so they are fenced off rather than run together with it. */
+.today-benchmarks {
+  margin: 0 0 1rem;
+  padding: 0.75rem 0.85rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+}
+
+.today-benchmarks-heading {
+  margin: 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.today-benchmarks-note {
+  margin: 0.25rem 0 0.55rem;
+  font-size: 0.7rem;
+  line-height: 1.45;
+  color: var(--muted);
 }
 
 .benchmark-result {

--- a/site/index.html
+++ b/site/index.html
@@ -282,6 +282,11 @@
                 <span id="today-sort"></span>
               </div>
             </div>
+            <section class="today-benchmarks" id="today-benchmarks" hidden aria-labelledby="today-benchmarks-heading">
+              <h3 class="today-benchmarks-heading" id="today-benchmarks-heading" data-i18n="Benchmarks with this name">Benchmarks with this name</h3>
+              <p class="today-benchmarks-note" id="today-benchmarks-note"></p>
+              <div id="today-benchmarks-results"></div>
+            </section>
             <div class="signal-list" id="today-list"></div>
             <button class="secondary-link today-show-more" id="today-show-more" type="button" hidden data-i18n="Show more results">
               Show more results

--- a/tests/test_leaderboard_workbench.py
+++ b/tests/test_leaderboard_workbench.py
@@ -292,11 +292,15 @@ def test_detail_panel_renders_for_any_selected_record():
 def test_search_selection_updates_the_detail_panel():
     script = source("site/assets/app.js")
 
-    row = script.split("function benchmarkResultRow(record)", 1)[1].split(
+    row = script.split("function benchmarkResultRow(record", 1)[1].split(
         "function renderBenchmarkSearch", 1
     )[0]
     assert "selectFrontier(record.slug)" in row
     assert "renderAdoptionFrontier(board)" in row
+    # Issue #245 added a `navigate` path for rows rendered outside the
+    # leaderboard, where updating the panel in place would look like the click
+    # did nothing. It must not replace the in-place update the panel relies on.
+    assert "setView(\"leaderboard\")" in row
 
 
 def test_crawled_scores_are_partitioned_by_source_with_no_merge_path():

--- a/tests/test_leaderboard_workbench.py
+++ b/tests/test_leaderboard_workbench.py
@@ -300,7 +300,7 @@ def test_search_selection_updates_the_detail_panel():
     # Issue #245 added a `navigate` path for rows rendered outside the
     # leaderboard, where updating the panel in place would look like the click
     # did nothing. It must not replace the in-place update the panel relies on.
-    assert "setView(\"leaderboard\")" in row
+    assert 'setView("leaderboard")' in row
 
 
 def test_crawled_scores_are_partitioned_by_source_with_no_merge_path():

--- a/tests/test_saturation_view.py
+++ b/tests/test_saturation_view.py
@@ -231,12 +231,16 @@ def test_curated_search_matches_aliases_and_ranks_the_exact_one_first():
     # a prefix hit for "HLE" and, ranked on entry-name length, beat the record
     # literally named HLE. The matched alias is what gets ranked.
     script = source("site/assets/app.js")
-    search = script.split("function searchCuratedEntries(board, query)", 1)[1].split("\n}", 1)[0]
+    search = script.split("function searchCuratedEntries(board, query", 1)[1].split("\n}", 1)[0]
 
     assert "entry.aliases || []" in search
     assert "name === needle ? 0 : name.startsWith(needle) ? 1 : 2" in search
     # Only scored benchmarks are offered, same rule as the picker.
-    assert "if (!scoreRecord(entry.benchmark_id)) continue;" in search
+    # The picker drives a chart, so it still skips entries with no score
+    # record. Issue #245 added an opt-in for callers asking only "is this
+    # tracked?"; the default must stay off so this panel is unaffected.
+    assert "if (!includeUnscored && !scoreRecord(entry.benchmark_id)) continue;" in search
+    assert "includeUnscored = false" in search
 
 
 def test_search_still_works_when_the_crawled_index_is_unavailable():
@@ -365,7 +369,7 @@ def test_search_matches_the_fields_the_placeholder_promises():
     # publisher and modality are the equivalent there.
     script = source("site/assets/app.js")
 
-    curated = script.split("function searchCuratedEntries(board, query)", 1)[1].split("\n}", 1)[0]
+    curated = script.split("function searchCuratedEntries(board, query", 1)[1].split("\n}", 1)[0]
     assert "foldName(entry.domain).includes(needle)" in curated
     # A field hit is a weaker answer than a name hit and ranks below every one.
     assert "const best = hits.length ? Math.min(...hits.map(tier)) : 3;" in curated

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1572,9 +1572,7 @@ def test_an_empty_source_filter_says_why_instead_of_blaming_the_filter():
     # Sliced to the next top-level function rather than a fixed character
     # count, so adding a branch to this helper cannot silently push the
     # assertions below out of the window being checked.
-    helper = script.split("function emptyTodayMessage(day", 1)[1].split(
-        "\nfunction ", 1
-    )[0]
+    helper = script.split("function emptyTodayMessage(day", 1)[1].split("\nfunction ", 1)[0]
     assert "zeroItemSources(day)" in helper
     for state in ("unreachable", "empty", "unranked"):
         assert state in helper, state
@@ -1672,9 +1670,7 @@ def test_a_benchmark_name_search_reaches_the_registry_not_only_the_daily_feed():
 
     # And the empty list stops advising a filter change that cannot help when
     # the thing being searched for was found in the registry instead.
-    helper = script.split("function emptyTodayMessage(day", 1)[1].split(
-        "\nfunction ", 1
-    )[0]
+    helper = script.split("function emptyTodayMessage(day", 1)[1].split("\nfunction ", 1)[0]
     assert "benchmarkMatches" in helper
 
     # The claim is only made when the query is the sole filter. With a second

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1637,7 +1637,14 @@ def test_a_benchmark_name_search_reaches_the_registry_not_only_the_daily_feed():
     # matched. Only saying so on an empty result would present half a registry
     # search as a whole one.
     assert "const indexFailed =" in section
-    assert "if (!rows.length && !indexFailed)" in section
+    assert "if (!rows.length && !indexFailed && !indexPending)" in section
+
+    # And an unsettled catalog is a third state. Zero matches is not a fact
+    # while the request is in flight, so a cold search for a crawled-only
+    # benchmark must not print "clear one or more filters" in the meantime.
+    assert "const indexPending = !state.benchmarkIndexLoaded;" in section
+    assert 'return !total && indexPending ? "pending" : total;' in section
+    assert 'benchmarkMatches === "pending"' in script
 
     # With no leaderboard to land on, rows render inert rather than as buttons
     # whose click does nothing the reader can see.

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1627,6 +1627,22 @@ def test_a_benchmark_name_search_reaches_the_registry_not_only_the_daily_feed():
     # still does not pay for it.
     assert "if (!state.benchmarkIndexLoaded)" in section
 
+    # Capped before the rows are built. "bench" matches 355 of the 1,148
+    # crawled records, and building all of them into DOM subtrees with
+    # listeners to then drop all but 50 is work repeated on every keystroke.
+    assert "curated.slice(0, BENCHMARK_SEARCH_LIMIT)" in section
+    assert section.index("externalShown") < section.index("benchmarkResultRow(record")
+
+    # A failed catalog fetch is reported whether or not the curated layer
+    # matched. Only saying so on an empty result would present half a registry
+    # search as a whole one.
+    assert "const indexFailed =" in section
+    assert "if (!rows.length && !indexFailed)" in section
+
+    # With no leaderboard to land on, rows render inert rather than as buttons
+    # whose click does nothing the reader can see.
+    assert "inert: !navigate" in section
+
     # Clicking a row must draw the view it lands on. setView() toggles
     # visibility and the URL but does not render, so without this a first-time
     # visitor arrives at an empty leaderboard: 0 chart children, 0 table rows.

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1612,7 +1612,7 @@ def test_a_benchmark_name_search_reaches_the_registry_not_only_the_daily_feed():
     section = script.split("function renderTodayBenchmarks()", 1)[1].split(
         "function renderToday(", 1
     )[0]
-    assert "searchCuratedEntries(board, query)" in section
+    assert "searchCuratedEntries(board, query, { includeUnscored: true })" in section
     assert "searchBenchmarkIndex(state.benchmarkIndex || [], query)" in section
 
     # Curated rows rank above crawled ones: same order the leaderboard picker
@@ -1630,7 +1630,6 @@ def test_a_benchmark_name_search_reaches_the_registry_not_only_the_daily_feed():
     # Clicking a row must draw the view it lands on. setView() toggles
     # visibility and the URL but does not render, so without this a first-time
     # visitor arrives at an empty leaderboard: 0 chart children, 0 table rows.
-    assert section.count("renderLeaderboard()") == 0
     for row in ("function curatedResultRow(entry", "function benchmarkResultRow(record"):
         body = script.split(row, 1)[1].split("\nfunction ", 1)[0]
         assert 'setView("leaderboard");\n      renderLeaderboard();' in body, row

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1564,12 +1564,12 @@ def test_an_empty_source_filter_says_why_instead_of_blaming_the_filter():
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
 
     # The empty list asks the helper rather than hardcoding one sentence.
-    assert "text: emptyTodayMessage(day)," in script
-    assert "function emptyTodayMessage(day)" in script
+    assert "text: emptyTodayMessage(day, benchmarkMatches)," in script
+    assert "function emptyTodayMessage(day" in script
 
     # It reuses issue #260's three states rather than inventing a fourth
     # answer that could disagree with the ledger on the same day.
-    helper = script.split("function emptyTodayMessage(day)", 1)[1][:1400]
+    helper = script.split("function emptyTodayMessage(day", 1)[1][:2000]
     assert "zeroItemSources(day)" in helper
     for state in ("unreachable", "empty", "unranked"):
         assert state in helper, state
@@ -1585,3 +1585,55 @@ def test_an_empty_source_filter_says_why_instead_of_blaming_the_filter():
         "Try another date, or clear the filter.",
     ):
         assert script.count(f'"{phrase}"') >= 2, phrase
+
+
+def test_a_benchmark_name_search_reaches_the_registry_not_only_the_daily_feed():
+    """Issue #245: the search box read the daily feed and nothing else.
+
+    Two wrong answers came out of that. "researchclawbench" returned "No
+    observations match these filters. Clear one or more filters", advice that
+    cannot work, because no filter setting adds a dataset the box never read.
+    "terminal-bench" was worse: it returned an arXiv paper on uncertainty
+    propagation, ranked because the string "Terminal-Bench-2" happens to appear
+    in its abstract, while the six Terminal-Bench records in the registry, one
+    of them carrying 51 reported scores, were unreachable.
+
+    Both benchmarks are in the registry. The query has to reach it.
+    """
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    # The query runs against both registry layers, reusing the matchers the
+    # leaderboard already uses rather than a second, drifting implementation.
+    section = script.split("function renderTodayBenchmarks()", 1)[1].split(
+        "function renderToday(", 1
+    )[0]
+    assert "searchCuratedEntries(board, query)" in section
+    assert "searchBenchmarkIndex(state.benchmarkIndex || [], query)" in section
+
+    # Curated rows rank above crawled ones: same order the leaderboard picker
+    # uses, and the layer with a protocol and a time axis.
+    assert section.index("curatedResultRow") < section.index("benchmarkResultRow")
+
+    # Registry matches are named as such. Folding them into a list sorted by
+    # daily priority is what surfaced the arXiv paper over the benchmark.
+    assert "today-benchmarks" in section
+
+    # The catalog is only fetched once someone searches, so a normal visit
+    # still does not pay for it.
+    assert "if (!state.benchmarkIndexLoaded)" in section
+
+    # And the empty list stops advising a filter change that cannot help when
+    # the thing being searched for was found in the registry instead.
+    helper = script.split("function emptyTodayMessage(day", 1)[1][:1200]
+    assert "benchmarkMatches" in helper
+
+    # A t() string needs both halves in app.js: the English key the call site
+    # passes and the zh value it looks up. Missing the second is the silent
+    # failure mode, since the lookup just falls through to English.
+    assert script.count("Nothing was collected about") >= 2
+
+    # A data-i18n string is keyed from the HTML instead, so app.js carries the
+    # translation only and the English lives in the markup.
+    markup = Path("site/index.html").read_text(encoding="utf-8")
+    assert 'data-i18n="Benchmarks with this name"' in markup
+    assert '"Benchmarks with this name":' in script

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1647,8 +1647,18 @@ def test_a_benchmark_name_search_reaches_the_registry_not_only_the_daily_feed():
     assert 'benchmarkMatches === "pending"' in script
 
     # With no leaderboard to land on, rows render inert rather than as buttons
-    # whose click does nothing the reader can see.
+    # whose click does nothing the reader can see. "Has entries" is not the
+    # test: renderAdoptionFrontier() gives up unless an adopted entry has a
+    # readable score record and a default entry resolves.
     assert "inert: !navigate" in section
+    assert "scoreRecord(item.benchmark_id)" in section
+    assert "frontierDefaultEntry(board)" in section
+
+    # A truncated list says so. Presenting 50 of 383 as "the matches" invites
+    # the reader to conclude a benchmark past row 50 is absent, which is the
+    # same wrong conclusion this issue is about.
+    assert "const truncated = total > rows.length;" in section
+    assert "Showing {shown} of {total} registry records" in section
 
     # Clicking a row must draw the view it lands on. setView() toggles
     # visibility and the URL but does not render, so without this a first-time

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1625,7 +1625,10 @@ def test_a_benchmark_name_search_reaches_the_registry_not_only_the_daily_feed():
 
     # The catalog is only fetched once someone searches, so a normal visit
     # still does not pay for it.
-    assert "if (!state.benchmarkIndexLoaded)" in section
+    # Attached once. The promise is cached, so one handler per keystroke would
+    # all fire together on a slow fetch, each re-filtering and rebuilding.
+    assert "!state.benchmarkIndexLoaded && !benchmarkIndexRerenderQueued" in section
+    assert "benchmarkIndexRerenderQueued = true;" in section
 
     # Capped before the rows are built. "bench" matches 355 of the 1,148
     # crawled records, and building all of them into DOM subtrees with

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1569,7 +1569,12 @@ def test_an_empty_source_filter_says_why_instead_of_blaming_the_filter():
 
     # It reuses issue #260's three states rather than inventing a fourth
     # answer that could disagree with the ledger on the same day.
-    helper = script.split("function emptyTodayMessage(day", 1)[1][:2000]
+    # Sliced to the next top-level function rather than a fixed character
+    # count, so adding a branch to this helper cannot silently push the
+    # assertions below out of the window being checked.
+    helper = script.split("function emptyTodayMessage(day", 1)[1].split(
+        "\nfunction ", 1
+    )[0]
     assert "zeroItemSources(day)" in helper
     for state in ("unreachable", "empty", "unranked"):
         assert state in helper, state
@@ -1622,10 +1627,32 @@ def test_a_benchmark_name_search_reaches_the_registry_not_only_the_daily_feed():
     # still does not pay for it.
     assert "if (!state.benchmarkIndexLoaded)" in section
 
+    # Clicking a row must draw the view it lands on. setView() toggles
+    # visibility and the URL but does not render, so without this a first-time
+    # visitor arrives at an empty leaderboard: 0 chart children, 0 table rows.
+    assert section.count("renderLeaderboard()") == 0
+    for row in ("function curatedResultRow(entry", "function benchmarkResultRow(record"):
+        body = script.split(row, 1)[1].split("\nfunction ", 1)[0]
+        assert 'setView("leaderboard");\n      renderLeaderboard();' in body, row
+
     # And the empty list stops advising a filter change that cannot help when
     # the thing being searched for was found in the registry instead.
-    helper = script.split("function emptyTodayMessage(day", 1)[1][:1200]
+    helper = script.split("function emptyTodayMessage(day", 1)[1].split(
+        "\nfunction ", 1
+    )[0]
     assert "benchmarkMatches" in helper
+
+    # The claim is only made when the query is the sole filter. With a second
+    # one active a matching observation may exist and have been filtered out,
+    # so "nothing was collected" would assert more than this function knows.
+    assert "queryOnly" in helper
+    for other in ("state.kind", "state.category", "state.source", "state.event"):
+        assert other in helper, other
+
+    # "on this date" is false in All dates mode, where the search already
+    # covered the whole archive, so that mode gets its own sentence.
+    assert 'state.todayDate === "all"' in helper
+    assert "No collected observation mentions" in helper
 
     # A t() string needs both halves in app.js: the English key the call site
     # passes and the zh value it looks up. Missing the second is the silent


### PR DESCRIPTION
Fixes the search half of #245, reported from two URLs that both gave a wrong answer.

## The bug

`?q=` searched the daily feed and nothing else: the titles, summaries and source names of what the crawl collected on a date. The benchmark registry is a separate dataset, and nothing joined them.

- `?q=researchclawbench` → "No observations match these filters. Clear one or more filters to widen the view." No filter setting could have helped. ResearchClawBench is in the registry with a reported score.
- `?q=terminal-bench` → an arXiv paper on relational uncertainty propagation, ranked because the string `Terminal-Bench-2` appears in its abstract. The six Terminal-Bench records in the registry, one with 51 reported scores, were unreachable from the box that looks like the way to find them.

## The fix

The query now runs against the registry too, reusing `searchCuratedEntries` and `searchBenchmarkIndex` rather than growing a second matcher that would drift from the leaderboard's. Matches are named as benchmarks and listed above the day's results, since a prose mention inside an abstract and a registry record are different kinds of answer. Curated rows rank above crawled ones, the same order the leaderboard's own picker uses.

Clicking a row carries the reader to the leaderboard panel with that benchmark selected. The empty list stops advising a filter change that cannot help, and says why it is empty instead: the same rule as #254 and #260.

## Codex review

Six rounds. Everything below was found by review, not by me, and each one is a case I had not tested:

| Finding | Severity |
|---|---|
| `setView()` toggles visibility but does not render, so the first click landed on an empty leaderboard | **P1** |
| The empty-state claim was unprovable with a second filter active, and said "on this date" in All-dates mode | P2 |
| `searchCuratedEntries` skipped unscored entries, leaving CVE-Bench, Chatbot Arena, CursorBench, MTOB and ViBench invisible — the same bug with a different benchmark | P2 |
| Rows offered navigation to a leaderboard that could not render | P2 |
| A failed catalog fetch was indistinguishable from a search that matched nothing | P2 |
| The 50-row cap ran after building every match: "bench" built 383 DOM subtrees to show 50 | P2 |
| Truncation was undisclosed, so 50 of 383 read as the whole answer | P2 |
| An in-flight fetch printed the wrong empty-state message until it landed | P2 |
| Each keystroke stacked another completion handler on the same cached promise | P2 |

Final review: "no actionable regression was identified."

## Verification

- `pytest` → 841 passed
- `python scripts/audit_jargon.py` → 0 hits
- Browser: both reported URLs, plus CVE-Bench / Chatbot Arena / MTOB, the truncation notice ("Showing 50 of 383"), click-through to a drawn Terminal-Bench chart, English and Chinese, and 390px mobile with no overflow. No console errors.

Registry identity work (model cards, publication dates) is still open in #245 and not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
