### PR TITLE
Date the four undated benchmarks, and let the era filter ask for undated ones

### DIFF
--- a/data/model_cards.yml
+++ b/data/model_cards.yml
@@ -733,23 +733,24 @@ benchmarks:
     name: ExploitBench
     aliases: ["ExploitBench", "ExploitBench (Cap%)"]
     domain: security
-    url: https://deploymentsafety.openai.com/gpt-5-6-preview
-    # Unset rather than guessed. This previously carried 2026-06-26, the
-    # publication date of the GPT-5.6 preview the URL points at, which records
-    # when OpenAI reported the benchmark rather than when the instrument was
-    # published. That reading was demonstrably wrong: Anthropic's 2026-06-09
-    # table already measures against it. The earlier date is evidence the
-    # benchmark existed by then, but "first seen" is not a release date, and
-    # this field's contract is to say nothing rather than carry a guess.
-    released: null
+    # The benchmark's own project site. This previously pointed at the GPT-5.6
+    # preview system card, which reports scores against the instrument rather
+    # than publishing it.
+    url: https://exploitbench.ai/
+    # arXiv:2605.14153 v1, submitted 2026-05-13. Not the 2026-06-26 GPT-5.6
+    # preview date this field once carried: that records when OpenAI reported
+    # the benchmark, and Anthropic's 2026-06-09 table already measured against
+    # it, so the reporting date cannot be the release date.
+    released: 2026-05-13
     caveat: >-
       Offensive-security capability measured as a risk indicator against a
       preparedness threshold, not a leaderboard to top. Reported as a
-      capability percentage, and no public specification of the task set has
-      been published, so the number cannot be independently reproduced. In use
-      by 2026-06-09; no announced publication date. The fullest public
-      description is GPT-5.6 Preview System Card §9.1.2.4.1 (41 V8 N-day
-      vulnerabilities, 16 grader-verified capability flags).
+      capability percentage. Published by Seunghyun Lee and David Brumley
+      (Carnegie Mellon; Brumley also lists Bugcrowd) as arXiv:2605.14153 with
+      code at github.com/exploitbench/exploitbench. 41 V8 N-day
+      vulnerabilities scored by 16 grader-verified capability flags; vendor
+      runs report the capability percentage without publishing per-flag
+      results, so a reported number is not reproducible from the paper alone.
 
   # ---------------------------------------------------------------------------
   # Instruments first observed in Anthropic's 2026-06-09 Claude Fable 5 /
@@ -788,16 +789,16 @@ benchmarks:
     aliases: ["Blueprint-Bench 2", "Blueprint-Bench", "BlueprintBench 2"]
     domain: spatial_reasoning
     url: https://andonlabs.com/evals/blueprint-bench-2
-    # Unset: the Andon Labs eval page states "released in May 2026" with no
-    # day. A guessed day would be a fabricated release date, and this field's
-    # contract is to say nothing rather than carry one.
-    released: null
+    # The eval page states only "released in May 2026". The day comes from Andon
+    # Labs' own launch post, x.com/andonlabs/status/2051348274666504587
+    # ("Introducing Blueprint-Bench 2", 2026-05-04, linking this eval page).
+    released: 2026-05-04
     caveat: >-
       Spatial-reasoning set: 50 apartments, ~20 photos each, scored by a
       connectivity-graph grader, with a public leaderboard on the Andon Labs
       eval page (run in-house; dataset not openly downloadable). Builds on the
-      original Blueprint-Bench paper (arXiv:2509.25229). Released May 2026;
-      no day published.
+      original Blueprint-Bench paper (arXiv:2509.25229), a distinct instrument
+      released 2025-09-24 whose scores must not be compared across versions.
 
   - id: legal_agent_benchmark
     name: Legal Agent Benchmark
@@ -816,15 +817,20 @@ benchmarks:
     name: BioMysteryBench
     aliases: ["BioMysteryBench"]
     domain: biology
-    url: null
-    released: null
+    # The dataset itself, not the system card that reports scores against it.
+    url: https://huggingface.co/datasets/Anthropic/BioMysteryBench-full
+    # Anthropic's own announcement post, 2026-04-29. The Fable 5 system card
+    # §8.20.1 reports it without citing this publication, which is why the
+    # entry read as unpublished until the announcement was located.
+    released: 2026-04-29
     caveat: >-
       Reported in two splits ("hard" and "human solved") that differ by more
       than 35 points, so a bare score is unreadable without its split.
       Anthropic notes its own safety refusals depress this number, which means
