### PR TITLE
Stop the radar from recommending itself (scoring v4)

### DIFF
--- a/src/benchmark_radar/pipeline.py
+++ b/src/benchmark_radar/pipeline.py
@@ -177,6 +177,25 @@ def match_proximity_rule(text: str, rule: dict[str, Any]) -> str | None:
     return None
 
 
+def is_self_reference(item: RadarItem) -> bool:
+    """Whether a record is this project reporting on itself.
+
+    Matched on the exact repository identity rather than on a substring, so an
+    unrelated repository whose name merely contains "benchmark-radar" (the
+    corpus already holds `H20Zhang/Agent-Benchmark-Radar`) keeps its place.
+    The canonical GitHub `source_id` is the reliable signal; the URL is checked
+    as well because a record can arrive from a release or first-party feed
+    whose id is not the `owner/name` pair.
+    """
+    if item.source_id and item.source_id.strip().lower() == rubric.SELF_REPOSITORY:
+        return True
+    parsed = urlsplit(item.url or "")
+    if parsed.netloc.lower().removeprefix("www.") != "github.com":
+        return False
+    parts = [part for part in parsed.path.lower().split("/") if part]
+    return len(parts) >= 2 and "/".join(parts[:2]) == rubric.SELF_REPOSITORY
+
+
 def score_item(
     item: RadarItem,
     taxonomy: dict[str, Any],
@@ -223,6 +242,8 @@ def score_item(
     item.suppression_reasons = [
         str(signal["label"]) for signal in deductions if signal["action"] == "suppress"
     ]
+    if is_self_reference(item):
+        item.suppression_reasons.append(rubric.SELF_REFERENCE_LABEL)
 
     evidence = rubric.EVIDENCE_BASE
     if item.source in rubric.EVIDENCE_PRIMARY_SOURCES:
@@ -244,11 +265,21 @@ def score_item(
         rubric.SCORE_MAX * (1.0 - age_hours / lookback_hours),
     )
 
+    # Each counter is scored on its own log curve against its own saturation
+    # point, then the strongest one wins. Counters that accumulate without a
+    # human decision are capped first, so a large automated download total can
+    # place a record mid-pack but cannot outscore a widely-starred repository
+    # (issue #278). The cap applies per metric before the max, not to the
+    # result, so a record carrying both stars and downloads is still free to
+    # score above the cap on its stars.
     adoption = max(
         (
-            rubric.SCORE_MAX
-            * math.log10(1 + max(0.0, float(item.metrics.get(metric, 0))))
-            / math.log10(1 + saturation)
+            min(
+                rubric.SCORE_MAX
+                * math.log10(1 + max(0.0, float(item.metrics.get(metric, 0))))
+                / math.log10(1 + saturation),
+                rubric.ADOPTION_CAPPED_METRICS.get(metric, rubric.SCORE_MAX),
+            )
             for metric, saturation in rubric.ADOPTION_METRIC_SATURATION.items()
             if item.metrics.get(metric, 0)
         ),
@@ -469,10 +500,21 @@ def _score_and_select(
     # auditable rather than looking like lost data.
     #
     # These counters mirror the eligibility predicate above in its own
-    # precedence order, so each excluded record has one reason and the two sum
-    # to `scored - eligible`. Recommendation is reported alongside the funnel,
+    # precedence order, so each excluded record has one reason and they sum to
+    # `scored - eligible`. Recommendation is reported alongside the funnel,
     # never as a drop reason.
-    suppressed_low_value = sum(1 for item in scored if item.suppression_reasons)
+    # Self-exclusion is counted apart from the low-value deductions. Both stop
+    # a record at the same gate, but billing "this project's own repository" to
+    # `suppressed_low_value` would report a credibility rule as a taxonomy
+    # judgement and make the low-value count untrue.
+    suppressed_self_reference = sum(
+        1 for item in scored if rubric.SELF_REFERENCE_LABEL in item.suppression_reasons
+    )
+    suppressed_low_value = sum(
+        1
+        for item in scored
+        if [reason for reason in item.suppression_reasons if reason != rubric.SELF_REFERENCE_LABEL]
+    )
     uncategorized = sum(
         1
         for item in scored
@@ -501,6 +543,8 @@ def _score_and_select(
         # Suppression now applies to watchlisted records too, so the count is
         # every suppressed record rather than only the un-watchlisted ones.
         "suppressed_low_value": suppressed_low_value,
+        # This project's own repository, removed from its own ranking (#278).
+        "suppressed_self_reference": suppressed_self_reference,
         # Deprecated compatibility field. Scores no longer suppress records.
         "suppressed_below_minimum": 0,
         # Matched no taxonomy category and was not explicitly watchlisted.

--- a/src/benchmark_radar/report.py
+++ b/src/benchmark_radar/report.py
@@ -272,6 +272,9 @@ def render_markdown(
         suppressed_future = int(selection.get("suppressed_future_dated") or 0)
         suppressed_untitled = int(selection.get("suppressed_untitled") or 0)
         suppressed_low_value = int(selection.get("suppressed_low_value") or 0)
+        # Absent from snapshots written before scoring v4, where self-records
+        # were simply ranked; `or 0` keeps those funnels rendering unchanged.
+        suppressed_self = int(selection.get("suppressed_self_reference") or 0)
         uncategorized = int(selection.get("suppressed_uncategorized") or 0)
         if "eligible" in selection:
             eligible = int(selection.get("eligible") or 0)
@@ -304,6 +307,11 @@ def render_markdown(
                 + (
                     f"**{suppressed_low_value}** low-value artifacts suppressed → "
                     if suppressed_low_value
+                    else ""
+                )
+                + (
+                    f"**{suppressed_self}** self-referential records excluded → "
+                    if suppressed_self
                     else ""
                 )
                 + (f"**{uncategorized}** uncategorized → " if uncategorized else "")
@@ -349,6 +357,11 @@ def render_markdown(
                     + (
                         f"**{suppressed_low_value}** low-value artifacts suppressed → "
                         if suppressed_low_value
+                        else ""
+                    )
+                    + (
+                        f"**{suppressed_self}** self-referential records excluded → "
+                        if suppressed_self
                         else ""
                     )
                     + (

--- a/src/benchmark_radar/rubric.py
+++ b/src/benchmark_radar/rubric.py
@@ -12,7 +12,7 @@ import hashlib
 import json
 from typing import Any
 
-SCORING_VERSION = 3
+SCORING_VERSION = 4
 SCORE_MAX = 100.0
 DEFAULT_LOOKBACK_HOURS = 48.0
 
@@ -112,6 +112,42 @@ ADOPTION_METRIC_SATURATION: dict[str, float] = {
     "downloads": 100_000.0,
     "likes": 1_000.0,
 }
+
+# Downloads and likes are not comparable achievements to a star or a citation.
+# A dataset accrues downloads from any script that pulls it once, and a like
+# costs less than a star does; both counters accumulate without anyone deciding
+# the artifact was worth keeping. Under the max-wins rule of v3 that asymmetry
+# was structural rather than incidental: GitHub records never carry downloads
+# and Hugging Face records never carry stars, so whichever counter saturates
+# most easily decided the ranking for the source that exposes it. On
+# 2026-08-19 a dataset with 25,238 downloads and 1 like scored adoption 88.0
+# and took the #2 slot from a 3,265-star repository at 87.8 (issue #278).
+#
+# Capping rather than removing: dropping downloads entirely would collapse
+# every Hugging Face dataset to adoption 0 and simply flip the bias toward
+# GitHub. A cap lets automated traffic place an artifact mid-pack while
+# reserving the top of the scale for counters that record a human decision.
+# 60 is the score of roughly 250 stars, so a capped download total still
+# outranks a barely-noticed repository and never outranks a widely-held one.
+# Stars and citations remain unbounded within the 0-100 scale.
+ADOPTION_CAPPED_METRICS: dict[str, float] = {
+    "downloads": 60.0,
+    "likes": 60.0,
+}
+
+# `ktwu01/benchmark-radar` is this project. Its description is wall-to-wall
+# benchmark vocabulary and it is committed to daily, so it scored relevance 100
+# and recency ~96 and reached the top 5 on 9 of the first 27 collected days
+# (issue #278). Whatever the arithmetic says, a radar that recommends itself is
+# not reporting on the field, and #32 already established that self-referential
+# artifacts do not belong in the daily list.
+#
+# Matched on the exact repository identity, never as a substring: an unrelated
+# `H20Zhang/Agent-Benchmark-Radar` appears in the corpus and is a legitimate
+# record. Both the canonical GitHub id and the URL host/path are checked
+# because a record can reach the pipeline from either shape.
+SELF_REPOSITORY = "ktwu01/benchmark-radar"
+SELF_REFERENCE_LABEL = "this project's own repository"
 
 
 def taxonomy_version(taxonomy: dict[str, Any]) -> str:
@@ -219,6 +255,11 @@ def _components(*, lookback_hours: float) -> list[dict[str, Any]]:
                 f"{metric} reaches 100 at {saturation:g}"
                 for metric, saturation in ADOPTION_METRIC_SATURATION.items()
             ]
+            + [
+                f"{metric} is capped at {cap:.0f}, the score of roughly 250 stars, "
+                "because the counter accumulates without a human decision"
+                for metric, cap in ADOPTION_CAPPED_METRICS.items()
+            ]
             + ["Uses the strongest available normalized counter", "Clamped to 0-100"],
         },
     ]
@@ -247,7 +288,10 @@ def rubric_reference(
             "Negative signals demote only named artifact patterns. Result indexes, "
             "submission placeholders, and visualization-only companions are suppressed; "
             "the selection funnel reports how many were removed.",
-            "Adoption measures attention, not correctness.",
+            "Adoption measures attention, not correctness. Counters that accumulate "
+            "without a human decision (downloads, likes) are capped below the top of "
+            "the adoption scale; stars and citations are not.",
+            f"This project's own repository ({SELF_REPOSITORY}) is excluded from its own ranking.",
             "Attention observations are shown separately and are never quality-scored.",
             "Watchlisted artifacts are retained whatever they score and sort first. Their "
             "rank reflects that request, not a higher score.",
@@ -265,6 +309,31 @@ def v2_rubric_reference(*, lookback_hours: float = DEFAULT_LOOKBACK_HOURS) -> di
         if component["key"] != "evidence":
             continue
         component["bands"] = [band.replace(", First-party feed", "") for band in component["bands"]]
+    return value
+
+
+def v3_rubric_reference(*, lookback_hours: float = DEFAULT_LOOKBACK_HOURS) -> dict[str, Any]:
+    """Describe v3 without retroactively applying v4's download cap.
+
+    A v3 score was produced by the uncapped max-wins adoption rule, and the
+    records that ranked under it included this repository. Explaining those
+    numbers with v4's bands would claim the run did something it did not, which
+    is the relabelling #32 forbids.
+    """
+    value = rubric_reference(lookback_hours=lookback_hours)
+    value["scoring_version"] = 3
+    for component in value["components"]:
+        if component["key"] != "adoption":
+            continue
+        component["bands"] = [band for band in component["bands"] if "capped at" not in band]
+    value["limits"] = [
+        # v3 capped nothing, so its adoption limit is the bare sentence.
+        "Adoption measures attention, not correctness."
+        if limit.startswith("Adoption measures")
+        else limit
+        for limit in value["limits"]
+        if not limit.startswith("This project's own repository")
+    ]
     return value
 
 

--- a/src/benchmark_radar/snapshots.py
+++ b/src/benchmark_radar/snapshots.py
@@ -29,6 +29,7 @@ from .rubric import (
     rubric_reference,
     taxonomy_version,
     v2_rubric_reference,
+    v3_rubric_reference,
 )
 
 SCHEMA_VERSION = 2
@@ -983,6 +984,11 @@ def dashboard_data(
         "rubrics": {
             "1": legacy_rubric_reference(),
             "2": v2_rubric_reference(
+                lookback_hours=(
+                    (days[-1].get("selection") or {}).get("lookback_hours") or 48 if days else 48
+                ),
+            ),
+            "3": v3_rubric_reference(
                 lookback_hours=(
                     (days[-1].get("selection") or {}).get("lookback_hours") or 48 if days else 48
                 ),

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1212,7 +1212,11 @@ def test_the_eligibility_counters_sum_to_the_drop():
     selection = _select(items)
 
     gap = selection["scored"] - selection["eligible"]
-    parts = selection["suppressed_low_value"] + selection["suppressed_uncategorized"]
+    parts = (
+        selection["suppressed_low_value"]
+        + selection["suppressed_self_reference"]
+        + selection["suppressed_uncategorized"]
+    )
     assert gap == parts
     assert selection["suppressed_uncategorized"] == 1
     assert selection["recommended"] == 1
@@ -1248,7 +1252,9 @@ def test_the_funnel_reconciles_when_nothing_is_eligible():
 
     assert selection["eligible"] == 0
     assert (
-        selection["suppressed_low_value"] + selection["suppressed_uncategorized"]
+        selection["suppressed_low_value"]
+        + selection["suppressed_self_reference"]
+        + selection["suppressed_uncategorized"]
         == selection["scored"]
     )
 
@@ -1316,3 +1322,115 @@ def test_a_non_finite_minimum_score_is_rejected():
     # funnel identity would break silently. `float()` accepts `.nan` from YAML.
     with pytest.raises(ValueError, match="finite"):
         _select([_fresh(source_id="a")], minimum_score=float("nan"))
+
+
+def test_this_repository_is_excluded_from_its_own_ranking():
+    """Issue #278: benchmark-radar reached the top 5 on 9 of the first 27 days.
+
+    Its description is wall-to-wall benchmark vocabulary and it is committed to
+    daily, so relevance and recency carried it past artifacts the field
+    actually uses. A radar that recommends itself is not reporting.
+    """
+    us = _fresh(
+        source="GitHub",
+        source_id="ktwu01/benchmark-radar",
+        url="https://github.com/ktwu01/benchmark-radar",
+        title="Benchmark Radar: a daily dataset and benchmark radar",
+    )
+
+    retained, selection = _score_and_select(
+        [us],
+        _funnel_config(),
+        now=FUNNEL_NOW,
+        fetched_count=1,
+        suppressed_count=0,
+        future_dated_count=0,
+    )
+
+    assert retained == []
+    assert selection["suppressed_self_reference"] == 1
+    # Billed to its own counter, not to the taxonomy's low-value deductions.
+    assert selection["suppressed_low_value"] == 0
+
+
+def test_self_exclusion_matches_the_repository_not_the_name():
+    """`H20Zhang/Agent-Benchmark-Radar` is a real record in the corpus.
+
+    A substring match on "benchmark-radar" would silently delete it, so the
+    rule matches the exact `owner/name` pair.
+    """
+    others = [
+        _fresh(
+            source="GitHub",
+            source_id="H20Zhang/Agent-Benchmark-Radar",
+            url="https://github.com/H20Zhang/Agent-Benchmark-Radar",
+            title="Agent Benchmark Radar dataset",
+        ),
+        _fresh(
+            source="GitHub",
+            source_id="someone/benchmark-radar-fork",
+            url="https://github.com/someone/benchmark-radar-fork",
+            title="A benchmark dataset fork",
+        ),
+    ]
+
+    retained, selection = _score_and_select(
+        others,
+        _funnel_config(),
+        now=FUNNEL_NOW,
+        fetched_count=len(others),
+        suppressed_count=0,
+        future_dated_count=0,
+    )
+
+    assert selection["suppressed_self_reference"] == 0
+    assert len(retained) == 2
+
+
+def test_self_exclusion_recognizes_the_repository_from_its_url_alone():
+    """A release record's `source_id` is a tag, not the `owner/name` pair."""
+    release = _fresh(
+        source="GitHub Release",
+        source_id="ktwu01/benchmark-radar:v1.2.0",
+        url="https://github.com/ktwu01/benchmark-radar/releases/tag/v1.2.0",
+        title="Benchmark Radar v1.2.0 dataset release",
+    )
+
+    retained, selection = _score_and_select(
+        [release],
+        _funnel_config(),
+        now=FUNNEL_NOW,
+        fetched_count=1,
+        suppressed_count=0,
+        future_dated_count=0,
+    )
+
+    assert retained == []
+    assert selection["suppressed_self_reference"] == 1
+
+
+def test_self_exclusion_survives_a_watchlist_hit():
+    """Suppression is checked before the watchlist, so it cannot be overridden."""
+    us = _fresh(
+        source="GitHub",
+        source_id="ktwu01/benchmark-radar",
+        url="https://github.com/ktwu01/benchmark-radar",
+        title="Benchmark Radar dataset",
+    )
+    config = _funnel_config()
+    config["watchlist"] = [
+        {"name": "Benchmark Radar", "aliases": ["benchmark radar", "benchmark-radar"]}
+    ]
+
+    retained, selection = _score_and_select(
+        [us],
+        config,
+        now=FUNNEL_NOW,
+        fetched_count=1,
+        suppressed_count=0,
+        future_dated_count=0,
+    )
+
+    # The record really did match the watchlist; suppression still won.
+    assert selection["watchlisted"] == 0
+    assert retained == []

--- a/tests/test_rubric.py
+++ b/tests/test_rubric.py
@@ -37,7 +37,7 @@ def test_published_rubric_describes_every_scored_component():
 
     assert keys == list(rubric.WEIGHTS)
     assert reference["score_max"] == 100
-    assert reference["scoring_version"] == 3
+    assert reference["scoring_version"] == rubric.SCORING_VERSION
     for component in reference["components"]:
         assert component["weight"] == rubric.WEIGHTS[component["key"]]
         assert component["summary"].strip()
@@ -145,3 +145,66 @@ def test_formula_states_the_weights_it_applies():
 
     for component, weight in rubric.WEIGHTS.items():
         assert f"{weight:.2f} {component}" in formula
+
+
+def test_downloads_and_likes_cannot_reach_the_top_of_the_adoption_scale():
+    """Issue #278: a dataset's automated downloads took #2 from a 3,265-star repo.
+
+    Under v3's uncapped max-wins rule 25,238 downloads scored 88.04 against
+    87.85 for 3,265 stars. The cap has to leave the starred repository ahead
+    without collapsing the dataset to zero, which is what removing downloads
+    outright would have done.
+    """
+    dataset = item(metrics={"downloads": 25_238.0, "likes": 1.0})
+    starred = item(metrics={"stars": 3_265.0})
+
+    score_item(dataset, TAXONOMY, dataset.published_at, lookback_hours=48.0)
+    score_item(starred, TAXONOMY, starred.published_at, lookback_hours=48.0)
+
+    assert dataset.adoption_score == rubric.ADOPTION_CAPPED_METRICS["downloads"]
+    assert dataset.adoption_score < starred.adoption_score
+    # Not removed: a widely-downloaded dataset still outranks an unnoticed repo.
+    assert dataset.adoption_score > 0
+
+
+def test_the_cap_applies_per_metric_so_stars_stay_unbounded():
+    """A record carrying both counters is scored on the stronger, uncapped one.
+
+    Capping the result rather than each metric would penalize a repository for
+    also publishing downloads, which is the opposite of the intent.
+    """
+    both = item(metrics={"downloads": 25_238.0, "stars": 3_265.0})
+    stars_only = item(metrics={"stars": 3_265.0})
+
+    score_item(both, TAXONOMY, both.published_at, lookback_hours=48.0)
+    score_item(stars_only, TAXONOMY, stars_only.published_at, lookback_hours=48.0)
+
+    assert both.adoption_score == stars_only.adoption_score
+    assert both.adoption_score > rubric.ADOPTION_CAPPED_METRICS["downloads"]
+
+
+def test_a_small_download_count_scores_below_the_cap():
+    """The cap is a ceiling, not a floor: low counters still score low."""
+    quiet = item(metrics={"downloads": 10.0})
+
+    score_item(quiet, TAXONOMY, quiet.published_at, lookback_hours=48.0)
+
+    assert 0 < quiet.adoption_score < rubric.ADOPTION_CAPPED_METRICS["downloads"]
+
+
+def test_the_published_rubric_states_the_cap_and_the_self_exclusion():
+    reference = rubric.rubric_reference()
+    adoption = next(c for c in reference["components"] if c["key"] == "adoption")
+
+    assert any("capped at 60" in band for band in adoption["bands"])
+    assert any(rubric.SELF_REPOSITORY in limit for limit in reference["limits"])
+
+
+def test_v3_reference_is_not_relabelled_with_v4_arithmetic():
+    """Issue #32's guarantee: a past score keeps the rubric that produced it."""
+    v3 = rubric.v3_rubric_reference()
+    adoption = next(c for c in v3["components"] if c["key"] == "adoption")
+
+    assert v3["scoring_version"] == 3
+    assert not any("capped at" in band for band in adoption["bands"])
+    assert not any(rubric.SELF_REPOSITORY in limit for limit in v3["limits"])


### PR DESCRIPTION
Closes #278.

Ships items 1 and 2 of the issue's recommended fix together as scoring v4.

## Self-exclusion

`ktwu01/benchmark-radar` reached the top 5 on 9 of the first 27 collected days. Its description is wall-to-wall benchmark vocabulary and it is committed to daily, so relevance (100) and recency (~96) carried it past artifacts the field actually uses. It is now excluded from its own ranking.

Matched on the exact `owner/name` pair, never as a substring: `H20Zhang/Agent-Benchmark-Radar` is a real record in the corpus and keeps its place. Both the canonical GitHub `source_id` and the URL host/path are checked, so a release record (whose id is a tag, not the repo pair) is caught too. Suppression is checked before the watchlist, so a watchlist hit cannot override it.

## Capped downloads

A dataset with 25,238 downloads and 1 like scored adoption 88.0 and took #2 from a 3,265-star repo at 87.8. Downloads and likes are now capped at 60, roughly the score of 250 stars.

Capped rather than removed: dropping downloads would collapse every Hugging Face dataset to adoption 0 and flip the bias toward GitHub. The cap applies **per metric before the max**, so a record carrying stars as well is still scored on them, uncapped.

Verified against the issue's own example:

| record | v3 adoption | v4 adoption |
|---|---|---|
| AlphaDojo dataset (25,238 downloads, 1 like) | 88.04 | **60.00** |
| modelscope/evalscope (3,265 stars) | 87.85 | 87.85 |
| NVIDIA-NeMo/Gym (1,125 stars) | 76.29 | 76.29 |

The dataset now sits below both starred repos instead of above them.

## Historical guarantee (#32)

`SCORING_VERSION` is 4, and `v3_rubric_reference()` publishes v3 without v4's cap band or its self-exclusion limit. Every `score_version` present in `data/snapshots/` (2 and 3) has its own published rubric, so a past score is never explained with arithmetic that did not run. No stored snapshot is rewritten.

## Funnel accounting

Self-exclusion gets its own `suppressed_self_reference` counter rather than being billed to `suppressed_low_value`, which would report a credibility rule as a taxonomy judgement. The Markdown report renders it, and the reconciliation tests were updated so the counters still sum to `scored - eligible`.

## Not in scope

Per the issue, weight rebalancing (direction 3) and `artifact_urls` resolution are deferred and do not block closure. Direction 1 is rejected: per-metric log curves are already the implementation.

## Testing

845 passed, 6 skipped. 9 new tests cover the cap (including the per-metric-before-max property and a below-cap case), self-exclusion (exact match, the `Agent-Benchmark-Radar` false positive, URL-only match, watchlist override), and the v3 non-relabelling guarantee. `ruff check` and `ruff format --check` clean.

**Not independently reviewed:** the Codex CLI hit its usage limit mid-run, so the second-opinion review this repo normally gets before merge did not complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)