### PR TITLE
fix(site): give the leaderboard ranking columns, bars, and a lighter disclosure

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -403,10 +403,13 @@ const I18N = {
     "All tracked benchmarks": "所有追踪的基准",
     "Search every benchmark": "搜索全部基准",
     "Most reported benchmarks in model cards": "模型卡中报告最多的benchmark",
+    Rank: "排名",
+    Benchmark: "基准",
+    "leaderboard.column.model_cards": "模型卡数量",
     "Jump to a benchmark": "跳转到某个基准",
     "One score, copied from the report that published it": "一个分数，照抄自发布它的报告",
-    "Show all {n} ranked benchmarks": "显示全部 {n} 个排名基准",
-    "Show the top {n}": "只显示前 {n} 个",
+    "Show all {n} benchmarks": "显示全部 {n} 个基准",
+    "Show top {n}": "只显示前 {n} 个",
     "A report counts once per test, even if it lists that test several times. Some reports publish their results as a picture rather than text, and we read those with software that can misread a digit, so the list at the bottom of this page links every count back to the report it came from.":
       "一份报告对同一项测试只计一次，即使它列出了多次。有些报告以图片而非文字发布结果，我们用软件读取，可能会看错数字，因此本页底部的清单把每个计数链接回它的来源报告。",
     model: "个模型",
@@ -6277,6 +6280,10 @@ function renderLeaderboardTop(board) {
     if (more) more.hidden = true;
     return;
   }
+  // Each row's bar is scaled against the top entry currently on screen, so the
+  // gap the reader is meant to see (e.g. GPQA Diamond vs. everything below it)
+  // stays visible whether five rows are shown or all of them are (issue #314).
+  const maxCount = Math.max(...entries.map((entry) => entry.card_count));
   replaceChildren(
     host,
     entries.map((entry) =>
@@ -6286,6 +6293,12 @@ function renderLeaderboardTop(board) {
           text: String(entry.rank).padStart(2, "0"),
         }),
         element("span", { className: "leaderboard-top-name", text: entry.name }),
+        element("span", { className: "leaderboard-top-bar" }, [
+          element("span", {
+            className: "leaderboard-top-bar-fill",
+            attrs: { style: `width:${((entry.card_count / maxCount) * 100).toFixed(1)}%` },
+          }),
+        ]),
         element("span", {
           className: "leaderboard-top-count",
           text: metricLabel(entry.card_count, "model card"),
@@ -6296,8 +6309,8 @@ function renderLeaderboardTop(board) {
   if (more) {
     more.hidden = ranked.length <= LEADERBOARD_TOP_LIMIT;
     more.textContent = state.leaderboardTopExpanded
-      ? t("Show the top {n}").replace("{n}", String(LEADERBOARD_TOP_LIMIT))
-      : t("Show all {n} ranked benchmarks").replace("{n}", String(ranked.length));
+      ? `${t("Show top {n}").replace("{n}", String(LEADERBOARD_TOP_LIMIT))} ↑`
+      : `${t("Show all {n} benchmarks").replace("{n}", String(ranked.length))} ↓`;
   }
 }
 

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -2323,6 +2323,27 @@ td a {
   margin: 0;
 }
 
+/* Named columns, not a wall of whitespace between the name and the count
+   (issue #314): a fixed rank marker, a name column capped so a short benchmark
+   name doesn't force the reader's eye across the full row width, a bar that
+   makes the gap between ranks visible at a glance, and a fixed count. */
+.leaderboard-top-columns {
+  display: grid;
+  grid-template-columns: 2rem minmax(0, 16rem) minmax(0, 1fr) 6.5rem;
+  gap: 0.75rem;
+  padding: 0 0.85rem 0.3rem;
+  color: var(--muted);
+  font-family: var(--utility);
+  font-size: 0.66rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.leaderboard-top-columns-count {
+  grid-column: 4;
+  text-align: right;
+}
+
 .leaderboard-top-list {
   list-style: none;
   margin: 0;
@@ -2333,10 +2354,10 @@ td a {
 
 .leaderboard-top-row {
   display: grid;
-  grid-template-columns: 2rem minmax(0, 1fr) auto;
+  grid-template-columns: 2rem minmax(0, 16rem) minmax(0, 1fr) 6.5rem;
   gap: 0.75rem;
-  align-items: baseline;
-  padding: 0.22rem 0.85rem;
+  align-items: center;
+  padding: 0.3rem 0.85rem;
   border-bottom: 1px solid var(--line);
 }
 
@@ -2357,11 +2378,45 @@ td a {
   overflow-wrap: anywhere;
 }
 
+.leaderboard-top-bar {
+  display: block;
+  height: 0.55rem;
+  background: var(--canvas);
+}
+
+.leaderboard-top-bar-fill {
+  display: block;
+  height: 100%;
+  background: var(--blue);
+}
+
 .leaderboard-top-count {
   font-variant-numeric: tabular-nums;
   font-size: 0.82rem;
   color: var(--muted);
+  text-align: right;
   white-space: nowrap;
+}
+
+/* A disclosure toggle for the rest of the ranking, not an action button
+   (issue #314): the heavy bordered all-caps control it replaces read as a
+   destructive or system command for what is really "show more of this list". */
+.leaderboard-top-more {
+  display: inline-block;
+  margin-top: 0.5rem;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--blue-deep);
+  font-family: var(--body);
+  font-size: 0.85rem;
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
+}
+
+.leaderboard-top-more:hover,
+.leaderboard-top-more:focus-visible {
+  color: var(--blue);
 }
 
 /* The title and its (i) sit on one line, with the source and score count on a
@@ -3915,6 +3970,24 @@ footer {
 
   footer {
     display: grid;
+  }
+}
+
+@media (max-width: 560px) {
+  /* The bar's job is comparing rows at a glance; on a narrow screen there is
+     no spare width left for it once rank, name and count are legible, so it
+     drops rather than squeezing everything past readable. */
+  .leaderboard-top-columns,
+  .leaderboard-top-row {
+    grid-template-columns: 2rem minmax(0, 1fr) auto;
+  }
+
+  .leaderboard-top-columns-count {
+    grid-column: 3;
+  }
+
+  .leaderboard-top-bar {
+    display: none;
   }
 }
 

--- a/site/index.html
+++ b/site/index.html
@@ -341,8 +341,13 @@
                  reader announces it with the heading. -->
             <p class="leaderboard-deck visually-hidden" id="leaderboard-measures"></p>
           </div>
+          <div class="leaderboard-top-columns" aria-hidden="true">
+            <span class="leaderboard-top-columns-rank" data-i18n="Rank">Rank</span>
+            <span class="leaderboard-top-columns-name" data-i18n="Benchmark">Benchmark</span>
+            <span class="leaderboard-top-columns-count" data-i18n="leaderboard.column.model_cards">Model cards</span>
+          </div>
           <ol class="leaderboard-top-list" id="leaderboard-top-list"></ol>
-          <button class="secondary-link leaderboard-top-more" id="leaderboard-top-more" type="button"></button>
+          <button class="leaderboard-top-more" id="leaderboard-top-more" type="button"></button>
         </section>
 
         <div class="benchmark-workbench">


### PR DESCRIPTION
Fixes #314.

## Summary
- Added a column header row (Rank / Benchmark / Model cards) above the top-5 ranking list. Previously the row had no labels, so the eye had to travel from the rank number on the left across a wide gap to the count on the right with nothing explaining what either number meant.
- Each row now draws a horizontal bar sized against the largest count currently on screen, so the gap between ranks (e.g. GPQA Diamond's 26 model cards vs. AIME's 17) reads at a glance rather than requiring two separate number lookups.
- Replaced the heavy bordered, all-caps "SHOW ALL 79 RANKED BENCHMARKS" button with a lightweight underlined disclosure link ("Show all 79 benchmarks ↓" / "Show top 5 ↑"), matching what it actually does (expand/collapse a list) instead of reading like a destructive or system action.
- Below 560px the bar drops and the row returns to a 3-column layout (rank, name, count) instead of squeezing four columns past legible width.

## Test plan
- `uv run pytest -q`: 865 passed, 6 skipped.
- `node --check site/assets/app.js`.
- `codex review --base main`: caught and fixed two real issues before landing — a column header mis-aligned to the bar's grid track instead of the count column, and a duplicate `"Model cards"` i18n key that silently discarded the new column label under the Chinese locale (renamed to a distinct key). Clean on the third pass.
- Verified visually with the browse skill: desktop top-5 view, the expanded 79-row view, the sub-560px layout, and the Chinese locale toggle.