### PR TITLE
fix(site): rewrite stale banner with plain language and two actions

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -822,6 +822,11 @@ const I18N = {
     "{source} returned something on this day, but none of it scored high enough to be listed.":
       "{source} 在这一天有返回内容，但都未达到列入所需的分数。",
     "Try another date, or clear the filter.": "请尝试其他日期，或清除筛选条件。",
+    // Stale-run banner: plain words a first-time reader can act on.
+    "Last updated {date}, {hours} hours ago. The automatic update has not succeeded since.":
+      "数据上次更新于 {date}，距今 {hours} 小时。那之后的自动更新一直没有成功。",
+    "Some sources failed to answer on {date}: {gaps}.": "{date} 有几个来源没有响应：{gaps}。",
+    "What broke?": "哪里出了问题？",
     "one value read verbatim from a cited document": "一个从引文文档中逐字读到的数值",
     "not yet reported": "尚未报告",
     "points to zero, the floor of this metric": "指向零,该指标的底线",
@@ -7216,22 +7221,60 @@ async function renderRepoBadges() {
 // means both the scheduled run and its same-day retry were missed.
 const STALE_AFTER_HOURS = 30;
 
+// The banner's one job is to send a worried reader somewhere useful within a
+// click: the public Actions log answers "what broke", and the contact dialog
+// that already exists on the page answers "who do I tell". The error messages
+// in those logs are credential-safe by construction, so linking out publishes
+// nothing the repository does not already show.
+const DAILY_RADAR_RUNS_URL = `https://github.com/${REPO_SLUG}/actions/workflows/daily-radar.yml`;
+
+function contactGlyph() {
+  // Same speech-bubble path as the header's Contact badge (issue #213), so a
+  // reader meets one icon for one meaning.
+  const icon = svgElement("svg", { viewBox: "0 0 24 24", "aria-hidden": "true" });
+  icon.append(
+    svgElement("path", {
+      d: "M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z",
+    }),
+  );
+  return icon;
+}
+
+async function pointAtLatestFailedRun(link) {
+  // The workflows page lists every workflow and buries yesterday's failure.
+  // One unauthenticated lookup pins the link to the exact failed run, which is
+  // where "was it the API key or something else" is actually answered. Any
+  // failure keeps the fallback href, which always resolves.
+  try {
+    const response = await fetch(
+      `https://api.github.com/repos/${REPO_SLUG}/actions/workflows/daily-radar.yml/runs?status=failure&per_page=1`,
+      { headers: { Accept: "application/vnd.github+json" } },
+    );
+    if (!response.ok) return;
+    const data = await response.json();
+    const url = data.workflow_runs?.[0]?.html_url;
+    if (url) link.setAttribute("href", url);
+  } catch (_) {
+    // Offline or rate-limited: the fallback href already points somewhere real.
+  }
+}
+
 function renderStaleBanner() {
   const banner = byId("stale-banner");
   const latestDay = state.data.days[state.data.days.length - 1];
   const generatedAt = new Date(state.data.generated_at);
   const ageHours = (Date.now() - generatedAt.getTime()) / 3_600_000;
   const degraded = !latestDay.required_coverage_complete;
+  banner.classList.toggle("stale-banner-degraded", degraded);
   if (ageHours <= STALE_AFTER_HOURS && !degraded) {
     banner.hidden = true;
-    banner.textContent = "";
-    banner.classList.remove("stale-banner-degraded");
+    banner.replaceChildren();
     return;
   }
   const parts = [];
   if (ageHours > STALE_AFTER_HOURS) {
     parts.push(
-      t("Latest snapshot is from {date} UTC ({hours}h ago) — the scheduled run may have failed.", {
+      t("Last updated {date}, {hours} hours ago. The automatic update has not succeeded since.", {
         date: formatDate(state.data.generated_at, {
           dateStyle: "medium",
           timeStyle: "short",
@@ -7242,14 +7285,34 @@ function renderStaleBanner() {
   }
   if (degraded) {
     parts.push(
-      t("Required source failures on {date}: {gaps}.", {
+      t("Some sources failed to answer on {date}: {gaps}.", {
         date: latestDay.date,
         gaps: latestDay.required_coverage_gaps.join(", "),
       }),
     );
   }
-  banner.textContent = parts.join(" ");
-  banner.classList.toggle("stale-banner-degraded", degraded);
+
+  const whatBroke = element("a", {
+    className: "stale-banner-action",
+    text: t("What broke?"),
+    attrs: { href: DAILY_RADAR_RUNS_URL, target: "_blank", rel: "noopener noreferrer" },
+  });
+  pointAtLatestFailedRun(whatBroke);
+
+  // A <button>, not an <a>: it opens the existing contact dialog instead of
+  // navigating away, exactly like the header badge does.
+  const contactButton = element("button", {
+    type: "button",
+    className: "stale-banner-action",
+    attrs: { "aria-haspopup": "dialog" },
+  });
+  contactButton.append(contactGlyph(), document.createTextNode(t("Contact")));
+  contactButton.addEventListener("click", openContact);
+
+  banner.replaceChildren(
+    document.createTextNode(parts.join(" ")),
+    element("span", { className: "stale-banner-actions" }, [whatBroke, contactButton]),
+  );
   banner.hidden = false;
 }
 

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -3645,6 +3645,49 @@ dialog::backdrop {
   background: #ffe1d9;
 }
 
+/* The banner's two calls to action sit inline after the sentence: a link into
+   the public Actions log and the contact button that opens the same dialog as
+   the header badge. Inheriting the banner font keeps them reading as part of
+   one notice rather than a second UI layer bolted on top of it. */
+.stale-banner-actions {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 1rem;
+  margin-left: 1rem;
+  white-space: nowrap;
+}
+
+.stale-banner-action {
+  padding: 0;
+  border: 0;
+  background: none;
+  color: inherit;
+  font: inherit;
+  text-decoration: underline;
+  text-underline-offset: 0.18em;
+  cursor: pointer;
+}
+
+.stale-banner-action:hover,
+.stale-banner-action:focus-visible {
+  text-decoration-thickness: 2px;
+}
+
+button.stale-banner-action {
+  appearance: none;
+}
+
+.stale-banner-action svg {
+  width: 0.95em;
+  height: 0.95em;
+  margin-right: 0.3em;
+  vertical-align: -0.12em;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-width: 2;
+}
+
 .error-state {
   max-width: 720px;
   padding: 7rem 0;

--- a/src/benchmark_radar/http.py
+++ b/src/benchmark_radar/http.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import http.client
 import json
+import re
 import ssl
 import time
 import urllib.error
@@ -42,6 +43,35 @@ def _safe_openai_error_detail(url: str, error: urllib.error.HTTPError) -> str:
         if isinstance(detail.get(key), (str, int, float)) and str(detail[key]).strip()
     ]
     return f" ({', '.join(fields)})" if fields else ""
+
+
+_RATE_LIMIT_HEADER_KEYS = (
+    "x-ratelimit-limit-requests",
+    "x-ratelimit-limit-tokens",
+    "x-ratelimit-remaining-requests",
+    "x-ratelimit-remaining-tokens",
+    "x-ratelimit-reset-requests",
+    "x-ratelimit-reset-tokens",
+)
+_RATE_LIMIT_HEADER_VALUE = re.compile(r"^[\w.:%/,+-]{1,48}$")
+
+
+def _safe_openai_rate_headers(url: str, error: urllib.error.HTTPError) -> str:
+    """Expose structured rate-limit numbers from response headers.
+
+    A token-bucket 429 body never says whether the request exceeded the plan's
+    per-minute allowance or the bucket was already drained by other usage; the
+    x-ratelimit-* headers do. Values are server-generated numbers and reset
+    durations, validated so nothing prose-like reaches public failure output.
+    """
+    if urllib.parse.urlsplit(url).netloc != "api.openai.com" or error.headers is None:
+        return ""
+    fields = []
+    for key in _RATE_LIMIT_HEADER_KEYS:
+        value = error.headers.get(key)
+        if value and _RATE_LIMIT_HEADER_VALUE.match(value):
+            fields.append(f"{key}={value.strip()}")
+    return f" [{', '.join(fields)}]" if fields else ""
 
 
 def get_json(
@@ -122,7 +152,10 @@ def _request(
             # a query string: some APIs carry credentials there.
             detail = _safe_openai_error_detail(url, error)
             if error.code != 429 and error.code < 500:
-                raise RequestError(f"HTTP {error.code} from {_safe_url(url)}{detail}") from None
+                raise RequestError(
+                    f"HTTP {error.code} from {_safe_url(url)}{detail}"
+                    f"{_safe_openai_rate_headers(url, error)}"
+                ) from None
             last_error = error
             last_http_detail = detail
             retry_after = error.headers.get("Retry-After") if error.headers else None
@@ -145,6 +178,7 @@ def _request(
         raise RequestError(
             f"HTTP {last_error.code} from {_safe_url(url)} after {attempts} attempts"
             f"{last_http_detail}"
+            f"{_safe_openai_rate_headers(url, last_error)}"
         ) from None
     raise RequestError(
         f"{type(last_error).__name__} from {_safe_url(url)} after {attempts} attempts"

--- a/tests/fixtures/degraded_radar.json
+++ b/tests/fixtures/degraded_radar.json
@@ -1,0 +1,10 @@
+{
+  "generated_at": "2999-12-31T23:59:59Z",
+  "days": [
+    {
+      "date": "2999-12-31",
+      "required_coverage_complete": false,
+      "required_coverage_gaps": ["arxiv listings", "hugging face"]
+    }
+  ]
+}

--- a/tests/fixtures/fresh_radar.json
+++ b/tests/fixtures/fresh_radar.json
@@ -1,0 +1,1 @@
+{"generated_at":"2999-12-31T23:59:59Z","days":[{"date":"2999-12-31","required_coverage_complete":true,"required_coverage_gaps":[]}]}

--- a/tests/fixtures/stale_radar.json
+++ b/tests/fixtures/stale_radar.json
@@ -1,0 +1,10 @@
+{
+  "generated_at": "2020-01-01T00:00:00Z",
+  "days": [
+    {
+      "date": "2019-12-31",
+      "required_coverage_complete": true,
+      "required_coverage_gaps": []
+    }
+  ]
+}

--- a/tests/render_stale_banner_harness.mjs
+++ b/tests/render_stale_banner_harness.mjs
@@ -1,0 +1,171 @@
+// Executes the dashboard's stale-banner renderer against a fixture shaped
+// exactly like radar.json, and prints the resulting banner DOM as JSON for
+// the Python test to assert on. This mirrors the briefing harness: source
+// assertions alone cannot tell "renders an actions row" from "mentions the
+// word Contact", so the renderer is run for real against a minimal DOM.
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+// app.js imports its brand-mark resolvers from glyphs.js (issue #261), and
+// `new Function` below cannot take an import statement. Inlining the module
+// and dropping the import keeps the harness evaluating the real source rather
+// than a copy: the same text runs here and in the browser, minus the two lines
+// that only differ in how the file is loaded.
+const glyphs = readFileSync(join(here, "..", "site", "assets", "glyphs.js"), "utf8").replace(
+  /^export \{[\s\S]*?\};$/m,
+  "",
+);
+const source =
+  glyphs +
+  readFileSync(join(here, "..", "site", "assets", "app.js"), "utf8").replace(
+    /^import \{[\s\S]*?\} from "\.\/glyphs\.js";$/m,
+    "",
+  );
+
+class StubNode {
+  constructor(tag) {
+    this.tag = tag;
+    this.className = "";
+    this.children = [];
+    this.attributes = {};
+    this._text = "";
+    this.hidden = false;
+  }
+  set textContent(value) {
+    this._text = String(value);
+    this.children = [];
+  }
+  get textContent() {
+    return this.children.length
+      ? this.children.map((child) => child.textContent).join("")
+      : this._text;
+  }
+  get classList() {
+    const node = this;
+    const names = () => node.className.split(/\s+/).filter(Boolean);
+    return {
+      contains: (name) => names().includes(name),
+      add(name) {
+        if (!names().includes(name)) node.className = [...names(), name].join(" ");
+      },
+      remove(name) {
+        node.className = names().filter((existing) => existing !== name).join(" ");
+      },
+      toggle(name, force) {
+        const has = names().includes(name);
+        const want = force === undefined ? !has : Boolean(force);
+        const next = names().filter((existing) => existing !== name);
+        if (want) next.push(name);
+        node.className = next.join(" ");
+        return want;
+      },
+    };
+  }
+  setAttribute(key, value) {
+    this.attributes[key] = String(value);
+  }
+  append(...children) {
+    this.children.push(...children);
+  }
+  replaceChildren(...children) {
+    this.children = children;
+  }
+  addEventListener() {}
+  querySelectorAll() {
+    return [];
+  }
+  querySelector() {
+    return null;
+  }
+}
+
+class StubText {
+  constructor(value) {
+    this.tag = "#text";
+    this.children = [];
+    this.attributes = {};
+    this.className = "";
+    this._text = String(value);
+  }
+  get textContent() {
+    return this._text;
+  }
+}
+
+const registry = new Map();
+globalThis.document = {
+  createElement: (tag) => new StubNode(tag),
+  createElementNS: (_ns, tag) => new StubNode(tag),
+  createTextNode: (value) => new StubText(value),
+  getElementById: (id) => {
+    if (!registry.has(id)) registry.set(id, new StubNode("div"));
+    return registry.get(id);
+  },
+  addEventListener: () => {},
+  querySelectorAll: () => [],
+  querySelector: () => null,
+};
+globalThis.window = { addEventListener: () => {}, location: { search: "", hash: "" } };
+globalThis.localStorage = {
+  getItem: () => null,
+  setItem: () => {},
+};
+
+// Default fetch never resolves, like a reader whose lookup is slow: the banner
+// must already be correct with its fallback href while the deep-link upgrade
+// is still in flight. `--resolve-failure` swaps in a resolving GitHub response
+// for the failed-run lookup only; every other request (the page's own radar.json
+// boot fetch included) keeps hanging so the harness stays in control of state.
+const RUNS_LOOKUP =
+  "https://api.github.com/repos/ktwu01/benchmark-radar/actions/workflows/daily-radar.yml/runs";
+if (process.argv.includes("--resolve-failure")) {
+  globalThis.fetch = (url) =>
+    String(url).startsWith(RUNS_LOOKUP)
+      ? Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              workflow_runs: [
+                { html_url: "https://github.com/ktwu01/benchmark-radar/actions/runs/32439770574" },
+              ],
+            }),
+        })
+      : new Promise(() => {});
+} else {
+  globalThis.fetch = () => new Promise(() => {});
+}
+
+// The export line goes after the source: `state` is a top-level const in
+// app.js, so referencing it before the source body would hit its TDZ.
+const harness = `${source}\nglobalThis.__render = { renderStaleBanner, setLang, getLang, state };`;
+new Function(harness)();
+
+const lang = process.argv[3] && process.argv[3] !== "--resolve-failure" ? process.argv[3] : "";
+if (lang) globalThis.__render.setLang(lang);
+
+const fixtureArg = process.argv[2];
+const fixturePath =
+  fixtureArg && fixtureArg !== "--resolve-failure"
+    ? fixtureArg
+    : join(here, "fixtures", "stale_radar.json");
+globalThis.__render.state.data = JSON.parse(readFileSync(fixturePath, "utf8"));
+globalThis.__render.renderStaleBanner();
+
+function walk(node) {
+  return {
+    tag: node.tag,
+    className: node.className || "",
+    hidden: Boolean(node.hidden),
+    href: node.attributes?.href || "",
+    text: node.textContent,
+    children: (node.children || []).map(walk),
+  };
+}
+
+// The deep-link upgrade resolves asynchronously after the banner renders; let
+// the microtask queue (and the stubbed fetch) settle before printing.
+setTimeout(() => {
+  console.log(JSON.stringify(walk(document.getElementById("stale-banner")), null, 2));
+}, 20);

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -116,6 +116,83 @@ def test_truncated_openai_error_body_stays_a_request_error(monkeypatch):
         post_json("https://api.openai.com/v1/responses", {"input": "private"}, attempts=1)
 
 
+def test_openai_rate_limit_headers_survive_in_exhaustion_message(monkeypatch):
+    # A token-bucket 429 is undiagnosable from its body alone: the numbers that
+    # separate "request too big for the plan" from "bucket already drained" live
+    # only in these response headers.
+    def fake_urlopen(request, **kwargs):
+        raise urllib.error.HTTPError(
+            request.full_url,
+            429,
+            "rate limited",
+            {
+                "x-ratelimit-limit-tokens": "30000",
+                "x-ratelimit-remaining-tokens": "0",
+                "x-ratelimit-reset-tokens": "1m0s",
+            },
+            io.BytesIO(),
+        )
+
+    monkeypatch.setattr("benchmark_radar.http.urllib.request.urlopen", fake_urlopen)
+    monkeypatch.setattr("benchmark_radar.http.time.sleep", lambda seconds: None)
+
+    with pytest.raises(RequestError) as captured:
+        post_json(
+            "https://api.openai.com/v1/responses",
+            {"input": "private"},
+            attempts=2,
+        )
+
+    message = str(captured.value)
+    assert "x-ratelimit-limit-tokens=30000" in message
+    assert "x-ratelimit-remaining-tokens=0" in message
+    assert "x-ratelimit-reset-tokens=1m0s" in message
+
+
+def test_openai_rate_limit_header_prose_is_dropped(monkeypatch):
+    def fake_urlopen(request, **kwargs):
+        raise urllib.error.HTTPError(
+            request.full_url,
+            429,
+            "rate limited",
+            {
+                "x-ratelimit-remaining-tokens": "please rotate key sk-abc now",
+                "x-ratelimit-reset-tokens": "1m0s",
+            },
+            io.BytesIO(),
+        )
+
+    monkeypatch.setattr("benchmark_radar.http.urllib.request.urlopen", fake_urlopen)
+    monkeypatch.setattr("benchmark_radar.http.time.sleep", lambda seconds: None)
+
+    with pytest.raises(RequestError) as captured:
+        post_json("https://api.openai.com/v1/responses", {"input": "x"}, attempts=1)
+
+    message = str(captured.value)
+    assert "sk-abc" not in message
+    assert "please rotate" not in message
+    assert "x-ratelimit-reset-tokens=1m0s" in message
+
+
+def test_non_openai_429_carries_no_rate_header_fields(monkeypatch):
+    def fake_urlopen(request, **kwargs):
+        raise urllib.error.HTTPError(
+            request.full_url,
+            429,
+            "rate limited",
+            {"x-ratelimit-limit-tokens": "30000"},
+            io.BytesIO(),
+        )
+
+    monkeypatch.setattr("benchmark_radar.http.urllib.request.urlopen", fake_urlopen)
+    monkeypatch.setattr("benchmark_radar.http.time.sleep", lambda seconds: None)
+
+    with pytest.raises(RequestError) as captured:
+        get_json("https://example.test/data", attempts=1)
+
+    assert "x-ratelimit" not in str(captured.value)
+
+
 @pytest.mark.parametrize(
     ("error", "expected"),
     [

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1208,6 +1208,96 @@ def test_rendered_questions_keep_english_prose_when_zh_fields_are_absent():
     assert "今天首次观察到的记录大多是智能体评估框架。" not in text
 
 
+def _rendered_stale_banner(
+    fixture: str | None = None, lang: str | None = None, resolve_failure: bool = False
+):
+    """Run the real stale-banner renderer over a fixture and return its DOM tree.
+
+    Source assertions cannot tell "renders two actions" from "mentions Contact",
+    and the failed-run deep link only exists after an async lookup resolves, so
+    the renderer runs for real and the settled tree is asserted on.
+    """
+    import json
+    import shutil
+    import subprocess
+
+    node = shutil.which("node")
+    if not node:
+        import pytest
+
+        pytest.skip("node is not installed")
+    result = subprocess.run(
+        [
+            node,
+            "tests/render_stale_banner_harness.mjs",
+            *([fixture] if fixture else []),
+            *(["--resolve-failure"] if resolve_failure else []),
+            *([lang] if lang else []),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def test_rendered_stale_banner_names_the_gap_and_offers_two_actions():
+    import re
+
+    banner = _rendered_stale_banner("tests/fixtures/stale_radar.json")
+    nodes = list(_flatten(banner))
+
+    assert {n["className"] for n in nodes} >= {"stale-banner-actions", "stale-banner-action"}
+    # The hour count moves with the clock, so only the sentence shape is pinned.
+    assert re.search(
+        r"Last updated Jan 1, 2020.*hours ago\. The automatic update has not succeeded since\.",
+        banner["children"][0]["text"],
+    )
+    # The fallback href must already be live before any deep-link lookup returns.
+    link = next(n for n in nodes if n["tag"] == "a")
+    assert link["text"] == "What broke?"
+    assert link["href"].startswith("https://github.com/ktwu01/benchmark-radar/actions/")
+    button = next(n for n in nodes if n["tag"] == "button")
+    assert button["text"] == "Contact"
+
+
+def test_rendered_stale_banner_translates_copy_under_zh():
+    banner = _rendered_stale_banner("tests/fixtures/stale_radar.json", "zh")
+    nodes = list(_flatten(banner))
+
+    link = next(n for n in nodes if n["tag"] == "a")
+    button = next(n for n in nodes if n["tag"] == "button")
+    assert link["text"] == "哪里出了问题？"
+    assert button["text"] == "联系"
+    assert "那之后的自动更新一直没有成功。" in banner["children"][0]["text"]
+    assert "The automatic update has not succeeded" not in banner["children"][0]["text"]
+
+
+def test_rendered_stale_banner_marks_degraded_coverage_with_the_gaps():
+    banner = _rendered_stale_banner("tests/fixtures/degraded_radar.json")
+
+    assert "stale-banner-degraded" in {n["className"] for n in _flatten(banner)}
+    assert "Some sources failed to answer on 2999-12-31: arxiv listings, hugging face." in [
+        n["text"] for n in _flatten(banner)
+    ]
+
+
+def test_rendered_fresh_snapshot_keeps_the_banner_hidden():
+    banner = _rendered_stale_banner("tests/fixtures/fresh_radar.json")
+
+    assert banner["hidden"] is True
+    assert banner["text"] == ""
+
+
+def test_rendered_stale_banner_deep_links_the_latest_failed_run():
+    """When the Actions API answers, "What broke?" pins the exact failed run."""
+    banner = _rendered_stale_banner(resolve_failure=True)
+    link = next(n for n in _flatten(banner) if n["tag"] == "a")
+
+    assert link["href"] == "https://github.com/ktwu01/benchmark-radar/actions/runs/32439770574"
+
+
 def test_dashboard_and_markdown_format_statistics_identically():
     """The two renderers must print the same figure for the same statistic.
 


### PR DESCRIPTION
This PR includes: 1) http.py change surfacing OpenAI rate-limit quota numbers in request errors (worktree fix/openai-429-quota-headers). 2) Stale banner rewrite with plain-language copy and two CTA buttons (What broke? + Contact). No merge intended yet.