### PR TITLE
fix(site): load the Today list a page at a time; data requests go to contact

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -1953,8 +1953,12 @@ function renderToday({ resultsOnly = false } = {}) {
   const growsInPlace =
     !resultsKeyChanged && renderedCount > 0 && visibleObservations.length > renderedCount;
   if (growsInPlace) {
+    // The appended slice maps from zero, so the rank offset travels with it:
+    // page two continues at 21, not back at 01.
     listHost.append(
-      ...visibleObservations.slice(renderedCount).map(observationCard),
+      ...visibleObservations
+        .slice(renderedCount)
+        .map((item, offset) => observationCard(item, renderedCount + offset)),
     );
   } else {
     replaceChildren(

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -14,7 +14,11 @@ import {
   modelGlyph,
 } from "./glyphs.js";
 
-const ALL_DATES_PAGE_SIZE = 100;
+// One page of results, in the list and at a time (issue #311). The first
+// paint carries 20 cards; each further page is loaded by scrolling to the
+// sentinel below the list. 100 at once was the archive bound, and a busy day
+// paid for all of it before the reader could scroll.
+const TODAY_PAGE_SIZE = 20;
 // Snapshots recorded before SourceHealth.method existed carry no method
 // field; this fills the gap for historical dates only (issue #174).
 const LEGACY_SOURCE_COLLECTION_METHODS = {
@@ -317,7 +321,6 @@ const I18N = {
     "Site utilities": "网站工具",
     "Switch to Chinese (中文)": "切换到中文",
     "Switch to English": "切换到英文",
-    "Export the dataset": "导出数据集",
     "Get in touch · Email, WeChat, Discord": "联系我 · 邮件、微信、Discord",
     Data: "数据",
     Contact: "联系",
@@ -371,7 +374,6 @@ const I18N = {
     "Refresh data": "刷新数据",
     "Today's radar": "今日雷达",
     "Matching observations": "匹配结果",
-    "Show more results": "显示更多结果",
     Sources: "来源",
     "All-time totals": "全部统计",
     All: "全部",
@@ -383,10 +385,10 @@ const I18N = {
     "{n}h ago": "{n} 小时前",
     "{n}d ago": "{n} 天前",
     "yesterday": "昨天",
-    "result": "条结果",
-    "results": "条结果",
+    "{loaded} of {total} results loaded · scroll for more":
+      "已加载 {loaded}/{total} 条结果 · 下滑加载更多",
+    "All {total} results loaded": "已加载全部 {total} 条结果",
     "normal": "正常",
-    "need attention": "需关注",
     "Sort: Priority ↓": "排序:优先度 ↓",
     "Sort: Date, then Priority ↓": "排序:日期,再按优先度 ↓",
     "Sort: Date ↓": "排序:日期 ↓",
@@ -516,13 +518,8 @@ const I18N = {
     new: "新增",
     active: "活跃",
     none: "无",
-    result: "条结果",
-    results: "条结果",
     evidence: "条证据",
-    attention: "个关注信号",
-    Show: "显示",
-    more: "更多",
-    remaining: "条剩余",
+    attention: "关注",
     flat: "持平",
     up: "上升",
     down: "下降",
@@ -712,16 +709,19 @@ const I18N = {
     "shown": "显示",
     "tracked": "追踪",
     "of": "共",
-    // --- Export / contact -----------------------------------------------------
-    "Benchmark Radar · data export": "Benchmark Radar · 数据导出",
-    "Take the data with you": "把数据带走",
-    "Download full dataset (JSON)": "下载全量数据集 (JSON)",
-    "Download current view (CSV · {rows} rows)": "下载当前视图 (CSV · {rows} 行)",
+    // --- Contact --------------------------------------------------------------
     "Benchmark Radar": "Benchmark 雷达日报",
     "Get in touch": "联系我",
     Email: "邮件",
     WeChat: "微信",
     Discord: "Discord",
+    "Want the full dataset? No crawler needed: star the repository, then get in touch and I will share a one-click export.":
+      "想要完整数据集？不需要爬虫：先给仓库点个 Star，然后联系我，我会告诉你怎么一键导出。",
+    "Star the repository": "给仓库点 Star",
+    "Want the dataset? No crawler needed: star the repository, then":
+      "想要数据集？不需要爬虫：先给仓库点 Star，然后",
+    "contact the author": "联系作者",
+    "for a one-click export.": "即可一键导出。",
     // --- Remaining dynamic strings ------------------------------------------
     " on a": " 以",
     " scored records on": " 项已评分记录,以",
@@ -742,14 +742,11 @@ const I18N = {
     "Click to pin record details": "点击固定记录详情",
     Comments: "评论",
     "Discovery sources": "发现来源",
-    "Doing related-work research, or hunting for a benchmark on a topic? This database aggregates every benchmark, evaluation, and dataset the radar has surfaced, and you can query it by topic, source, or organization before you export. Everything listed below is the same data the dashboard renders.":
-      "在做相关工作研究,或想按主题查找基准?这个数据库汇总了雷达发现过的每一个基准、评测与数据集,可以在导出前按主题、来源或机构查询。下方列出的所有内容与仪表盘渲染的是同一份数据。",
     "Every benchmark this document puts in front of readers, counted once each. These are mentions, not scores: the source records the configuration, and this registry deliberately does not.":
       "此文档呈现给读者的每个基准,各计一次。这是提及次数,不是分数:来源记录了配置,而这个登记册刻意不记录。",
     "Every record matching at least one taxonomy category is retained. A score of":
       "只要匹配至少一个分类类别的记录都会被保留。达到分数",
     "How priority is scored": "优先度如何评分",
-    "Leaderboard (CSV)": "排行榜 (CSV)",
     "Most represented organizations": "出现最多的机构",
     "No benchmark is reported by a curated card yet.": "目前还没有精选模型卡报告任何基准。",
     "No description published at the source.": "来源没有发布描述。",
@@ -904,7 +901,7 @@ const state = {
   leaderboardShowAll: false,
   leaderboardTopExpanded: false,
   todayResultsKey: "",
-  todayResultsLimit: ALL_DATES_PAGE_SIZE,
+  todayResultsLimit: TODAY_PAGE_SIZE,
   observations: null,
 };
 
@@ -1846,6 +1843,34 @@ function renderTodayBenchmarks() {
   return !total && indexPending ? "pending" : total;
 }
 
+// Loads the next page when the sentinel below the list scrolls into view
+// (issue #311). One observer for the session: the sentinel never leaves the
+// DOM, so a render only re-teaches it how many results remain. A load bumps
+// the bound and re-renders, which re-fires this callback while the sentinel
+// is still on screen -- that is what keeps filling a short first page until
+// something scrollable exists, without ever carding the whole day up front.
+let todaySentinelObserver = null;
+
+function watchTodaySentinel(remainingResults) {
+  const sentinel = byId("today-sentinel");
+  if (!sentinel) return;
+  // No observer support, no scroll loading: the note still reports what is
+  // loaded, and the reader gets every result on the renders that filters
+  // already trigger rather than a dead end.
+  if (typeof IntersectionObserver === "undefined") return;
+  if (!todaySentinelObserver) {
+    todaySentinelObserver = new IntersectionObserver((entries) => {
+      if (!entries.some((entry) => entry.isIntersecting)) return;
+      const total = filteredObservations().length;
+      if (state.todayResultsLimit >= total) return;
+      state.todayResultsLimit += TODAY_PAGE_SIZE;
+      renderToday({ resultsOnly: true });
+    });
+  }
+  todaySentinelObserver.disconnect();
+  todaySentinelObserver.observe(sentinel);
+}
+
 function renderToday({ resultsOnly = false } = {}) {
   // Events are bound before the data file resolves (initialize), so a nav
   // click or filter keystroke in the load window must no-op, not throw.
@@ -1883,28 +1908,23 @@ function renderToday({ resultsOnly = false } = {}) {
   ].join("\u0000");
   if (resultsKey !== state.todayResultsKey) {
     state.todayResultsKey = resultsKey;
-    state.todayResultsLimit = ALL_DATES_PAGE_SIZE;
+    state.todayResultsLimit = TODAY_PAGE_SIZE;
   }
   // A single busy scan can carry hundreds of observations. Bound every render,
   // not just the all-dates archive, so initial load and filter feedback never
   // have to build the entire card list before the reader can interact.
   const visibleObservations = observations.slice(0, state.todayResultsLimit);
   const remainingResults = observations.length - visibleObservations.length;
-  const showMore = byId("today-show-more");
-  showMore.hidden = remainingResults <= 0;
-  showMore.textContent = remainingResults > 0
-    ? `${t("Show")} ${Math.min(ALL_DATES_PAGE_SIZE, remainingResults)} ${t("more")} · ${remainingResults} ${t("remaining")}`
-    : t("Show more results");
+  // The legend is two readings, not three (issue #311): the class breakdown
+  // and the order. The raw total repeated what the breakdown already adds up
+  // to, and the attention noun lost its verb now that it stands beside
+  // "normal" instead of a sentence.
   const evidenceCount = observations.filter(
     (item) => item.observation_kind === "evidence",
   ).length;
   const attentionCount = observations.length - evidenceCount;
-  byId("today-count").textContent =
-    `${observations.length} ${observations.length === 1 ? t("result") : t("results")}`;
-  // The two classes are mutually exclusive, so name them instead of leaving
-  // EVIDENCE and ATTENTION as unexplained jargon (issue #248).
   byId("today-breakdown").textContent =
-    `${evidenceCount} ${t("normal")} · ${attentionCount} ${t("need attention")}`;
+    `${evidenceCount} ${t("normal")} · ${attentionCount} ${t("attention")}`;
   // The list is sorted by priority within a day; say so at the point of use
   // rather than making the reader infer it. Attention rows carry no priority,
   // so a kind-filtered attention set falls back to date order, and in All
@@ -1927,6 +1947,17 @@ function renderToday({ resultsOnly = false } = {}) {
           }),
         ],
   );
+  // What is loaded, said where more loads from (issue #311). Scrolling this
+  // paragraph into view pulls the next page, so the count doubles as the
+  // control's own status line.
+  byId("today-loaded").textContent =
+    remainingResults > 0
+      ? t("{loaded} of {total} results loaded · scroll for more", {
+          loaded: visibleObservations.length,
+          total: observations.length,
+        })
+      : t("All {total} results loaded", { total: observations.length });
+  watchTodaySentinel(remainingResults);
 
   if (resultsOnly) {
     writeUrl();
@@ -6825,119 +6856,16 @@ function brandIcon(name) {
   return svg;
 }
 
-function observationsToCsv(observations) {
-  const columns = [
-    "date",
-    "kind",
-    "title",
-    "summary",
-    "source",
-    "event_kind",
-    "categories",
-    "organizations",
-    "url",
-    "score",
-  ];
-  const escape = (value) => {
-    const text = String(value ?? "");
-    // Quotes and separators force quoting; a leading =, +, -, or @ is also
-    // quoted so a scraped cell cannot execute as a spreadsheet formula.
-    const mustQuote = /[",\n\r]/.test(text) || /^[=+\-@]/.test(text);
-    return mustQuote ? `"${text.replaceAll('"', '""')}"` : text;
-  };
-  const rows = observations.map((item) =>
-    [
-      item.snapshot_date,
-      item.observation_kind,
-      escape(item.title),
-      escape(item.summary || ""),
-      escape(item.source),
-      escape(item.event_kind),
-      escape((item.categories || []).join("; ")),
-      escape((item.organizations || []).join("; ")),
-      escape(item.url || item.primary_artifact_url || ""),
-      Number(item.total_score || 0).toFixed(2),
-    ].join(","),
-  );
-  return [columns.join(","), ...rows].join("\r\n");
-}
-
-function downloadText(filename, text, mimeType = "text/plain") {
-  const blob = new Blob([text], { type: mimeType });
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement("a");
-  link.href = url;
-  link.download = filename;
-  document.body.append(link);
-  link.click();
-  link.remove();
-  URL.revokeObjectURL(url);
-}
-
-// The export dialog (issue #193) does two things at once: it states the
-// usecase that makes this more than a dump, and it puts one-click downloads
-// behind a single control. The usecase is the reason the site exists for a
-// reader doing related-work research: find every benchmark on a topic, or take
-// the whole corpus with you. The JSON link and the client-side CSV are both
-// derived from the same in-memory data the dashboard renders, so an export can
-// never disagree with the screen it came from.
-function openExport() {
-  const dialog = byId("export-dialog");
-  if (!state.data) return;
-  const filtered = filteredObservations();
-  replaceChildren(byId("export-content"), [
-    element("p", { className: "detail-source", text: t("Benchmark Radar · data export") }),
-    element("h2", {
-      className: "detail-title export-title",
-      text: t("Take the data with you"),
-      attrs: { id: "export-title" },
-    }),
-    element("p", {
-      className: "detail-summary",
-      text: t("Doing related-work research, or hunting for a benchmark on a topic? This database aggregates every benchmark, evaluation, and dataset the radar has surfaced, and you can query it by topic, source, or organization before you export. Everything listed below is the same data the dashboard renders."),
-    }),
-    element("div", { className: "export-actions" }, [
-      element("a", {
-        className: "primary-link",
-        text: t("Download full dataset (JSON)"),
-        attrs: { href: "data/radar.json", download: "benchmark-radar.json" },
-      }),
-      element("button", {
-        className: "secondary-link export-csv-button",
-        text: t("Download current view (CSV · {rows} rows)", { rows: filtered.length }),
-        attrs: { type: "button" },
-      }),
-      element("a", {
-        className: "secondary-link",
-        text: t("Leaderboard (CSV)"),
-        attrs: { href: "data/leaderboard.csv", download: "leaderboard.csv" },
-      }),
-    ]),
-    element("p", {
-      className: "discovery-note",
-      text: t("{observations} observations across {snapshots} daily snapshots.", {
-        observations: allObservations().length,
-        snapshots: state.data.snapshot_count,
-      }),
-    }),
-  ]);
-  byId("export-content")
-    .querySelector(".export-csv-button")
-    .addEventListener("click", () => {
-      downloadText(
-        `benchmark-radar-${state.todayDate === "all" ? "all" : state.todayDate}.csv`,
-        observationsToCsv(filtered),
-        "text/csv;charset=utf-8",
-      );
-    });
-  dialog.showModal();
-}
-
 // The contact dialog (issue #191) keeps every reach-out channel in one place:
 // email, WeChat, and Discord. The header badge (issue #213) merged the two
 // separate WeChat and Discord buttons into a single Contact control that
 // opens this dialog, so a reader lands on a choice rather than being launched
 // out of the page on a guess.
+//
+// Since issue #311 it also answers "where is the data": the header export
+// button is gone, and dataset requests are meant to arrive as a conversation.
+// Star first, then ask -- the note says so, so neither side wastes a round
+// trip.
 function openContact() {
   const dialog = byId("contact-dialog");
   replaceChildren(byId("contact-content"), [
@@ -6977,6 +6905,24 @@ function openContact() {
         ]),
         element("span", { className: "contact-value", text: `ID ${DISCORD_ID}` }),
       ]),
+    ]),
+    // The dataset answer travels with the contact channels (issue #311): a
+    // reader opening this sheet to ask for data reads the terms of the ask
+    // before writing it.
+    element("div", { className: "contact-dataset" }, [
+      element("p", {
+        className: "detail-summary",
+        text: t("Want the full dataset? No crawler needed: star the repository, then get in touch and I will share a one-click export."),
+      }),
+      element("a", {
+        className: "secondary-link",
+        text: t("Star the repository"),
+        attrs: {
+          href: `https://github.com/${REPO_SLUG}`,
+          target: "_blank",
+          rel: "noopener noreferrer",
+        },
+      }),
     ]),
   ]);
   dialog.showModal();
@@ -7047,10 +6993,6 @@ function bindEvents() {
   byId("today-date").addEventListener("change", (event) => {
     state.todayDate = event.target.value;
     renderToday();
-  });
-  byId("today-show-more").addEventListener("click", () => {
-    state.todayResultsLimit += ALL_DATES_PAGE_SIZE;
-    renderToday({ resultsOnly: true });
   });
   byId("trend-released-only").addEventListener("change", (event) => {
     state.trendReleasedOnly = event.target.checked;
@@ -7156,12 +7098,10 @@ function bindEvents() {
   // Reachable without a record in hand, for a reader who wants the method
   // before they trust any single row.
   byId("rubric-nav").addEventListener("click", () => openRubric());
-  byId("badge-export").addEventListener("click", openExport);
   byId("badge-contact").addEventListener("click", openContact);
-  byId("export-close").addEventListener("click", () => byId("export-dialog").close());
-  byId("export-dialog").addEventListener("click", (event) => {
-    if (event.target === byId("export-dialog")) byId("export-dialog").close();
-  });
+  // The footer's "contact the author" opens the same sheet as the header
+  // badge (issue #311): one contact surface, two doors.
+  byId("footer-contact").addEventListener("click", openContact);
   byId("contact-close").addEventListener("click", () => byId("contact-dialog").close());
   byId("contact-dialog").addEventListener("click", (event) => {
     if (event.target === byId("contact-dialog")) byId("contact-dialog").close();

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -902,6 +902,7 @@ const state = {
   leaderboardTopExpanded: false,
   todayResultsKey: "",
   todayResultsLimit: TODAY_PAGE_SIZE,
+  todayRenderedCount: 0,
   observations: null,
 };
 
@@ -1906,7 +1907,9 @@ function renderToday({ resultsOnly = false } = {}) {
     state.organization,
     state.event,
   ].join("\u0000");
+  let resultsKeyChanged = false;
   if (resultsKey !== state.todayResultsKey) {
+    resultsKeyChanged = true;
     state.todayResultsKey = resultsKey;
     state.todayResultsLimit = TODAY_PAGE_SIZE;
   }
@@ -1936,17 +1939,31 @@ function renderToday({ resultsOnly = false } = {}) {
     : showingAllDates
       ? t("Sort: Date, then Priority ↓")
       : t("Sort: Priority ↓");
-  replaceChildren(
-    byId("today-list"),
-    visibleObservations.length
-      ? visibleObservations.map(observationCard)
-      : [
-          element("p", {
-            className: "empty-state",
-            text: emptyTodayMessage(day, benchmarkMatches),
-          }),
-        ],
-  );
+  // A load-more pass appends the new page rather than rebuilding the list:
+  // replaceChildren would recreate every <details> closed, collapsing a card
+  // the reader had expanded and jumping them up the page mid-read.
+  const listHost = byId("today-list");
+  const renderedCount = state.todayRenderedCount || 0;
+  const growsInPlace =
+    !resultsKeyChanged && renderedCount > 0 && visibleObservations.length > renderedCount;
+  if (growsInPlace) {
+    listHost.append(
+      ...visibleObservations.slice(renderedCount).map(observationCard),
+    );
+  } else {
+    replaceChildren(
+      listHost,
+      visibleObservations.length
+        ? visibleObservations.map(observationCard)
+        : [
+            element("p", {
+              className: "empty-state",
+              text: emptyTodayMessage(day, benchmarkMatches),
+            }),
+          ],
+    );
+  }
+  state.todayRenderedCount = visibleObservations.length;
   // What is loaded, said where more loads from (issue #311). Scrolling this
   // paragraph into view pulls the next page, so the count doubles as the
   // control's own status line.

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -1852,12 +1852,18 @@ function renderTodayBenchmarks() {
 // something scrollable exists, without ever carding the whole day up front.
 let todaySentinelObserver = null;
 
+function todayPageLimit() {
+  // Without IntersectionObserver there is no scroll trigger, and the manual
+  // button is gone; capping the list there would strand every row past the
+  // first page behind a control that does not exist. The bound is the scroll
+  // loading mechanism, so an engine without one gets the uncapped list.
+  if (typeof IntersectionObserver === "undefined") return Infinity;
+  return state.todayResultsLimit;
+}
+
 function watchTodaySentinel(remainingResults) {
   const sentinel = byId("today-sentinel");
   if (!sentinel) return;
-  // No observer support, no scroll loading: the note still reports what is
-  // loaded, and the reader gets every result on the renders that filters
-  // already trigger rather than a dead end.
   if (typeof IntersectionObserver === "undefined") return;
   if (!todaySentinelObserver) {
     todaySentinelObserver = new IntersectionObserver((entries) => {
@@ -1916,7 +1922,7 @@ function renderToday({ resultsOnly = false } = {}) {
   // A single busy scan can carry hundreds of observations. Bound every render,
   // not just the all-dates archive, so initial load and filter feedback never
   // have to build the entire card list before the reader can interact.
-  const visibleObservations = observations.slice(0, state.todayResultsLimit);
+  const visibleObservations = observations.slice(0, todayPageLimit());
   const remainingResults = observations.length - visibleObservations.length;
   // The legend is two readings, not three (issue #311): the class breakdown
   // and the order. The raw total repeated what the breakdown already adds up

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -170,7 +170,8 @@ th {
 
 .masthead-end {
   display: grid;
-  grid-template-columns: repeat(7, 2.6rem);
+  /* RSS, language, contact, then the three-square star/fork/issues group. */
+  grid-template-columns: repeat(6, 2.6rem);
   gap: 0.7rem;
   align-items: center;
   justify-content: flex-end;
@@ -244,10 +245,10 @@ th {
   visibility: visible;
 }
 
-/* The export and contact controls are <button>s, not <a>s, because they open
-   dialogs instead of navigating. Without these resets a button renders with
-   the user agent's default chrome (grey background, distinct font) over the
-   repo-badge styling shared with the links beside it. */
+/* The language and contact controls are <button>s, not <a>s, because they
+   open dialogs and toggle state instead of navigating. Without these resets a
+   button renders with the user agent's default chrome (grey background,
+   distinct font) over the repo-badge styling shared with the links beside it. */
 button.repo-badge {
   appearance: none;
   background: transparent;
@@ -3473,51 +3474,17 @@ dialog::backdrop {
   font-size: 0.85rem;
 }
 
-.export-actions {
+/* The dataset note inside the contact sheet (issue #311): the ask's terms sit
+   under the channels, with the star action one click away. */
+.contact-dataset {
   display: grid;
-  gap: 0.6rem;
-  margin: 1.5rem 0;
+  gap: 0.75rem;
+  justify-items: start;
+  margin-top: 1.5rem;
 }
 
-.export-actions .primary-link,
-.export-actions .secondary-link {
-  display: block;
-  padding: 0.75rem 1rem;
-  border: 1px solid var(--line);
-  font-family: var(--utility);
-  font-size: 0.72rem;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-}
-
-.export-actions .primary-link {
-  border-color: var(--blue);
-  color: var(--blue);
-}
-
-.export-actions .primary-link:hover {
-  background: var(--blue);
-  color: var(--panel);
-}
-
-.export-actions button.secondary-link {
-  width: 100%;
-  appearance: none;
-  background: transparent;
-  cursor: pointer;
-  font: inherit;
-  letter-spacing: 0.05em;
-  text-align: left;
-  text-transform: uppercase;
-}
-
-.export-actions .secondary-link:hover {
-  border-color: var(--ink);
-  color: var(--ink);
-}
-
-.export-title {
-  font-size: clamp(1.8rem, 4vw, 2.8rem);
+.contact-dataset .detail-summary {
+  margin: 0;
 }
 
 .contact-list {
@@ -3625,9 +3592,39 @@ dialog::backdrop {
   text-transform: uppercase;
 }
 
-.today-show-more {
-  margin-top: 1.5rem;
-  background: transparent;
+/* The load status sits where more results load from (issue #311): quiet
+   metadata, not a control, because scrolling is the control. */
+.today-loaded-note {
+  margin: 1.25rem 0 0;
+  color: var(--muted);
+  font-family: var(--utility);
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+/* The scroll target the observer watches. Zero-height elements can report
+   degenerate intersections in some engines, so it keeps one pixel. */
+#today-sentinel {
+  height: 1px;
+}
+
+.footer-dataset {
+  margin: 0.4rem 0 0;
+  color: var(--muted);
+  font-family: var(--body);
+  font-size: 0.78rem;
+}
+
+.footer-contact-link {
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--ink);
+  font: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
 .stale-banner {
@@ -3762,9 +3759,9 @@ footer {
   }
 
   .masthead-end {
-    /* 7 * 2.1rem + 6 * 0.5rem gaps = 283px, so the full row still fits a
+    /* 6 * 2.1rem + 5 * 0.5rem gaps = 241px, so the full row still fits a
        320px-wide phone once it wraps below the brand (issue #213 squares). */
-    grid-template-columns: repeat(7, 2.1rem);
+    grid-template-columns: repeat(6, 2.1rem);
     gap: 0.5rem;
   }
 

--- a/site/index.html
+++ b/site/index.html
@@ -78,27 +78,12 @@
           <span class="repo-badge-glyph" id="lang-toggle-label">中</span>
         </button>
         <!--
-          These two open dialogs rather than linking out: exporting a dataset
-          needs a moment of explanation about what is being handed over, and the
-          contact button (issue #213) opens one sheet that keeps email, WeChat,
-          and Discord in a single place. Reachable without navigating away from
-          the current view.
+          The contact button (issue #213) opens one sheet that keeps email,
+          WeChat, and Discord in a single place, reachable without navigating
+          away from the current view. Dataset access (issue #311) travels with
+          it: the header carries no export button any more, and the contact
+          sheet plus the footer note say how to get the data.
         -->
-        <button
-          type="button"
-          class="repo-badge"
-          id="badge-export"
-          aria-haspopup="dialog"
-          title="Export the dataset"
-          data-i18n-title="Export the dataset"
-        >
-          <svg viewBox="0 0 24 24" aria-hidden="true">
-            <path d="M12 3v12"></path>
-            <path d="m7 8 5 5 5-5"></path>
-            <path d="M4 21h16"></path>
-          </svg>
-          <span class="repo-badge-label" data-i18n="Data">Data</span>
-        </button>
         <button
           type="button"
           class="repo-badge"
@@ -277,7 +262,6 @@
             <div class="section-title">
               <h2 data-i18n="Today's radar">Today's radar</h2>
               <div class="results-meta" aria-live="polite">
-                <span id="today-count"></span>
                 <span id="today-breakdown"></span>
                 <span id="today-sort"></span>
               </div>
@@ -288,9 +272,15 @@
               <div id="today-benchmarks-results"></div>
             </section>
             <div class="signal-list" id="today-list"></div>
-            <button class="secondary-link today-show-more" id="today-show-more" type="button" hidden data-i18n="Show more results">
-              Show more results
-            </button>
+            <!--
+              The list is bounded (issue #311): the first paint carries one page
+              of results, and this note states how many of the day's results are
+              on screen. Scrolling to it loads the next page in place, so a
+              reader never waits on the whole day (or the whole archive) being
+              carded before they can read.
+            -->
+            <p class="today-loaded-note" id="today-loaded" role="status"></p>
+            <div id="today-sentinel" aria-hidden="true"></div>
           </div>
           <div>
             <!-- The day's narrative and Q&A describe the whole scan date
@@ -673,16 +663,6 @@
       <div id="rubric-content"></div>
     </dialog>
 
-    <dialog id="export-dialog" aria-labelledby="export-title">
-      <button
-        class="dialog-close"
-        id="export-close"
-        type="button"
-        aria-label="Close data export"
-      >×</button>
-      <div id="export-content"></div>
-    </dialog>
-
     <dialog id="contact-dialog" aria-labelledby="contact-title">
       <button
         class="dialog-close"
@@ -695,6 +675,22 @@
 
     <footer>
       <p id="build-meta">Updated —</p>
+      <!--
+        Dataset access without a crawler (issue #311): the header export button
+        is gone, so this note is the standing answer to "where is the data".
+        Star first, then ask; the contact button opens the same sheet as the
+        header badge.
+      -->
+      <p class="footer-dataset">
+        <span data-i18n="Want the dataset? No crawler needed: star the repository, then">Want the dataset? No crawler needed: star the repository, then</span>
+        <button
+          type="button"
+          class="footer-contact-link"
+          id="footer-contact"
+          data-i18n="contact the author"
+        >contact the author</button>
+        <span data-i18n="for a one-click export.">for a one-click export.</span>
+      </p>
     </footer>
   </body>
 </html>

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1877,6 +1877,12 @@ def test_issue_311_the_today_list_loads_one_page_at_a_time():
     assert "watchTodaySentinel(remainingResults);" in renderer
     assert 'id="today-show-more"' not in html
 
+    # A load-more pass appends the new page instead of rebuilding the list,
+    # so a card the reader expanded stays open under them.
+    assert "const growsInPlace =" in renderer
+    assert "listHost.append(" in renderer
+    assert "state.todayRenderedCount = visibleObservations.length;" in renderer
+
     # The bottom line reports what loaded.
     assert "{loaded} of {total} results loaded · scroll for more" in renderer
     assert "All {total} results loaded" in renderer

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -95,7 +95,7 @@ def test_scan_date_can_be_reset_to_all_dates():
     assert 'params.set("date", "all")' in script
     # The list is bounded and scroll-fed (issue #311): one page at a time, no
     # button, a status line saying how much is loaded.
-    assert "observations.slice(0, state.todayResultsLimit)" in script
+    assert "observations.slice(0, todayPageLimit())" in script
     assert "state.todayResultsLimit += TODAY_PAGE_SIZE" in script
     assert "const TODAY_PAGE_SIZE = 20;" in script
     assert 'id="today-loaded"' in html
@@ -112,7 +112,7 @@ def test_dashboard_bounds_work_before_and_during_filtering():
 
     assert "state.observations = [...evidence, ...attention].sort" in script
     assert "if (state.observations) return state.observations" in script
-    assert "const visibleObservations = observations.slice(0, state.todayResultsLimit)" in script
+    assert "const visibleObservations = observations.slice(0, todayPageLimit())" in script
     assert "renderToday({ resultsOnly: true })" in script
     assert 'if (state.view === "today") renderToday()' in script
     assert 'if (state.view === "leaderboard") renderLeaderboard()' in script
@@ -1865,7 +1865,7 @@ def test_issue_311_the_today_list_loads_one_page_at_a_time():
         "\nfunction ", 1
     )[0]
     assert "state.todayResultsLimit = TODAY_PAGE_SIZE;" in renderer
-    assert "const visibleObservations = observations.slice(0, state.todayResultsLimit);" in renderer
+    assert "const visibleObservations = observations.slice(0, todayPageLimit());" in renderer
 
     # Scroll loads; no button competes with it.
     assert "function watchTodaySentinel(" in script

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -93,10 +93,15 @@ def test_scan_date_can_be_reset_to_all_dates():
     assert 'state.todayDate === "all" || item.snapshot_date === state.todayDate' in script
     assert 'state.todayDate = "all";' in script
     assert 'params.set("date", "all")' in script
-    assert 'id="today-show-more"' in html
-    assert 'id="source-health-panel"' in html
+    # The list is bounded and scroll-fed (issue #311): one page at a time, no
+    # button, a status line saying how much is loaded.
     assert "observations.slice(0, state.todayResultsLimit)" in script
-    assert "state.todayResultsLimit += ALL_DATES_PAGE_SIZE" in script
+    assert "state.todayResultsLimit += TODAY_PAGE_SIZE" in script
+    assert "const TODAY_PAGE_SIZE = 20;" in script
+    assert 'id="today-loaded"' in html
+    assert 'id="today-sentinel"' in html
+    assert "function watchTodaySentinel(" in script
+    assert 'id="today-show-more"' not in html
     assert 'byId("daily-briefing").hidden = showingAllDates' in script
     assert 'byId("source-health-panel").hidden = showingAllDates' in script
 
@@ -160,17 +165,21 @@ def test_top_right_utilities_use_shared_icon_geometry_and_contact_control():
     styles = Path("site/assets/styles.css").read_text(encoding="utf-8")
 
     assert 'id="badge-contact"' in html
+    # The export badge is gone (issue #311): dataset requests go through the
+    # contact sheet and the footer note, not a header button.
+    assert 'id="badge-export"' not in html
+    assert 'id="export-dialog"' not in html
     assert 'id="badge-wechat"' not in html
     assert 'id="badge-discord"' not in html
     assert 'id="lang-toggle"' in html
     assert 'class="repo-badge"' in html
-    assert "grid-template-columns: repeat(7, 2.6rem)" in styles
+    assert "grid-template-columns: repeat(6, 2.6rem)" in styles
     assert "width: 2.6rem" in styles
     assert "height: 2.6rem" in styles
     assert "grid-column: span 3" in styles
     assert 'class="repo-badge-glyph" id="lang-toggle-label">中<' in html
     assert 'class="brand-icon github-icon"' in html
-    assert "grid-template-columns: repeat(7, 2.1rem)" in styles
+    assert "grid-template-columns: repeat(6, 2.1rem)" in styles
     assert "flex: 0 0 1.5rem" in styles
     assert ".repo-badge svg," in styles
 
@@ -347,10 +356,11 @@ def test_records_expand_inline_without_an_exclusive_accordion_or_record_modal():
     assert "detail-dialog" not in script
     # A shared details[name] would force one row closed when another opens.
     assert "attrs: { name:" not in script
-    # The three dialogs on the page are non-record chrome: the scoring rubric,
-    # the data export, and the contact sheet. Record detail must stay inline,
-    # so any fourth showModal() is a regression to a record modal.
-    assert script.count(".showModal()") == 3
+    # The two dialogs on the page are non-record chrome: the scoring rubric and
+    # the contact sheet (the export dialog went with the export button,
+    # issue #311). Record detail must stay inline, so any third showModal()
+    # is a regression to a record modal.
+    assert script.count(".showModal()") == 2
 
 
 def test_hugging_face_expansion_links_to_the_full_card():
@@ -391,9 +401,11 @@ def test_dashboard_links_are_validated_escaped_and_non_swallowing():
     # Regression guards for the browser-side hardening: every external href is
     # produced by safeHttpUrl; the interactive map is role="group" (ARIA makes
     # descendants of role="img" presentational, hiding its focusable markers);
-    # CSV export quotes cells that would run as spreadsheet formulas; Escape
-    # yields to an open dialog instead of swallowing the first press; and
-    # clearing the adoption frontier also clears its org color key.
+    # Escape yields to an open dialog instead of swallowing the first press;
+    # and clearing the adoption frontier also clears its org color key.
+    #
+    # The CSV formula-quoting guard retired with the client-side export
+    # (issue #311 removed the export dialog and its CSV builder).
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
 
     assert "function safeHttpUrl(" in script
@@ -405,7 +417,6 @@ def test_dashboard_links_are_validated_escaped_and_non_swallowing():
     # tooltip, not role="img", because it is a focusable, clickable marker.
     assert 'role: "group"' in script
     assert script.count('role: "img"') == 1
-    assert "/^[=+\\-@]/" in script
     assert 'document.querySelector("dialog[open]")' in script
     assert "Do not swallow Escape" in script
     assert 'replaceChildren(byId("frontier-org-key"), [])' in script
@@ -1834,3 +1845,58 @@ def test_issue_286_navigation_is_backable_but_typing_is_not():
 
     # Pushing the URL already shown would make Back a no-op that looks broken.
     assert 'if (mode === "push" && url !== current)' in script
+
+
+def test_issue_311_the_today_list_loads_one_page_at_a_time():
+    """A busy day carded 100+ results before the reader could scroll.
+
+    The first paint now carries 20 cards, the legend is two readings instead
+    of three, and more load only when the reader scrolls to the sentinel under
+    the list. The status line at the bottom states how much is on screen, so
+    progressive loading never reads as a truncated list.
+    """
+    html = Path("site/index.html").read_text(encoding="utf-8")
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    # One named page size, applied at first paint and on every filter change.
+    assert "const TODAY_PAGE_SIZE = 20;" in script
+    assert "todayResultsLimit: TODAY_PAGE_SIZE," in script
+    renderer = script.split("function renderToday({ resultsOnly = false } = {})", 1)[1].split(
+        "\nfunction ", 1
+    )[0]
+    assert "state.todayResultsLimit = TODAY_PAGE_SIZE;" in renderer
+    assert "const visibleObservations = observations.slice(0, state.todayResultsLimit);" in renderer
+
+    # Scroll loads; no button competes with it.
+    assert "function watchTodaySentinel(" in script
+    watcher = script.split("function watchTodaySentinel(", 1)[1].split("\nfunction ", 1)[0]
+    assert "new IntersectionObserver(" in watcher
+    assert "state.todayResultsLimit += TODAY_PAGE_SIZE;" in watcher
+    assert "renderToday({ resultsOnly: true });" in watcher
+    assert 'id="today-sentinel"' in html
+    assert "watchTodaySentinel(remainingResults);" in renderer
+    assert 'id="today-show-more"' not in html
+
+    # The bottom line reports what loaded.
+    assert "{loaded} of {total} results loaded · scroll for more" in renderer
+    assert "All {total} results loaded" in renderer
+
+    # The legend keeps the class breakdown and the order; the raw total and
+    # its duplicated noun are gone, and "need attention" lost its verb.
+    assert 'id="today-count"' not in html
+    assert 'byId("today-breakdown").textContent =' in renderer
+    assert '${attentionCount} ${t("attention")}' in renderer
+    assert '"need attention"' not in script
+
+    # Dataset access moved out of the header: contact-first, star-first.
+    assert 'id="badge-export"' not in html
+    assert 'id="export-dialog"' not in html
+    assert "function openExport(" not in script
+    assert "function observationsToCsv(" not in script
+    assert "function downloadText(" not in script
+    footer = html.split('<p class="footer-dataset">', 1)[1].split("</p>", 1)[0]
+    assert "No crawler needed: star the repository" in footer
+    assert 'id="footer-contact"' in footer
+    contact = script.split("function openContact()", 1)[1].split("dialog.showModal();", 1)[0]
+    assert "No crawler needed: star the repository" in contact
+    assert 'className: "contact-dataset"' in contact

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1881,6 +1881,7 @@ def test_issue_311_the_today_list_loads_one_page_at_a_time():
     # so a card the reader expanded stays open under them.
     assert "const growsInPlace =" in renderer
     assert "listHost.append(" in renderer
+    assert "observationCard(item, renderedCount + offset))" in renderer
     assert "state.todayRenderedCount = visibleObservations.length;" in renderer
 
     # No IntersectionObserver, no scroll trigger, no button: the cap would

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1883,6 +1883,12 @@ def test_issue_311_the_today_list_loads_one_page_at_a_time():
     assert "listHost.append(" in renderer
     assert "state.todayRenderedCount = visibleObservations.length;" in renderer
 
+    # No IntersectionObserver, no scroll trigger, no button: the cap would
+    # strand every row past the first page, so the bound is removed instead.
+    fallback = script.split("function todayPageLimit()", 1)[1].split("\nfunction ", 1)[0]
+    assert "return Infinity;" in fallback
+    assert "observations.slice(0, todayPageLimit())" in renderer
+
     # The bottom line reports what loaded.
     assert "{loaded} of {total} results loaded · scroll for more" in renderer
     assert "All {total} results loaded" in renderer


### PR DESCRIPTION
Fixes #311.

## Summary
- First paint cards 20 observations (TODAY_PAGE_SIZE); further pages load when a sentinel below the list scrolls into view. A load-more pass appends in place so expanded cards stay open and row ranks continue across pages.
- The bottom status line states what loaded: "{loaded} of {total} results loaded · scroll for more".
- Legend trimmed to the two readings worth keeping: "136 normal · 9 attention" plus the sort note; the duplicated raw total is gone.
- Header export badge, export dialog and client-side CSV builder removed. The contact sheet now answers dataset requests ("No crawler needed: star the repository, then get in touch for a one-click export") and a footer note says the same, with a button that opens the contact dialog.
- Without IntersectionObserver support the cap is lifted entirely instead of stranding rows past page one.

## Test plan
- pytest: 865 passed, 6 skipped (includes new test_issue_311_the_today_list_loads_one_page_at_a_time).
- node --check on app.js; briefing/questions/stale-banner render harnesses run inside pytest.
- codex review --base main: clean after three rounds (append-not-rebuild, no-observer fallback, rank offset).