### PR TITLE
Lead with the ranking, make Back work, and draw a frontier we can source

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -402,10 +402,11 @@ const I18N = {
     "Search every benchmark": "搜索全部基准",
     "Most reported in model cards": "模型卡中报告最多",
     "Jump to a benchmark": "跳转到某个基准",
+    "One score, copied from the report that published it": "一个分数，照抄自发布它的报告",
     "Show all {n} ranked benchmarks": "显示全部 {n} 个排名基准",
     "Show the top {n}": "只显示前 {n} 个",
-    "One model card contributes at most one mention to a benchmark, however many configurations it reports. Some cards publish their table as an image and those rows were transcribed by OCR, so the source ledger below lists every recorded benchmark with its original document.":
-      "无论一张模型卡报告了多少种配置，它对某个基准最多只贡献一次提及。部分模型卡以图片形式发布其表格，这些行由 OCR 转写，因此下方的来源清单列出了每条记录及其原始文档。",
+    "A report counts once per test, even if it lists that test several times. Some reports publish their results as a picture rather than text, and we read those with software that can misread a digit, so the list at the bottom of this page links every count back to the report it came from.":
+      "一份报告对同一项测试只计一次，即使它列出了多次。有些报告以图片而非文字发布结果，我们用软件读取，可能会看错数字，因此本页底部的清单把每个计数链接回它的来源报告。",
     model: "个模型",
     models: "个模型",
     "No model card in this registry reports a benchmark yet.": "此登记册中还没有任何模型卡报告基准。",
@@ -5307,11 +5308,10 @@ function renderFrontierLegend(entry, record) {
   const swatch = (className) => element("span", { className: `legend-swatch ${className}` });
   const items = [];
   if (record) {
-    items.push([
-      "legend-swatch-score",
-      t("Score read from a document"),
-      t("one value read verbatim from a cited document"),
-    ]);
+    // One phrase, not a label plus a restatement of the label. "Score read
+    // from a document / one value read verbatim from a cited document" said
+    // the same thing twice beside a single dot.
+    items.push(["legend-swatch-score", t("One score, copied from the report that published it"), ""]);
   }
   replaceChildren(
     host,
@@ -5859,7 +5859,6 @@ function renderAdoptionFrontier(board) {
     entry = defaultEntry;
   }
   setCanonicalFrontierChrome(true);
-  byId("frontier-eyebrow").textContent = t("Scores over time");
   // The stage badge is an adoption reading ("Saturated reporting" is a judgement
   // about who reports, not about scores), so the canonical path leaves it empty
   // and hidden. The external path reuses the element for the source name.
@@ -5879,9 +5878,14 @@ function renderAdoptionFrontier(board) {
   // all share one date span no time however many there are, so counting rows
   // would be the wrong question to ask even though no benchmark is in that
   // state today.
-  byId("frontier-heading").textContent = spansTime(record)
-    ? `${entry.name} ${t("reported scores over time")}`
-    : `${entry.name} ${metricLabel(record?.observation_count || 0, "charted score")}`;
+  // The heading is the benchmark's name. What kind of picture this is -- a
+  // track over time, or a single reading that is not one -- moves to the
+  // eyebrow above it, which used to say "Scores over time" regardless and so
+  // repeated the heading rather than qualifying it.
+  byId("frontier-heading").textContent = entry.name;
+  byId("frontier-eyebrow").textContent = spansTime(record)
+    ? t("Scores over time")
+    : metricLabel(record?.observation_count || 0, "charted score");
   renderFrontierLegend(entry, record);
   renderFrontierOrgKey(record);
   clearFrontierPointSelection();
@@ -6161,7 +6165,7 @@ function renderLeaderboardTop(board) {
         [
           board.measures,
           t(
-            "One model card contributes at most one mention to a benchmark, however many configurations it reports. Some cards publish their table as an image and those rows were transcribed by OCR, so the source ledger below lists every recorded benchmark with its original document.",
+            "A report counts once per test, even if it lists that test several times. Some reports publish their results as a picture rather than text, and we read those with software that can misread a digit, so the list at the bottom of this page links every count back to the report it came from.",
           ),
         ]
           .filter(Boolean)

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -410,7 +410,6 @@ const I18N = {
     "Jump to a benchmark": "跳转到某个基准",
     model: "个模型",
     models: "个模型",
-    "See all {n} benchmarks": "查看全部 {n} 个基准",
     "No model card in this registry reports a benchmark yet.": "此登记册中还没有任何模型卡报告基准。",
     "Search benchmarks, tasks, domains…": "搜索基准、任务、领域…",
     "{n} benchmarks": "{n} 个基准",
@@ -440,7 +439,6 @@ const I18N = {
     "leaderboard.ledger.note":
       "这是计算排名的精选来源列表。展开任意一张卡可看到其报告的全部基准,并按源文档的分组方式分组,以便我们的数据能逐行对照原文核查。",
     "Benchmarks with this name": "同名的基准",
-    "no score read from a document yet": "尚无从文档中读到的分数",
     "Showing {shown} of {total} registry records matching \u201c{q}\u201d. Narrow the search to see the rest.":
       "显示与\u201c{q}\u201d匹配的 {total} 条登记册记录中的 {shown} 条。缩小搜索范围可查看其余记录。",
     "Still checking the benchmark registry\u2026": "正在查询基准登记册\u2026",
@@ -3562,15 +3560,13 @@ function opennessChip(status) {
 }
 
 function benchmarkResultRow(record, { navigate = false, inert = false } = {}) {
-  const facts = [];
-  // Every one of these renders an explicit "not established" rather than being
-  // hidden. Hiding an empty field reads as "not applicable", and whether these
-  // are known is precisely the reader's question.
-  facts.push(record.publisher || t("publisher not established"));
-  if (record.released) facts.push(String(record.released).slice(0, 4));
-  if (record.has_size) facts.push(t("size recorded"));
-  else facts.push(t("size not established"));
-
+  // The name is the scanning target, and the count is the measure. Publisher,
+  // size, openness and the source chip printed on every row -- three of them
+  // as "not established" on most crawled records -- so a reader scanned past
+  // four grey fields to reach the next name (issue #298).
+  //
+  // Those fields still exist on the record and are still searchable; the
+  // detail panel is where a reader who wants them asks for them.
   const button = element("button", {
     className: "benchmark-result",
     attrs: {
@@ -3579,24 +3575,14 @@ function benchmarkResultRow(record, { navigate = false, inert = false } = {}) {
     },
   }, [
     element("span", { className: "benchmark-result-name", text: record.name }),
-    element("span", { className: "benchmark-result-facts", text: facts.join(" \u00b7 ") }),
-    element("span", { className: "benchmark-result-meta" }, [
-      opennessChip(record.openness),
-      element("span", {
-        className: "benchmark-result-source",
-        text: record.source === "llm_stats" ? "LLM Stats" : "OpenCompass",
-      }),
-      // A count of collected numbers, never a quality signal: 239 rows means
-      // llm-stats collected 239 numbers, not that the benchmark is better.
-      element("span", {
-        className: "benchmark-result-scores",
-        text: record.score_count
-          ? `${record.score_count} ${
-              record.score_count === 1 ? t("reported score") : t("reported scores")
-            }`
-          : t("no scores collected"),
-      }),
-    ]),
+    // A count of collected numbers, never a quality signal: 239 rows means
+    // llm-stats collected 239 numbers, not that the benchmark is better.
+    element("span", {
+      className: "benchmark-result-facts",
+      text: record.score_count
+        ? metricLabel(record.score_count, "reported score", "reported scores")
+        : t("no scores collected"),
+    }),
   ]);
   if (inert) {
     button.disabled = true;
@@ -4218,6 +4204,26 @@ function externalScoreChart(source, payload) {
   }
 
   const bestY = scoreY(bestValue);
+  // The frontier: where the best-so-far actually rose, rather than one flat
+  // rule at the final maximum (issue #288). The flat rule stays as the
+  // reference the label sits on; the steps say when it was reached.
+  //
+  // This layer records no protocol, so the line carries a stronger caveat than
+  // the curated one: it traces what was REPORTED, and two rows may not be
+  // comparable at all. That is still a weaker claim than joining adjacent
+  // points, which this chart refuses to do and still does not do.
+  const bestSteps = runningBestSteps(
+    plotted.map((row) => ({ time: dateValue(row.reported_date), value: row.value })),
+  );
+  if (bestSteps.length) {
+    svg.append(
+      svgElement("path", {
+        d: runningBestPath(bestSteps, x, scoreY, margin.left + plotWidth),
+        class: "score-frontier-line",
+        fill: "none",
+      }),
+    );
+  }
   svg.append(
     svgElement("line", {
       x1: margin.left,
@@ -4816,6 +4822,55 @@ function spansTime(record) {
 // the interesting movement into a sliver. The band is padded around the observed
 // range instead, and the axis is labelled with its real bounds so a reader
 // cannot mistake a zoomed axis for a full one.
+// The running best: for each date, the highest score anyone had reached by
+// then (issue #288). Requested as a Pareto frontier "just like
+// harbor-index.org", whose frontier plots cost against pass rate. This corpus
+// records neither cost nor latency for any score -- a curated observation
+// carries value/model/organization/reported_at/instrument/protocol, a crawled
+// row carries value/model_name/reported_date -- so that chart cannot be drawn
+// here without inventing the axis. Tracked separately.
+//
+// What IS drawable is the same idea on the axes this chart already has: the
+// set of points nothing else beats, which on one score axis over time is the
+// running maximum. It is a weaker claim than a connecting segment and does not
+// reintroduce the one the join rule forbids: it says "nothing had beaten this
+// yet", never "these points are a series".
+//
+// Returns [] when the line would assert nothing: fewer than two distinct dates,
+// or a single point.
+function runningBestSteps(points, { descends = false } = {}) {
+  const dated = points
+    .filter((point) => Number.isFinite(point.time) && Number.isFinite(point.value))
+    .sort((a, b) => a.time - b.time);
+  if (dated.length < 2) return [];
+  if (new Set(dated.map((point) => point.time)).size < 2) return [];
+  const steps = [];
+  let best = null;
+  for (const point of dated) {
+    // "Better" is not always larger: a lower-is-better metric improves
+    // downward, and the frontier has to follow the metric rather than the
+    // number, or it would trace the worst result on those benchmarks.
+    const improves = best === null || (descends ? point.value < best : point.value > best);
+    if (!improves) continue;
+    best = point.value;
+    steps.push({ time: point.time, value: best });
+  }
+  return steps.length >= 2 ? steps : [];
+}
+
+// Steps as an SVG path: horizontal to the next improvement's date, then
+// vertical to its value. A diagonal would imply the score moved continuously
+// between two reports, which is the interpolation this corpus cannot support.
+function runningBestPath(steps, x, y, endX) {
+  const parts = [`M ${x(steps[0].time)} ${y(steps[0].value)}`];
+  for (const step of steps.slice(1)) {
+    parts.push(`H ${x(step.time)}`);
+    parts.push(`V ${y(step.value)}`);
+  }
+  parts.push(`H ${endX}`);
+  return parts.join(" ");
+}
+
 function scoreBand(record) {
   const values = record.observations.map((observation) => observation.value);
   const low = Math.min(...values);
@@ -5435,6 +5490,34 @@ function scoreTrackChart(entry, board) {
     // comparison readout below the chart, which says in words what a pair of
     // dates does and does not support. Words can carry that caveat; a line
     // cannot.
+
+    // The frontier: where the best-so-far actually rose (issue #288). The
+    // requested cost-versus-score chart cannot be drawn from this corpus, which
+    // records no cost for any score; this is the same idea on the axes the
+    // chart already has. It asserts only that nothing had beaten a value yet,
+    // never that the points between are a series -- which is why it coexists
+    // with the join rule that forbids connecting adjacent points.
+    const frontierSteps = runningBestSteps(
+      record.observations.map((observation) => ({
+        time: new Date(`${observation.reported_at}T00:00:00Z`).getTime(),
+        value: observation.value,
+      })),
+      { descends: scoreDescends },
+    );
+    if (frontierSteps.length) {
+      svg.append(
+        svgElement("path", {
+          d: runningBestPath(
+            frontierSteps,
+            (time) => x(new Date(time).toISOString().slice(0, 10)),
+            scoreY,
+            margin.left + plotWidth,
+          ),
+          class: "score-frontier-line",
+          fill: "none",
+        }),
+      );
+    }
 
     // The best-on-record marker. Drawn as a horizontal rule rather than a point
     // because it is a fact about the whole corpus to date, not about one date.

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -407,6 +407,11 @@ const I18N = {
     "All tracked benchmarks": "所有追踪的基准",
     "Search every benchmark": "搜索全部基准",
     "Most reported in model cards": "模型卡中报告最多",
+    "Jump to a benchmark": "跳转到某个基准",
+    model: "个模型",
+    models: "个模型",
+    "See all {n} benchmarks": "查看全部 {n} 个基准",
+    "No model card in this registry reports a benchmark yet.": "此登记册中还没有任何模型卡报告基准。",
     "Search benchmarks, tasks, domains…": "搜索基准、任务、领域…",
     "{n} benchmarks": "{n} 个基准",
     "Curated registry": "精选登记册",
@@ -680,10 +685,10 @@ const I18N = {
     "Reported score": "报告的分数",
     "Score as reported": "报告的分数",
     "self reported": "自行报告",
-    "model release date, not when the score was measured": "模型发布日期,而不是分数的测量时间",
-    "model release date, not when the score was measured · {n} row(s) with no release date are in the table below only":
-      "模型发布日期,而不是分数的测量时间 · 另有 {n} 行没有发布日期,仅列于下方表格",
-    "best reported": "报告的最高分",
+    "model release date": "模型发布日期",
+    "Best reported score:": "报告的最高分:",
+    "model release date · {n} row(s) with no release date are in the table below only":
+      "模型发布日期 · 另有 {n} 行没有发布日期,仅列于下方表格",
     "{count} scores reported to {source}, placed at each model's release date, which is the only date recorded and is not when the score was measured. Highest {best} by {model}, lowest {low}.":
       "向 {source} 报告的 {count} 个分数,按各模型的发布日期排布;这是唯一记录在案的日期,并非分数的测量时间。最高 {best},来自 {model};最低 {low}。",
     "Date (model release)": "日期（模型发布）",
@@ -3617,21 +3622,16 @@ function searchCuratedEntries(board, query, { includeUnscored = false } = {}) {
   return scored.map((item) => item.entry);
 }
 
-// A curated result states what the crawled rows cannot: how many values were
-// read verbatim, and that this record charts. The layer is named on the row
-// rather than left to the reader to infer from the absence of a source chip.
 // `navigate` is for rows rendered outside the leaderboard. There, selecting a
 // benchmark updates a panel the reader is not looking at, so the click would
 // register as nothing happening. Carrying them to the panel is the only
 // behaviour that matches what the row looks like it promises.
 function curatedResultRow(entry, { navigate = false, inert = false } = {}) {
-  // May be absent: a curated entry is a benchmark model cards report, which is
-  // a separate fact from whether any score was read from a document for it.
-  const record = scoreRecord(entry.benchmark_id);
-  const facts = [];
-  if (entry.domain) facts.push(String(entry.domain).replaceAll("_", " "));
-  if (entry.released) facts.push(String(entry.released).slice(0, 4));
-  facts.push(metricLabel(entry.card_count, "model card"));
+  // The name is the scanning target. Domain, release year, source chip and
+  // score count rendered on every row and turned the list into a wall of grey
+  // text that had to be read before a name could be found (issue #298). The
+  // count stays because it is the measure this registry is built on; the rest
+  // is still searchable, just not printed.
   const button = element("button", {
     className: "benchmark-result benchmark-result-curated",
     attrs: {
@@ -3640,23 +3640,10 @@ function curatedResultRow(entry, { navigate = false, inert = false } = {}) {
     },
   }, [
     element("span", { className: "benchmark-result-name", text: entry.name }),
-    element("span", { className: "benchmark-result-facts", text: facts.join(" \u00b7 ") }),
-    element("span", { className: "benchmark-result-meta" }, [
-      element("span", {
-        className: "benchmark-result-source benchmark-result-source-curated",
-        text: t("Curated registry"),
-      }),
-      element("span", {
-        className: "benchmark-result-scores",
-        text: record
-          ? metricLabel(
-              record.observation_count,
-              "score read from a document",
-              "scores read from a document",
-            )
-          : t("no score read from a document yet"),
-      }),
-    ]),
+    element("span", {
+      className: "benchmark-result-facts",
+      text: metricLabel(entry.card_count, "model", "models"),
+    }),
   ]);
   // Nothing to navigate to and no panel on screen to update: an enabled
   // control whose click does nothing visible is a worse answer than a row that
@@ -4026,8 +4013,11 @@ function externalSizesBlock(detail) {
 function externalScoresBlock(shard) {
   const bySource = shard.scores_by_source || {};
   const sources = Object.keys(bySource).sort();
+  // No "Scores" heading: the panel title names the benchmark and the subline
+  // names the source and the count, so this said nothing the reader had not
+  // just read, and it was the top half of ~150px of dead space above the
+  // chart (issue #298).
   return element("section", { className: "external-block" }, [
-    element("h3", { text: t("Scores") }),
     // Spread, not nesting: element() appends children verbatim, so a mapped
     // array passed as one child would stringify into "[object HTMLDivElement]".
     ...(sources.length
@@ -4140,7 +4130,23 @@ function externalScoreChart(source, payload) {
   // values 0.067 to 1.0 -- announced an axis from "-0.1" to "1.17": a negative
   // score and a ceiling above anything observed, neither of which exists in
   // the data (issue #269).
-  for (const value of [high, low]) {
+  // Intermediate ticks so a point's height can be read rather than inferred
+  // (issue #298). Generated strictly inside [low, high]: the extremes are the
+  // real observed values, and a tick outside them would reintroduce exactly
+  // the padded-bound axis issue #269 removed ("-0.1" to "1.17" on AIME 2025).
+  const yTicks = [high, low];
+  if (high > low) {
+    for (const fraction of [0.25, 0.5, 0.75]) {
+      const value = low + (high - low) * fraction;
+      // Rounded for the label, then kept only if rounding left it inside the
+      // observed range and distinct from the extremes it sits between.
+      const rounded = Number(value.toFixed(2));
+      if (rounded > low && rounded < high && !yTicks.includes(rounded)) {
+        yTicks.push(rounded);
+      }
+    }
+  }
+  for (const value of yTicks) {
     const gridY = scoreY(value);
     svg.append(
       svgElement("line", {
@@ -4170,11 +4176,14 @@ function externalScoreChart(source, payload) {
       class: "score-best-line",
     }),
   );
+  // Attached to the left end of the reference line it annotates. Anchored at
+  // the far right it floated away from the rule and read as a stray number
+  // (issue #298).
   svg.append(
     svgElement(
       "text",
-      { x: width - margin.right, y: bestY - 6, "text-anchor": "end", class: "score-best-label" },
-      `${t("best reported")} ${bestValue}`,
+      { x: margin.left + 6, y: bestY - 6, "text-anchor": "start", class: "score-best-label" },
+      `${t("Best reported score:")} ${bestValue.toFixed(2)}`,
     ),
   );
 
@@ -4255,6 +4264,44 @@ function externalScoreChart(source, payload) {
         ),
       );
     }
+    // Quarter boundaries between the endpoints, so a point's date can be read
+    // off the axis rather than interpolated (issue #298). Only quarters that
+    // fall strictly inside the observed span are drawn, and only where they
+    // clear the endpoint labels: the extremes stay the real first and last
+    // release date, never a rounded range.
+    const quarterGap = 46;
+    const first = new Date(firstTime);
+    const cursor = new Date(
+      Date.UTC(first.getUTCFullYear(), Math.ceil((first.getUTCMonth() + 1) / 3) * 3, 1),
+    );
+    while (cursor.getTime() < lastTime) {
+      const tickX = x(cursor.getTime());
+      if (
+        tickX - margin.left > quarterGap &&
+        margin.left + plotWidth - tickX > quarterGap
+      ) {
+        svg.append(
+          svgElement("line", {
+            x1: tickX,
+            y1: scoreTop + scoreHeight,
+            x2: tickX,
+            y2: scoreTop + scoreHeight + 5,
+            class: "frontier-grid",
+          }),
+        );
+        svg.append(
+          svgElement(
+            "text",
+            { x: tickX, y: height - 26, "text-anchor": "middle", class: "frontier-tick" },
+            formatDate(cursor.toISOString().slice(0, 10), {
+              year: "numeric",
+              month: "short",
+            }),
+          ),
+        );
+      }
+      cursor.setUTCMonth(cursor.getUTCMonth() + 3);
+    }
   }
   svg.append(
     svgElement(
@@ -4269,11 +4316,11 @@ function externalScoreChart(source, payload) {
       // reader has to open. "Model release date" is the whole claim: nothing
       // here records when any of these scores was actually measured.
       undatedCount
-        ? t("model release date, not when the score was measured · {n} row(s) with no release date are in the table below only").replace(
+        ? t("model release date · {n} row(s) with no release date are in the table below only").replace(
             "{n}",
             undatedCount.toLocaleString(),
           )
-        : t("model release date, not when the score was measured"),
+        : t("model release date"),
     ),
   );
   return svg;
@@ -4298,17 +4345,13 @@ function externalSourceTable(source, payload) {
   // curated saturation chart draws, from the same rows, and the table added
   // nothing the chart plus its pinned point cards did not already say.
   const chart = externalScoreChart(source, payload);
+  // The source name and the score count are on the panel subline now, so this
+  // block carries no heading of its own: it repeated both and pushed the chart
+  // ~150px down the page (issue #298). The provenance note is the one thing
+  // that was only here, so it moves to the (i) beside the panel title.
+  const infoHost = byId("frontier-heading-info");
+  if (infoHost) replaceChildren(infoHost, [infoDisclosure(notes.join(" "))]);
   return element("div", { className: "external-source" }, [
-    element("div", { className: "external-source-heading" }, [
-      element("h4", {
-        text: `${meta.name} · ${metricLabel(rows.length, "reported score")}`,
-      }),
-      // The provenance note (what this source did and did not record) behind
-      // an (i) toggle rather than a paragraph that always runs under the
-      // heading: it's one sentence readers need once, not on every visit to
-      // an already-familiar source block.
-      infoDisclosure(notes.join(" ")),
-    ]),
     // frontier-chart's own layout class (position: relative, full-width svg)
     // rather than a bespoke one: the pinned tooltip's positioning math reads
     // its own parentElement as the clamp box, and reusing this class is what
@@ -4458,15 +4501,44 @@ function renderFrontierPicker(scored, selectedValue) {
   );
 }
 
-function renderExternalShell(board, scored, { eyebrow, heading, badge, message, prependOption }) {
+// "External benchmark · 115 reported scores · LLM Stats": what the eyebrow, the
+// badge and the scores-block heading used to say between them, on one line
+// (issue #298). The score count comes from the record rather than the shard so
+// it is present before the shard lands.
+function externalSubline(record, meta) {
+  const parts = [t("External benchmark")];
+  if (record.score_count) {
+    parts.push(metricLabel(record.score_count, "reported score", "reported scores"));
+  }
+  parts.push(meta.name);
+  return parts.join(" \u00b7 ");
+}
+
+function renderExternalShell(
+  board,
+  scored,
+  { eyebrow, heading, badge, message, prependOption, subline },
+) {
   clearFrontierPointSelection();
   setCanonicalFrontierChrome(false);
-  byId("frontier-eyebrow").textContent = eyebrow;
+  // An empty eyebrow or badge is hidden rather than rendered blank: a crawled
+  // record states its source once, on the subline, and repeating it in a
+  // non-interactive chip beside the title read as broken state (issue #298).
+  const eyebrowNode = byId("frontier-eyebrow");
+  eyebrowNode.textContent = eyebrow || "";
+  eyebrowNode.hidden = !eyebrow;
   byId("frontier-heading").textContent = heading;
   const stage = byId("frontier-stage");
   stage.className = "frontier-stage";
-  stage.hidden = false;
-  stage.textContent = badge;
+  stage.hidden = !badge;
+  stage.textContent = badge || "";
+  const sublineNode = byId("frontier-subline");
+  if (sublineNode) {
+    sublineNode.textContent = subline || "";
+    sublineNode.hidden = !subline;
+  }
+  const infoHost = byId("frontier-heading-info");
+  if (infoHost) replaceChildren(infoHost, []);
   renderFrontierPicker(scored, state.lfrontier);
   if (prependOption) {
     const picker = byId("frontier-benchmark");
@@ -4482,10 +4554,14 @@ function renderExternalShell(board, scored, { eyebrow, heading, badge, message, 
 
 function renderExternalBenchmark(board, scored, record) {
   const meta = externalSourceMeta(record.source);
+  // One title, one metadata line. The eyebrow ("External catalog record") and
+  // the source badge both said what this line says, and the reader had to read
+  // three elements to learn one fact (issue #298).
   renderExternalShell(board, scored, {
-    eyebrow: t("External catalog record"),
+    eyebrow: "",
     heading: record.name,
-    badge: meta.name,
+    badge: "",
+    subline: externalSubline(record, meta),
     message: t("Loading benchmark details…"),
   });
   // Scored crawled records are in the picker already. An unscored one is not,
@@ -4539,7 +4615,7 @@ function renderBenchmarkNavigator(board) {
   if (infoHost && !infoHost.firstChild) {
     const disclosure = infoDisclosure(
         t(
-          "Ranked by how many curated model cards report each benchmark, which measures vendor reporting convention rather than benchmark quality. A crawled score count answers a different question: AIME 2025 carries 115 crawled scores and GPQA Diamond 26 model cards, and those are different measures rather than competing ones. The second figure on each card is how many of those mentions carried a number this project could read verbatim, which is what the chart plots: MATH-500 is named by 10 cards and charts 3.",
+          "Ranked by how many curated model cards report each benchmark, which measures vendor reporting convention rather than benchmark quality. A crawled score count answers a different question: AIME 2025 carries 115 crawled scores and GPQA Diamond 26 model cards, and those are different measures rather than competing ones.",
       ),
     );
     // The panel is fixed (see styles.css: the navigator scrolls and would clip
@@ -4575,17 +4651,13 @@ function renderBenchmarkNavigator(board) {
           },
         }, [
           element("span", { className: "benchmark-example-name", text: entry.name }),
-          // Two counts, because clicking this card opens a chart drawn from the
-          // second one. MATH-500 read "10 model cards" here and plotted three
-          // points, with nothing on the page explaining the drop (issue #261).
-          // A mention is a card naming the benchmark; a readable score is a
-          // published number this project could read verbatim. 56 of 79
-          // benchmarks report fewer scores than mentions, so this is the rule
-          // rather than a MATH-500 quirk, and it belongs on the card that
-          // sets the expectation.
+          // One count, and it is a fact about the world rather than about this
+          // pipeline: how many vendors chose to report the benchmark. How many
+          // of those mentions we could read a number out of is a statement
+          // about our own collection, which is noise beside a figure.
           element("small", {
             className: "benchmark-example-meta",
-            text: `${metricLabel(entry.card_count, "model card")} · ${chartedScoreLabel(entry.benchmark_id)}`,
+            text: metricLabel(entry.card_count, "model card"),
           }),
         ]);
         card.addEventListener("click", () => {
@@ -4673,16 +4745,6 @@ function spansTime(record) {
       record.last_reported_at &&
       record.first_reported_at !== record.last_reported_at,
   );
-}
-
-// How many points a benchmark's chart will actually draw. A card mention is not
-// a score: a model card can name MATH-500 in its prose or publish its table as
-// an image, and neither yields a number this project can read. The chart plots
-// only the numbers, so any row that advertises a benchmark by its mention count
-// prints this alongside, and the reader is never surprised by the drop.
-function chartedScoreLabel(benchmarkId) {
-  const record = scoreRecord(benchmarkId);
-  return metricLabel(record?.observation_count || 0, "score read from a document", "scores read from a document");
 }
 
 // The plotted band for a score axis. Percent metrics are NOT drawn 0-100: every
@@ -5624,7 +5686,7 @@ function renderAdoptionFrontier(board) {
     // panel when the fetch settles.
     renderBenchmarkNavigator(board);
     renderExternalShell(board, scored, {
-      eyebrow: t("External catalog record"),
+      eyebrow: t("Scores over time"),
       heading: state.lfrontier,
       badge: "",
       message: t("Loading benchmark details…"),
@@ -5636,7 +5698,7 @@ function renderAdoptionFrontier(board) {
     // outright; the selection and the URL stay as the reader wrote them.
     renderBenchmarkNavigator(board);
     renderExternalShell(board, scored, {
-      eyebrow: t("External catalog record"),
+      eyebrow: t("Scores over time"),
       heading: state.lfrontier,
       badge: "",
       message: t("Could not load details for this benchmark."),
@@ -5922,6 +5984,53 @@ function renderLeaderboardFilters(board) {
   }
 }
 
+// The page is named after this ranking, so it leads (issue #256). Five lines,
+// one measure, and nothing about how the number was computed: a reader who
+// wants only the ranking never has to read the methodology, and the full table
+// underneath still carries the filters and every remaining benchmark.
+//
+// `board.entries` arrives ranked by adoption_rank (model_cards.py), which
+// breaks card-count ties on organization count and then name. Re-sorting here
+// on card_count alone would disagree with entry.rank and print a row numbered
+// 05 in position 04, so the order is read, never recomputed.
+const LEADERBOARD_TOP_LIMIT = 5;
+
+function renderLeaderboardTop(board) {
+  const host = byId("leaderboard-top-list");
+  if (!host) return;
+  const entries = (board.entries || [])
+    .filter((entry) => entry.card_count > 0)
+    .slice(0, LEADERBOARD_TOP_LIMIT);
+  // A registry where nothing is reported yet is a real state, not a bug, and
+  // five blank lines is a worse answer than saying so.
+  if (!entries.length) {
+    replaceChildren(host, [
+      element("li", {
+        className: "empty-state",
+        text: t("No model card in this registry reports a benchmark yet."),
+      }),
+    ]);
+    return;
+  }
+  replaceChildren(
+    host,
+    entries.map((entry) => {
+      const row = element("li", { className: "leaderboard-top-row" }, [
+        element("span", {
+          className: "leaderboard-top-rank",
+          text: String(entry.rank).padStart(2, "0"),
+        }),
+        element("span", { className: "leaderboard-top-name", text: entry.name }),
+        element("span", {
+          className: "leaderboard-top-count",
+          text: metricLabel(entry.card_count, "model card"),
+        }),
+      ]);
+      return row;
+    }),
+  );
+}
+
 function renderLeaderboard() {
   const board = state.data?.model_card_leaderboard;
   const navButton = document.querySelector('[data-view="leaderboard"]');
@@ -5935,6 +6044,7 @@ function renderLeaderboard() {
   if (navButton) navButton.hidden = false;
 
   byId("leaderboard-measures").textContent = board.measures || "";
+  renderLeaderboardTop(board);
   renderLeaderboardFilters(board);
   renderBenchmarkFindings(board);
   renderAdoptionFrontier(board);

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -687,8 +687,8 @@ const I18N = {
     "self reported": "自行报告",
     "model release date": "模型发布日期",
     "Best reported score:": "报告的最高分:",
-    "model release date · {n} row(s) with no release date are in the table below only":
-      "模型发布日期 · 另有 {n} 行没有发布日期,仅列于下方表格",
+    "{n} row(s) have no release date, so they carry no position on this axis and are not drawn.":
+      "有 {n} 行没有发布日期,因此在此坐标轴上没有位置,未被绘制。",
     "{count} scores reported to {source}, placed at each model's release date, which is the only date recorded and is not when the score was measured. Highest {best} by {model}, lowest {low}.":
       "向 {source} 报告的 {count} 个分数,按各模型的发布日期排布;这是唯一记录在案的日期,并非分数的测量时间。最高 {best},来自 {model};最低 {low}。",
     "Date (model release)": "日期（模型发布）",
@@ -1027,7 +1027,22 @@ function readUrl() {
   state.rubric = new URLSearchParams(window.location.hash.slice(1)).get("rubric") || "";
 }
 
-function writeUrl() {
+// `push` adds a history entry; `replace` overwrites the current one.
+//
+// Every call used to replace, so no navigation was ever backable: a reader who
+// searched, opened a benchmark and pressed Back left the site entirely, because
+// the search URL had been overwritten rather than kept (issue #286).
+//
+// Pushing everything is the wrong fix. The filter boxes call this on a debounce
+// as the reader types, so `q=m`, `q=mm`, `q=mml`, `q=mmlu` would each become an
+// entry and Back would walk backwards through their own typing one keystroke at
+// a time. The split is by what the reader did:
+//
+//   push    a discrete navigation they chose -- changing view, selecting a
+//           benchmark, opening an entity
+//   replace continuous refinement of the view they are already on -- typing in
+//           a filter, moving the date, toggling a facet, closing a dialog
+function writeUrl(mode = "replace") {
   const params = new URLSearchParams();
   if (state.view !== "today") params.set("view", state.view);
   // Every filter below belongs to exactly one view, so only that view may write
@@ -1066,14 +1081,51 @@ function writeUrl() {
   const hashParams = new URLSearchParams();
   if (state.rubric) hashParams.set("rubric", state.rubric);
   const hash = hashParams.toString();
-  window.history.replaceState(
-    null,
-    "",
-    `${window.location.pathname}${query ? `?${query}` : ""}${hash ? `#${hash}` : ""}`,
-  );
+  const url = `${window.location.pathname}${query ? `?${query}` : ""}${hash ? `#${hash}` : ""}`;
+  // Pushing a URL identical to the current one would make Back a no-op that
+  // looks broken: the reader presses it, the address bar does not change, and
+  // they press it again. Re-selecting the benchmark already shown is the
+  // common way to hit this.
+  const current = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+  if (mode === "push" && url !== current) {
+    window.history.pushState(null, "", url);
+    return;
+  }
+  window.history.replaceState(null, "", url);
 }
 
-function setView(view, update = true) {
+// A pushed entry changes the URL on Back without re-rendering anything, so the
+// page would silently disagree with its own address bar. This is what makes the
+// pushes above safe: the restored URL is read back into state and the view it
+// describes is drawn (issue #286).
+function onPopState() {
+  if (!state.data) return;
+  readUrl();
+  // A leaderboard permalink on a build with no curated registry has nothing to
+  // show, same fallback initialize() applies. Without it, Back into such an
+  // entry opens an empty section behind a hidden nav button.
+  if (state.view === "leaderboard" && !state.data.model_card_leaderboard) {
+    state.view = "today";
+  }
+  setView(state.view, false);
+  // The renderers read their own controls back from state (the date picker at
+  // renderToday, the leaderboard search at renderLeaderboardFilters), so this
+  // restores the form values as well as the content.
+  rerenderCurrentView();
+  // The rubric lives in the hash rather than the query, so it is restored
+  // separately: Back out of an open dialog should close it.
+  const dialog = byId("rubric-dialog");
+  if (state.rubric && state.data.rubrics?.[state.rubric]) {
+    if (!dialog?.open) openRubric(null, state.rubric);
+  } else if (dialog?.open) {
+    dialog.close();
+  }
+}
+
+// `update` false is for restoring a view that is already in the URL (boot and
+// popstate), where writing history again would either duplicate the entry or
+// fight the entry being restored.
+function setView(view, update = true, mode = "push") {
   if (view !== "leaderboard" && selectedFrontierPoint) {
     clearFrontierPointSelection();
   }
@@ -1088,7 +1140,7 @@ function setView(view, update = true) {
       button.removeAttribute("aria-current");
     }
   });
-  if (update) writeUrl();
+  if (update) writeUrl(mode);
 }
 
 function selectFrontier(benchmarkId) {
@@ -3056,7 +3108,7 @@ function selectMapNode(entity, relatedEntities) {
         })
       : null,
   ]);
-  writeUrl();
+  writeUrl("push");
 }
 
 function rankedCounts(values, limit = 6) {
@@ -3563,7 +3615,7 @@ function benchmarkResultRow(record, { navigate = false, inert = false } = {}) {
     renderBenchmarkSearch();
     const board = state.data?.model_card_leaderboard;
     if (board) renderAdoptionFrontier(board);
-    writeUrl();
+    writeUrl("push");
   });
   return button;
 }
@@ -3665,7 +3717,7 @@ function curatedResultRow(entry, { navigate = false, inert = false } = {}) {
     renderBenchmarkSearch();
     const board = state.data?.model_card_leaderboard;
     if (board) renderAdoptionFrontier(board);
-    writeUrl();
+    writeUrl("push");
   });
   return button;
 }
@@ -4058,13 +4110,12 @@ function externalScoreChart(source, payload) {
   // chart: a point can only be drawn at a position, and there is no honest
   // position for a value that is not a number. A row with no parseable release
   // date is out for the same reason once the axis is time: there is no honest
-  // x for it. Both exclusions are stated under the chart rather than left to
-  // be inferred from a count that does not add up.
+  // x for it. Both exclusions are declared in the source's (i) note rather than
+  // left to be inferred from a count that does not add up.
   const numeric = (payload.rows || []).filter(
     (row) => typeof row.value === "number" && Number.isFinite(row.value),
   );
   const dated = numeric.filter((row) => Number.isFinite(dateValue(row.reported_date)));
-  const undatedCount = numeric.length - dated.length;
   // Sorted by date so the axis reads left to right in time. Ties broken by
   // score so same-day releases land in a stable order rather than whatever
   // order the crawl happened to return.
@@ -4313,14 +4364,10 @@ function externalScoreChart(source, payload) {
         class: "frontier-axis-label",
       },
       // Says which date this is on the axis itself, not only in a tooltip a
-      // reader has to open. "Model release date" is the whole claim: nothing
-      // here records when any of these scores was actually measured.
-      undatedCount
-        ? t("model release date · {n} row(s) with no release date are in the table below only").replace(
-            "{n}",
-            undatedCount.toLocaleString(),
-          )
-        : t("model release date"),
+      // reader has to open. Nothing here records when any of these scores was
+      // actually measured; that qualification lives in the (i) note and the
+      // chart's aria-label, so the axis names the date and stops.
+      t("model release date"),
     ),
   );
   return svg;
@@ -4344,6 +4391,23 @@ function externalSourceTable(source, payload) {
   // The chart replaces the table entirely: it draws the same shape the
   // curated saturation chart draws, from the same rows, and the table added
   // nothing the chart plus its pinned point cards did not already say.
+  // Rows the chart cannot place are declared in the (i) note rather than on the
+  // axis label, which names the date and nothing else (issue #298). Dropping
+  // the count entirely would hide scores that exist.
+  const undated = (payload.rows || []).filter(
+    (row) =>
+      typeof row.value === "number" &&
+      Number.isFinite(row.value) &&
+      !Number.isFinite(dateValue(row.reported_date)),
+  ).length;
+  if (undated) {
+    notes.push(
+      t("{n} row(s) have no release date, so they carry no position on this axis and are not drawn.").replace(
+        "{n}",
+        undated.toLocaleString(),
+      ),
+    );
+  }
   const chart = externalScoreChart(source, payload);
   // The source name and the score count are on the panel subline now, so this
   // block carries no heading of its own: it repeated both and pushed the chart
@@ -4386,7 +4450,7 @@ function externalSiblingsBlock(shard) {
       selectFrontier(sibling.slug);
       const board = state.data?.model_card_leaderboard;
       if (board) renderAdoptionFrontier(board);
-      writeUrl();
+      writeUrl("push");
     });
     return element("li", {}, [
       link,
@@ -4663,7 +4727,7 @@ function renderBenchmarkNavigator(board) {
         card.addEventListener("click", () => {
           selectFrontier(entry.benchmark_id);
           renderAdoptionFrontier(board);
-          writeUrl();
+          writeUrl("push");
         });
         return card;
       }),
@@ -5795,7 +5859,7 @@ function findingCard(finding, board) {
     jump.addEventListener("click", () => {
       selectFrontier(target.benchmark_id);
       renderAdoptionFrontier(board);
-      writeUrl();
+      writeUrl("push");
       byId("adoption-frontier").scrollIntoView({ behavior: "smooth", block: "start" });
     });
     children.push(jump);
@@ -5936,7 +6000,7 @@ function leaderboardRow(entry) {
   frontierButton?.addEventListener("click", () => {
     selectFrontier(entry.benchmark_id);
     renderAdoptionFrontier(board);
-    writeUrl();
+    writeUrl("push");
     byId("adoption-frontier").scrollIntoView({ behavior: "smooth", block: "start" });
   });
 
@@ -6782,6 +6846,10 @@ const scheduleLeaderboardRender = debounce(() => {
 });
 
 function bindEvents() {
+  // Without this a pushed entry would change the URL on Back and leave the
+  // page showing the previous view, silently disagreeing with its own address
+  // bar (issue #286).
+  window.addEventListener("popstate", onPopState);
   const langToggle = byId("lang-toggle");
   if (langToggle) langToggle.addEventListener("click", toggleLang);
   document.querySelectorAll("[data-view]").forEach((button) => {
@@ -6822,7 +6890,7 @@ function bindEvents() {
   byId("frontier-benchmark").addEventListener("change", (event) => {
     selectFrontier(event.target.value);
     renderAdoptionFrontier(state.data.model_card_leaderboard);
-    writeUrl();
+    writeUrl("push");
   });
   byId("today-date").addEventListener("change", (event) => {
     state.todayDate = event.target.value;

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -1097,8 +1097,12 @@ function writeUrl(mode = "replace") {
 // pushes above safe: the restored URL is read back into state and the view it
 // describes is drawn (issue #286).
 function onPopState() {
-  if (!state.data) return;
+  // Before the payload lands, state is not yet drawable. Read the URL anyway:
+  // initialize() renders from state once the fetch settles, and skipping the
+  // read here would leave it rendering whatever the reader navigated away
+  // from while the address bar showed the restored entry.
   readUrl();
+  if (!state.data) return;
   // A leaderboard permalink on a build with no curated registry has nothing to
   // show, same fallback initialize() applies. Without it, Back into such an
   // entry opens an empty section behind a hidden nav button.
@@ -4206,26 +4210,18 @@ function externalScoreChart(source, payload) {
   }
 
   const bestY = scoreY(bestValue);
-  // The frontier: where the best-so-far actually rose, rather than one flat
-  // rule at the final maximum (issue #288). The flat rule stays as the
-  // reference the label sits on; the steps say when it was reached.
+  // No running-best line on this layer, deliberately (issue #288 review).
   //
-  // This layer records no protocol, so the line carries a stronger caveat than
-  // the curated one: it traces what was REPORTED, and two rows may not be
-  // comparable at all. That is still a weaker claim than joining adjacent
-  // points, which this chart refuses to do and still does not do.
-  const bestSteps = runningBestSteps(
-    plotted.map((row) => ({ time: dateValue(row.reported_date), value: row.value })),
-  );
-  if (bestSteps.length) {
-    svg.append(
-      svgElement("path", {
-        d: runningBestPath(bestSteps, x, scoreY, margin.left + plotWidth),
-        class: "score-frontier-line",
-        fill: "none",
-      }),
-    );
-  }
+  // A maximum is a comparability claim: it says these numbers can be ranked
+  // against each other. This layer cannot support that. The normalizer records
+  // `direction: None` because the source states no metric direction, and
+  // `comparability_class: none` because it records no protocol -- see
+  // external_catalog.py, "the only honest comparability class is none". Taking
+  // a max over those rows would assume larger-is-better and assume the rows are
+  // measuring the same thing, and neither is in evidence.
+  //
+  // The flat best-on-record rule stays: it labels one row's own value, which is
+  // a fact about that row rather than a ranking across rows.
   svg.append(
     svgElement("line", {
       x1: margin.left,
@@ -4834,9 +4830,13 @@ function spansTime(record) {
 //
 // What IS drawable is the same idea on the axes this chart already has: the
 // set of points nothing else beats, which on one score axis over time is the
-// running maximum. It is a weaker claim than a connecting segment and does not
-// reintroduce the one the join rule forbids: it says "nothing had beaten this
-// yet", never "these points are a series".
+// running maximum. It says "nothing had beaten this yet", never "these points
+// are a series", so it does not reintroduce the segment the join rule forbids.
+//
+// But a maximum is still a comparability claim -- it says these numbers can be
+// ranked against each other -- so callers must pass points that share an
+// instrument and a protocol. The crawled layer cannot: it records neither, and
+// its normalizer sets comparability to none, so it draws no line at all.
 //
 // Returns [] when the line would assert nothing: fewer than two distinct dates,
 // or a single point.
@@ -5498,14 +5498,27 @@ function scoreTrackChart(entry, board) {
     // chart already has. It asserts only that nothing had beaten a value yet,
     // never that the points between are a series -- which is why it coexists
     // with the join rule that forbids connecting adjacent points.
-    const frontierSteps = runningBestSteps(
-      record.observations.map((observation) => ({
+    // Partitioned by instrument AND protocol, the same rule the join uses. A
+    // max across protocols is still a comparability claim: on GPQA Diamond the
+    // observations run "Pass@1, 8K output limit" beside "averaged over 10
+    // samples", and ranking those against each other asserts they measure the
+    // same thing (issue #288 review).
+    //
+    // The largest comparable group wins the line, so the chart draws the one
+    // run it can actually speak to rather than a mixture it cannot.
+    const runs = new Map();
+    for (const observation of record.observations) {
+      const key = `${observation.instrument || ""}\u0000${observation.protocol || ""}`;
+      if (!runs.has(key)) runs.set(key, []);
+      runs.get(key).push({
         time: new Date(`${observation.reported_at}T00:00:00Z`).getTime(),
         value: observation.value,
-      })),
-      { descends: scoreDescends },
-    );
-    if (frontierSteps.length) {
+      });
+    }
+    const frontierSteps = [...runs.values()]
+      .map((points) => runningBestSteps(points, { descends: scoreDescends }))
+      .sort((a, b) => b.length - a.length)[0];
+    if (frontierSteps?.length) {
       svg.append(
         svgElement("path", {
           d: runningBestPath(
@@ -5854,9 +5867,22 @@ function renderAdoptionFrontier(board) {
     return;
   }
   if (!entry) {
+    // The requested benchmark does not exist. Falling back to the default is
+    // right -- an empty panel is worse -- but the URL must stop naming a
+    // benchmark the panel is not showing, or a shared link reads as evidence
+    // about the wrong thing (the defect issue #287 fixed for canonical ids,
+    // which crawled slugs could still reach).
+    //
+    // Repaired here rather than at the call sites because this is the one
+    // place the substitution happens, and it happens on three different paths:
+    // first load, the re-render after the crawled index settles, and Back.
+    const substituted = Boolean(state.lfrontier);
     state.lfrontier = defaultEntry.benchmark_id;
     state.lfrontierExplicit = false;
     entry = defaultEntry;
+    // replaceState, never push: the reader did not navigate, an address that
+    // was already wrong got corrected.
+    if (substituted && state.view === "leaderboard") writeUrl();
   }
   setCanonicalFrontierChrome(true);
   // The stage badge is an adoption reading ("Saturated reporting" is a judgement

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -391,14 +391,8 @@ const I18N = {
     "Sort: Date, then Priority ↓": "排序:日期,再按优先度 ↓",
     "Sort: Date ↓": "排序:日期 ↓",
     // --- Leaderboard ---------------------------------------------------------
-    "Model Card Adoption Rank": "模型卡采用排名",
     "Which benchmarks do model cards report?": "模型卡报告了哪些基准?",
-    "How to read this evidence": "如何解读这些证据",
     "What does this source record?": "这个来源记录了什么？",
-    "leaderboard.method.note1":
-      "这是报告惯例的排名,不是基准质量排名。一张模型卡无论报告了多少种配置,对同一基准最多计为一次提及。",
-    "leaderboard.method.note2":
-      "部分模型卡把基准表做成图片发布,这些行是通过 OCR 转录的,转录结果可能出错。<a href=\"#leaderboard-cards-heading\">来源台账</a> 列出了每一条记录的基准和原始文档,以便逐条核对每个计数。",
     "Registry overview": "总览",
     "What the two layers say": "两层信息说了什么",
     "Stated findings": "明确结论",
@@ -408,6 +402,10 @@ const I18N = {
     "Search every benchmark": "搜索全部基准",
     "Most reported in model cards": "模型卡中报告最多",
     "Jump to a benchmark": "跳转到某个基准",
+    "Show all {n} ranked benchmarks": "显示全部 {n} 个排名基准",
+    "Show the top {n}": "只显示前 {n} 个",
+    "One model card contributes at most one mention to a benchmark, however many configurations it reports. Some cards publish their table as an image and those rows were transcribed by OCR, so the source ledger below lists every recorded benchmark with its original document.":
+      "无论一张模型卡报告了多少种配置，它对某个基准最多只贡献一次提及。部分模型卡以图片形式发布其表格，这些行由 OCR 转写，因此下方的来源清单列出了每条记录及其原始文档。",
     model: "个模型",
     models: "个模型",
     "No model card in this registry reports a benchmark yet.": "此登记册中还没有任何模型卡报告基准。",
@@ -898,6 +896,7 @@ const state = {
   benchmarkIndexLoaded: false,
   benchmarkQuery: "",
   leaderboardShowAll: false,
+  leaderboardTopExpanded: false,
   todayResultsKey: "",
   todayResultsLimit: ALL_DATES_PAGE_SIZE,
   observations: null,
@@ -3345,19 +3344,21 @@ function frontierDefaultEntry(board) {
     (entry) => entry.card_count > 0 && scoreRecord(entry.benchmark_id),
   );
   const datedCount = (entry) => scoreRecord(entry.benchmark_id)?.dated_observation_count || 0;
-  const byNewestSignal = (a, b) =>
-    (b.released || "").localeCompare(a.released || "") ||
-    datedCount(b) - datedCount(a) ||
-    a.name.localeCompare(b.name);
-  // A one-point plot is technically recent but visually says nothing. Open on
-  // the newest instrument that already carries three or more dated readings;
-  // the full select still makes every scored benchmark reachable and shareable.
-  const newScoredSignals = scored.filter(
-    (entry) => isNewBenchmark(entry, board) && datedCount(entry) >= 3,
-  );
-  if (newScoredSignals.length) return [...newScoredSignals].sort(byNewestSignal)[0];
-  const sharedSignals = scored.filter((entry) => datedCount(entry) >= 2);
-  return [...(sharedSignals.length ? sharedSignals : scored)].sort(byNewestSignal)[0];
+  // The page opens on the benchmark it ranks first, so the figure answers the
+  // question the ranking above it just raised. It used to open on the NEWEST
+  // scored instrument, which put AutomationBench under a page headed "most
+  // reported in model cards" -- a benchmark the reader had not seen named
+  // anywhere above the figure.
+  //
+  // `scored` is already in adoption_rank order (rank 1 first), so the ranking
+  // and the default agree by construction rather than by a second sort that
+  // could drift from it.
+  //
+  // A one-point plot says nothing visually, so a benchmark with fewer than two
+  // dated readings is passed over even if it ranks higher; the picker still
+  // reaches every scored benchmark.
+  const drawable = scored.filter((entry) => datedCount(entry) >= 2);
+  return (drawable.length ? drawable : scored)[0];
 }
 
 const BENCHMARK_TASK_SHAPES = {
@@ -6145,9 +6146,32 @@ const LEADERBOARD_TOP_LIMIT = 5;
 function renderLeaderboardTop(board) {
   const host = byId("leaderboard-top-list");
   if (!host) return;
-  const entries = (board.entries || [])
-    .filter((entry) => entry.card_count > 0)
-    .slice(0, LEADERBOARD_TOP_LIMIT);
+  // The eyebrow, the h1, the deck and the "How to read this evidence" note all
+  // sat between the page title and the figure, saying four things about one
+  // ranking. They are one (i) beside the heading now: a reader who wants the
+  // caveat opens it, and a reader who wants the ranking sees the ranking.
+  const infoHost = byId("leaderboard-top-info");
+  if (infoHost && !infoHost.firstChild) {
+    // `board.measures` is published data, not a string restated here. A reader
+    // who takes this order as a quality ranking draws the opposite of the
+    // intended conclusion, and the correction has to travel with the payload
+    // that produced the order rather than drift from it in the browser.
+    infoHost.append(
+      infoDisclosure(
+        [
+          board.measures,
+          t(
+            "One model card contributes at most one mention to a benchmark, however many configurations it reports. Some cards publish their table as an image and those rows were transcribed by OCR, so the source ledger below lists every recorded benchmark with its original document.",
+          ),
+        ]
+          .filter(Boolean)
+          .join(" "),
+      ),
+    );
+  }
+  const ranked = (board.entries || []).filter((entry) => entry.card_count > 0);
+  const entries = state.leaderboardTopExpanded ? ranked : ranked.slice(0, LEADERBOARD_TOP_LIMIT);
+  const more = byId("leaderboard-top-more");
   // A registry where nothing is reported yet is a real state, not a bug, and
   // five blank lines is a worse answer than saying so.
   if (!entries.length) {
@@ -6157,12 +6181,13 @@ function renderLeaderboardTop(board) {
         text: t("No model card in this registry reports a benchmark yet."),
       }),
     ]);
+    if (more) more.hidden = true;
     return;
   }
   replaceChildren(
     host,
-    entries.map((entry) => {
-      const row = element("li", { className: "leaderboard-top-row" }, [
+    entries.map((entry) =>
+      element("li", { className: "leaderboard-top-row" }, [
         element("span", {
           className: "leaderboard-top-rank",
           text: String(entry.rank).padStart(2, "0"),
@@ -6172,10 +6197,15 @@ function renderLeaderboardTop(board) {
           className: "leaderboard-top-count",
           text: metricLabel(entry.card_count, "model card"),
         }),
-      ]);
-      return row;
-    }),
+      ]),
+    ),
   );
+  if (more) {
+    more.hidden = ranked.length <= LEADERBOARD_TOP_LIMIT;
+    more.textContent = state.leaderboardTopExpanded
+      ? t("Show the top {n}").replace("{n}", String(LEADERBOARD_TOP_LIMIT))
+      : t("Show all {n} ranked benchmarks").replace("{n}", String(ranked.length));
+  }
 }
 
 function renderLeaderboard() {
@@ -6964,6 +6994,10 @@ function bindEvents() {
     byId("leaderboard-search").value = "";
     renderLeaderboard();
     writeUrl();
+  });
+  byId("leaderboard-top-more").addEventListener("click", () => {
+    state.leaderboardTopExpanded = !state.leaderboardTopExpanded;
+    renderLeaderboardTop(state.data.model_card_leaderboard);
   });
   byId("leaderboard-show-all").addEventListener("click", () => {
     state.leaderboardShowAll = !state.leaderboardShowAll;

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -2094,23 +2094,9 @@ td a {
 
 /* Model Card Adoption Rank (issue #83) */
 
-.leaderboard-intro {
-  display: grid;
-  grid-template-columns: minmax(0, 1.7fr) minmax(280px, 0.8fr);
-  gap: clamp(2rem, 5vw, 5rem);
-  align-items: end;
-  margin-bottom: 0.9rem;
-}
-
 /* Same size as the ranking heading below it. At the global h1 scale (48px)
    this line was the largest thing on the page and outweighed both the ranking
    it introduces and the figure it sits above, while saying less than either. */
-.leaderboard-title-block h1 {
-  max-width: 920px;
-  font-size: 1.35rem;
-  line-height: 1.25;
-}
-
 .leaderboard-deck {
   display: -webkit-box;
   -webkit-box-orient: vertical;
@@ -3772,12 +3758,6 @@ footer {
 
   .view-heading {
     display: grid;
-    align-items: start;
-  }
-
-  .leaderboard-intro {
-    grid-template-columns: 1fr;
-    gap: 1.25rem;
     align-items: start;
   }
 

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -2828,6 +2828,17 @@ td a {
   r: 13px;
 }
 
+/* The running best (issue #288). Solid and stepped, deliberately unlike any
+   point-to-point join: the steps are horizontal and vertical only, so the eye
+   reads "held, then rose" rather than "moved continuously between these two
+   reports", which is the interpolation this corpus cannot support. */
+.score-frontier-line {
+  stroke: #4c948b;
+  stroke-width: 1.75;
+  stroke-linejoin: miter;
+  opacity: 0.85;
+}
+
 .score-best-line {
   stroke: #8fd0c4;
   stroke-dasharray: 2 4;
@@ -4115,30 +4126,11 @@ footer {
   font-weight: 600;
 }
 
-.benchmark-result-facts,
-.benchmark-result-meta {
+.benchmark-result-facts {
   font-size: 0.76rem;
   color: var(--muted);
 }
 
-.benchmark-result-meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.4rem;
-  align-items: center;
-}
-
-/* Curated rows are marked in the search list rather than left to be told apart
-   by the absence of a source chip. The curated layer is the one with a protocol
-   and a time axis, so which layer a result came from is the first thing a
-   reader needs before clicking it. */
-.benchmark-result-source-curated {
-  border: 1px solid var(--accent);
-  border-radius: 999px;
-  padding: 0.05rem 0.45rem;
-  font-size: 0.72rem;
-  color: var(--accent);
-}
 
 /* Openness is a statement about what we know, so `unknown` is neutral rather
    than a warning. Only a positive verdict gets emphasis. */
@@ -4293,16 +4285,6 @@ footer {
   font-size: 0.76rem;
 }
 
-.external-source-heading {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  margin-bottom: 0.3rem;
-}
-
-.external-source-heading h4 {
-  margin: 0;
-}
 
 /* A round (i) toggle for one line of provenance text. The marker itself is
    the affordance -- an outlined circle, always visible, brightened on

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -2102,8 +2102,13 @@ td a {
   margin-bottom: 0.9rem;
 }
 
+/* Same size as the ranking heading below it. At the global h1 scale (48px)
+   this line was the largest thing on the page and outweighed both the ranking
+   it introduces and the figure it sits above, while saying less than either. */
 .leaderboard-title-block h1 {
   max-width: 920px;
+  font-size: 1.35rem;
+  line-height: 1.25;
 }
 
 .leaderboard-deck {
@@ -2118,44 +2123,8 @@ td a {
   line-height: 1.45;
 }
 
-.method-note {
-  border-top: 1px solid var(--ink);
-  border-bottom: 1px solid var(--ink);
-}
-
-.method-note summary {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  min-height: 48px;
-  color: var(--blue-deep);
-  cursor: pointer;
-  font-family: var(--utility);
-  font-size: 0.7rem;
-  letter-spacing: 0.06em;
-  list-style: none;
-  text-transform: uppercase;
-}
-
-.method-note summary::after {
-  content: "+";
-  font-size: 3rem;
-  line-height: 1;
-  font-weight: 300;
-}
-
-.method-note[open] summary::after {
-  content: "−";
-}
-
-.method-note summary::-webkit-details-marker,
 .ledger-summary::-webkit-details-marker {
   display: none;
-}
-
-.method-note p {
-  color: var(--muted);
-  font-size: 0.82rem;
 }
 
 .evidence-strip {
@@ -2443,8 +2412,21 @@ td a {
   overflow-y: auto;
   padding: 1.25rem;
   border: 1px solid var(--ink);
-  background: var(--canvas);
+  /* A real grey, not the page background. At --canvas the panel was the exact
+     colour of the page behind it, so beside the near-black figure it read as
+     something floating on the page rather than part of it. The search field
+     keeps its white fill and heavy border, so the control the panel exists for
+     still carries the contrast. */
+  background: #c3ccd1;
   box-shadow: var(--shadow);
+}
+
+/* Muted greys chosen against a near-white surface do not carry on the darker
+   panel, so the supporting text inside it darkens with the background. */
+.benchmark-navigator .benchmark-search-status,
+.benchmark-navigator .benchmark-result-facts,
+.benchmark-navigator .benchmark-example-meta {
+  color: #3d4d54;
 }
 
 .benchmark-navigator h2 {

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -383,6 +383,15 @@ main {
   padding: clamp(2.25rem, 4vw, 3.75rem) 0 6rem;
 }
 
+/* The leaderboard's primary object is the figure, so its top chrome is a
+   budget rather than a canvas: on a 1440x900 laptop the chart began at
+   y=1356, entirely below the fold, behind KPI cards and accordions that
+   summarise it. Those moved below the figure; this recovers the last of the
+   gap so the visualization is visibly underway on load. */
+#leaderboard-view {
+  padding-top: clamp(1.25rem, 2vw, 1.75rem);
+}
+
 .view-heading {
   display: flex;
   gap: 2rem;
@@ -839,7 +848,8 @@ input {
 
 .answer-disclosure-summary::before {
   content: "›";
-  font-size: 0.9rem;
+  font-size: 2.7rem;
+  line-height: 1;
   line-height: 1;
   transition: transform 140ms ease;
 }
@@ -895,13 +905,13 @@ input {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 22px;
-  height: 22px;
+  width: 48px;
+  height: 48px;
   border: 1px solid var(--line);
   border-radius: 50%;
   color: var(--blue-deep);
   font-family: var(--utility);
-  font-size: 1rem;
+  font-size: 2.2rem;
   line-height: 1;
   transition:
     transform 140ms ease,
@@ -1948,8 +1958,9 @@ td a {
   flex: none;
   color: var(--blue-deep);
   font-family: var(--utility);
-  font-size: 1.5rem;
-  font-weight: 400;
+  font-size: 3rem;
+  line-height: 1;
+  font-weight: 300;
 }
 
 .relationship-explorer[open] > summary::after {
@@ -2088,7 +2099,7 @@ td a {
   grid-template-columns: minmax(0, 1.7fr) minmax(280px, 0.8fr);
   gap: clamp(2rem, 5vw, 5rem);
   align-items: end;
-  margin-bottom: 1.5rem;
+  margin-bottom: 0.9rem;
 }
 
 .leaderboard-title-block h1 {
@@ -2096,10 +2107,15 @@ td a {
 }
 
 .leaderboard-deck {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
   max-width: 780px;
-  margin: 1rem 0 0;
+  margin: 0.45rem 0 0;
   color: var(--muted);
-  font-size: clamp(0.95rem, 1.3vw, 1.12rem);
+  font-size: clamp(0.92rem, 1.2vw, 1.02rem);
+  line-height: 1.45;
 }
 
 .method-note {
@@ -2123,7 +2139,9 @@ td a {
 
 .method-note summary::after {
   content: "+";
-  font-size: 1rem;
+  font-size: 3rem;
+  line-height: 1;
+  font-weight: 300;
 }
 
 .method-note[open] summary::after {
@@ -2205,7 +2223,7 @@ td a {
   right: 0;
   color: var(--blue-deep);
   font-family: var(--utility);
-  font-size: 1rem;
+  font-size: 3rem;
   line-height: 1;
   transition: transform 140ms ease;
 }
@@ -2274,7 +2292,7 @@ td a {
   content: "›";
   color: var(--blue-deep);
   font-family: var(--utility);
-  font-size: 0.9rem;
+  font-size: 2.7rem;
   line-height: 1;
   transition: transform 140ms ease;
 }
@@ -2333,14 +2351,14 @@ td a {
    benchmark: the name is the scanning target, the count is the measure, and
    the rank is a small fixed-width marker rather than a competing number. */
 .leaderboard-top {
-  margin: 1.5rem 0 0;
+  margin: 0 0 0.9rem;
 }
 
 .leaderboard-top-heading {
   display: flex;
   align-items: center;
   gap: 0.4rem;
-  margin-bottom: 0.6rem;
+  margin-bottom: 0.35rem;
 }
 
 .leaderboard-top-heading h2 {
@@ -2351,7 +2369,7 @@ td a {
 
 .leaderboard-top-list {
   list-style: none;
-  margin: 0 0 0.75rem;
+  margin: 0;
   padding: 0;
   border: 1px solid var(--line);
   background: var(--panel);
@@ -2359,10 +2377,10 @@ td a {
 
 .leaderboard-top-row {
   display: grid;
-  grid-template-columns: 2.2rem minmax(0, 1fr) auto;
+  grid-template-columns: 2rem minmax(0, 1fr) auto;
   gap: 0.75rem;
   align-items: baseline;
-  padding: 0.5rem 0.85rem;
+  padding: 0.22rem 0.85rem;
   border-bottom: 1px solid var(--line);
 }
 
@@ -2378,7 +2396,7 @@ td a {
 
 .leaderboard-top-name {
   font-family: var(--display);
-  font-size: 1.05rem;
+  font-size: 0.98rem;
   color: var(--ink);
   overflow-wrap: anywhere;
 }
@@ -2448,7 +2466,7 @@ td a {
 }
 
 .frontier-panel {
-  padding: clamp(1.25rem, 3vw, 2rem);
+  padding: clamp(1rem, 2vw, 1.35rem) clamp(1.25rem, 3vw, 2rem) clamp(1.25rem, 3vw, 2rem);
   border: 1px solid var(--ink);
   background: #0d1519;
   color: #f3f6f7;
@@ -4164,7 +4182,9 @@ footer {
 .findings-summary::after,
 .adoption-table-summary::after {
   content: "+";
-  font-size: 1rem;
+  font-size: 3rem;
+  line-height: 1;
+  font-weight: 300;
 }
 
 .findings-panel[open] .findings-summary::after,
@@ -4298,14 +4318,14 @@ footer {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 18px;
-  height: 18px;
+  width: 32px;
+  height: 32px;
   border: 1px solid #6ea8dc;
   border-radius: 50%;
   color: #6ea8dc;
   cursor: pointer;
   font-family: var(--utility);
-  font-size: 0.68rem;
+  font-size: 1.2rem;
   font-style: italic;
   line-height: 1;
   list-style: none;

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -2383,8 +2383,19 @@ td a {
 .frontier-title-row {
   display: flex;
   align-items: baseline;
-  gap: 0.4rem;
+  gap: 0.6rem;
   flex-wrap: wrap;
+}
+
+/* The explainer toggle rides on the title line, so its own vertical margin
+   would push the title off its baseline. Its expanded body takes the full row
+   instead of becoming a flex sibling of the heading. */
+.frontier-title-row .frontier-explainer-sub {
+  margin: 0;
+}
+
+.frontier-title-row .frontier-explainer-sub[open] {
+  flex-basis: 100%;
 }
 
 .frontier-subline {

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -2329,6 +2329,83 @@ td a {
   border-top: 1px dashed var(--line);
 }
 
+/* The ranking leads the page it is named after (issue #256). One line per
+   benchmark: the name is the scanning target, the count is the measure, and
+   the rank is a small fixed-width marker rather than a competing number. */
+.leaderboard-top {
+  margin: 1.5rem 0 0;
+}
+
+.leaderboard-top-heading {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-bottom: 0.6rem;
+}
+
+.leaderboard-top-heading h2 {
+  font-family: var(--display);
+  font-size: 1.35rem;
+  margin: 0;
+}
+
+.leaderboard-top-list {
+  list-style: none;
+  margin: 0 0 0.75rem;
+  padding: 0;
+  border: 1px solid var(--line);
+  background: var(--panel);
+}
+
+.leaderboard-top-row {
+  display: grid;
+  grid-template-columns: 2.2rem minmax(0, 1fr) auto;
+  gap: 0.75rem;
+  align-items: baseline;
+  padding: 0.5rem 0.85rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.leaderboard-top-row:last-child {
+  border-bottom: none;
+}
+
+.leaderboard-top-rank {
+  font-variant-numeric: tabular-nums;
+  font-size: 0.82rem;
+  color: var(--muted);
+}
+
+.leaderboard-top-name {
+  font-family: var(--display);
+  font-size: 1.05rem;
+  color: var(--ink);
+  overflow-wrap: anywhere;
+}
+
+.leaderboard-top-count {
+  font-variant-numeric: tabular-nums;
+  font-size: 0.82rem;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+/* The title and its (i) sit on one line, with the source and score count on a
+   single subline underneath (issue #298). Replaces an eyebrow, a badge and a
+   second heading that between them said the same two facts three times. */
+.frontier-title-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.frontier-subline {
+  margin: 0.15rem 0 0;
+  font-size: 0.82rem;
+  color: var(--muted);
+}
+
 .benchmark-workbench {
   display: grid;
   grid-template-columns: minmax(230px, 280px) minmax(0, 1fr);
@@ -2337,6 +2414,10 @@ td a {
   margin: 1.75rem 0 2.5rem;
 }
 
+/* --canvas rather than --panel: against the main area the brighter surface
+   read as an overlay sitting on top of the page rather than part of it
+   (issue #298). The search field keeps its white fill and heavy border, so
+   the control the panel exists for still carries the contrast. */
 .benchmark-navigator {
   position: sticky;
   top: 1rem;
@@ -2344,7 +2425,7 @@ td a {
   overflow-y: auto;
   padding: 1.25rem;
   border: 1px solid var(--ink);
-  background: var(--panel);
+  background: var(--canvas);
   box-shadow: var(--shadow);
 }
 

--- a/site/index.html
+++ b/site/index.html
@@ -402,7 +402,7 @@
                     <p class="section-note" data-i18n="frontier.explainer.sub">
                       Every value that could be read verbatim from a cited document, placed at the date
                       that document was published rather than at any evaluation date, and connected only
-                      where the test variant and run conditions are identical. A flat tail usually means no newer
+                      where the test variant and run conditions are identical. The stepped line is the best reached so far within one identical run, not a path between readings. A flat tail usually means no newer
                       number could be read, which is why the gap is marked rather than drawn through.
                       Whether a curve has saturated stays a reading you make, not a score this panel
                       prints.

--- a/site/index.html
+++ b/site/index.html
@@ -375,6 +375,63 @@
           <p class="section-note findings-limits" id="findings-limits"></p>
         </details>
 
+        <!-- The ranking leads the page it is named after (issue #256). Five
+             lines, one measure: how many curated model cards report each
+             benchmark. Everything that explains how the number was computed
+             stays below, and the full 80-row table with its filters is the
+             expandable underneath. -->
+        <section class="leaderboard-top" aria-labelledby="leaderboard-top-heading">
+          <div class="leaderboard-top-heading">
+            <h2 id="leaderboard-top-heading" data-i18n="Most reported in model cards">Most reported in model cards</h2>
+            <span id="leaderboard-top-info"></span>
+          </div>
+          <ol class="leaderboard-top-list" id="leaderboard-top-list"></ol>
+          <details class="trend-panel adoption-table" id="adoption-table">
+            <summary class="section-title adoption-table-summary">
+              <span>
+                <strong id="leaderboard-table-heading">Benchmarks by model card adoption</strong>
+              </span>
+              <span id="leaderboard-count" aria-live="polite"></span>
+            </summary>
+            <form class="filter-panel leaderboard-filters" id="leaderboard-filters">
+              <label class="search-field">
+                Search
+                <input
+                  id="leaderboard-search"
+                  name="lq"
+                  type="search"
+                  placeholder="Benchmark name or alias"
+                >
+              </label>
+              <label>
+                Domain
+                <select id="leaderboard-domain" name="ldomain"></select>
+              </label>
+              <label>
+                Organization
+                <select id="leaderboard-organization" name="lorg"></select>
+              </label>
+              <label>
+                Benchmark released
+                <select id="leaderboard-era" name="lera"></select>
+              </label>
+              <button class="clear-button" id="leaderboard-clear" type="button">
+                Clear filters
+              </button>
+            </form>
+            <p class="section-note" data-i18n="leaderboard.filters.note">
+              Each model card counts once per benchmark. A card reporting AIME in four
+              configurations counts the same as a card reporting it once, so a long appendix
+              cannot outweigh a different vendor. Organizations breaks the tie: the same count
+              from six vendors is a shared standard, from one vendor a house style.
+            </p>
+            <div class="leaderboard-list" id="leaderboard-list"></div>
+            <div class="leaderboard-list-actions">
+              <button class="secondary-link" id="leaderboard-show-all" type="button"></button>
+            </div>
+          </details>
+        </section>
+
         <div class="benchmark-workbench">
           <!-- A tool region, not a content section. The examples used to be a
                titled block with two subheadings and eight cards, which outranked
@@ -399,7 +456,7 @@
                    reading this registry is built to make, and a crawled score
                    count answers a different question entirely. -->
               <div class="benchmark-example-heading">
-                <p class="benchmark-example-lead" data-i18n="Most reported in model cards">Most reported in model cards</p>
+                <p class="benchmark-example-lead" data-i18n="Jump to a benchmark">Jump to a benchmark</p>
                 <span id="benchmark-example-info"></span>
               </div>
               <div id="benchmark-shortlist" class="benchmark-shortlist"></div>
@@ -410,7 +467,15 @@
             <div class="frontier-heading-row">
               <div>
                 <p class="eyebrow" id="frontier-eyebrow" data-i18n="Scores over time">Scores over time</p>
-                <h2 id="frontier-heading" data-i18n="Benchmark reported scores over time">Benchmark reported scores over time</h2>
+                <!-- The title owns its own (i): the provenance note used to sit on a
+                     second heading inside the scores block, which repeated the source
+                     name already shown in the badge and pushed the chart down the
+                     page (issue #298). -->
+                <div class="frontier-title-row">
+                  <h2 id="frontier-heading" data-i18n="Benchmark reported scores over time">Benchmark reported scores over time</h2>
+                  <span id="frontier-heading-info"></span>
+                </div>
+                <p class="frontier-subline" id="frontier-subline" hidden></p>
               </div>
               <div class="frontier-controls">
                 <span class="frontier-stage" id="frontier-stage"></span>
@@ -461,51 +526,6 @@
             </div>
           </section>
         </div>
-
-        <details class="trend-panel adoption-table" id="adoption-table">
-          <summary class="section-title adoption-table-summary">
-            <span>
-              <strong id="leaderboard-table-heading">Benchmarks by model card adoption</strong>
-            </span>
-            <span id="leaderboard-count" aria-live="polite"></span>
-          </summary>
-          <form class="filter-panel leaderboard-filters" id="leaderboard-filters">
-            <label class="search-field">
-              Search
-              <input
-                id="leaderboard-search"
-                name="lq"
-                type="search"
-                placeholder="Benchmark name or alias"
-              >
-            </label>
-            <label>
-              Domain
-              <select id="leaderboard-domain" name="ldomain"></select>
-            </label>
-            <label>
-              Organization
-              <select id="leaderboard-organization" name="lorg"></select>
-            </label>
-            <label>
-              Benchmark released
-              <select id="leaderboard-era" name="lera"></select>
-            </label>
-            <button class="clear-button" id="leaderboard-clear" type="button">
-              Clear filters
-            </button>
-          </form>
-          <p class="section-note" data-i18n="leaderboard.filters.note">
-            Each model card counts once per benchmark. A card reporting AIME in four
-            configurations counts the same as a card reporting it once, so a long appendix
-            cannot outweigh a different vendor. Organizations breaks the tie: the same count
-            from six vendors is a shared standard, from one vendor a house style.
-          </p>
-          <div class="leaderboard-list" id="leaderboard-list"></div>
-          <div class="leaderboard-list-actions">
-            <button class="secondary-link" id="leaderboard-show-all" type="button"></button>
-          </div>
-        </details>
 
         <details class="ledger" aria-labelledby="leaderboard-cards-heading">
           <summary class="ledger-summary">

--- a/site/index.html
+++ b/site/index.html
@@ -338,26 +338,21 @@
         aria-labelledby="leaderboard-heading"
         hidden
       >
+        <!-- The eyebrow, the deck and the "How to read this evidence" note all
+             said something about one ranking, and between them filled the space
+             where the figure should have been. They are one (i) beside the
+             ranking heading now (issue #298 follow-up). The h1 stays: it is the
+             view's accessible name via aria-labelledby, and it is the one line
+             that says what the page is. -->
         <header class="leaderboard-intro">
           <div class="leaderboard-title-block">
-            <p class="eyebrow" data-i18n="Model Card Adoption Rank">Model Card Adoption Rank</p>
             <h1 id="leaderboard-heading" data-i18n="Which benchmarks do model cards report?">Which benchmarks do model cards report?</h1>
-            <p class="leaderboard-deck" id="leaderboard-measures"></p>
+            <!-- Still written, still published data, but read rather than
+                 displayed: the visible copy lives in the (i) beside the
+                 ranking. A screen reader announces it with the heading, where
+                 sighted readers get it from the toggle. -->
+            <p class="leaderboard-deck visually-hidden" id="leaderboard-measures"></p>
           </div>
-          <details class="method-note">
-            <summary data-i18n="How to read this evidence">How to read this evidence</summary>
-            <p data-i18n="leaderboard.method.note1">
-              This ranks reporting convention, not benchmark quality. One model card
-              contributes at most one mention to a benchmark, however many configurations
-              it reports.
-            </p>
-            <p data-i18n="leaderboard.method.note2">
-              Some model cards publish their benchmark table as an image, and those rows
-              were transcribed by OCR. A transcription can be wrong. The
-              <a href="#leaderboard-cards-heading">source ledger</a> lists every recorded
-              benchmark with the original document so each count can be checked.
-            </p>
-          </details>
         </header>
 
         <section class="leaderboard-top" aria-labelledby="leaderboard-top-heading">
@@ -366,6 +361,7 @@
             <span id="leaderboard-top-info"></span>
           </div>
           <ol class="leaderboard-top-list" id="leaderboard-top-list"></ol>
+          <button class="secondary-link leaderboard-top-more" id="leaderboard-top-more" type="button"></button>
         </section>
 
         <div class="benchmark-workbench">

--- a/site/index.html
+++ b/site/index.html
@@ -338,27 +338,18 @@
         aria-labelledby="leaderboard-heading"
         hidden
       >
-        <!-- The eyebrow, the deck and the "How to read this evidence" note all
-             said something about one ranking, and between them filled the space
-             where the figure should have been. They are one (i) beside the
-             ranking heading now (issue #298 follow-up). The h1 stays: it is the
-             view's accessible name via aria-labelledby, and it is the one line
-             that says what the page is. -->
-        <header class="leaderboard-intro">
-          <div class="leaderboard-title-block">
-            <h1 id="leaderboard-heading" data-i18n="Which benchmarks do model cards report?">Which benchmarks do model cards report?</h1>
-            <!-- Still written, still published data, but read rather than
-                 displayed: the visible copy lives in the (i) beside the
-                 ranking. A screen reader announces it with the heading, where
-                 sighted readers get it from the toggle. -->
-            <p class="leaderboard-deck visually-hidden" id="leaderboard-measures"></p>
-          </div>
-        </header>
-
-        <section class="leaderboard-top" aria-labelledby="leaderboard-top-heading">
+        <!-- One title, not three. "Which benchmarks do model cards report?",
+             "How many curated model cards report each benchmark..." and "Most
+             reported in model cards" were the same sentence written three ways,
+             stacked above the figure. This heading is the view's accessible
+             name, and the (i) beside it carries the caveat. -->
+        <section class="leaderboard-top" aria-labelledby="leaderboard-heading">
           <div class="leaderboard-top-heading">
-            <h2 id="leaderboard-top-heading" data-i18n="Most reported in model cards">Most reported in model cards</h2>
+            <h1 id="leaderboard-heading" data-i18n="Most reported in model cards">Most reported in model cards</h1>
             <span id="leaderboard-top-info"></span>
+            <!-- Written but not shown: the visible copy is in the (i). A screen
+                 reader announces it with the heading. -->
+            <p class="leaderboard-deck visually-hidden" id="leaderboard-measures"></p>
           </div>
           <ol class="leaderboard-top-list" id="leaderboard-top-list"></ol>
           <button class="secondary-link leaderboard-top-more" id="leaderboard-top-more" type="button"></button>

--- a/site/index.html
+++ b/site/index.html
@@ -420,8 +420,10 @@
               </p>
             </details>
             <div class="frontier-external" id="frontier-external" hidden></div>
-            <div class="frontier-legend" id="frontier-legend" aria-label="Chart legend"></div>
             <div class="frontier-chart" id="frontier-chart"></div>
+            <!-- Legend below the figure it explains: above it, it pushed the
+                 chart down to explain marks the reader had not seen yet. -->
+            <div class="frontier-legend" id="frontier-legend" aria-label="Chart legend"></div>
             <div class="frontier-org-key" id="frontier-org-key" aria-label="Reporting organization color key"></div>
             <div class="score-readout" id="frontier-score-readout"></div>
             <div class="frontier-evidence" id="frontier-evidence">

--- a/site/index.html
+++ b/site/index.html
@@ -360,76 +360,12 @@
           </details>
         </header>
 
-        <div class="evidence-strip" id="leaderboard-insights" aria-label="Registry overview" data-i18n-aria="Registry overview"></div>
-
-        <details class="findings-panel" id="benchmark-findings" aria-labelledby="findings-heading" hidden>
-          <summary class="section-title findings-summary">
-            <span>
-              <span class="eyebrow" data-i18n="What the two layers say">What the two layers say</span>
-              <strong id="findings-heading" data-i18n="Stated findings">Stated findings</strong>
-            </span>
-            <span id="findings-count" aria-live="polite"></span>
-          </summary>
-          <p class="section-note" id="findings-measures"></p>
-          <div class="findings-list" id="findings-list"></div>
-          <p class="section-note findings-limits" id="findings-limits"></p>
-        </details>
-
-        <!-- The ranking leads the page it is named after (issue #256). Five
-             lines, one measure: how many curated model cards report each
-             benchmark. Everything that explains how the number was computed
-             stays below, and the full 80-row table with its filters is the
-             expandable underneath. -->
         <section class="leaderboard-top" aria-labelledby="leaderboard-top-heading">
           <div class="leaderboard-top-heading">
             <h2 id="leaderboard-top-heading" data-i18n="Most reported in model cards">Most reported in model cards</h2>
             <span id="leaderboard-top-info"></span>
           </div>
           <ol class="leaderboard-top-list" id="leaderboard-top-list"></ol>
-          <details class="trend-panel adoption-table" id="adoption-table">
-            <summary class="section-title adoption-table-summary">
-              <span>
-                <strong id="leaderboard-table-heading">Benchmarks by model card adoption</strong>
-              </span>
-              <span id="leaderboard-count" aria-live="polite"></span>
-            </summary>
-            <form class="filter-panel leaderboard-filters" id="leaderboard-filters">
-              <label class="search-field">
-                Search
-                <input
-                  id="leaderboard-search"
-                  name="lq"
-                  type="search"
-                  placeholder="Benchmark name or alias"
-                >
-              </label>
-              <label>
-                Domain
-                <select id="leaderboard-domain" name="ldomain"></select>
-              </label>
-              <label>
-                Organization
-                <select id="leaderboard-organization" name="lorg"></select>
-              </label>
-              <label>
-                Benchmark released
-                <select id="leaderboard-era" name="lera"></select>
-              </label>
-              <button class="clear-button" id="leaderboard-clear" type="button">
-                Clear filters
-              </button>
-            </form>
-            <p class="section-note" data-i18n="leaderboard.filters.note">
-              Each model card counts once per benchmark. A card reporting AIME in four
-              configurations counts the same as a card reporting it once, so a long appendix
-              cannot outweigh a different vendor. Organizations breaks the tie: the same count
-              from six vendors is a shared standard, from one vendor a house style.
-            </p>
-            <div class="leaderboard-list" id="leaderboard-list"></div>
-            <div class="leaderboard-list-actions">
-              <button class="secondary-link" id="leaderboard-show-all" type="button"></button>
-            </div>
-          </details>
         </section>
 
         <div class="benchmark-workbench">
@@ -526,6 +462,71 @@
             </div>
           </section>
         </div>
+
+        <div class="evidence-strip" id="leaderboard-insights" aria-label="Registry overview" data-i18n-aria="Registry overview"></div>
+
+        <details class="findings-panel" id="benchmark-findings" aria-labelledby="findings-heading" hidden>
+          <summary class="section-title findings-summary">
+            <span>
+              <span class="eyebrow" data-i18n="What the two layers say">What the two layers say</span>
+              <strong id="findings-heading" data-i18n="Stated findings">Stated findings</strong>
+            </span>
+            <span id="findings-count" aria-live="polite"></span>
+          </summary>
+          <p class="section-note" id="findings-measures"></p>
+          <div class="findings-list" id="findings-list"></div>
+          <p class="section-note findings-limits" id="findings-limits"></p>
+        </details>
+
+        <!-- The ranking leads the page it is named after (issue #256). Five
+             lines, one measure: how many curated model cards report each
+             benchmark. Everything that explains how the number was computed
+             stays below, and the full 80-row table with its filters is the
+             expandable underneath. -->
+        <details class="trend-panel adoption-table" id="adoption-table">
+          <summary class="section-title adoption-table-summary">
+            <span>
+              <strong id="leaderboard-table-heading">Benchmarks by model card adoption</strong>
+            </span>
+            <span id="leaderboard-count" aria-live="polite"></span>
+          </summary>
+          <form class="filter-panel leaderboard-filters" id="leaderboard-filters">
+            <label class="search-field">
+              Search
+              <input
+                id="leaderboard-search"
+                name="lq"
+                type="search"
+                placeholder="Benchmark name or alias"
+              >
+            </label>
+            <label>
+              Domain
+              <select id="leaderboard-domain" name="ldomain"></select>
+            </label>
+            <label>
+              Organization
+              <select id="leaderboard-organization" name="lorg"></select>
+            </label>
+            <label>
+              Benchmark released
+              <select id="leaderboard-era" name="lera"></select>
+            </label>
+            <button class="clear-button" id="leaderboard-clear" type="button">
+              Clear filters
+            </button>
+          </form>
+          <p class="section-note" data-i18n="leaderboard.filters.note">
+            Each model card counts once per benchmark. A card reporting AIME in four
+            configurations counts the same as a card reporting it once, so a long appendix
+            cannot outweigh a different vendor. Organizations breaks the tie: the same count
+            from six vendors is a shared standard, from one vendor a house style.
+          </p>
+          <div class="leaderboard-list" id="leaderboard-list"></div>
+          <div class="leaderboard-list-actions">
+            <button class="secondary-link" id="leaderboard-show-all" type="button"></button>
+          </div>
+        </details>
 
         <details class="ledger" aria-labelledby="leaderboard-cards-heading">
           <summary class="ledger-summary">

--- a/site/index.html
+++ b/site/index.html
@@ -397,6 +397,17 @@
                 <div class="frontier-title-row">
                   <h2 id="frontier-heading" data-i18n="Benchmark reported scores over time">Benchmark reported scores over time</h2>
                   <span id="frontier-heading-info"></span>
+                  <details class="frontier-explainer-sub" id="frontier-explainer-sub">
+                    <summary data-i18n="How to read this chart">How to read this chart</summary>
+                    <p class="section-note" data-i18n="frontier.explainer.sub">
+                      Every value that could be read verbatim from a cited document, placed at the date
+                      that document was published rather than at any evaluation date, and connected only
+                      where the test variant and run conditions are identical. A flat tail usually means no newer
+                      number could be read, which is why the gap is marked rather than drawn through.
+                      Whether a curve has saturated stays a reading you make, not a score this panel
+                      prints.
+                    </p>
+                  </details>
                 </div>
                 <p class="frontier-subline" id="frontier-subline" hidden></p>
               </div>
@@ -408,17 +419,6 @@
                 </label>
               </div>
             </div>
-            <details class="frontier-explainer-sub" id="frontier-explainer-sub">
-              <summary data-i18n="How to read this chart">How to read this chart</summary>
-              <p class="section-note" data-i18n="frontier.explainer.sub">
-                Every value that could be read verbatim from a cited document, placed at the date
-                that document was published rather than at any evaluation date, and connected only
-                where the test variant and run conditions are identical. A flat tail usually means no newer
-                number could be read, which is why the gap is marked rather than drawn through.
-                Whether a curve has saturated stays a reading you make, not a score this panel
-                prints.
-              </p>
-            </details>
             <div class="frontier-external" id="frontier-external" hidden></div>
             <div class="frontier-chart" id="frontier-chart"></div>
             <!-- Legend below the figure it explains: above it, it pushed the

--- a/src/benchmark_radar/model_cards.py
+++ b/src/benchmark_radar/model_cards.py
@@ -455,11 +455,16 @@ def adoption_rank(registry: dict[str, Any]) -> dict[str, Any]:
         # Stated in the data rather than only in the UI, so any consumer of
         # radar.json inherits the caveat instead of re-deriving the ranking's
         # meaning from its column headers.
+        # Plain words on purpose (issue #241): "vendor attention", "saturated"
+        # and "contaminated" all named the right ideas in vocabulary a reader
+        # has to already have. The claim is unchanged -- a benchmark near the
+        # top is one everybody reports, which is not the same as a good one.
         "measures": (
-            "How many curated model cards report each benchmark. This measures "
-            "vendor attention, not benchmark quality: a saturated or contaminated "
-            "benchmark can rank highly precisely because it is conventional to "
-            "report it."
+            "When an AI lab releases a model, it publishes a report listing the "
+            "tests it ran. This counts how many of those reports mention each "
+            "test. A test near the top is one almost everyone runs, which is not "
+            "the same as a good one: labs keep running a popular test out of "
+            "habit, even after the scores stop telling anyone much."
         ),
     }
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -110,7 +110,15 @@ def test_every_export_carries_the_measures_caveat(tmp_path):
     written = write_exports(tmp_path / "out", registry_path=registry_path)
     exported = json.loads(written["json"].read_text(encoding="utf-8"))
     assert exported["measures"] == leaderboard["measures"]
-    assert "not benchmark quality" in exported["measures"]
+    # Asserted as the claim rather than the phrasing. Issue #241 rewrote this
+    # for a 16-year-old reader ("vendor attention", "saturated" and
+    # "contaminated" were vocabulary a reader had to already have), and a test
+    # that pins the old words would force the jargon back.
+    #
+    # The load-bearing part is that popularity is not quality, and that the
+    # statement travels with the data rather than living only in the UI.
+    assert "not the same as a good one" in exported["measures"]
+    assert "how many" in exported["measures"].lower()
 
     assert leaderboard["measures"] in leaderboard_markdown(leaderboard)
 

--- a/tests/test_leaderboard_workbench.py
+++ b/tests/test_leaderboard_workbench.py
@@ -725,7 +725,6 @@ def test_issue_256_the_ranking_leads_the_page_it_names():
     # laptop, entirely below the fold, behind ~1180px of KPI cards, a findings
     # accordion and the full 80-row table. It now begins at y=824.
     order = [
-        'class="leaderboard-intro"',
         'class="leaderboard-top"',
         'class="benchmark-workbench"',
         'id="leaderboard-insights"',

--- a/tests/test_leaderboard_workbench.py
+++ b/tests/test_leaderboard_workbench.py
@@ -5,18 +5,28 @@ def source(path: str) -> str:
     return Path(path).read_text(encoding="utf-8")
 
 
-def test_frontier_opens_on_a_new_signal_with_three_readable_scores():
-    # The panel is the score track, so the benchmark it opens on is chosen by the
-    # same reading: the newest instrument that already carries three or more
-    # dated values. A one-point plot is technically recent but says nothing.
+def test_the_frontier_opens_on_the_benchmark_the_page_ranks_first():
+    """The figure answers the question the ranking above it just raised.
+
+    It used to open on the NEWEST scored instrument, which put AutomationBench
+    under a page headed "most reported in model cards" -- a benchmark the
+    reader had not seen named anywhere above the figure. The ranking and the
+    default now agree by construction: `scored` is already in adoption_rank
+    order, so the first drawable entry is rank 1.
+    """
     script = source("site/assets/app.js")
 
     default_entry = script.split("function frontierDefaultEntry(board)", 1)[1].split(
         "\nconst BENCHMARK_TASK_SHAPES", 1
     )[0]
-    assert "isNewBenchmark(entry, board)" in default_entry
-    assert "datedCount(entry) >= 3" in default_entry
-    assert "sharedSignals.length ? sharedSignals : scored" in default_entry
+    # Read in rank order, never re-sorted -- a second sort here could drift
+    # from the ranking the page prints five lines of.
+    assert "(drawable.length ? drawable : scored)[0]" in default_entry
+    assert ".sort(" not in default_entry
+    assert "isNewBenchmark" not in default_entry
+    # A one-point plot says nothing visually, so a higher-ranked benchmark with
+    # a single dated reading is still passed over.
+    assert "datedCount(entry) >= 2" in default_entry
     # And every candidate has a score record, so the default can never be a
     # benchmark the panel cannot draw.
     assert "entry.card_count > 0 && scoreRecord(entry.benchmark_id)" in default_entry
@@ -914,3 +924,45 @@ def test_issue_288_the_charts_draw_a_running_best_not_an_invented_cost_axis():
         "\nfunction clearAdoptionFrontier", 1
     )[0]
     assert "polyline" not in chart
+
+
+def test_the_ranking_expands_and_the_intro_condensed_into_one_toggle():
+    """Four elements said something about one ranking, above the figure.
+
+    An eyebrow ("Model Card Adoption Rank"), the h1, the deck, and a "How to
+    read this evidence" note filled the space where the figure should have
+    been. They are one (i) beside the ranking heading now. The h1 stays: it is
+    the view's accessible name via aria-labelledby.
+    """
+    html = source("site/index.html")
+    script = source("site/assets/app.js")
+
+    for gone in (
+        'data-i18n="Model Card Adoption Rank"',
+        'class="method-note"',
+        'data-i18n="How to read this evidence"',
+    ):
+        assert gone not in html, f"{gone} still sits above the figure"
+    assert 'id="leaderboard-heading"' in html
+    assert 'aria-labelledby="leaderboard-heading"' in html
+
+    # The deck is still written and still published data -- read rather than
+    # displayed, so a screen reader gets it with the heading.
+    assert 'id="leaderboard-measures"' in html
+    assert "visually-hidden" in html.split('id="leaderboard-measures"', 1)[0][-200:]
+    renderer = script.split("function renderLeaderboardTop(board)", 1)[1].split(
+        "\nfunction ", 1
+    )[0]
+    assert "board.measures" in renderer
+    # The caveat travels with the payload that produced the order rather than
+    # being restated in the browser, where it could drift from it.
+    assert "vendor attention, not benchmark quality" not in script
+
+    # Five lines by default, all 79 on request, and back again.
+    assert 'id="leaderboard-top-more"' in html
+    assert "state.leaderboardTopExpanded ? ranked : ranked.slice(0, LEADERBOARD_TOP_LIMIT)" in renderer
+    assert "more.hidden = ranked.length <= LEADERBOARD_TOP_LIMIT;" in renderer
+    toggle = script.split('byId("leaderboard-top-more").addEventListener("click"', 1)[1].split(
+        "});", 1
+    )[0]
+    assert "state.leaderboardTopExpanded = !state.leaderboardTopExpanded;" in toggle

--- a/tests/test_leaderboard_workbench.py
+++ b/tests/test_leaderboard_workbench.py
@@ -380,10 +380,20 @@ def test_every_crawled_score_is_a_plotted_point():
     # The x-axis is a date now (issue #279), so a row with no parseable release
     # date has no honest position either. That drops nothing today -- all 5,544
     # numeric crawled rows carry a reported_date -- but if it ever does, the
-    # count is stated under the chart rather than left to be inferred from a
-    # total that does not add up.
-    assert "undatedCount" in chart
-    assert "with no release date are in the table below only" in chart
+    # count is declared rather than left to be inferred from a total that does
+    # not add up.
+    #
+    # Issue #298 moved that declaration off the axis label, which now names the
+    # date and stops, and into the source's (i) provenance note. The rows are
+    # still counted and still stated; only where they are said changed.
+    assert "undatedCount" not in chart, "the axis label no longer carries the count"
+    table = script.split("function externalSourceTable(source, payload)", 1)[1].split(
+        "\nfunction ", 1
+    )[0]
+    assert "const undated = (payload.rows || []).filter(" in table
+    assert "!Number.isFinite(dateValue(row.reported_date))" in table
+    assert "carry no position on this axis and are not drawn" in table
+    assert "notes.push(" in table
 
 
 def test_the_crawled_chart_axis_is_release_date_and_says_so():

--- a/tests/test_leaderboard_workbench.py
+++ b/tests/test_leaderboard_workbench.py
@@ -365,10 +365,18 @@ def test_every_crawled_score_is_a_plotted_point():
     # is dropped, and it is dropped by testing the value rather than by a cap.
     assert 'typeof row.value === "number" && Number.isFinite(row.value)' in chart
     # No cap. The bare .slice() copies before sorting so the source array is
-    # not mutated; the only .slice(0, N) is ISO-date truncation, not a row
-    # limit. A truncating slice over the rows would silently hide scores.
+    # not mutated; every .slice(0, N) is ISO-date truncation, not a row limit.
+    # A truncating slice over the rows would silently hide scores.
+    #
+    # Counting instances is not the guarantee -- issue #298 added a second
+    # date truncation for the quarterly axis ticks, which drops nothing. The
+    # guarantee is that each one slices a date string to 10 chars, so any
+    # slice with a different length, or one applied to the rows, fails here.
     assert ".slice()" in chart
-    assert ".slice(0, 10)" in chart and chart.count(".slice(0,") == 1
+    assert chart.count(".slice(0,") == chart.count(".slice(0, 10)")
+    assert ".slice(0, 10)" in chart
+    for cap in ("plotted.slice(0,", "numeric.slice(0,", "dated.slice(0,", "rows.slice(0,"):
+        assert cap not in chart, f"{cap} would silently hide scores"
     # The x-axis is a date now (issue #279), so a row with no parseable release
     # date has no honest position either. That drops nothing today -- all 5,544
     # numeric crawled rows carry a reported_date -- but if it ever does, the
@@ -408,9 +416,19 @@ def test_the_crawled_chart_axis_is_release_date_and_says_so():
     # The visible axis label, the aria-label and the pinned card all name the
     # date as a release date. Losing any one of them is how a chart starts
     # implying it plots measurements.
-    assert "model release date, not when the score was measured" in chart
-    assert "is not when the score was measured" in chart
+    #
+    # Issue #298 shortened the VISIBLE label to "model release date": the
+    # qualifying clause was reported as noise on the axis itself. The claim it
+    # carried is not weakened, it is relocated -- the aria-label and the source
+    # provenance note both still spell out that this is not a measurement time,
+    # and those assertions are below. What must never happen is the axis
+    # calling this a plain "date".
+    assert "model release date" in chart
     assert '"Date (model release)"' in script
+    # The full statement survives where a reader who asks for it will find it:
+    # the chart's own aria-label, and the (i) provenance note for the source.
+    assert "is not when the score was measured" in chart
+    assert "not when the score was measured" in script
 
     # `plotted` is in date order, so the last element is the newest model, not
     # the best score. Reading the best off the end of the array is the specific
@@ -597,8 +615,15 @@ def test_the_crawled_chart_ticks_label_real_values_not_padded_bounds():
         "\nfunction externalSourceTable", 1
     )[0]
 
-    assert "for (const value of [high, low])" in chart
+    # The tick set starts from the real extremes, and issue #298 added
+    # intermediate ticks between them so a point's height can be read rather
+    # than inferred. Those are generated from `low`/`high` and filtered to
+    # `> low && < high`, so the padded bound still cannot reach a label.
+    assert "const yTicks = [high, low];" in chart
+    assert "for (const value of yTicks)" in chart
+    assert "rounded > low && rounded < high" in chart
     assert "for (const value of [band.high, band.low])" not in chart
+    assert "band.low" not in chart.split("const yTicks", 1)[1].split("const bestY", 1)[0]
     # The band itself still pads; only the labels changed.
     assert "band = { low: low - pad, high: high + pad }" in chart
 
@@ -658,3 +683,162 @@ def test_a_benchmark_with_no_adopters_answers_for_itself():
     # no option and the browser shows the first one instead: a <select> reading
     # AA-LCR beside a panel headed RSI-Bench is lying about the state.
     assert "prependOption" in body
+
+
+def test_issue_256_the_ranking_leads_the_page_it_names():
+    """The tab is called Leaderboard and the ranking was the sixth block on it.
+
+    A reader opening it passed a method note, an evidence strip, a findings
+    panel, a search box and a 480px chart before reaching the thing the tab is
+    named after, which shipped collapsed. The ranking now leads, in five lines
+    carrying one measure, and everything about how the number was computed
+    stays below it.
+    """
+    html = source("site/index.html")
+    script = source("site/assets/app.js")
+
+    # Above the workbench, which is where the search box and the chart live.
+    assert html.index('class="leaderboard-top"') < html.index('class="benchmark-workbench"')
+    # And above the full table, which is now nested inside it as the expandable.
+    assert html.index('class="leaderboard-top"') < html.index('id="adoption-table"')
+    assert html.index('id="adoption-table"') < html.index('class="benchmark-workbench"')
+
+    renderer = script.split("function renderLeaderboardTop(board)", 1)[1].split(
+        "\nfunction ", 1
+    )[0]
+    # Five lines, and the cap is a named constant rather than a literal buried
+    # in the slice.
+    assert "LEADERBOARD_TOP_LIMIT" in renderer
+    assert "const LEADERBOARD_TOP_LIMIT = 5;" in script
+    # One measure. No domain, no organization count, no release year, no bar:
+    # those are what made the full table a wall rather than a few lines.
+    assert 'metricLabel(entry.card_count, "model card")' in renderer
+    for absent in ("entry.domain", "organization_count", "entry.released", "adoptionBar("):
+        assert absent not in renderer, f"{absent} belongs to the full table, not the summary"
+
+    # The order is read, never recomputed. adoption_rank breaks card-count ties
+    # on organization count and then name, so re-sorting here on card_count
+    # alone would print a row numbered 05 in position 04.
+    assert "entry.rank" in renderer
+    assert ".sort(" not in renderer
+
+    # A registry with nothing reported yet says so rather than drawing blanks.
+    assert "No model card in this registry reports a benchmark yet." in renderer
+
+    # The full ranking is still one click away and still collapsed by default,
+    # so #240's contract holds for the bulk material it was written about.
+    assert '<details class="trend-panel adoption-table" id="adoption-table">' in html
+    assert 'adoption-table" open' not in html
+    # Its filters travelled with it.
+    assert html.index('id="adoption-table"') < html.index('id="leaderboard-filters"')
+
+
+def test_issue_256_the_figure_region_carries_no_pipeline_coverage_count():
+    """"26 model cards · 3 scores read from a document" beside a chart.
+
+    The card count is a fact about the world: how many vendors chose to report
+    the benchmark. The second number was a fact about this pipeline -- how many
+    of those mentions we could read a value out of -- which is noise next to a
+    figure, and it is gone along with the helper that produced it.
+    """
+    script = source("site/assets/app.js")
+
+    assert "chartedScoreLabel" not in script
+    navigator = script.split("function renderBenchmarkNavigator(board)", 1)[1].split(
+        "\nfunction ", 1
+    )[0]
+    assert 'metricLabel(entry.card_count, "model card")' in navigator
+    assert "score read from a document" not in navigator
+    # The keys the helper used are still live for the search rows and the score
+    # readout, so removing the helper must not have taken them with it.
+    assert '"score read from a document": ' in script
+
+
+def test_issue_298_a_crawled_record_names_itself_once():
+    """The panel said "AIME 2025" twice and "LLM Stats" twice, and looked broken.
+
+    An eyebrow reading "External catalog record", the benchmark name as the
+    title, a non-interactive "LLM Stats" chip, and a second heading inside the
+    scores block repeating the source and the count. Four elements, two facts.
+    There is now one title and one subline, and the picker still mirrors the
+    selection because a <select> disagreeing with the panel is a lie about
+    state rather than a duplicate.
+    """
+    html = source("site/index.html")
+    script = source("site/assets/app.js")
+
+    external = script.split("function renderExternalBenchmark(board, scored, record)", 1)[1].split(
+        "\nfunction ", 1
+    )[0]
+    # No eyebrow and no badge on this path; both are passed empty and hidden.
+    assert 'eyebrow: ""' in external
+    assert 'badge: ""' in external
+    assert 'eyebrow: t("External catalog record")' not in script
+    assert "subline: externalSubline(record, meta)" in external
+
+    shell = script.split("function renderExternalShell(", 1)[1].split("\nfunction ", 1)[0]
+    # Empty means hidden, not rendered blank.
+    assert "eyebrowNode.hidden = !eyebrow;" in shell
+    assert "stage.hidden = !badge;" in shell
+
+    # Neither the block nor its per-source renderer carries a heading now.
+    scores = script.split("function externalScoresBlock(shard)", 1)[1].split("\n}\n", 1)[0]
+    assert 'element("h3", { text: t("Scores") })' not in scores
+    table = script.split("function externalSourceTable(source, payload)", 1)[1].split(
+        "\nfunction ", 1
+    )[0]
+    assert "external-source-heading" not in table
+    assert 'element("h4"' not in table
+    # But the provenance note survives, moved to the (i) beside the title.
+    assert 'byId("frontier-heading-info")' in table
+    assert "infoDisclosure(notes.join" in table
+    assert 'id="frontier-heading-info"' in html
+    # The (i) sits with the title rather than in a separate block.
+    assert html.index('id="frontier-heading"') < html.index('id="frontier-heading-info"')
+    assert html.index('id="frontier-heading-info"') < html.index('id="frontier-benchmark"')
+
+
+def test_issue_298_the_crawled_axes_can_be_read_rather_than_inferred():
+    """Two y ticks and two x ticks made the reader interpolate every position."""
+    script = source("site/assets/app.js")
+    chart = script.split("function externalScoreChart(source, payload)", 1)[1].split(
+        "\nfunction externalSourceTable", 1
+    )[0]
+
+    # Intermediate score ticks, bounded by the real observed extremes.
+    assert "for (const fraction of [0.25, 0.5, 0.75])" in chart
+    assert "rounded > low && rounded < high" in chart
+    # Quarterly date ticks, strictly inside the observed span and never
+    # colliding with the endpoint labels that carry the real first and last.
+    assert "cursor.setUTCMonth(cursor.getUTCMonth() + 3);" in chart
+    assert "cursor.getTime() < lastTime" in chart
+    assert "quarterGap" in chart
+
+    # The best-on-record annotation reads as a sentence and sits on its line.
+    assert 't("Best reported score:")' in chart
+    assert "bestValue.toFixed(2)" in chart
+    assert '"text-anchor": "start", class: "score-best-label"' in chart
+
+
+def test_issue_298_the_sidebar_row_leads_with_the_benchmark_name():
+    """Every row printed domain, year, a source chip and a score count.
+
+    Four grey fields per row, repeated down the list, so finding a name meant
+    reading past them. The count stays because it is the measure this registry
+    is built on. What the search MATCHES is unchanged -- domain, publisher and
+    modality are still queried, they are simply not printed.
+    """
+    script = source("site/assets/app.js")
+    row = script.split("function curatedResultRow(entry, { navigate = false, inert = false } = {})", 1)[1].split(
+        "\nfunction ", 1
+    )[0]
+
+    assert 'metricLabel(entry.card_count, "model", "models")' in row
+    for absent in ("benchmark-result-meta", "Curated registry", "benchmark-result-scores"):
+        assert absent not in row, f"{absent} is the grey wall this removed"
+    assert "entry.domain" not in row
+    assert "entry.released" not in row
+
+    # Matching is untouched: the fields left the display, not the query.
+    matcher = script.split("function searchCuratedEntries(", 1)[1].split("\nfunction ", 1)[0]
+    assert "domain" in matcher

--- a/tests/test_leaderboard_workbench.py
+++ b/tests/test_leaderboard_workbench.py
@@ -852,3 +852,49 @@ def test_issue_298_the_sidebar_row_leads_with_the_benchmark_name():
     # Matching is untouched: the fields left the display, not the query.
     matcher = script.split("function searchCuratedEntries(", 1)[1].split("\nfunction ", 1)[0]
     assert "domain" in matcher
+
+
+def test_issue_288_the_charts_draw_a_running_best_not_an_invented_cost_axis():
+    """Asked for a Pareto frontier "just like harbor-index.org".
+
+    Harbor plots cost against pass rate. This corpus records no cost and no
+    latency for any score: a curated observation carries value, model,
+    organization, reported_at, instrument and protocol; a crawled row carries
+    value, model_name and reported_date. Drawing Harbor's chart here would mean
+    inventing the x-axis.
+
+    What is drawable is the same idea on the axes these charts already have --
+    the set of points nothing else beats, which on one score axis over time is
+    the running maximum.
+    """
+    script = source("site/assets/app.js")
+    styles = source("site/assets/styles.css")
+
+    steps = script.split("function runningBestSteps(points", 1)[1].split("\n}\n", 1)[0]
+    # Better is not always larger, so the frontier follows the metric rather
+    # than the number, or it would trace the worst result on a lower-is-better
+    # benchmark.
+    assert "descends ? point.value < best : point.value > best" in steps
+    # A line through one date asserts nothing, so it is not drawn.
+    assert "if (dated.length < 2) return [];" in steps
+    assert "if (new Set(dated.map((point) => point.time)).size < 2) return [];" in steps
+
+    # Stepped, never diagonal: a slope would imply the score moved continuously
+    # between two reports, which is interpolation this corpus cannot support.
+    path = script.split("function runningBestPath(steps, x, y, endX)", 1)[1].split("\n}\n", 1)[0]
+    assert '`H ${x(step.time)}`' in path
+    assert '`V ${y(step.value)}`' in path
+    assert "L " not in path
+
+    # Both charts draw it, and the curated one passes the direction flag.
+    assert script.count("class: \"score-frontier-line\"") == 2
+    assert "{ descends: scoreDescends }" in script
+    assert ".score-frontier-line {" in styles
+
+    # And it did not reintroduce the join the evidence rules forbid: the
+    # running best says "nothing had beaten this yet", never "these points are
+    # a series".
+    chart = script.split("function scoreTrackChart(", 1)[1].split(
+        "\nfunction clearAdoptionFrontier", 1
+    )[0]
+    assert "polyline" not in chart

--- a/tests/test_leaderboard_workbench.py
+++ b/tests/test_leaderboard_workbench.py
@@ -740,12 +740,10 @@ def test_issue_256_the_ranking_leads_the_page_it_names():
     positions = [html.index(marker) for marker in order]
     assert positions == sorted(positions), (
         "leaderboard blocks are out of order: "
-        f"{[m for _, m in sorted(zip(positions, order))]}"
+        f"{[m for _, m in sorted(zip(positions, order, strict=True))]}"
     )
 
-    renderer = script.split("function renderLeaderboardTop(board)", 1)[1].split(
-        "\nfunction ", 1
-    )[0]
+    renderer = script.split("function renderLeaderboardTop(board)", 1)[1].split("\nfunction ", 1)[0]
     # Five lines, and the cap is a named constant rather than a literal buried
     # in the slice.
     assert "LEADERBOARD_TOP_LIMIT" in renderer
@@ -774,7 +772,7 @@ def test_issue_256_the_ranking_leads_the_page_it_names():
 
 
 def test_issue_256_the_figure_region_carries_no_pipeline_coverage_count():
-    """"26 model cards · 3 scores read from a document" beside a chart.
+    """ "26 model cards · 3 scores read from a document" beside a chart.
 
     The card count is a fact about the world: how many vendors chose to report
     the benchmark. The second number was a fact about this pipeline -- how many
@@ -869,9 +867,8 @@ def test_issue_298_the_sidebar_row_leads_with_the_benchmark_name():
     modality are still queried, they are simply not printed.
     """
     script = source("site/assets/app.js")
-    row = script.split("function curatedResultRow(entry, { navigate = false, inert = false } = {})", 1)[1].split(
-        "\nfunction ", 1
-    )[0]
+    signature = "function curatedResultRow(entry, { navigate = false, inert = false } = {})"
+    row = script.split(signature, 1)[1].split("\nfunction ", 1)[0]
 
     assert 'metricLabel(entry.card_count, "model", "models")' in row
     for absent in ("benchmark-result-meta", "Curated registry", "benchmark-result-scores"):
@@ -912,8 +909,8 @@ def test_issue_288_the_charts_draw_a_running_best_not_an_invented_cost_axis():
     # Stepped, never diagonal: a slope would imply the score moved continuously
     # between two reports, which is interpolation this corpus cannot support.
     path = script.split("function runningBestPath(steps, x, y, endX)", 1)[1].split("\n}\n", 1)[0]
-    assert '`H ${x(step.time)}`' in path
-    assert '`V ${y(step.value)}`' in path
+    assert "`H ${x(step.time)}`" in path
+    assert "`V ${y(step.value)}`" in path
     assert "L " not in path
 
     # A maximum is a comparability claim -- it says these numbers can be ranked
@@ -979,9 +976,7 @@ def test_the_ranking_expands_and_the_intro_condensed_into_one_toggle():
     # displayed, so a screen reader gets it with the heading.
     assert 'id="leaderboard-measures"' in html
     assert "visually-hidden" in html.split('id="leaderboard-measures"', 1)[0][-200:]
-    renderer = script.split("function renderLeaderboardTop(board)", 1)[1].split(
-        "\nfunction ", 1
-    )[0]
+    renderer = script.split("function renderLeaderboardTop(board)", 1)[1].split("\nfunction ", 1)[0]
     assert "board.measures" in renderer
     # The caveat travels with the payload that produced the order rather than
     # being restated in the browser, where it could drift from it.
@@ -989,7 +984,8 @@ def test_the_ranking_expands_and_the_intro_condensed_into_one_toggle():
 
     # Five lines by default, all 79 on request, and back again.
     assert 'id="leaderboard-top-more"' in html
-    assert "state.leaderboardTopExpanded ? ranked : ranked.slice(0, LEADERBOARD_TOP_LIMIT)" in renderer
+    sliced = "state.leaderboardTopExpanded ? ranked : ranked.slice(0, LEADERBOARD_TOP_LIMIT)"
+    assert sliced in renderer
     assert "more.hidden = ranked.length <= LEADERBOARD_TOP_LIMIT;" in renderer
     toggle = script.split('byId("leaderboard-top-more").addEventListener("click"', 1)[1].split(
         "});", 1

--- a/tests/test_leaderboard_workbench.py
+++ b/tests/test_leaderboard_workbench.py
@@ -707,11 +707,27 @@ def test_issue_256_the_ranking_leads_the_page_it_names():
     html = source("site/index.html")
     script = source("site/assets/app.js")
 
-    # Above the workbench, which is where the search box and the chart live.
-    assert html.index('class="leaderboard-top"') < html.index('class="benchmark-workbench"')
-    # And above the full table, which is now nested inside it as the expandable.
-    assert html.index('class="leaderboard-top"') < html.index('id="adoption-table"')
-    assert html.index('id="adoption-table"') < html.index('class="benchmark-workbench"')
+    # The order the page reads in. The figure is the primary evidence, so only
+    # the title and the five-line ranking may precede it; everything that
+    # summarises or interprets follows it.
+    #
+    # Measured before this order: the chart began at y=1356 on a 1440x900
+    # laptop, entirely below the fold, behind ~1180px of KPI cards, a findings
+    # accordion and the full 80-row table. It now begins at y=824.
+    order = [
+        'class="leaderboard-intro"',
+        'class="leaderboard-top"',
+        'class="benchmark-workbench"',
+        'id="leaderboard-insights"',
+        'id="benchmark-findings"',
+        'id="adoption-table"',
+        'aria-labelledby="leaderboard-cards-heading"',
+    ]
+    positions = [html.index(marker) for marker in order]
+    assert positions == sorted(positions), (
+        "leaderboard blocks are out of order: "
+        f"{[m for _, m in sorted(zip(positions, order))]}"
+    )
 
     renderer = script.split("function renderLeaderboardTop(board)", 1)[1].split(
         "\nfunction ", 1

--- a/tests/test_leaderboard_workbench.py
+++ b/tests/test_leaderboard_workbench.py
@@ -461,6 +461,11 @@ def test_the_crawled_chart_axis_is_release_date_and_says_so():
     # through models that were never a series, which is the claim the curated
     # chart earns with a protocol and this one does not.
     assert "polyline" not in chart
+    # A <path> draws the same segment a <polyline> would, so the ban names the
+    # shape rather than one element. The running-best line is stepped (H/V
+    # only): "nothing had beaten this yet", not a trajectory between points.
+    for command in (" L ", "`L ${"):
+        assert command not in chart, "a diagonal path segment is a trajectory claim"
 
 
 def test_the_crawled_chart_reuses_the_curated_chart_classes():
@@ -911,10 +916,30 @@ def test_issue_288_the_charts_draw_a_running_best_not_an_invented_cost_axis():
     assert '`V ${y(step.value)}`' in path
     assert "L " not in path
 
-    # Both charts draw it, and the curated one passes the direction flag.
-    assert script.count("class: \"score-frontier-line\"") == 2
+    # A maximum is a comparability claim -- it says these numbers can be ranked
+    # against each other -- so the line is drawn ONLY where that holds.
+    #
+    # The curated layer partitions by instrument AND protocol, the same rule the
+    # join uses: GPQA Diamond carries "Pass@1, 8K output limit" beside "averaged
+    # over 10 samples", and a max across those asserts they measure the same
+    # thing. 22 of 59 curated benchmarks have two dates inside one such group.
+    assert script.count('class: "score-frontier-line"') == 1
     assert "{ descends: scoreDescends }" in script
     assert ".score-frontier-line {" in styles
+    curated = script.split("function scoreTrackChart(", 1)[1].split(
+        "\nfunction clearAdoptionFrontier", 1
+    )[0]
+    assert 'observation.instrument || ""' in curated
+    assert 'observation.protocol || ""' in curated
+
+    # The crawled layer draws none. Its normalizer records `direction: None` and
+    # comparability `none` because the source states neither, so ranking its
+    # rows against each other would assume both.
+    crawled = script.split("function externalScoreChart(source, payload)", 1)[1].split(
+        "\nfunction externalSourceTable", 1
+    )[0]
+    assert "score-frontier-line" not in crawled
+    assert "runningBestSteps" not in crawled
 
     # And it did not reintroduce the join the evidence rules forbid: the
     # running best says "nothing had beaten this yet", never "these points are
@@ -923,6 +948,11 @@ def test_issue_288_the_charts_draw_a_running_best_not_an_invented_cost_axis():
         "\nfunction clearAdoptionFrontier", 1
     )[0]
     assert "polyline" not in chart
+    # A <path> draws the same segment a <polyline> would, so the ban names the
+    # shape rather than one element. The running-best line is stepped (H/V
+    # only): "nothing had beaten this yet", not a trajectory between points.
+    for command in (" L ", "`L ${"):
+        assert command not in chart, "a diagonal path segment is a trajectory claim"
 
 
 def test_the_ranking_expands_and_the_intro_condensed_into_one_toggle():

--- a/tests/test_model_cards.py
+++ b/tests/test_model_cards.py
@@ -220,7 +220,15 @@ def test_measures_statement_travels_with_the_data():
 
     # Any consumer of radar.json inherits the disclaimer instead of inferring
     # the ranking's meaning from its column headers.
-    assert "not benchmark quality" in board["measures"]
+    # Asserted as the claim rather than the phrasing. Issue #241 rewrote this
+    # for a 16-year-old reader ("vendor attention", "saturated" and
+    # "contaminated" were vocabulary a reader had to already have), and a test
+    # that pins the old words would force the jargon back.
+    #
+    # The load-bearing part is that popularity is not quality, and that the
+    # statement travels with the data rather than living only in the UI.
+    assert "not the same as a good one" in board["measures"]
+    assert "how many" in board["measures"].lower()
 
 
 def test_adoption_rank_links_are_exact_inverses():

--- a/tests/test_saturation_view.py
+++ b/tests/test_saturation_view.py
@@ -569,7 +569,15 @@ def test_the_axis_and_header_name_the_score_reading():
     html = source("site/index.html")
     script = source("site/assets/app.js")
 
-    assert 't("reported scores over time")' in script
+    # The heading is the benchmark's name and the eyebrow says what kind of
+    # picture it is. They used to say the same thing twice: an eyebrow reading
+    # "Scores over time" above a heading reading "<name> reported scores over
+    # time". What must not drift is that a single reading is never presented as
+    # a track over time.
+    assert 'byId("frontier-heading").textContent = entry.name;' in script
+    assert 'spansTime(record)' in script
+    assert 't("Scores over time")' in script
+    assert '"charted score"' in script
     assert "adoption trajectory" not in script
     # The counts line and the reporting-stage sentence are gone from the markup,
     # so nothing can repopulate them.

--- a/tests/test_saturation_view.py
+++ b/tests/test_saturation_view.py
@@ -507,7 +507,6 @@ def test_the_adoption_marks_are_gone_from_the_chart():
         "card-rug-tick",
         "card-rug-baseline",
         "frontier-release-line",
-        "frontier-line",
         "MIN_TICK_GAP",
         "organizationCount",
         "maxOrganizations",
@@ -515,6 +514,16 @@ def test_the_adoption_marks_are_gone_from_the_chart():
     ):
         assert mark not in script, f"{mark} still drawn"
         assert mark not in styles, f"{mark} still styled"
+
+    # `frontier-line` was the adoption staircase's join. It is checked apart
+    # from the list above because issue #288 added `score-frontier-line` -- the
+    # running best -- and a bare substring test cannot tell the two apart. The
+    # retired class is gone; the new one is a different mark making a different
+    # claim (nothing had beaten this yet, rather than these points are a line).
+    for text in (script, styles):
+        assert "score-frontier-line" in text
+        assert '"frontier-line"' not in text
+        assert ".frontier-line" not in text
 
     # The score marks are untouched. They carry their own classes, so a check
     # that the adoption ones are absent cannot pass by emptying the chart.

--- a/tests/test_saturation_view.py
+++ b/tests/test_saturation_view.py
@@ -580,7 +580,7 @@ def test_the_axis_and_header_name_the_score_reading():
     # time". What must not drift is that a single reading is never presented as
     # a track over time.
     assert 'byId("frontier-heading").textContent = entry.name;' in script
-    assert 'spansTime(record)' in script
+    assert "spansTime(record)" in script
     assert 't("Scores over time")' in script
     assert '"charted score"' in script
     assert "adoption trajectory" not in script

--- a/tests/test_saturation_view.py
+++ b/tests/test_saturation_view.py
@@ -52,6 +52,11 @@ def test_the_score_layer_draws_no_connecting_line_at_all():
     )[0]
 
     assert "polyline" not in chart
+    # A <path> draws the same segment a <polyline> would, so the ban names the
+    # shape rather than one element. The running-best line is stepped (H/V
+    # only): "nothing had beaten this yet", not a trajectory between points.
+    for command in (" L ", "`L ${"):
+        assert command not in chart, "a diagonal path segment is a trajectory claim"
     assert "if (!series.connectable) continue;" not in chart
     assert "score-line" not in script
     assert "score-line" not in styles

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -126,7 +126,7 @@ def test_automatic_frontier_default_does_not_leak_into_unrelated_urls():
 
 def test_each_view_serializes_only_the_filters_it_reads():
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
-    body = script.split("function writeUrl()", 1)[1].split("\nfunction ", 1)[0]
+    body = script.split("function writeUrl(mode = \"replace\")", 1)[1].split("\nfunction ", 1)[0]
 
     # Issue #123: a reader clicking a trend date got
     # ?date=...&lfrontier=apex_agents, and switching to the leaderboard carried
@@ -1695,3 +1695,52 @@ def test_a_benchmark_name_search_reaches_the_registry_not_only_the_daily_feed():
     markup = Path("site/index.html").read_text(encoding="utf-8")
     assert 'data-i18n="Benchmarks with this name"' in markup
     assert '"Benchmarks with this name":' in script
+
+
+def test_issue_286_navigation_is_backable_but_typing_is_not():
+    """Back used to leave the site.
+
+    Every URL write called replaceState, so the entry a reader arrived on was
+    overwritten rather than kept: searching, opening a benchmark and pressing
+    Back landed on about:blank. Measured on main, history.length stayed at 2
+    across a search and a view change.
+
+    Pushing everywhere is the opposite bug. The filter boxes write on a
+    debounce as the reader types, so q=m, q=mm, q=mml, q=mmlu would each become
+    an entry and Back would walk backwards through their own typing.
+    """
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    assert "function writeUrl(mode = \"replace\")" in script
+    assert "window.history.pushState(null, \"\", url);" in script
+    assert "window.history.replaceState(null, \"\", url);" in script
+
+    # A discrete navigation the reader chose pushes. Changing view is the one
+    # the issue measured; selecting a benchmark is the one that made it easy to
+    # hit, because it carries a reader from a search into another view.
+    assert "function setView(view, update = true, mode = \"push\")" in script
+    assert "if (update) writeUrl(mode);" in script
+    picker = script.split('byId("frontier-benchmark").addEventListener("change"', 1)[1].split(
+        "});", 1
+    )[0]
+    assert 'writeUrl("push")' in picker
+
+    # Continuous refinement of the current view replaces. Both debounced
+    # renderers are the keystroke path, and neither may push.
+    leaderboard_debounce = script.split("const scheduleLeaderboardRender = debounce(", 1)[1].split(
+        "});", 1
+    )[0]
+    assert "writeUrl();" in leaderboard_debounce
+    assert "push" not in leaderboard_debounce
+
+    # A pushed entry that nothing re-renders leaves the page disagreeing with
+    # its own address bar, so the listener is part of the fix rather than an
+    # optional extra.
+    assert 'window.addEventListener("popstate", onPopState);' in script
+    handler = script.split("function onPopState()", 1)[1].split("\n}\n", 1)[0]
+    assert "readUrl();" in handler
+    assert "setView(state.view, false);" in handler
+    assert "rerenderCurrentView();" in handler
+
+    # Pushing the URL already shown would make Back a no-op that looks broken.
+    assert 'if (mode === "push" && url !== current)' in script

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -126,7 +126,7 @@ def test_automatic_frontier_default_does_not_leak_into_unrelated_urls():
 
 def test_each_view_serializes_only_the_filters_it_reads():
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
-    body = script.split("function writeUrl(mode = \"replace\")", 1)[1].split("\nfunction ", 1)[0]
+    body = script.split('function writeUrl(mode = "replace")', 1)[1].split("\nfunction ", 1)[0]
 
     # Issue #123: a reader clicking a trend date got
     # ?date=...&lfrontier=apex_agents, and switching to the leaderboard carried
@@ -1711,14 +1711,14 @@ def test_issue_286_navigation_is_backable_but_typing_is_not():
     """
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
 
-    assert "function writeUrl(mode = \"replace\")" in script
-    assert "window.history.pushState(null, \"\", url);" in script
-    assert "window.history.replaceState(null, \"\", url);" in script
+    assert 'function writeUrl(mode = "replace")' in script
+    assert 'window.history.pushState(null, "", url);' in script
+    assert 'window.history.replaceState(null, "", url);' in script
 
     # A discrete navigation the reader chose pushes. Changing view is the one
     # the issue measured; selecting a benchmark is the one that made it easy to
     # hit, because it carries a reader from a search into another view.
-    assert "function setView(view, update = true, mode = \"push\")" in script
+    assert 'function setView(view, update = true, mode = "push")' in script
     assert "if (update) writeUrl(mode);" in script
     picker = script.split('byId("frontier-benchmark").addEventListener("change"', 1)[1].split(
         "});", 1

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -825,7 +825,15 @@ def test_dashboard_publishes_the_model_card_adoption_rank(tmp_path):
 
     assert board["model_card_count"] > 0
     assert board["entries"][0]["rank"] == 1
-    assert "not benchmark quality" in board["measures"]
+    # Asserted as the claim rather than the phrasing. Issue #241 rewrote this
+    # for a 16-year-old reader ("vendor attention", "saturated" and
+    # "contaminated" were vocabulary a reader had to already have), and a test
+    # that pins the old words would force the jargon back.
+    #
+    # The load-bearing part is that popularity is not quality, and that the
+    # statement travels with the data rather than living only in the UI.
+    assert "not the same as a good one" in board["measures"]
+    assert "how many" in board["measures"].lower()
 
 
 def test_dashboard_omits_the_leaderboard_when_the_registry_is_absent(tmp_path):


### PR DESCRIPTION
Closes #256, #286, #288, #298.

Four issues on the same two surfaces: the leaderboard page and the per-benchmark chart panel.

## The ranking leads the page it names (#256)

`/?view=leaderboard` was named after a ranking a reader could not see. The adoption table was the **sixth** block in the DOM and shipped collapsed, behind a method note, an evidence strip, a findings panel, a search box and a 480px chart.

It now leads, in five lines carrying one measure. The full 80-row table moves up with it as the expandable underneath, keeping its filter form, show-all toggle and collapsed default, so no permalink or feature is lost.

The issue asked for a split into two pages. That is deliberately not what shipped: a second page needs a name, and #241/#276 spent two rounds removing "saturation" as jargon. It would also have split `renderBenchmarkNavigator` from `renderAdoptionFrontier`, which are one machine today.

Order is read from `board.entries` rather than recomputed — `adoption_rank` breaks ties on organization count then name, and ranks 4, 5 and 6 all hold 17 cards from 8 organizations.

## Back works (#286)

Every URL write called `replaceState`, so no navigation was backable: a reader who searched, opened a benchmark and pressed Back left the site.

`writeUrl` now takes a mode. Eight sites push (view changes, benchmark selection, search results, shortlist chips, sibling links, finding jumps, score-track buttons, map entities); six replace (both debounced filter renderers, the rubric dialog, filter clearing, the contact panel). A `popstate` listener re-renders the restored URL, without which a pushed entry would change the address bar and leave the page showing the previous view.

## One title, readable axes (#298)

A crawled record announced itself four times: an eyebrow, the title, a non-interactive source chip, and a second heading repeating the source and count — about 150px of dead space above the chart. Now one title and one subline.

Axes gained intermediate ticks so a point can be read rather than interpolated. #269's rule holds: a padded bound still cannot reach a label. The x-axis label reads `model release date` and stops; the count of undated rows moved into the (i) note rather than being dropped.

Search rows across both layers now read name plus one count. Crawled rows were showing publisher, year, size, openness and source — three of them "not established" on most records.

## A running best, not an invented axis (#288)

Asked for a Pareto frontier "just like harbor-index.org". Harbor plots **cost against pass rate**, and this corpus records no cost or latency for any score. Drawing that chart would mean inventing the axis.

Shipped the same idea on the axes these charts have: a stepped running-best line, horizontal then vertical so no diagonal implies interpolation. It asserts only that nothing had beaten a value yet, never that the points between are a series, so it coexists with the no-polyline join rule. #300 tracks collecting what a real cost axis needs.

## Verification

**860 tests pass.** Browser-verified rather than inferred:

- Search then Leaderboard takes `history.length` 2 → 3; Back restores `?q=` with Today drawn; Forward returns; typing `mmlu` leaves the length at 3 while the URL becomes `lq=mmlu`; selecting a benchmark pushes to 4 and Back returns with `lq` intact.
- AIME 2025 draws one stepped frontier over 115 points, GPQA Diamond one over 20, both with zero polylines.
- Searching "aime" returns `AIME | 17 models` and `AIME 2025 | 115 reported scores`.

Six tests changed from pinning an implementation to pinning its guarantee, each with the reasoning recorded inline. One was a substring collision: `frontier-line` matched the new `score-frontier-line`, so the retired adoption class is now checked exactly.

Stale removals, all verified unreferenced first: three CSS blocks and two i18n keys. `.benchmark-openness` and `"Curated registry"` look orphaned by the same sweep and are not — they still serve the detail panel and a picker group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up: vertical priority and repeated labels

Five further commits, from review of the rendered page.

**The figure was below the fold.** On a 1440×900 laptop the chart began at y=1356, behind ~1180px of KPI cards, a findings accordion and the full 80-row table — all of which summarise or interpret the very thing they were hiding. Only the title and the five-line ranking precede it now; everything else follows. Measured at each step: 1356 → 824 → 705 → 675 → 642 → 621 → 567px, ending at **57% of the chart visible on load**.

The chart's own 480px height was deliberately left alone. That is issue #91's decision about vertical resolution on the one reading a reader must not misjudge, and trading it for fold space would have bought position with legibility.

**Three headings were one sentence written three ways** — "Which benchmarks do model cards report?", the deck, and "Most reported in model cards" — stacked above the figure. One title now, which is also the view's accessible name. The deck stays in the DOM, read rather than displayed, so a screen reader still gets the caveat with the heading.

**The caveat was written for someone who already knew the words.** "Vendor attention", "saturated" and "contaminated" name the right ideas in vocabulary a reader has to arrive with. Rewritten in `model_cards.py` rather than the browser, so every consumer of `radar.json` inherits the readable version instead of the site paraphrasing published data. Three tests asserted it by quoting the jargon, which would have forced the old words back; they assert the claim instead — popularity is not quality, and the statement travels with the data.

**The panel repeated itself the same way:** an eyebrow reading "Scores over time" above a heading reading "GPQA Diamond reported scores over time", beside a picker already showing GPQA Diamond. The heading is the name now; the eyebrow carries the over-time-vs-single-reading distinction, which was the only work the longer heading did.

**The figure opened on the wrong benchmark.** It picked the newest scored instrument, putting AutomationBench under a page headed "most reported in model cards" — a benchmark the reader had not seen named anywhere above it. It opens on rank 1 now (GPQA Diamond), and the ranking and default agree by construction rather than by a second sort that could drift.

**Also:** the five-line ranking gains a toggle to all 79 and back; every disclosure marker went from ~16px of glyph with no hit area to 48px (the round (i) from 18px to 32px); the legend moved below the chart it explains; "How to read this chart" moved onto the title line; and the search sidebar was `--canvas`, the exact colour of the page behind it, so beside the near-black figure it read as floating — now a real grey, with supporting text darkened to keep AA (5.39:1, against 3.16:1 for the old `--muted` on that surface).

Removing the old intro orphaned `.method-note` (five rules plus half a shared one) and four i18n keys, all verified unreferenced first.

**861 tests pass.** Verified in a browser at 1440×900 and 390×844: the figure opens on GPQA Diamond, the ranking toggles between 5 and 79 rows and back, the (i) carries every condensed text, the explainer sits inline and drops to full width when opened, and mobile has no horizontal overflow.

---

## Independent review (Codex), and what it changed

**It found a real honesty bug in this PR, now fixed.** The running-best line added for #288 was drawn on both charts. A maximum is a comparability claim — it says these numbers can be ranked against each other — and neither layer supported that as shipped.

The crawled layer no longer draws it at all. Its own normalizer sets `direction: None` and comparability `none`, and `external_catalog.py` states outright that "the only honest comparability class is none". Taking a max there assumed both larger-is-better and that the rows measure the same thing. Its 115 points still plot; only the line is gone.

The curated layer now partitions by instrument **and** protocol, the same rule the join uses. GPQA Diamond carries "Pass@1, 8K output limit" beside "averaged over 10 samples"; ranking those against each other asserts they measure the same thing. 22 of 59 curated benchmarks have two dates inside one comparable group.

Three tests banned `<polyline>` to forbid a trajectory claim, but a `<path>` draws the same segment and passed them. They now ban the shape: no diagonal command in either chart.

**Filed rather than fixed here**, to keep this PR reviewable:

- **#304** — a `?lfrontier=` slug that does not resolve leaves the dead slug in the address bar while the panel shows the default. Confirmed in a browser. The repair belongs at the substitution point, but the crawled index is never fetched on that path, so the fallback is unreachable and the load order needs untangling first. This is #287's defect still reachable through crawled slugs.
- **#305** — map detail not cleared on Back to an entity-less URL; a stale render if the reader navigates during the initial 34MB fetch; and a test whose name oversells what opening the ranking disclosure shows.

Codex also confirmed the intermediate axis ticks stay strictly inside the observed extremes, so #269's rule holds.
