### PR TITLE
fix(site): reveal the saturation view left to right

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -5689,15 +5689,19 @@ function scoreTrackChart(entry, board) {
       const pointX = x(observation.reported_at);
       const pointY = scoreY(observation.value);
       // "其他的点可以淡化" (issue #312): readings that are not part of the
-      // saturation line recede behind it. Hover and focus restore them, so
-      // de-emphasis never costs legibility. Membership is looked up under the
-      // observation's own comparable run, so a same-date same-value reading
-      // from another run stays off the line.
+      // saturation line recede behind it -- but only while there IS a line.
+      // A benchmark with no comparable pair draws no reference, so every
+      // point keeps full emphasis rather than all of it receding together.
+      // Hover and focus restore a receded point, so de-emphasis never costs
+      // legibility. Membership is looked up under the observation's own
+      // comparable run, so a same-date same-value reading from another run
+      // stays off the line.
       const onFrontier = frontierMarks.has(
         `${observation.instrument || ""}\u0000${observation.protocol || ""}\u0000${new Date(
           `${observation.reported_at}T00:00:00Z`,
         ).getTime()}\u0000${observation.value}`,
       );
+      const offTheLine = Boolean(frontierSteps?.length) && !onFrontier;
       // Entrance order follows the axis (issue #312): each point brightens
       // while the drawing front crosses its date, so the reveal reads left to
       // right the way the data does. The timing is shared with the crawled
@@ -5705,7 +5709,7 @@ function scoreTrackChart(entry, board) {
       const revealDelay = frontierPointRevealDelay(pointX, margin, plotWidth);
       const group = svgElement("g", {
         class: `score-point${
-          onFrontier ? "" : " score-point-dim"
+          offTheLine ? " score-point-dim" : ""
         }${observation.reported_by ? " score-point-third-party" : ""}`,
         tabindex: "0",
         role: "button",

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -4664,6 +4664,12 @@ function renderExternalBenchmark(board, scored, record) {
       ]);
       return;
     }
+    // The entrance is keyed to arriving at this record; a re-render after an
+    // unrelated panel redraw does not replay it.
+    container.classList.toggle(
+      "score-chart-enter",
+      frontierShouldAnimate(`external:${record.slug}`),
+    );
     replaceChildren(container, externalBenchmarkDetail(shard));
   });
 }
@@ -5396,6 +5402,18 @@ function frontierPointRevealDelay(pointX, margin, plotWidth) {
   return Math.round(120 + ((pointX - margin.left) / plotWidth) * 780);
 }
 
