### PR TITLE
fix(site): translate the benchmark detail panel into Chinese (#316)

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -709,6 +709,43 @@ const I18N = {
     "shown": "显示",
     "tracked": "追踪",
     "of": "共",
+    // --- External catalog detail (issue #316) --------------------------------
+    // The crawled benchmark detail panel (identity / openness / size) shipped
+    // its section headings, field labels and "not established" placeholders in
+    // English under zh, so only the shared "Released" line came through. These
+    // cover the rest of that panel; the benchmark's own description text stays
+    // as authored because it is source data, not chrome.
+    Identity: "基本信息",
+    "description not established": "简介尚未确定",
+    Publisher: "发布方",
+    "publisher not established": "发布方尚未确定",
+    "release date not established": "发布日期尚未确定",
+    Modality: "模态",
+    "modality not established": "模态尚未确定",
+    "No paper, repository, dataset or site link established.":
+      "尚未确定论文、代码仓库、数据集或站点链接。",
+    Openness: "开放性",
+    "openness not established": "开放性尚未确定",
+    open: "开放",
+    restricted: "受限",
+    "Code licence": "代码许可证",
+    "Data licence": "数据许可证",
+    "not established": "尚未确定",
+    "No openness evidence recorded.": "未记录开放性证据。",
+    Size: "规模",
+    "size not established": "规模尚未确定",
+    "counts the": "统计的是",
+    "what it counts is unclear": "统计对象不明",
+    "evidence ↗": "证据 ↗",
+    // Publisher roles and artifact kinds are label maps keyed by a raw enum, so
+    // an unmapped role/kind still falls back to its raw value rather than blank.
+    "published the hub card": "发布了 Hub 卡片",
+    "organization behind the paper": "论文背后的机构",
+    maintainer: "维护者",
+    Paper: "论文",
+    "Code repository": "代码仓库",
+    Dataset: "数据集",
+    "Project site": "项目站点",
     // --- Contact --------------------------------------------------------------
     "Benchmark Radar": "Benchmark 雷达日报",
     "Get in touch": "联系我",

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -212,6 +212,50 @@ def test_language_toggle_and_contact_labels_are_translated():
         assert key in script
 
 
+def test_issue_316_benchmark_detail_labels_are_translated():
+    # The crawled benchmark detail panel (identity / openness / size) rendered
+    # its headings, field labels and "not established" placeholders through t(),
+    # but only "Released" had a zh entry -- so under Chinese the whole panel
+    # except that one line fell back to English. Every label the panel draws
+    # must have a zh translation.
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    for key in (
+        'Identity: "基本信息"',
+        'Publisher: "发布方"',
+        'Modality: "模态"',
+        'Openness: "开放性"',
+        'Size: "规模"',
+        '"Code licence": "代码许可证"',
+        '"Data licence": "数据许可证"',
+        '"not established": "尚未确定"',
+        '"description not established": "简介尚未确定"',
+        '"publisher not established": "发布方尚未确定"',
+        '"release date not established": "发布日期尚未确定"',
+        '"modality not established": "模态尚未确定"',
+        '"openness not established": "开放性尚未确定"',
+        '"size not established": "规模尚未确定"',
+        '"No openness evidence recorded.": "未记录开放性证据。"',
+        'open: "开放"',
+        'restricted: "受限"',
+        'Paper: "论文"',
+        '"Code repository": "代码仓库"',
+        'Dataset: "数据集"',
+        '"Project site": "项目站点"',
+        'maintainer: "维护者"',
+        '"published the hub card": "发布了 Hub 卡片"',
+        '"organization behind the paper": "论文背后的机构"',
+        '"counts the": "统计的是"',
+        '"what it counts is unclear": "统计对象不明"',
+        '"evidence ↗": "证据 ↗"',
+    ):
+        assert key in script, f"missing zh translation for {key!r}"
+
+    # The longest placeholder wraps onto its own line in the source, so assert
+    # the value rather than a single-line "key": "value" pair.
+    assert "尚未确定论文、代码仓库、数据集或站点链接。" in script
+
+
 def test_language_toggle_click_handler_is_wired():
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
 


### PR DESCRIPTION
Fixes #316.

## Summary
The crawled benchmark detail panel (identity / openness / size blocks) routed its section headings, field labels and every "not established" placeholder through `t()`, but only the shared **Released → 发布于** line had a `zh` entry. Under the Chinese locale the rest of the panel fell back to English — exactly the mixed EN/zh the issue shows.

Added the missing `zh` translations for:
- **Section headings:** Identity 基本信息 · Publisher 发布方 · Modality 模态 · Openness 开放性 · Size 规模 · Code/Data licence 代码/数据许可证
- **"not established" placeholders:** the description / publisher / release-date / modality / openness / size variants, the bare `not established`, plus "No paper, repository, dataset or site link established." and "No openness evidence recorded."
- **Openness statuses:** open 开放 · restricted 受限
- **Publisher-role and artifact-kind label maps:** maintainer 维护者, "published the hub card", "organization behind the paper"; Paper 论文 · Code repository 代码仓库 · Dataset 数据集 · Project site 项目站点
- **Size helpers:** "counts the" 统计的是 · "what it counts is unclear" 统计对象不明 · "evidence ↗" 证据 ↗

The benchmark's own description text is deliberately left as authored — it is source data, not UI chrome, and is not translated here.

## Notes
- No duplicate `I18N.zh` keys introduced. `open` / `restricted` / `maintainer` also appear in `opennessChip` / `publisherRoleLabel`, but those are separate enum→label maps that call `t()`, not entries in the translation table.

## Test plan
- Added `test_issue_316_benchmark_detail_labels_are_translated` in `tests/test_site.py`, asserting every detail-panel label has a `zh` entry (mirrors the existing `test_language_toggle_and_contact_labels_are_translated`).
- (CI runs the full pytest suite, `ruff format --check`, and `node --check` on app.js.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)