### PR TITLE
Make pytest import the checkout's own source

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,10 @@ packages = ["src/benchmark_radar"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+# Make the checkout's own src/ win over the installed editable package. Without
+# this, running pytest from a git worktree imports benchmark_radar from whichever
+# checkout was pip-installed, so the tests silently measure the wrong source tree.
+pythonpath = ["src"]
 
 [tool.ruff]
 line-length = 100

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+import benchmark_radar
+
+
+def test_tests_import_this_checkouts_source():
+    """Guard against a worktree silently testing another checkout's code.
+
+    The venv has the repo installed as an editable package, so without
+    `pythonpath = ["src"]` in pyproject.toml a bare `pytest` run inside a git
+    worktree imports benchmark_radar from whichever checkout was pip-installed.
+    The suite then passes while measuring source the branch never touched.
+    """
+    imported = Path(benchmark_radar.__file__).resolve()
+    expected = (Path(__file__).parent.parent / "src" / "benchmark_radar" / "__init__.py").resolve()
+    assert imported == expected, f"tests import {imported}, expected {expected}"


### PR DESCRIPTION
Follow-up to #296, fixing the test-harness footgun I hit while working on it.

## The problem

The venv has this repo installed as an editable package. `pytest` adds the rootdir to `sys.path` but not `src/`, so inside a git worktree a bare `pytest` resolves `benchmark_radar` from whichever checkout was pip-installed, not from the worktree. The suite goes green while measuring source the branch never touched.

Reproduced directly: from a fresh worktree at merged `main`, `import benchmark_radar` resolved to `/Users/ktwu/Documents/dev/benchmark-radar/src/...`, the main checkout.

## The fix

`pythonpath = ["src"]` in `[tool.pytest.ini_options]` puts the checkout's own `src/` ahead of the installed package.

Verified as a clean A/B, using a sentinel edit made only in the worktree's source and asserted from inside a test pytest itself collects:

- with `pythonpath = ["src"]`: passes, imports resolve to the worktree
- without it: fails, imports resolve to the other checkout

`tests/test_packaging.py` keeps that guarantee by asserting the resolved import path, so a regression fails loudly instead of silently testing the wrong tree.

## Checks

853 passed (up from 846: the new guard, plus the 6 previously-skipped tests now run, since `pythonpath` makes the package importable without relying on the editable install). Ruff check and format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