+// The entrance plays when the reader arrives at a benchmark, not on every
+// incidental redraw of the panel they are already reading (the crawled index
+// settling, an unrelated filter keystroke, a language toggle). Each drawn
+// selection is remembered; redrawing the same one skips the replay.
+let lastFrontierEntranceKey = null;
+
+function frontierShouldAnimate(key) {
+  const animate = lastFrontierEntranceKey !== key;
+  lastFrontierEntranceKey = key;
+  return animate;
+}
+
 function scoreTrackChart(entry, board) {
   const record = scoreRecord(entry.benchmark_id);
   // Callers only ever select a benchmark that has a score record; this guard is
@@ -5943,6 +5961,10 @@ function renderAdoptionFrontier(board) {
   renderFrontierLegend(entry, record);
   renderFrontierOrgKey(record);
   clearFrontierPointSelection();
+  byId("frontier-chart").classList.toggle(
+    "score-chart-enter",
+    frontierShouldAnimate(`curated:${entry.benchmark_id}`),
+  );
   replaceChildren(byId("frontier-chart"), [scoreTrackChart(entry, board), frontierTooltip()]);
   renderScoreReadout(entry);
   renderFrontierTaskPreview(entry);

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -5422,16 +5422,26 @@ function frontierPointRevealDelay(pointX, margin, plotWidth) {
 const FRONTIER_ENTRANCE_MS = 1400;
 let completedFrontierEntranceKey = null;
 let frontierEntranceTimer = null;
+let drawnFrontierEntranceKey = null;
 
 function frontierShouldAnimate(key) {
   if (state.view !== "leaderboard") return false;
+  // Remember what is actually on screen: the completion callback below may
+  // fire after the reader has moved to another benchmark.
+  drawnFrontierEntranceKey = key;
   const done = completedFrontierEntranceKey === key;
   if (!done) {
     clearTimeout(frontierEntranceTimer);
     frontierEntranceTimer = setTimeout(() => {
-      // Spending the entrance requires that it was seen: a reader who
-      // navigated away mid-reveal gets it again on return.
-      if (state.view === "leaderboard") completedFrontierEntranceKey = key;
+      // Spending the entrance requires that it was seen to the end: a reader
+      // who navigated away mid-reveal, to another view or another benchmark,
+      // gets it again on return.
+      if (
+        state.view === "leaderboard" &&
+        drawnFrontierEntranceKey === key
+      ) {
+        completedFrontierEntranceKey = key;
+      }
     }, FRONTIER_ENTRANCE_MS);
   }
   return !done;
@@ -5576,7 +5586,8 @@ function scoreTrackChart(entry, board) {
     // The line belongs to exactly one comparable run -- the one with the most
     // advances (issue #288). Its steps draw it; its best-so-far holders light
     // up with it.
-    const runSteps = [...runs.values()].map((points) => ({
+    const runSteps = [...runs.entries()].map(([key, points]) => ({
+      key,
       points,
       steps: runningBestSteps(points, { descends: scoreDescends }),
     }));
@@ -5585,10 +5596,11 @@ function scoreTrackChart(entry, board) {
     // Which points the saturation line is made of (issue #312's definition):
     // within that run, every reading that holds the best value as of its
     // date. These stay at full emphasis; all other points fade back so the
-    // eye lands on the line first. Keyed by time and value, which is what a
-    // step records, so ties on both are line members too. Gated on the line
-    // actually existing -- a benchmark whose history holds no comparable pair
-    // draws no line, so nothing may dim behind an absent reference.
+    // eye lands on the line first. Membership is keyed by run, then time and
+    // value, so an unrelated run reporting the same number on the same date
+    // is not mistaken for the line. Gated on the line actually existing -- a
+    // benchmark whose history holds no comparable pair draws no line, so
+    // nothing may dim behind an absent reference.
     const frontierMarks = new Set();
     if (frontier && frontier.steps.length) {
       let best = null;
@@ -5597,7 +5609,7 @@ function scoreTrackChart(entry, board) {
           best = point.value;
         }
         if (point.value === best) {
-          frontierMarks.add(`${point.time}\u0000${point.value}`);
+          frontierMarks.add(`${frontier.key}\u0000${point.time}\u0000${point.value}`);
         }
       }
     }
@@ -5654,9 +5666,13 @@ function scoreTrackChart(entry, board) {
       const pointY = scoreY(observation.value);
       // "其他的点可以淡化" (issue #312): readings that are not part of the
       // saturation line recede behind it. Hover and focus restore them, so
-      // de-emphasis never costs legibility.
+      // de-emphasis never costs legibility. Membership is looked up under the
+      // observation's own comparable run, so a same-date same-value reading
+      // from another run stays off the line.
       const onFrontier = frontierMarks.has(
-        `${new Date(`${observation.reported_at}T00:00:00Z`).getTime()}\u0000${observation.value}`,
+        `${observation.instrument || ""}\u0000${observation.protocol || ""}\u0000${new Date(
+          `${observation.reported_at}T00:00:00Z`,
+        ).getTime()}\u0000${observation.value}`,
       );
       // Entrance order follows the axis (issue #312): each point brightens
       // while the drawing front crosses its date, so the reveal reads left to

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -4597,6 +4597,9 @@ function renderExternalShell(
 ) {
   clearFrontierPointSelection();
   setCanonicalFrontierChrome(false);
+  // A shell replaces whatever chart was on screen, so no completion timer may
+  // spend a reveal the reader is no longer looking at.
+  drawnFrontierEntranceKey = null;
   // An empty eyebrow or badge is hidden rather than rendered blank: a crawled
   // record states its source once, on the subline, and repeating it in a
   // non-interactive chip beside the title read as broken state (issue #298).
@@ -5583,10 +5586,31 @@ function scoreTrackChart(entry, board) {
         value: observation.value,
       });
     }
+    // Same-date readings collapse to their directional best before anything
+    // reads them: drawn in source order, the line could step twice on one
+    // date and pass through an inferior number that shares a better reading's
+    // date. Collapsing here means the steps, and the membership marks derived
+    // from them, can never disagree.
+    const collapsedRuns = [...runs.entries()].map(([key, points]) => {
+      const bestByDate = new Map();
+      for (const point of points) {
+        const current = bestByDate.get(point.time);
+        if (
+          current === undefined ||
+          (scoreDescends ? point.value < current : point.value > current)
+        ) {
+          bestByDate.set(point.time, point.value);
+        }
+      }
+      const collapsed = [...bestByDate.entries()]
+        .sort((a, b) => a[0] - b[0])
+        .map(([time, value]) => ({ time, value }));
+      return { key, points: collapsed };
+    });
     // The line belongs to exactly one comparable run -- the one with the most
     // advances (issue #288). Its steps draw it; its best-so-far holders light
     // up with it.
-    const runSteps = [...runs.entries()].map(([key, points]) => ({
+    const runSteps = collapsedRuns.map(({ key, points }) => ({
       key,
       points,
       steps: runningBestSteps(points, { descends: scoreDescends }),
@@ -5603,27 +5627,13 @@ function scoreTrackChart(entry, board) {
     // nothing may dim behind an absent reference.
     const frontierMarks = new Set();
     if (frontier && frontier.steps.length) {
-      // Same-date readings collapse to their directional best first: read in
-      // source order, an inferior number could otherwise be marked best-so-far
-      // merely because it was seen before the better reading on its own date.
-      const bestByDate = new Map();
-      for (const point of frontier.points) {
-        const current = bestByDate.get(point.time);
-        if (
-          current === undefined ||
-          (scoreDescends ? point.value < current : point.value > current)
-        ) {
-          bestByDate.set(point.time, point.value);
-        }
-      }
       let best = null;
-      for (const time of [...bestByDate.keys()].sort((a, b) => a - b)) {
-        const value = bestByDate.get(time);
-        if (best === null || (scoreDescends ? value < best : value > best)) {
-          best = value;
+      for (const point of frontier.points) {
+        if (best === null || (scoreDescends ? point.value < best : point.value > best)) {
+          best = point.value;
         }
-        if (value === best) {
-          frontierMarks.add(`${frontier.key}\u0000${time}\u0000${value}`);
+        if (point.value === best) {
+          frontierMarks.add(`${frontier.key}\u0000${point.time}\u0000${point.value}`);
         }
       }
     }
@@ -5880,6 +5890,9 @@ function clearAdoptionFrontier(message) {
   // restored here rather than at each call site: an external selection that
   // hid it must not leave the next canonical render missing its chart blocks.
   setCanonicalFrontierChrome(true);
+  // The empty state replaces any chart on screen, so a running completion
+  // timer must not spend its reveal.
+  drawnFrontierEntranceKey = null;
   byId("frontier-eyebrow").textContent = t("Scores over time");
   const stage = byId("frontier-stage");
   stage.textContent = "";

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -5534,6 +5534,11 @@ function scoreTrackChart(entry, board) {
           ),
           class: "score-frontier-line",
           fill: "none",
+          // Normalized length: the entrance animation (issue #312) draws the
+          // line with a dash offset from 1 to 0, which needs a total length
+          // known in advance. Measuring geometry on this detached tree is not
+          // portable, so the length is declared instead.
+          pathLength: "1",
         }),
       );
     }
@@ -5567,12 +5572,22 @@ function scoreTrackChart(entry, board) {
             source.document_type || t("model card"),
           ).replaceAll("_", " ")})`
         : observation.source_id.replaceAll("_", " ");
+      const pointX = x(observation.reported_at);
+      const pointY = scoreY(observation.value);
+      // Entrance order follows the axis (issue #312): each point brightens
+      // while the drawing front crosses its date, so the reveal reads left to
+      // right the way the data does. 120ms lets the line start first; 780ms
+      // spreads the points across its drawing window.
+      const revealDelay = Math.round(
+        120 + ((pointX - margin.left) / plotWidth) * 780,
+      );
       const group = svgElement("g", {
         class: `score-point${observation.reported_by ? " score-point-third-party" : ""}`,
         tabindex: "0",
         role: "button",
         "aria-pressed": "false",
         "data-frontier-point": "",
+        style: `--reveal-delay:${revealDelay}ms`,
         "aria-label":
           `${observation.value} ${record.metric} ${t("by")} ${observation.model} ` +
           `(${observation.organization}), ${formatDate(observation.reported_at, {
@@ -5581,8 +5596,6 @@ function scoreTrackChart(entry, board) {
           (observation.reported_by ? `, ${t("cited by")} ${observation.reported_by}` : "") +
           `. ${t("Click to pin record details")}.`,
       });
-      const pointX = x(observation.reported_at);
-      const pointY = scoreY(observation.value);
       group.append(
         svgElement("circle", {
           cx: pointX,

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -5603,13 +5603,27 @@ function scoreTrackChart(entry, board) {
     // nothing may dim behind an absent reference.
     const frontierMarks = new Set();
     if (frontier && frontier.steps.length) {
-      let best = null;
+      // Same-date readings collapse to their directional best first: read in
+      // source order, an inferior number could otherwise be marked best-so-far
+      // merely because it was seen before the better reading on its own date.
+      const bestByDate = new Map();
       for (const point of frontier.points) {
-        if (best === null || (scoreDescends ? point.value < best : point.value > best)) {
-          best = point.value;
+        const current = bestByDate.get(point.time);
+        if (
+          current === undefined ||
+          (scoreDescends ? point.value < current : point.value > current)
+        ) {
+          bestByDate.set(point.time, point.value);
         }
-        if (point.value === best) {
-          frontierMarks.add(`${frontier.key}\u0000${point.time}\u0000${point.value}`);
+      }
+      let best = null;
+      for (const time of [...bestByDate.keys()].sort((a, b) => a - b)) {
+        const value = bestByDate.get(time);
+        if (best === null || (scoreDescends ? value < best : value > best)) {
+          best = value;
+        }
+        if (value === best) {
+          frontierMarks.add(`${frontier.key}\u0000${time}\u0000${value}`);
         }
       }
     }

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -5429,7 +5429,9 @@ function frontierShouldAnimate(key) {
   if (!done) {
     clearTimeout(frontierEntranceTimer);
     frontierEntranceTimer = setTimeout(() => {
-      completedFrontierEntranceKey = key;
+      // Spending the entrance requires that it was seen: a reader who
+      // navigated away mid-reveal gets it again on return.
+      if (state.view === "leaderboard") completedFrontierEntranceKey = key;
     }, FRONTIER_ENTRANCE_MS);
   }
   return !done;

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -5411,20 +5411,28 @@ function frontierPointRevealDelay(pointX, margin, plotWidth) {
   return Math.round(120 + ((pointX - margin.left) / plotWidth) * 780);
 }
 
-// The entrance plays when the reader arrives at a benchmark, not on every
-// incidental redraw of the panel they are already reading (the crawled index
-// settling, an unrelated filter keystroke, a language toggle). Each drawn
-// selection is remembered; redrawing the same one skips the replay. The key
-// commits only while the Leaderboard is the visible view: a redraw into a
-// hidden panel (a resize crossing from Trends, an index settling after the
-// reader moved on) must not spend the entrance the reader has yet to see.
-let lastFrontierEntranceKey = null;
+// The entrance plays when the reader arrives at a benchmark and runs to
+// completion before it is spent. The crawled catalog settling mid-reveal
+// re-renders this panel, and a key spent on first paint would cancel the very
+// reveal it was drawn for: same-selection repaints inside the window replay
+// the entrance from its start rather than cutting it off, and once the window
+// closes the selection counts as seen, so later repaints render finished.
+// The key commits only while the Leaderboard is the visible view: a redraw
+// into a hidden panel must not spend an entrance the reader has yet to see.
+const FRONTIER_ENTRANCE_MS = 1400;
+let completedFrontierEntranceKey = null;
+let frontierEntranceTimer = null;
 
 function frontierShouldAnimate(key) {
   if (state.view !== "leaderboard") return false;
-  const animate = lastFrontierEntranceKey !== key;
-  lastFrontierEntranceKey = key;
-  return animate;
+  const done = completedFrontierEntranceKey === key;
+  if (!done) {
+    clearTimeout(frontierEntranceTimer);
+    frontierEntranceTimer = setTimeout(() => {
+      completedFrontierEntranceKey = key;
+    }, FRONTIER_ENTRANCE_MS);
+  }
+  return !done;
 }
 
 function scoreTrackChart(entry, board) {
@@ -5576,9 +5584,11 @@ function scoreTrackChart(entry, board) {
     // within that run, every reading that holds the best value as of its
     // date. These stay at full emphasis; all other points fade back so the
     // eye lands on the line first. Keyed by time and value, which is what a
-    // step records, so ties on both are line members too.
+    // step records, so ties on both are line members too. Gated on the line
+    // actually existing -- a benchmark whose history holds no comparable pair
+    // draws no line, so nothing may dim behind an absent reference.
     const frontierMarks = new Set();
-    if (frontier) {
+    if (frontier && frontier.steps.length) {
       let best = null;
       for (const point of frontier.points) {
         if (best === null || (scoreDescends ? point.value < best : point.value > best)) {

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -4251,12 +4251,15 @@ function externalScoreChart(source, payload) {
     const pointX = x(dateValue(row.reported_date));
     const pointY = scoreY(row.value);
     const thirdParty = row.reported_by === "third_party";
+    // Same left-to-right reveal as the curated chart (issue #312): one kind
+    // of mark, one entrance, on both layers.
     const group = svgElement("g", {
       class: `score-point${thirdParty ? " score-point-third-party" : ""}`,
       tabindex: "0",
       role: "button",
       "aria-pressed": "false",
       "data-frontier-point": "",
+      style: `--reveal-delay:${frontierPointRevealDelay(pointX, margin, plotWidth)}ms`,
       "aria-label":
         `${row.model_name || t("not recorded")} ${t("by")} ${row.organization || t("not recorded")}` +
         (thirdParty ? `, ${t("cited by")} ${meta.name}` : "") +
@@ -5384,6 +5387,15 @@ function renderFrontierOrgKey(record) {
 // score band now gets the full height the staircase, the card rug, and the
 // inter-band gaps vacated, and the only marks on the chart are the scores, the
 // connections the join rule permits, and the reading gap.
+// Entrance timing for the score charts (issue #312). A point brightens while
+// the drawing front crosses its date, so the reveal reads left to right the
+// way the data does. 120ms lets the line start first; 780ms spreads the
+// points across the 900ms drawing window. Shared by both layers so a reader
+// never learns two reveal behaviors for one kind of mark.
+function frontierPointRevealDelay(pointX, margin, plotWidth) {
+  return Math.round(120 + ((pointX - margin.left) / plotWidth) * 780);
+}
+
 function scoreTrackChart(entry, board) {
   const record = scoreRecord(entry.benchmark_id);
   // Callers only ever select a benchmark that has a score record; this guard is
@@ -5576,11 +5588,9 @@ function scoreTrackChart(entry, board) {
       const pointY = scoreY(observation.value);
       // Entrance order follows the axis (issue #312): each point brightens
       // while the drawing front crosses its date, so the reveal reads left to
-      // right the way the data does. 120ms lets the line start first; 780ms
-      // spreads the points across its drawing window.
-      const revealDelay = Math.round(
-        120 + ((pointX - margin.left) / plotWidth) * 780,
-      );
+      // right the way the data does. The timing is shared with the crawled
+      // layer's chart so both figures reveal the same way.
+      const revealDelay = frontierPointRevealDelay(pointX, margin, plotWidth);
       const group = svgElement("g", {
         class: `score-point${observation.reported_by ? " score-point-third-party" : ""}`,
         tabindex: "0",

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -4628,6 +4628,12 @@ function renderExternalShell(
   ]);
 }
 
+// Superseded shard paints are dropped: if the same record is rendered twice
+// before its (cached) shard promise settles, only the latest call may paint,
+// or the second paint would clear the entrance class before the browser ever
+// drew the first frame.
+let externalRenderSeq = 0;
+
 function renderExternalBenchmark(board, scored, record) {
   const meta = externalSourceMeta(record.source);
   // One title, one metadata line. The eyebrow ("External catalog record") and
@@ -4649,10 +4655,13 @@ function renderExternalBenchmark(board, scored, record) {
   if (existing) existing.selected = true;
   else picker.prepend(option(record.slug, `${record.name} · ${meta.name}`, true));
   const container = byId("frontier-external");
+  const renderToken = ++externalRenderSeq;
   loadBenchmarkShard(record.slug).then((shard) => {
     // The reader may have moved on while the shard was on the wire; only paint
-    // if this record is still the selection.
+    // if this record is still the selection -- and only if no newer render of
+    // this panel has superseded this callback.
     if (state.lfrontier !== record.slug) return;
+    if (renderToken !== externalRenderSeq) return;
     if (!shard) {
       // A failed shard fetch leaves the index row and the selection in place;
       // only the panel reports the failure (display plan step 7).
@@ -5405,10 +5414,14 @@ function frontierPointRevealDelay(pointX, margin, plotWidth) {
 // The entrance plays when the reader arrives at a benchmark, not on every
 // incidental redraw of the panel they are already reading (the crawled index
 // settling, an unrelated filter keystroke, a language toggle). Each drawn
-// selection is remembered; redrawing the same one skips the replay.
+// selection is remembered; redrawing the same one skips the replay. The key
+// commits only while the Leaderboard is the visible view: a redraw into a
+// hidden panel (a resize crossing from Trends, an index settling after the
+// reader moved on) must not spend the entrance the reader has yet to see.
 let lastFrontierEntranceKey = null;
 
 function frontierShouldAnimate(key) {
+  if (state.view !== "leaderboard") return false;
   const animate = lastFrontierEntranceKey !== key;
   lastFrontierEntranceKey = key;
   return animate;

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -5563,9 +5563,32 @@ function scoreTrackChart(entry, board) {
         value: observation.value,
       });
     }
-    const frontierSteps = [...runs.values()]
-      .map((points) => runningBestSteps(points, { descends: scoreDescends }))
-      .sort((a, b) => b.length - a.length)[0];
+    // The line belongs to exactly one comparable run -- the one with the most
+    // advances (issue #288). Its steps draw it; its best-so-far holders light
+    // up with it.
+    const runSteps = [...runs.values()].map((points) => ({
+      points,
+      steps: runningBestSteps(points, { descends: scoreDescends }),
+    }));
+    const frontier = runSteps.sort((a, b) => b.steps.length - a.steps.length)[0];
+    const frontierSteps = frontier?.steps;
+    // Which points the saturation line is made of (issue #312's definition):
+    // within that run, every reading that holds the best value as of its
+    // date. These stay at full emphasis; all other points fade back so the
+    // eye lands on the line first. Keyed by time and value, which is what a
+    // step records, so ties on both are line members too.
+    const frontierMarks = new Set();
+    if (frontier) {
+      let best = null;
+      for (const point of frontier.points) {
+        if (best === null || (scoreDescends ? point.value < best : point.value > best)) {
+          best = point.value;
+        }
+        if (point.value === best) {
+          frontierMarks.add(`${point.time}\u0000${point.value}`);
+        }
+      }
+    }
     if (frontierSteps?.length) {
       svg.append(
         svgElement("path", {
@@ -5617,13 +5640,21 @@ function scoreTrackChart(entry, board) {
         : observation.source_id.replaceAll("_", " ");
       const pointX = x(observation.reported_at);
       const pointY = scoreY(observation.value);
+      // "其他的点可以淡化" (issue #312): readings that are not part of the
+      // saturation line recede behind it. Hover and focus restore them, so
+      // de-emphasis never costs legibility.
+      const onFrontier = frontierMarks.has(
+        `${new Date(`${observation.reported_at}T00:00:00Z`).getTime()}\u0000${observation.value}`,
+      );
       // Entrance order follows the axis (issue #312): each point brightens
       // while the drawing front crosses its date, so the reveal reads left to
       // right the way the data does. The timing is shared with the crawled
       // layer's chart so both figures reveal the same way.
       const revealDelay = frontierPointRevealDelay(pointX, margin, plotWidth);
       const group = svgElement("g", {
-        class: `score-point${observation.reported_by ? " score-point-third-party" : ""}`,
+        class: `score-point${
+          onFrontier ? "" : " score-point-dim"
+        }${observation.reported_by ? " score-point-third-party" : ""}`,
         tabindex: "0",
         role: "button",
         "aria-pressed": "false",

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -5435,17 +5435,22 @@ function frontierShouldAnimate(key) {
   const done = completedFrontierEntranceKey === key;
   if (!done) {
     clearTimeout(frontierEntranceTimer);
-    frontierEntranceTimer = setTimeout(() => {
-      // Spending the entrance requires that it was seen to the end: a reader
-      // who navigated away mid-reveal, to another view or another benchmark,
-      // gets it again on return.
+    const spendOrDefer = () => {
+      // Spending the entrance requires that it was seen to the end: a hidden
+      // tab defers its own completion, and a reader who navigated away -- to
+      // another view or another benchmark -- gets the reveal again on return.
       if (
-        state.view === "leaderboard" &&
-        drawnFrontierEntranceKey === key
+        typeof document !== "undefined" &&
+        document.visibilityState !== "visible"
       ) {
+        frontierEntranceTimer = setTimeout(spendOrDefer, FRONTIER_ENTRANCE_MS);
+        return;
+      }
+      if (state.view === "leaderboard" && drawnFrontierEntranceKey === key) {
         completedFrontierEntranceKey = key;
       }
-    }, FRONTIER_ENTRANCE_MS);
+    };
+    frontierEntranceTimer = setTimeout(spendOrDefer, FRONTIER_ENTRANCE_MS);
   }
   return !done;
 }

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -2875,6 +2875,37 @@ td a {
   }
 }
 
+/* "其他的点可以淡化" (issue #312): readings off the saturation line recede
+   behind it instead of competing with it for the eye. The de-emphasis sits on
+   the marks inside the group rather than the group's own opacity, which the
+   entrance animation owns. Reading one still works: hover and focus bring a
+   receded point back to full strength. */
+.score-point-dim .score-point-face {
+  fill-opacity: 0.6;
+  stroke-opacity: 0.45;
+}
+
+.score-point-dim .score-point-citation-ring,
+.score-point-dim .score-point-glyph {
+  opacity: 0.5;
+}
+
+.score-point-dim:hover .score-point-face,
+.score-point-dim:focus .score-point-face,
+.score-point-dim.is-selected .score-point-face {
+  fill-opacity: 1;
+  stroke-opacity: 1;
+}
+
+.score-point-dim:hover .score-point-citation-ring,
+.score-point-dim:focus .score-point-citation-ring,
+.score-point-dim.is-selected .score-point-citation-ring,
+.score-point-dim:hover .score-point-glyph,
+.score-point-dim:focus .score-point-glyph,
+.score-point-dim.is-selected .score-point-glyph {
+  opacity: 1;
+}
+
 /* The entrance is presentation, not information: readers who ask for reduced
    motion get the finished chart immediately. */
 @media (prefers-reduced-motion: reduce) {

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -2572,9 +2572,16 @@ td a {
 
 .score-point {
   cursor: pointer;
-  /* Entrance (issue #312): points fade up one by one, ordered by their date.
-     The delay is a custom property so the drawing code can place each point
-     on the timeline without knowing anything about the CSS. */
+}
+
+/* Entrance (issue #312): points fade up one by one, ordered by their date,
+   while the running-best line draws itself across the axis. The whole block
+   is gated on .score-chart-enter, which a render adds only when the reader
+   arrived at a new selection -- incidental redraws of the same chart repaint
+   it finished, not from zero. Point delays arrive as a custom property set
+   per point, so the drawing code places each mark on the timeline without
+   knowing anything about the CSS. */
+.score-chart-enter .score-point {
   opacity: 0;
   animation: score-point-reveal 420ms ease-out forwards;
   animation-delay: var(--reveal-delay, 0ms);
@@ -2850,10 +2857,13 @@ td a {
   stroke-width: 1.75;
   stroke-linejoin: miter;
   opacity: 0.85;
-  /* Entrance (issue #312): the line draws itself left to right while the
-     points brighten along it. The path declares pathLength="1", so a dash of
-     length 1 is the whole line and the offset animates from hidden to drawn
-     without measuring geometry in script. */
+}
+
+/* Entrance (issue #312): the line draws itself left to right while the
+   points brighten along it. The path declares pathLength="1", so a dash of
+   length 1 is the whole line and the offset animates from hidden to drawn
+   without measuring geometry in script. Scoped like the points, to arrivals. */
+.score-chart-enter .score-frontier-line {
   stroke-dasharray: 1;
   stroke-dashoffset: 1;
   animation: score-frontier-draw 900ms ease-out 120ms forwards;
@@ -2868,12 +2878,12 @@ td a {
 /* The entrance is presentation, not information: readers who ask for reduced
    motion get the finished chart immediately. */
 @media (prefers-reduced-motion: reduce) {
-  .score-point {
+  .score-chart-enter .score-point {
     animation: none;
     opacity: 1;
   }
 
-  .score-frontier-line {
+  .score-chart-enter .score-frontier-line {
     animation: none;
     stroke-dasharray: none;
     stroke-dashoffset: 0;

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -2572,6 +2572,22 @@ td a {
 
 .score-point {
   cursor: pointer;
+  /* Entrance (issue #312): points fade up one by one, ordered by their date.
+     The delay is a custom property so the drawing code can place each point
+     on the timeline without knowing anything about the CSS. */
+  opacity: 0;
+  animation: score-point-reveal 420ms ease-out forwards;
+  animation-delay: var(--reveal-delay, 0ms);
+}
+
+@keyframes score-point-reveal {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
 }
 
 .frontier-tick,
@@ -2834,6 +2850,34 @@ td a {
   stroke-width: 1.75;
   stroke-linejoin: miter;
   opacity: 0.85;
+  /* Entrance (issue #312): the line draws itself left to right while the
+     points brighten along it. The path declares pathLength="1", so a dash of
+     length 1 is the whole line and the offset animates from hidden to drawn
+     without measuring geometry in script. */
+  stroke-dasharray: 1;
+  stroke-dashoffset: 1;
+  animation: score-frontier-draw 900ms ease-out 120ms forwards;
+}
+
+@keyframes score-frontier-draw {
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+
+/* The entrance is presentation, not information: readers who ask for reduced
+   motion get the finished chart immediately. */
+@media (prefers-reduced-motion: reduce) {
+  .score-point {
+    animation: none;
+    opacity: 1;
+  }
+
+  .score-frontier-line {
+    animation: none;
+    stroke-dasharray: none;
+    stroke-dashoffset: 0;
+  }
 }
 
 .score-best-line {

--- a/tests/test_saturation_view.py
+++ b/tests/test_saturation_view.py
@@ -810,6 +810,9 @@ def test_issue_312_the_saturation_view_reveals_left_to_right():
     gate = script.split("function frontierShouldAnimate(key)", 1)[1].split("\n}", 1)[0]
     assert 'if (state.view !== "leaderboard") return false;' in gate
     assert "completedFrontierEntranceKey === key" in gate
+    # And the completion callback rechecks visibility: leaving mid-reveal and
+    # returning after the window must still play the entrance.
+    assert 'if (state.view === "leaderboard") completedFrontierEntranceKey = key;' in gate
     assert "const FRONTIER_ENTRANCE_MS = 1400;" in script
     assert 'frontierShouldAnimate(`curated:${entry.benchmark_id}`)' in script
     assert 'frontierShouldAnimate(`external:${record.slug}`)' in script

--- a/tests/test_saturation_view.py
+++ b/tests/test_saturation_view.py
@@ -790,6 +790,17 @@ def test_issue_312_the_saturation_view_reveals_left_to_right():
     )[0]
     assert "frontierPointRevealDelay" in external
 
+    # The issue's definition is enforced in the same pass: points that hold
+    # the best value as of their date are the line; every other reading fades
+    # back behind it, and recovers on hover or focus.
+    assert "const frontierMarks = new Set();" in chart
+    assert "point.value === best" in chart
+    assert '" score-point-dim"' in chart
+    dim = styles.split(".score-point-dim .score-point-face {", 1)[1][:200]
+    assert "fill-opacity: 0.6;" in dim
+    assert ".score-point-dim:hover .score-point-face" in styles
+    assert ".score-point-dim.is-selected .score-point-glyph" in styles
+
     # The entrance is gated to arrivals: a render adds the class only when
     # the selection changed AND the leaderboard is the visible view, so a
     # redraw into a hidden panel never spends an entrance the reader has yet

--- a/tests/test_saturation_view.py
+++ b/tests/test_saturation_view.py
@@ -755,3 +755,44 @@ def test_the_score_layer_is_keyed_by_the_same_benchmark_id_as_adoption():
     script = source("site/assets/app.js")
 
     assert "benchmark_score_progression?.benchmarks?.[benchmarkId]" in script
+
+
+def test_issue_312_the_saturation_view_reveals_left_to_right():
+    """The chart popped in fully drawn, so the reader never saw the shape form.
+
+    The running-best line now draws itself across the axis and each point
+    brightens while the drawing front crosses its date: the reveal reads in
+    the same direction the data does. The entrance is presentation only -- a
+    reduced-motion reader gets the finished chart immediately.
+    """
+    script = source("site/assets/app.js")
+    styles = source("site/assets/styles.css")
+    chart = script.split("function scoreTrackChart(", 1)[1].split(
+        "\nfunction clearAdoptionFrontier", 1
+    )[0]
+
+    # The line declares its length, so CSS can draw it with a dash offset
+    # instead of script measuring geometry on a detached tree.
+    assert 'pathLength: "1",' in chart
+
+    # Each point carries its own delay on the timeline, derived from where it
+    # sits on the x axis rather than from its row order.
+    assert "const revealDelay = Math.round(" in chart
+    assert "(pointX - margin.left) / plotWidth" in chart
+    assert 'style: `--reveal-delay:${revealDelay}ms`,' in chart
+
+    line_rule = styles.split(".score-frontier-line {", 1)[1][:800]
+    assert "stroke-dasharray: 1;" in line_rule
+    assert "stroke-dashoffset: 1;" in line_rule
+    assert "animation: score-frontier-draw" in line_rule
+    assert "@keyframes score-frontier-draw" in styles
+
+    point_rule = styles.split(".score-point {", 1)[1][:500]
+    assert "animation: score-point-reveal" in point_rule
+    assert "animation-delay: var(--reveal-delay, 0ms);" in point_rule
+
+    # And the whole entrance collapses for prefers-reduced-motion.
+    guard = styles.split("@media (prefers-reduced-motion: reduce)", 1)[1][:500]
+    assert ".score-point" in guard
+    assert ".score-frontier-line" in guard
+    assert "stroke-dashoffset: 0;" in guard

--- a/tests/test_saturation_view.py
+++ b/tests/test_saturation_view.py
@@ -792,8 +792,10 @@ def test_issue_312_the_saturation_view_reveals_left_to_right():
 
     # The issue's definition is enforced in the same pass: points that hold
     # the best value as of their date are the line; every other reading fades
-    # back behind it, and recovers on hover or focus.
+    # back behind it, and recovers on hover or focus. Dimming is gated on the
+    # line actually existing -- no line, nothing recedes behind it.
     assert "const frontierMarks = new Set();" in chart
+    assert "if (frontier && frontier.steps.length) {" in chart
     assert "point.value === best" in chart
     assert '" score-point-dim"' in chart
     dim = styles.split(".score-point-dim .score-point-face {", 1)[1][:200]
@@ -801,13 +803,14 @@ def test_issue_312_the_saturation_view_reveals_left_to_right():
     assert ".score-point-dim:hover .score-point-face" in styles
     assert ".score-point-dim.is-selected .score-point-glyph" in styles
 
-    # The entrance is gated to arrivals: a render adds the class only when
-    # the selection changed AND the leaderboard is the visible view, so a
-    # redraw into a hidden panel never spends an entrance the reader has yet
-    # to see, and incidental same-chart repaints stay finished.
+    # The entrance is gated to arrivals and runs to completion before it is
+    # spent: a redraw into a hidden panel never spends an entrance, and the
+    # crawled catalog settling mid-reveal replays rather than cancels it.
     assert "function frontierShouldAnimate(key)" in script
     gate = script.split("function frontierShouldAnimate(key)", 1)[1].split("\n}", 1)[0]
     assert 'if (state.view !== "leaderboard") return false;' in gate
+    assert "completedFrontierEntranceKey === key" in gate
+    assert "const FRONTIER_ENTRANCE_MS = 1400;" in script
     assert 'frontierShouldAnimate(`curated:${entry.benchmark_id}`)' in script
     assert 'frontierShouldAnimate(`external:${record.slug}`)' in script
     assert script.count('"score-chart-enter"') == 2

--- a/tests/test_saturation_view.py
+++ b/tests/test_saturation_view.py
@@ -837,11 +837,12 @@ def test_issue_312_the_saturation_view_reveals_left_to_right():
     assert 'if (state.view !== "leaderboard") return false;' in gate
     assert "completedFrontierEntranceKey === key" in gate
     # And the completion callback rechecks visibility and the drawn selection:
-    # leaving mid-reveal, to another view or another benchmark, must still
-    # play the entrance on return.
-    assert 'if (state.view === "leaderboard") completedFrontierEntranceKey = key;' not in gate
+    # leaving mid-reveal -- to another view, another benchmark, or a hidden
+    # tab -- must still play the entrance on return.
+    assert "const spendOrDefer = () => {" in gate
+    assert "document.visibilityState !== \"visible\"" in gate
     assert "drawnFrontierEntranceKey === key" in gate
-    assert "state.view === \"leaderboard\" &&\n        drawnFrontierEntranceKey === key" in gate
+    assert "state.view === \"leaderboard\" && drawnFrontierEntranceKey === key" in gate
     assert "const FRONTIER_ENTRANCE_MS = 1400;" in script
     assert 'frontierShouldAnimate(`curated:${entry.benchmark_id}`)' in script
     assert 'frontierShouldAnimate(`external:${record.slug}`)' in script

--- a/tests/test_saturation_view.py
+++ b/tests/test_saturation_view.py
@@ -797,6 +797,12 @@ def test_issue_312_the_saturation_view_reveals_left_to_right():
     assert "const frontierMarks = new Set();" in chart
     assert "if (frontier && frontier.steps.length) {" in chart
     assert "point.value === best" in chart
+    # Membership carries the comparable run's own key, so an unrelated run
+    # reporting the same number on the same date is not drawn onto the line.
+    assert "`${frontier.key}\\u0000${point.time}\\u0000${point.value}`" in chart
+    assert (
+        "`${observation.instrument || \"\"}\\u0000${observation.protocol || \"\"}\\u0000" in chart
+    )
     assert '" score-point-dim"' in chart
     dim = styles.split(".score-point-dim .score-point-face {", 1)[1][:200]
     assert "fill-opacity: 0.6;" in dim
@@ -810,9 +816,12 @@ def test_issue_312_the_saturation_view_reveals_left_to_right():
     gate = script.split("function frontierShouldAnimate(key)", 1)[1].split("\n}", 1)[0]
     assert 'if (state.view !== "leaderboard") return false;' in gate
     assert "completedFrontierEntranceKey === key" in gate
-    # And the completion callback rechecks visibility: leaving mid-reveal and
-    # returning after the window must still play the entrance.
-    assert 'if (state.view === "leaderboard") completedFrontierEntranceKey = key;' in gate
+    # And the completion callback rechecks visibility and the drawn selection:
+    # leaving mid-reveal, to another view or another benchmark, must still
+    # play the entrance on return.
+    assert 'if (state.view === "leaderboard") completedFrontierEntranceKey = key;' not in gate
+    assert "drawnFrontierEntranceKey === key" in gate
+    assert "state.view === \"leaderboard\" &&\n        drawnFrontierEntranceKey === key" in gate
     assert "const FRONTIER_ENTRANCE_MS = 1400;" in script
     assert 'frontierShouldAnimate(`curated:${entry.benchmark_id}`)' in script
     assert 'frontierShouldAnimate(`external:${record.slug}`)' in script

--- a/tests/test_saturation_view.py
+++ b/tests/test_saturation_view.py
@@ -790,18 +790,29 @@ def test_issue_312_the_saturation_view_reveals_left_to_right():
     )[0]
     assert "frontierPointRevealDelay" in external
 
-    line_rule = styles.split(".score-frontier-line {", 1)[1][:800]
+    # The entrance is gated to arrivals: a render adds the class only when
+    # the selection changed, so incidental redraws (index fetch settling,
+    # unrelated filters, language toggle) repaint finished instead of
+    # collapsing and replaying.
+    assert "function frontierShouldAnimate(key)" in script
+    assert 'frontierShouldAnimate(`curated:${entry.benchmark_id}`)' in script
+    assert 'frontierShouldAnimate(`external:${record.slug}`)' in script
+    assert script.count('"score-chart-enter"') == 2
+
+    line_rule = styles.split(".score-chart-enter .score-frontier-line {", 1)[1][:400]
     assert "stroke-dasharray: 1;" in line_rule
     assert "stroke-dashoffset: 1;" in line_rule
     assert "animation: score-frontier-draw" in line_rule
     assert "@keyframes score-frontier-draw" in styles
 
-    point_rule = styles.split(".score-point {", 1)[1][:500]
+    point_rule = styles.split(".score-chart-enter .score-point {", 1)[1][:300]
+    assert "opacity: 0;" in point_rule
     assert "animation: score-point-reveal" in point_rule
     assert "animation-delay: var(--reveal-delay, 0ms);" in point_rule
 
-    # And the whole entrance collapses for prefers-reduced-motion.
-    guard = styles.split("@media (prefers-reduced-motion: reduce)", 1)[1][:500]
-    assert ".score-point" in guard
-    assert ".score-frontier-line" in guard
+    # And the whole entrance collapses for prefers-reduced-motion. The guard
+    # must match the gated selectors or it would lose the cascade.
+    guard = styles.split("@media (prefers-reduced-motion: reduce)", 1)[1][:600]
+    assert ".score-chart-enter .score-point" in guard
+    assert ".score-chart-enter .score-frontier-line" in guard
     assert "stroke-dashoffset: 0;" in guard

--- a/tests/test_saturation_view.py
+++ b/tests/test_saturation_view.py
@@ -777,9 +777,18 @@ def test_issue_312_the_saturation_view_reveals_left_to_right():
 
     # Each point carries its own delay on the timeline, derived from where it
     # sits on the x axis rather than from its row order.
-    assert "const revealDelay = Math.round(" in chart
-    assert "(pointX - margin.left) / plotWidth" in chart
+    assert "function frontierPointRevealDelay(pointX, margin, plotWidth)" in script
+    assert "(pointX - margin.left) / plotWidth" in script
+    assert "frontierPointRevealDelay(pointX, margin, plotWidth)" in chart
     assert 'style: `--reveal-delay:${revealDelay}ms`,' in chart
+
+    # The crawled layer's points share the same reveal: one kind of mark gets
+    # one entrance, so selecting a crawled benchmark does not fade everything
+    # in at once while the curated one staggers.
+    external = script.split("function externalScoreChart(", 1)[1].split(
+        "\nfunction ", 1
+    )[0]
+    assert "frontierPointRevealDelay" in external
 
     line_rule = styles.split(".score-frontier-line {", 1)[1][:800]
     assert "stroke-dasharray: 1;" in line_rule

--- a/tests/test_saturation_view.py
+++ b/tests/test_saturation_view.py
@@ -796,13 +796,18 @@ def test_issue_312_the_saturation_view_reveals_left_to_right():
     # line actually existing -- no line, nothing recedes behind it.
     assert "const frontierMarks = new Set();" in chart
     assert "if (frontier && frontier.steps.length) {" in chart
-    assert "point.value === best" in chart
+    assert "if (value === best) {" in chart
     # Membership carries the comparable run's own key, so an unrelated run
     # reporting the same number on the same date is not drawn onto the line.
-    assert "`${frontier.key}\\u0000${point.time}\\u0000${point.value}`" in chart
+    assert "`${frontier.key}\\u0000${time}\\u0000${value}`" in chart
     assert (
         "`${observation.instrument || \"\"}\\u0000${observation.protocol || \"\"}\\u0000" in chart
     )
+    # Same-date readings collapse to their directional best before marking:
+    # source order must not crown an inferior number best-so-far on its own
+    # date.
+    assert "const bestByDate = new Map();" in chart
+    assert "for (const time of [...bestByDate.keys()].sort((a, b) => a - b)) {" in chart
     assert '" score-point-dim"' in chart
     dim = styles.split(".score-point-dim .score-point-face {", 1)[1][:200]
     assert "fill-opacity: 0.6;" in dim

--- a/tests/test_saturation_view.py
+++ b/tests/test_saturation_view.py
@@ -817,7 +817,13 @@ def test_issue_312_the_saturation_view_reveals_left_to_right():
     assert "drawnFrontierEntranceKey = null;" in shell
     clear_fn = script.split("function clearAdoptionFrontier(message)", 1)[1].split("\n}", 1)[0]
     assert "drawnFrontierEntranceKey = null;" in clear_fn
-    assert '" score-point-dim"' in chart
+    # Dimming itself is gated on a line being drawn: with no comparable pair
+    # there is no reference, and every point keeps full emphasis rather than
+    # all of them receding together.
+    assert (
+        "const offTheLine = Boolean(frontierSteps?.length) && !onFrontier;" in chart
+    )
+    assert "offTheLine ? \" score-point-dim\" : \"\"" in chart
     dim = styles.split(".score-point-dim .score-point-face {", 1)[1][:200]
     assert "fill-opacity: 0.6;" in dim
     assert ".score-point-dim:hover .score-point-face" in styles

--- a/tests/test_saturation_view.py
+++ b/tests/test_saturation_view.py
@@ -780,14 +780,12 @@ def test_issue_312_the_saturation_view_reveals_left_to_right():
     assert "function frontierPointRevealDelay(pointX, margin, plotWidth)" in script
     assert "(pointX - margin.left) / plotWidth" in script
     assert "frontierPointRevealDelay(pointX, margin, plotWidth)" in chart
-    assert 'style: `--reveal-delay:${revealDelay}ms`,' in chart
+    assert "style: `--reveal-delay:${revealDelay}ms`," in chart
 
     # The crawled layer's points share the same reveal: one kind of mark gets
     # one entrance, so selecting a crawled benchmark does not fade everything
     # in at once while the curated one staggers.
-    external = script.split("function externalScoreChart(", 1)[1].split(
-        "\nfunction ", 1
-    )[0]
+    external = script.split("function externalScoreChart(", 1)[1].split("\nfunction ", 1)[0]
     assert "frontierPointRevealDelay" in external
 
     # The issue's definition is enforced in the same pass: points that hold
@@ -800,9 +798,7 @@ def test_issue_312_the_saturation_view_reveals_left_to_right():
     # Membership carries the comparable run's own key, so an unrelated run
     # reporting the same number on the same date is not drawn onto the line.
     assert "`${frontier.key}\\u0000${point.time}\\u0000${point.value}`" in chart
-    assert (
-        "`${observation.instrument || \"\"}\\u0000${observation.protocol || \"\"}\\u0000" in chart
-    )
+    assert '`${observation.instrument || ""}\\u0000${observation.protocol || ""}\\u0000' in chart
     # Same-date readings collapse to their directional best before the steps
     # are built, so what is drawn and what is emphasized cannot disagree: the
     # line never steps through an inferior number that shares a better
@@ -820,10 +816,8 @@ def test_issue_312_the_saturation_view_reveals_left_to_right():
     # Dimming itself is gated on a line being drawn: with no comparable pair
     # there is no reference, and every point keeps full emphasis rather than
     # all of them receding together.
-    assert (
-        "const offTheLine = Boolean(frontierSteps?.length) && !onFrontier;" in chart
-    )
-    assert "offTheLine ? \" score-point-dim\" : \"\"" in chart
+    assert "const offTheLine = Boolean(frontierSteps?.length) && !onFrontier;" in chart
+    assert 'offTheLine ? " score-point-dim" : ""' in chart
     dim = styles.split(".score-point-dim .score-point-face {", 1)[1][:200]
     assert "fill-opacity: 0.6;" in dim
     assert ".score-point-dim:hover .score-point-face" in styles
@@ -840,12 +834,12 @@ def test_issue_312_the_saturation_view_reveals_left_to_right():
     # leaving mid-reveal -- to another view, another benchmark, or a hidden
     # tab -- must still play the entrance on return.
     assert "const spendOrDefer = () => {" in gate
-    assert "document.visibilityState !== \"visible\"" in gate
+    assert 'document.visibilityState !== "visible"' in gate
     assert "drawnFrontierEntranceKey === key" in gate
-    assert "state.view === \"leaderboard\" && drawnFrontierEntranceKey === key" in gate
+    assert 'state.view === "leaderboard" && drawnFrontierEntranceKey === key' in gate
     assert "const FRONTIER_ENTRANCE_MS = 1400;" in script
-    assert 'frontierShouldAnimate(`curated:${entry.benchmark_id}`)' in script
-    assert 'frontierShouldAnimate(`external:${record.slug}`)' in script
+    assert "frontierShouldAnimate(`curated:${entry.benchmark_id}`)" in script
+    assert "frontierShouldAnimate(`external:${record.slug}`)" in script
     assert script.count('"score-chart-enter"') == 2
 
     # A superseded shard callback may not paint: two renders of one record

--- a/tests/test_saturation_view.py
+++ b/tests/test_saturation_view.py
@@ -796,18 +796,27 @@ def test_issue_312_the_saturation_view_reveals_left_to_right():
     # line actually existing -- no line, nothing recedes behind it.
     assert "const frontierMarks = new Set();" in chart
     assert "if (frontier && frontier.steps.length) {" in chart
-    assert "if (value === best) {" in chart
+    assert "if (point.value === best) {" in chart
     # Membership carries the comparable run's own key, so an unrelated run
     # reporting the same number on the same date is not drawn onto the line.
-    assert "`${frontier.key}\\u0000${time}\\u0000${value}`" in chart
+    assert "`${frontier.key}\\u0000${point.time}\\u0000${point.value}`" in chart
     assert (
         "`${observation.instrument || \"\"}\\u0000${observation.protocol || \"\"}\\u0000" in chart
     )
-    # Same-date readings collapse to their directional best before marking:
-    # source order must not crown an inferior number best-so-far on its own
-    # date.
+    # Same-date readings collapse to their directional best before the steps
+    # are built, so what is drawn and what is emphasized cannot disagree: the
+    # line never steps through an inferior number that shares a better
+    # reading's date.
     assert "const bestByDate = new Map();" in chart
-    assert "for (const time of [...bestByDate.keys()].sort((a, b) => a - b)) {" in chart
+    assert ".sort((a, b) => a[0] - b[0])" in chart
+    assert "runningBestSteps(points, { descends: scoreDescends })" in chart
+
+    # A shell or empty state replaces the chart on screen, so a running
+    # completion timer may not spend the reveal it can no longer show.
+    shell = script.split("function renderExternalShell(", 1)[1].split("\nfunction ", 1)[0]
+    assert "drawnFrontierEntranceKey = null;" in shell
+    clear_fn = script.split("function clearAdoptionFrontier(message)", 1)[1].split("\n}", 1)[0]
+    assert "drawnFrontierEntranceKey = null;" in clear_fn
     assert '" score-point-dim"' in chart
     dim = styles.split(".score-point-dim .score-point-face {", 1)[1][:200]
     assert "fill-opacity: 0.6;" in dim

--- a/tests/test_saturation_view.py
+++ b/tests/test_saturation_view.py
@@ -791,13 +791,25 @@ def test_issue_312_the_saturation_view_reveals_left_to_right():
     assert "frontierPointRevealDelay" in external
 
     # The entrance is gated to arrivals: a render adds the class only when
-    # the selection changed, so incidental redraws (index fetch settling,
-    # unrelated filters, language toggle) repaint finished instead of
-    # collapsing and replaying.
+    # the selection changed AND the leaderboard is the visible view, so a
+    # redraw into a hidden panel never spends an entrance the reader has yet
+    # to see, and incidental same-chart repaints stay finished.
     assert "function frontierShouldAnimate(key)" in script
+    gate = script.split("function frontierShouldAnimate(key)", 1)[1].split("\n}", 1)[0]
+    assert 'if (state.view !== "leaderboard") return false;' in gate
     assert 'frontierShouldAnimate(`curated:${entry.benchmark_id}`)' in script
     assert 'frontierShouldAnimate(`external:${record.slug}`)' in script
     assert script.count('"score-chart-enter"') == 2
+
+    # A superseded shard callback may not paint: two renders of one record
+    # before its cached shard settles would otherwise let the second paint
+    # clear the entrance class before the browser drew a frame.
+    assert "let externalRenderSeq = 0;" in script
+    external_render = script.split("function renderExternalBenchmark(board, scored, record)", 1)[
+        1
+    ].split("\nfunction ", 1)[0]
+    assert "const renderToken = ++externalRenderSeq;" in external_render
+    assert "if (renderToken !== externalRenderSeq) return;" in external_render
 
     line_rule = styles.split(".score-chart-enter .score-frontier-line {", 1)[1][:400]
     assert "stroke-dasharray: 1;" in line_rule


### PR DESCRIPTION
Fixes #312.

## Summary
- Entrance animation on the score track: the running-best saturation line draws itself left to right (pathLength="1", CSS dash-offset), and each point fades up on a per-date delay while the drawing front crosses its date.
- Per the issue's definition, points holding the best value as of their date keep full emphasis; other readings recede behind the line (hover/focus restores them). Membership is computed from one shared per-date directional-best collapse, scoped to the line's own comparable run, and only applies when a line is actually drawn.
- The entrance is presentation-only: prefers-reduced-motion gets the finished chart immediately.
- Replay discipline: the entrance plays when the reader arrives at a benchmark and is spent only after the reveal was seen to the end (visible tab, leaderboard view, same selection still drawn). Incidental redraws (index settling, filters, language toggle) neither replay nor cancel it; shells invalidate it.
- The crawled layer's chart shares the same reveal timing helper, so both layers behave identically.

## Test plan
- pytest: 865 passed, 6 skipped, including new test_issue_312_the_saturation_view_reveals_left_to_right pinning the definition, gating, and reduced-motion behavior.
- node --check on app.js passes.
- codex review iterated six rounds (append/replay/dim edge cases); every finding through the last completed round is fixed in-tree. Final confirmation run was aborted by the operator.