### PR TITLE
fix(site): halve the leaderboard title and anchor its info toggle

### DIFF
--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -2311,9 +2311,22 @@ td a {
 
 .leaderboard-top-heading {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 0.4rem;
   margin-bottom: 0.35rem;
+}
+
+/* Half the global h1 scale (issue #313). The old 48px uppercase line was the
+   largest object on the page and compressed the ranking it names; and because
+   the wrapped title filled its whole max-width box, the (i) beside it landed
+   hundreds of pixels away in empty space with no anchor. At this size the
+   heading fits one line, so the toggle sits immediately after its last
+   glyph, and wrap keeps that true on narrow screens by stacking instead. */
+.leaderboard-top-heading h1 {
+  margin: 0;
+  font-size: clamp(1.25rem, 2vw, 1.5rem);
+  line-height: 1.05;
 }
 
 .leaderboard-top-heading h2 {

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -2325,14 +2325,9 @@ td a {
    glyph, and wrap keeps that true on narrow screens by stacking instead. */
 .leaderboard-top-heading h1 {
   margin: 0;
+  max-width: none;
   font-size: clamp(1.25rem, 2vw, 1.5rem);
-  line-height: 1.05;
-}
-
-.leaderboard-top-heading h2 {
-  font-family: var(--display);
-  font-size: 1.35rem;
-  margin: 0;
+  line-height: 1.2;
 }
 
 .leaderboard-top-list {

--- a/tests/test_leaderboard_workbench.py
+++ b/tests/test_leaderboard_workbench.py
@@ -1045,6 +1045,13 @@ def test_issue_313_the_title_is_half_size_and_its_info_is_anchored():
     rule = styles.split(".leaderboard-top-heading h1 {", 1)[1].split("}", 1)[0]
     assert "font-size: clamp(1.25rem, 2vw, 1.5rem);" in rule
     assert "margin: 0;" in rule
+    # The global h1 caps its width at 800px; the heading is a flex item, so that
+    # cap is what let the title's box stretch and strand the (i). Reset it here
+    # so the title is content-sized and the toggle anchors to its last glyph.
+    assert "max-width: none;" in rule
+    # The old dead h2 selector (markup is <h1> since #256) is gone, not left to
+    # rot beside the rule that replaced it.
+    assert ".leaderboard-top-heading h2" not in styles
 
     heading = styles.split(".leaderboard-top-heading {", 1)[1].split("}", 1)[0]
     assert "flex-wrap: wrap;" in heading

--- a/tests/test_leaderboard_workbench.py
+++ b/tests/test_leaderboard_workbench.py
@@ -1028,3 +1028,28 @@ def test_issue_304_an_unresolved_slug_stops_naming_itself_in_the_url():
     # showing the default under the reader's own slug.
     assert "!state.benchmarkIndexLoaded" in dispatch
     assert "Could not load details for this benchmark." in dispatch
+
+
+def test_issue_313_the_title_is_half_size_and_its_info_is_anchored():
+    """The h1 was the largest object on the page and its (i) floated away.
+
+    At 48px uppercase the heading wrapped and filled its max-width box, so the
+    info toggle rendered hundreds of pixels right of the last glyph with
+    nothing to explain. Half scale fits the title on one line, which is what
+    lets flexbox anchor the toggle immediately after it; wrap keeps that true
+    by stacking on narrow screens instead of drifting.
+    """
+    styles = source("site/assets/styles.css")
+    html = source("site/index.html")
+
+    rule = styles.split(".leaderboard-top-heading h1 {", 1)[1].split("}", 1)[0]
+    assert "font-size: clamp(1.25rem, 2vw, 1.5rem);" in rule
+    assert "margin: 0;" in rule
+
+    heading = styles.split(".leaderboard-top-heading {", 1)[1].split("}", 1)[0]
+    assert "flex-wrap: wrap;" in heading
+    assert "align-items: center;" in heading
+
+    # The toggle stays a sibling of the heading inside one flex row.
+    row = html.split('class="leaderboard-top-heading"', 1)[1].split("</div>", 1)[0]
+    assert row.index('id="leaderboard-heading"') < row.index('id="leaderboard-top-info"')


### PR DESCRIPTION
Fixes #313.

## Summary
- The leaderboard h1 drops to clamp(1.25rem, 2vw, 1.5rem), about half its former 48px scale, giving the first screen back to the ranking and the chart.
- The blue (i) no longer floats hundreds of pixels away: at half size the title fits one line, so the flex row anchors the toggle right after the last glyph. flex-wrap stacks them on narrow screens instead of letting either drift.
- New source test pins both halves of the contract.

## Test plan
- pytest: 865 passed, 6 skipped (adds test_issue_313_the_title_is_half_size_and_its_info_is_anchored).
- codex review --base main: clean, no findings.