-      the score mixes capability with policy. Anthropic-internal evaluation:
-      no published task set or release date. The Fable 5 system card §8.20.1
-      describes it without a citation or dataset link.
+      the score mixes capability with policy. First-party to Anthropic, which
+      built it and publishes the dataset. The task set was revised after an
+      answer-key audit, so the item count moved and scores are not comparable
+      across dataset versions.
 
   - id: gdp_pdf
     name: GDP.pdf
@@ -844,13 +850,21 @@ benchmarks:
     name: ViBench
     aliases: ["ViBench"]
     domain: coding_agent
-    url: null
-    released: null
+    url: https://vibench.ai/
+    # The CAIS '26 paper, published 2026-05-26 (doi:10.1145/3786335.3813162).
+    # The public repository's first import predates it (2026-05-13); the formal
+    # publication date is used, and the repo date is recorded here as the
+    # earliest public artifact.
+    released: 2026-05-26
     caveat: >-
-      End-to-end vibe-coding benchmark named in a customer testimonial in
-      Anthropic's Claude Fable 5 / Mythos 5 launch post, not in Anthropic's
-      own prose or its system card. Described qualitatively, not scored in the
-      comparison table. No published task set.
+      End-to-end vibe-coding benchmark by authors at Replit and Georgian AI
+      Lab, scoring web applications from the user's perspective. Tasks are
+      derived from anonymized Replit production traces, so the benchmark is
+      first-party to one of the agents it measures. It reaches this registry
+      through a customer testimonial in Anthropic's Claude Fable 5 / Mythos 5
+      launch post, where it is described qualitatively and never scored in the
+      comparison table. Distinct from VBench, an unrelated video-generation
+      benchmark.
 
   - id: healthbench_professional
     name: HealthBench Professional

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -3187,6 +3187,11 @@ const LEADERBOARD_ERAS = [
   { value: "2026", label: "Released in 2026", from: "2026-01-01", to: "2027-01-01" },
   { value: "2025", label: "Released 2025 or later", from: "2025-01-01" },
   { value: "pre2024", label: "Released before 2024", to: "2024-01-01" },
+  // A benchmark with no release date is excluded by every dated era above, so
+  // without this option it would be unreachable from the era control entirely
+  // (issue #292). An era filter is a claim about dates, and "we do not know
+  // this one's date" is an answer a reader has to be able to ask for.
+  { value: "undated", label: "No release date recorded", undated: true },
 ];
 
 function leaderboardEntries() {
@@ -3197,7 +3202,9 @@ function leaderboardEntries() {
   return (board.entries || []).filter((entry) => {
     if (state.ldomain && entry.domain !== state.ldomain) return false;
     if (state.lorg && !(entry.organizations || []).includes(state.lorg)) return false;
-    if (era) {
+    if (era?.undated) {
+      if (entry.released) return false;
+    } else if (era) {
       // ISO dates compare correctly as strings, so no Date parsing is needed
       // and no timezone can shift a benchmark across a year boundary.
       if (!entry.released) return false;


### PR DESCRIPTION
Closes #292.

All four benchmarks that carried `released: null` turn out to have their own publications, so all 80 registry benchmarks are now dated and the CSV export has no blank release cells.

| id | released | basis |
|---|---|---|
| `exploitbench` | 2026-05-13 | arXiv:2605.14153 v1 (Lee, Brumley; CMU) |
| `blueprint_bench_2` | 2026-05-04 | Andon Labs' own launch post |
| `biomysterybench` | 2026-04-29 | Anthropic's own announcement |
| `vibench` | 2026-05-26 | CAIS '26 paper, doi:10.1145/3786335.3813162 |

Two entries changed shape beyond the date. `exploitbench` had unclear provenance and pointed at the GPT-5.6 system card; it now points at the project site, and the paper establishes CMU as the publisher. `biomysterybench` was recorded as an unpublished internal evaluation, which was wrong: Anthropic announced it publicly and ships the dataset. `vibench` is by authors at Replit and Georgian AI Lab, and its tasks come from anonymized Replit production traces, which makes it first-party to an agent it measures.

No date comes from a document that merely reports the benchmark. The 2026-06-09 Anthropic post and the GPT-5.6 preview card are reporting dates and are recorded as such, not as release dates.

The era filter fix stands on its own regardless of the data: every dated era excludes an undated benchmark, so one with no release date was unreachable from the control rather than merely unlisted. A "No release date recorded" option makes it selectable. It currently matches nothing, which is the correct answer now that all 80 are dated.

Verified: 845 tests pass; every source URL fetched and read; leaderboard checked in a browser under `?lera=2026` (all four present) and `?lera=undated` (0 of 80, clean empty state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L4qs6eFa4Z5LfvVh5SBSLS
