### PR TITLE
Record RSI-Bench before anyone reports a score

### DIFF
--- a/data/model_cards.yml
+++ b/data/model_cards.yml
@@ -865,6 +865,28 @@ benchmarks:
       a public dataset; released 2026-04-22 per PDF metadata. Graded by an LLM
       against physician-written rubrics.
 
+  - id: rsi_bench
+    name: RSI-Bench
+    aliases:
+      - "RSI-Bench"
+      - "RSI Bench"
+      - "RSIBench"
+      - "Recursive Self-Improvement Benchmark"
+    domain: agent
+    url: https://www.rsi-benchmark.com/
+    released: 2026-08-07
+    caveat: >-
+      Announced by Scale AI on 2026-08-07 and still in preview: it is
+      soliciting task contributions rather than reporting results, so no model
+      card in this registry reports it and its adoption count is zero. That
+      zero is a real reading, not a gap in the crawl. Recorded now so the
+      benchmark is addressable by name before any score exists, and so the
+      first card to report it has an id to resolve against. Scores are
+      per-task against a baseline under a fixed compute budget, graded on
+      reliability, efficiency, generality and idea quality, so a single
+      headline number should not be expected. Not to be confused with the
+      llm-stats "RSI Index" record, which is a different instrument.
+
 # Model cards, technical reports and release posts.
 #
 # `organization` is the publisher of the document. `benchmarks` is the set of


### PR DESCRIPTION
Adds RSI-Bench to the benchmark registry. Refs #244.

## Why now, with no scores

The argument for waiting was that Scale AI announced RSI-Bench on 2026-08-07, it is still in preview soliciting task contributions, and no model card reports it. That reasoning is backwards: a benchmark nobody has scored is the one a reader cannot find by any other route, because there is no score row to stumble across and no adoption count to rank it into view.

It goes in with an adoption count of zero. That zero is a reading, not a hole in the crawl. The registry counts documents that report a benchmark, and no document reports this one yet. The entry gives the name, the aliases in circulation, the publisher, the release date, and an id for the first card that does report it to resolve against.

## That this is allowed, not assumed

`load_registry` validates card → benchmark, never the reverse, so an entry no card names is well-formed. Confirmed rather than assumed: `benchmark-radar rebuild` carries it through to `model_card_leaderboard` as entry 80 with `card_count: 0` and an empty `adopters` list.

Also confirmed findable in a browser, running this branch together with #284: `?q=rsi-bench`, `?q=rsibench` and `?q=recursive self-improvement` all return the record, labeled "0 model cards · no score read from a document yet". Without #284 a zero-score entry would not have been reachable by name, so the two changes need each other.

## Sourcing

Read from the announcement post and the benchmark's own site, not from the issue body, which lost its dollar figures and two file names to markdown parsing. Verified: Scale AI, 2026-08-07, preview status, graded on reliability, efficiency, generality and idea quality.

The caveat separates it from the llm-stats `RSI Index` record, a different instrument with a confusingly similar name that already exists in the crawled catalog.

## Verification

- `pytest` → 834 passed, 6 skipped
- `benchmark-radar rebuild` → succeeds, RSI-Bench present in the output

## Review status

**Not reviewed by Codex**: the CLI returned "You've hit your usage limit" (resets Aug 20). Flagging rather than omitting. This is a data entry validated by the registry loader, the test suite and a real rebuild; the two PRs in this batch that carry logic (#282, #284) both had full Codex review.

## Still open in #244

Adding `https://www.rsi-benchmark.com/` as a feed source belongs with the collection format in #264, and no scores exist to record. Neither is touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
