### PR TITLE
Let a benchmark nobody has scored answer for itself

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -761,6 +761,8 @@ const I18N = {
       "不是逐字的基准条目。这是根据记录领域生成的示例格式;请使用官方来源查看确切的题目与评分规则。",
     "No score for this benchmark could be read verbatim from the cited documents, so there is no track to draw. An absent value is not a zero and not a plateau.":
       "无法从引文文档中逐字读到该基准的分数,因此没有可绘制的轨道。缺失的数值既不是零,也不是平台期。",
+    "No model card in this registry reports this benchmark yet, so there is no score to draw. That zero is a reading, not a gap in the collection.":
+      "本登记册中还没有任何模型卡报告该基准,因此没有可绘制的分数。这个零是一个读数,而不是收集上的缺口。",
     "No score for this benchmark could be read verbatim from the cited documents. An absent value is not a zero and not a plateau.":
       "无法从引文文档中逐字读到该基准的分数。缺失的数值既不是零,也不是平台期。",
     "Open public discussion ↗": "打开公开讨论 ↗",
@@ -4376,7 +4378,7 @@ function renderFrontierPicker(scored, selectedValue) {
   );
 }
 
-function renderExternalShell(board, scored, { eyebrow, heading, badge, message }) {
+function renderExternalShell(board, scored, { eyebrow, heading, badge, message, prependOption }) {
   clearFrontierPointSelection();
   setCanonicalFrontierChrome(false);
   byId("frontier-eyebrow").textContent = eyebrow;
@@ -4386,6 +4388,13 @@ function renderExternalShell(board, scored, { eyebrow, heading, badge, message }
   stage.hidden = false;
   stage.textContent = badge;
   renderFrontierPicker(scored, state.lfrontier);
+  if (prependOption) {
+    const picker = byId("frontier-benchmark");
+    const [value, label] = prependOption;
+    const existing = [...picker.options].find((candidate) => candidate.value === value);
+    if (existing) existing.selected = true;
+    else picker.prepend(option(value, label, true));
+  }
   replaceChildren(byId("frontier-external"), [
     element("p", { className: "empty-state", text: message }),
   ]);
@@ -5487,8 +5496,16 @@ function renderAdoptionFrontier(board) {
   // The index is not consulted: a canonical id and an external slug are separate
   // namespaces (every slug is source-prefixed), so no pending fetch can change
   // this answer.
+  //
+  // Resolved against every registry entry, not just the adopted ones. `adopted`
+  // is gated on card_count > 0, so a benchmark recorded before any model card
+  // reports it was invisible here and fell through to the default: issue #287,
+  // where ?lfrontier=rsi_bench drew AutomationBench's track, its 31.8% best on
+  // record and its model points, under a URL still reading rsi_bench and with
+  // nothing on the page saying so. A benchmark nobody has scored is exactly the
+  // one a reader is most likely to ask about, so it has to answer for itself.
   const unscoredEntry = state.lfrontier
-    ? adopted.find(
+    ? (board.entries || []).find(
         (candidate) =>
           candidate.benchmark_id === state.lfrontier && !scoreRecord(candidate.benchmark_id),
       )
@@ -5498,10 +5515,24 @@ function renderAdoptionFrontier(board) {
     renderExternalShell(board, scored, {
       eyebrow: t("Scores over time"),
       heading: unscoredEntry.name,
+      // Same contract renderExternalBenchmark keeps for crawled records: the
+      // picker only lists scored benchmarks, so an unscored selection matches
+      // no option and the browser falls back to showing the first one. A
+      // <select> reading AA-LCR beside a panel headed RSI-Bench is lying about
+      // the state, so the selection is prepended as its own option.
+      prependOption: [unscoredEntry.benchmark_id, unscoredEntry.name],
       badge: "",
-      message: t(
-        "No score for this benchmark could be read verbatim from the cited documents, so there is no track to draw. An absent value is not a zero and not a plateau.",
-      ),
+      // Two different absences, and a reader chasing a brand-new benchmark
+      // wants to know which one they hit. No card has reported it yet is a
+      // statement about the field's attention; cards report it but no score
+      // could be read verbatim is a statement about our sources.
+      message: unscoredEntry.card_count
+        ? t(
+            "No score for this benchmark could be read verbatim from the cited documents, so there is no track to draw. An absent value is not a zero and not a plateau.",
+          )
+        : t(
+            "No model card in this registry reports this benchmark yet, so there is no score to draw. That zero is a reading, not a gap in the collection.",
+          ),
     });
     return;
   }

--- a/tests/test_leaderboard_workbench.py
+++ b/tests/test_leaderboard_workbench.py
@@ -606,3 +606,29 @@ def test_the_shortlist_says_what_it_ranks_by_behind_an_info_toggle():
     # And it escapes the navigator's scroll container rather than being clipped.
     pinned = styles.split(".benchmark-example-heading .info-disclosure-body", 1)[1][:200]
     assert "position: fixed" in pinned
+
+
+def test_a_benchmark_with_no_adopters_answers_for_itself():
+    # Issue #287: ?lfrontier=rsi_bench drew AutomationBench's chart. `adopted`
+    # is gated on card_count > 0, so a benchmark recorded before any model card
+    # reports it was filtered out before the unscored guard could see it. It
+    # matched no branch, fell through to the default entry, and the page
+    # printed another benchmark's track, its 31.8% best-on-record figure and
+    # its model points under a URL still reading rsi_bench, saying nothing.
+    script = source("site/assets/app.js")
+    body = script.split("function renderAdoptionFrontier(board)", 1)[1].split("\nfunction ", 1)[0]
+
+    # Resolved against every registry entry, not just the adopted subset.
+    guard = body.split("const unscoredEntry", 1)[1].split("if (unscoredEntry)", 1)[0]
+    assert "(board.entries || []).find(" in guard
+    assert "adopted.find(" not in guard
+
+    # Zero adopters and "adopters but no readable score" are different answers,
+    # and a reader chasing a brand-new benchmark wants to know which one it is.
+    assert "No model card in this registry reports this benchmark yet" in body
+    assert "unscoredEntry.card_count" in body
+
+    # The picker lists only scored benchmarks, so an unscored selection matches
+    # no option and the browser shows the first one instead: a <select> reading
+    # AA-LCR beside a panel headed RSI-Bench is lying about the state.
+    assert "prependOption" in body


### PR DESCRIPTION
Closes #287.

## The bug

`?view=leaderboard&lfrontier=rsi_bench` drew **AutomationBench**: its track, its `31.8%` best-on-record figure, and its three model points, under a URL still reading `rsi_bench`. The string "RSI-Bench" appeared nowhere on the page. The nearest thing to a confirmation a reader would find was `RSI Index` in the picker, a different instrument.

## Root cause

`renderAdoptionFrontier()` opens with `filter((entry) => entry.card_count > 0)` and every resolution step searches that subset, including the guard written to prevent exactly this outcome. RSI-Bench has no adopters yet, so it was filtered out before the guard could see it, matched no branch, and fell through to the default entry.

The comment above that guard already stated the rule being violated:

> Falling through to the default would show a different benchmark under the reader's own URL with nothing to say so, which is worse than an explicit refusal.

The rule was right; the guard just could not see a benchmark no model card reports.

## The fix

The guard now resolves against every registry entry rather than the adopted subset. It also distinguishes two absences worth not conflating:

- **no model card reports this yet** — a fact about the field's attention (RSI-Bench today)
- **cards report it, but no score could be read verbatim** — a fact about our sources (the existing 20 cases)

### A second disagreement, found while fixing it

The picker lists only *scored* benchmarks, so an unscored selection matched no option and the browser displayed the first one instead: the panel read **RSI-Bench** while the `<select>` read **AA-LCR**. This is present on `main` and not caused by this change — `?lfrontier=chatbot_arena` shows the same mismatch there. Curated unscored entries now prepend their own option, which is the contract `renderExternalBenchmark` already keeps for crawled records.

Verified on `rsi_bench`, `chatbot_arena` and `cvebench`: heading and picker agree, no foreign statistics.

## Verification

- `pytest` → 842 passed
- `ruff format --check` and `ruff check` → clean
- Browser: `?lfrontier=rsi_bench` now shows "RSI-BENCH" with an honest empty-state message; no `31.8%`, no "best on record", no DeepSeek point anywhere in the view

## Review status

**Not reviewed by Codex** — the CLI is rate-limited until 2026-08-20 15:23. Flagging rather than omitting.

## On #279, which is not in this PR

#279 asked for the crawled-layer x-axis to use dates instead of score order. I built it, then reverted it, because `c8e001d` already closed #279's actual scope and made the opposite call deliberately:

> Fixed the normalizer to read it through, tagged with a new `date_precision: "model_announcement"` field so nothing downstream can mistake it for the date the score was actually measured. **The chart's x-axis stays score-ordered, not time-ordered: a real date on a row is not the same claim as a verified measurement date, and the axis still does not have the latter.**

`test_the_crawled_chart_axis_is_score_not_time` pins that decision on purpose. Reversing it would have meant deleting a test that exists to prevent the reversal, which is not a call to make inside an unrelated fix. The date-axis work is stashed on the branch (`git stash list`) if the decision is revisited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
