### PR TITLE
Put the crawled scores on the date they belong to

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -680,11 +680,12 @@ const I18N = {
     "Reported score": "报告的分数",
     "Score as reported": "报告的分数",
     "self reported": "自行报告",
-    "ordered by score, low to high. Dates shown are model release dates, not when each score was measured.":
-      "按分数从低到高排列。所示日期为模型发布日期，而非各分数的测量日期。",
+    "model release date, not when the score was measured": "模型发布日期,而不是分数的测量时间",
+    "model release date, not when the score was measured · {n} row(s) with no release date are in the table below only":
+      "模型发布日期,而不是分数的测量时间 · 另有 {n} 行没有发布日期,仅列于下方表格",
     "best reported": "报告的最高分",
-    "{count} scores reported to {source}, ordered by score rather than by date: the only date recorded is each model's own announcement date, not when this score was measured. Highest {best} by {model}, lowest {low}.":
-      "向 {source} 报告的 {count} 个分数，按分数而非日期排列：唯一记录的日期是每个模型自身的发布日期，而非该分数的测量日期。最高 {best}（{model}），最低 {low}。",
+    "{count} scores reported to {source}, placed at each model's release date, which is the only date recorded and is not when the score was measured. Highest {best} by {model}, lowest {low}.":
+      "向 {source} 报告的 {count} 个分数,按各模型的发布日期排布;这是唯一记录在案的日期,并非分数的测量时间。最高 {best},来自 {model};最低 {low}。",
     "Date (model release)": "日期（模型发布）",
     "Benchmark home ↗": "基准主页 ↗",
     "Top cards": "头部模型卡",
@@ -1171,6 +1172,15 @@ function eventTimestamp(item) {
 
 // Time is one of the highest-signal attributes on a Today page, so rows show
 // how long ago an event happened instead of a bare "UPDATED" (issue #248).
+// A YYYY-MM-DD as a UTC timestamp, or NaN when it is absent or unparseable.
+// Pinned to T00:00:00Z for the same reason scoreTrackChart's axis is: a bare
+// date string is parsed in local time by some engines, which slides a point
+// across a day boundary depending on where the reader is sitting.
+function dateValue(date) {
+  if (!date) return Number.NaN;
+  return new Date(`${String(date).slice(0, 10)}T00:00:00Z`).getTime();
+}
+
 function relativeTime(iso) {
   if (!iso) return "";
   const time = new Date(iso).getTime();
@@ -4021,31 +4031,62 @@ function externalScoresBlock(shard) {
 
 // --- The reported field (crawled scores) -------------------------------------
 //
-// A crawled row carries no evaluation date and no protocol, so it cannot go on
-// the curated panel's time axis, and it is not joined to the curated layer's
+// A crawled row carries no protocol, so it is not joined to the curated layer's
 // `benchmark_scores.yml` records: none of the join-rule machinery in
 // `scoreTrackChart` (instrument/protocol grouping, evidence grading) applies to
-// a row with neither field. What it does share with that chart is everything
-// visual -- same margins, same point size, same pale-face-plus-brand-glyph
-// marker, same grid and tick classes -- because the reader should not have to
-// learn a second chart language to read a second kind of evidence. Only the
-// axis differs in kind: score low-to-high stands in for the time axis, and the
-// label says plainly that it is not one.
+// a row without one. What it does share with that chart is everything visual --
+// same margins, same point size, same pale-face-plus-brand-glyph marker, same
+// grid and tick classes -- because the reader should not have to learn a second
+// chart language to read a second kind of evidence.
+//
+// It does carry a date. Every one of the 5,544 crawled rows has a
+// `reported_date`, and `date_precision` is `model_announcement` for all of
+// them: it is when the model was announced, never when this score was measured
+// (issue #279). Those are different facts, and the axis is only honest if it
+// says which one it is drawing.
+//
+// So the x-axis is the model's release date, labelled as such. That answers a
+// real question -- are newer models better at this benchmark? -- without
+// claiming to answer one it cannot: nothing here says when anyone ran the
+// evaluation. A model released in March can be scored in August, so reading
+// these points as a measurement timeline would be wrong, and the axis label
+// and every tooltip say "model release" rather than "date" to stop that.
+//
+// Ordering by score, which is what this chart did before, threw the dates away
+// entirely and produced a monotonic ramp that looks like progress and is really
+// just a sorted list.
 function externalScoreChart(source, payload) {
   const meta = externalSourceMeta(source);
   // A row whose value did not parse is in the table verbatim and out of the
   // chart: a point can only be drawn at a position, and there is no honest
-  // position for a value that is not a number. Sorted ascending so the axis
-  // reads low-to-high left-to-right, same direction as every other quantity
-  // axis on the site.
-  const plotted = (payload.rows || [])
-    .filter((row) => typeof row.value === "number" && Number.isFinite(row.value))
-    .sort((a, b) => a.value - b.value);
+  // position for a value that is not a number. A row with no parseable release
+  // date is out for the same reason once the axis is time: there is no honest
+  // x for it. Both exclusions are stated under the chart rather than left to
+  // be inferred from a count that does not add up.
+  const numeric = (payload.rows || []).filter(
+    (row) => typeof row.value === "number" && Number.isFinite(row.value),
+  );
+  const dated = numeric.filter((row) => Number.isFinite(dateValue(row.reported_date)));
+  const undatedCount = numeric.length - dated.length;
+  // Sorted by date so the axis reads left to right in time. Ties broken by
+  // score so same-day releases land in a stable order rather than whatever
+  // order the crawl happened to return.
+  const plotted = dated
+    .slice()
+    .sort(
+      (a, b) => dateValue(a.reported_date) - dateValue(b.reported_date) || a.value - b.value,
+    );
   if (!plotted.length) return null;
 
-  const values = plotted.map((row) => row.value);
-  const low = Math.min(...values);
-  const high = Math.max(...values);
+  // Sorted for the band and the tick labels. `plotted` is in date order now, so
+  // its last element is the most recently released model, not the best score:
+  // reading the best off the end of the array is exactly the bug the date axis
+  // would introduce if these two orderings were conflated.
+  const values = plotted.map((row) => row.value).sort((a, b) => a - b);
+  const low = values[0];
+  const high = values[values.length - 1];
+  const bestRow = plotted.reduce((best, row) => (row.value > best.value ? row : best), plotted[0]);
+  const bestValue = high;
   const pad = Math.max((high - low) * 0.18, Math.abs(high) * 0.05, Number.EPSILON);
   const band = { low: low - pad, high: high + pad };
 
@@ -4058,11 +4099,15 @@ function externalScoreChart(source, payload) {
   const plotWidth = width - margin.left - margin.right;
   const height = margin.top + scoreHeight + margin.bottom;
   const scoreTop = margin.top;
-  // A single-model field has no interval to spread across, so its one point is
-  // drawn at the left edge of the plot rather than at the midpoint of a range
-  // that does not exist.
-  const step = plotted.length > 1 ? plotWidth / (plotted.length - 1) : 0;
-  const x = (index) => margin.left + index * step;
+  // Positioned by date, so a cluster of releases in one month reads as a
+  // cluster rather than being spread evenly by rank. A field whose releases all
+  // land on one day has no interval to spread across, so its points are drawn
+  // at the left edge rather than at the midpoint of a range that does not exist.
+  const times = plotted.map((row) => dateValue(row.reported_date));
+  const firstTime = Math.min(...times);
+  const lastTime = Math.max(...times);
+  const span = lastTime - firstTime;
+  const x = (time) => (span > 0 ? margin.left + ((time - firstTime) / span) * plotWidth : margin.left);
   const scoreY = (value) => {
     if (band.high <= band.low) return scoreTop + scoreHeight / 2;
     return scoreTop + scoreHeight - ((value - band.low) / (band.high - band.low)) * scoreHeight;
@@ -4072,12 +4117,12 @@ function externalScoreChart(source, payload) {
     viewBox: `0 0 ${width} ${height}`,
     role: "group",
     "aria-label": t(
-      "{count} scores reported to {source}, ordered by score rather than by date: the only date recorded is each model's own announcement date, not when this score was measured. Highest {best} by {model}, lowest {low}.",
+      "{count} scores reported to {source}, placed at each model's release date, which is the only date recorded and is not when the score was measured. Highest {best} by {model}, lowest {low}.",
       {
         count: plotted.length.toLocaleString(),
         source: meta.name,
-        best: values[values.length - 1],
-        model: plotted[plotted.length - 1].model_name || t("not recorded"),
+        best: bestValue,
+        model: bestRow.model_name || t("not recorded"),
         low: values[0],
       },
     ),
@@ -4108,7 +4153,6 @@ function externalScoreChart(source, payload) {
     );
   }
 
-  const bestValue = values[values.length - 1];
   const bestY = scoreY(bestValue);
   svg.append(
     svgElement("line", {
@@ -4127,8 +4171,8 @@ function externalScoreChart(source, payload) {
     ),
   );
 
-  for (const [index, row] of plotted.entries()) {
-    const pointX = x(index);
+  for (const row of plotted) {
+    const pointX = x(dateValue(row.reported_date));
     const pointY = scoreY(row.value);
     const thirdParty = row.reported_by === "third_party";
     const group = svgElement("g", {
@@ -4184,6 +4228,27 @@ function externalScoreChart(source, payload) {
   }
   enableFrontierTouchTargets(svg);
 
+  // Endpoint ticks, matching the curated chart's axis. They label the real
+  // first and last release date rather than a padded range, for the same
+  // reason the score ticks do (issue #269).
+  if (span > 0) {
+    const endpoints = [
+      [margin.left, firstTime, "start"],
+      [margin.left + plotWidth, lastTime, "end"],
+    ];
+    for (const [tickX, time, anchor] of endpoints) {
+      svg.append(
+        svgElement(
+          "text",
+          { x: tickX, y: height - 26, "text-anchor": anchor, class: "frontier-tick" },
+          formatDate(new Date(time).toISOString().slice(0, 10), {
+            year: "numeric",
+            month: "short",
+          }),
+        ),
+      );
+    }
+  }
   svg.append(
     svgElement(
       "text",
@@ -4193,7 +4258,15 @@ function externalScoreChart(source, payload) {
         "text-anchor": "middle",
         class: "frontier-axis-label",
       },
-      t("ordered by score, low to high. Dates shown are model release dates, not when each score was measured."),
+      // Says which date this is on the axis itself, not only in a tooltip a
+      // reader has to open. "Model release date" is the whole claim: nothing
+      // here records when any of these scores was actually measured.
+      undatedCount
+        ? t("model release date, not when the score was measured · {n} row(s) with no release date are in the table below only").replace(
+            "{n}",
+            undatedCount.toLocaleString(),
+          )
+        : t("model release date, not when the score was measured"),
     ),
   );
   return svg;

--- a/tests/test_leaderboard_workbench.py
+++ b/tests/test_leaderboard_workbench.py
@@ -361,41 +361,67 @@ def test_every_crawled_score_is_a_plotted_point():
     assert "externalScoreChart(source, payload)" in table
     assert "<table" not in table.replace('"table"', "").replace("'table'", "")
     assert "(payload.rows || [])" in chart
-    assert ".slice(" not in chart
     # A value that did not parse into a number has no position on an axis, so it
-    # is dropped. That is the only row the chart may drop, and it drops it by
-    # testing the value rather than by a cap.
+    # is dropped, and it is dropped by testing the value rather than by a cap.
     assert 'typeof row.value === "number" && Number.isFinite(row.value)' in chart
+    # No cap. The bare .slice() copies before sorting so the source array is
+    # not mutated; the only .slice(0, N) is ISO-date truncation, not a row
+    # limit. A truncating slice over the rows would silently hide scores.
+    assert ".slice()" in chart
+    assert ".slice(0, 10)" in chart and chart.count(".slice(0,") == 1
+    # The x-axis is a date now (issue #279), so a row with no parseable release
+    # date has no honest position either. That drops nothing today -- all 5,544
+    # numeric crawled rows carry a reported_date -- but if it ever does, the
+    # count is stated under the chart rather than left to be inferred from a
+    # total that does not add up.
+    assert "undatedCount" in chart
+    assert "with no release date are in the table below only" in chart
 
 
-def test_the_crawled_chart_axis_is_score_not_time():
-    # A crawled row's only date is announcement_date, the MODEL's own release
-    # date, not a measurement date -- normalize_llm_stats fills reported_date
-    # from it now (external_catalog.py:_observation), so the field is real,
-    # but it is still not a time this chart's x-axis is entitled to use: the
-    # x position comes from each row's own value (sorted ascending), and the
-    # axis label says in words that the date recorded is model release, not
-    # measurement time, so this is still not a time axis despite the date
-    # existing.
+def test_the_crawled_chart_axis_is_release_date_and_says_so():
+    # Supersedes test_the_crawled_chart_axis_is_score_not_time (issue #279).
+    #
+    # That test pinned a deliberate decision from c8e001d: the date exists on
+    # every row, but it is the MODEL's announcement date, so the axis stayed
+    # score-ordered rather than claim a measurement time it does not have.
+    # The concern was right; the remedy threw the date away and drew a sorted
+    # list that ramps upward and reads like progress.
+    #
+    # The axis is now that release date, and the honesty burden moves onto the
+    # label: every place the reader can look must say which date this is. A
+    # model released in March can be evaluated in August, so nothing here is a
+    # measurement timeline, and the assertions below are what stop it drifting
+    # into being presented as one.
     script = source("site/assets/app.js")
 
     chart = script.split("function externalScoreChart(source, payload)", 1)[1].split(
         "\nfunction externalSourceTable", 1
     )[0]
 
-    assert "a.value - b.value" in chart
-    # The label was shortened (issue #269): it had grown into a defensive
-    # sentence that read as an excuse for the dates rather than a description
-    # of the axis. The claim it has to make is unchanged -- ordered by score,
-    # and the dates are release dates rather than measurement times.
-    assert "ordered by score, low to high." in chart
-    assert "model release dates, not when each score was measured" in chart
-    # reported_date is read (for the pinned card's Date row), but never as an
-    # x-coordinate: the axis-building code above the point loop never touches it.
-    assert "row.reported_date" in chart
-    assert "x(row.reported_date)" not in chart
-    # And no segment between points, for the same reason the curated chart draws
-    # none: adjacency by score is not a trajectory.
+    # Positioned by date, so a burst of releases in one month reads as a burst
+    # rather than being spread evenly by rank.
+    assert "x(dateValue(row.reported_date))" in chart
+    assert "const times = plotted.map((row) => dateValue(row.reported_date));" in chart
+    # Ordered by date, ties broken by score so same-day releases are stable.
+    assert "dateValue(a.reported_date) - dateValue(b.reported_date) || a.value - b.value" in chart
+
+    # The visible axis label, the aria-label and the pinned card all name the
+    # date as a release date. Losing any one of them is how a chart starts
+    # implying it plots measurements.
+    assert "model release date, not when the score was measured" in chart
+    assert "is not when the score was measured" in chart
+    assert '"Date (model release)"' in script
+
+    # `plotted` is in date order, so the last element is the newest model, not
+    # the best score. Reading the best off the end of the array is the specific
+    # bug this reordering would introduce if the two were conflated.
+    assert "const bestRow = plotted.reduce(" in chart
+    assert "plotted[plotted.length - 1].model_name" not in chart
+    assert "const values = plotted.map((row) => row.value).sort((a, b) => a - b);" in chart
+
+    # And still no segment between points: a line would assert a trajectory
+    # through models that were never a series, which is the claim the curated
+    # chart earns with a protocol and this one does not.
     assert "polyline" not in chart
 
 


### PR DESCRIPTION
Closes #279.

## The problem

`?view=leaderboard&lfrontier=llm-stats-aime-2025` ordered its points by score, so it drew a clean ramp from 0.067 to 1.0 that looks like a progression and is really just a sorted list. Every date those rows carry was discarded to produce it.

## On reversing an earlier decision

`c8e001d` made the score-ordering choice deliberately, and `test_the_crawled_chart_axis_is_score_not_time` pinned it:

> The chart's x-axis stays score-ordered, not time-ordered: a real date on a row is not the same claim as a verified measurement date.

The concern behind that is correct and is preserved here. What is reversed is the remedy: dropping the date entirely was not the only way to avoid claiming a measurement time, and it cost the reader the one thing these 5,544 rows can show. That test is **replaced rather than deleted** — the new one asserts the axis is the release date *and* that all three places naming it still say which date it is, which is the guarantee the old test was really protecting.

## What the chart shows now

AIME 2025, 115 models across **Jan 2025 → Aug 2026**: a low cluster of early-2025 scores near 0.067, a steep climb through mid-2025, a dense band at the 1.0 ceiling by 2026. That shape is a real reading about how fast the field saturated this benchmark. Sorting by score cannot show it, because it produces the same monotonic ramp for every benchmark whether it saturated in three months or has not moved in two years.

## What keeps it honest

Nothing anywhere calls this a measurement time. A model released in March can be evaluated in August, so these points say when each model shipped, never when anyone ran the eval:

- axis label: `model release date, not when the score was measured`
- aria-label: the same claim in a sentence
- pinned card row: `Date (model release)` (verified: DeepSeek-V3.1, `0.498`, `Jan 10, 2025`)

## Details that mattered

- `plotted` is in date order now, so its last element is the newest model, **not the best score**. `values` is sorted separately for the band and ticks, and `bestRow` is reduced rather than read off the end. Conflating those two orderings is the bug this reordering invites, and the test asserts against it.
- Ties break by score, so same-day releases are stable rather than crawl-order.
- `dateValue` pins to `T00:00:00Z`, matching `scoreTrackChart`, because a bare date string parses in local time on some engines and slides a point across a day boundary depending on where the reader sits.
- **327 benchmarks** have every score on one date. Span is zero, date ticks are suppressed rather than printing the same month twice, points draw at the left edge. Verified on MTVQA (1 point, no ticks, no errors).
- A row with no parseable date has no honest x, so it is excluded and counted under the chart. That excludes nothing today: all 5,544 numeric crawled rows carry a `reported_date`.

## Verification

- `pytest` → 842 passed; `ruff format --check` and `ruff check` → clean
- Browser, rendered point counts: AIME 2025 **115**, GPQA **239**, Terminal-Bench 2.0 **51**, MTVQA **1**
- Chinese axis label renders (`模型发布日期,而不是分数的测量时间`), 115 points
- Mobile 390px: 115 points, no horizontal overflow, no console errors

One caveat worth recording: an early revision of this change had a temporal-dead-zone `ReferenceError` that left every crawled chart stuck on "Loading benchmark details…" — and **all 842 tests still passed**, because they inspect source text and never execute the chart. It was caught in the browser. The suite does not cover this code path's runtime behaviour.

## Review status

**Not reviewed by Codex** — the CLI is rate-limited until 2026-08-20 15:23. Flagging rather than omitting, given this reverses a prior deliberate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
