### PR TITLE
fix(site): shrink leaderboard heading and anchor its info icon

### DIFF
--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -2317,9 +2317,14 @@ td a {
   margin-bottom: 0.35rem;
 }
 
-.leaderboard-top-heading h2 {
+.leaderboard-top-heading h1 {
   font-family: var(--display);
   font-size: 1.35rem;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  text-transform: none;
+  line-height: 1.2;
+  max-width: none;
   margin: 0;
 }
 


### PR DESCRIPTION
Fixes #313.

## Summary
- The `.leaderboard-top-heading` CSS still targeted an `h2` selector after the markup moved to `<h1>` (issue #256's title consolidation), so the heading fell through to the global `h1` rule: uppercase, up to `3rem`, `max-width: 800px`. On the leaderboard view this made it wrap to two lines and take up most of the first screen.
- The `(i)` info toggle is laid out with `gap` next to the heading text; with the heading wrapping, it ended up floating far to the right of the first line in empty space instead of sitting beside the title.
- Added an `h1`-scoped rule matching the previous intended size (same scale as the ranking list below it), so the heading is a single line again and the icon sits directly beside it.

## Test plan
- `uv run pytest -q`: 865 passed, 6 skipped.
- Verified visually with the browse skill at `?view=leaderboard`: heading is one line, `(i)` anchored next to it.