### PR TITLE
feat(seo): generated sitemap, robots.txt, canonicals, and structured data (#236)

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -1169,10 +1169,60 @@ function onPopState() {
   }
 }
 
+// Issue #236. Crawlers see one document; these four states are still four
+// different pages a reader can land on and link to, so each one restates its
+// own title, description, and canonical URL when it becomes active. The
+// canonicals carry only the view parameter: filter permutations (q, date,
+// lq, lfrontier, ...) consolidate into the clean view URL instead of
+// fragmenting ranking signals across every state of the same page. These
+// strings are English on purpose: they describe the site to a search engine,
+// while the visible interface translates through data-i18n.
+const VIEW_SEO = {
+  today: {
+    title: "Benchmark Radar — today's new AI benchmarks",
+    description:
+      "A daily evidence-first map of new AI benchmarks, evaluations, and datasets, collected every day from arXiv, GitHub, Hugging Face, OpenReview, Semantic Scholar, Hacker News, and first-party lab feeds.",
+    query: "",
+  },
+  leaderboard: {
+    title: "Most reported AI benchmarks in frontier model cards | Benchmark Radar",
+    description:
+      "Which benchmarks frontier labs actually report: a live Model Card Adoption Rank computed from curated model cards and system cards, plus reported score progression over time.",
+    query: "view=leaderboard",
+  },
+  trends: {
+    title: "AI benchmark discovery trends over time | Benchmark Radar",
+    description:
+      "Daily volume of new AI benchmark evidence by category, source, and event, with a ledger of every collection day in the corpus.",
+    query: "view=trends",
+  },
+  map: {
+    title: "Explore connections across AI benchmarks | Benchmark Radar",
+    description:
+      "See how benchmarks, datasets, evaluations, sources, and organizations connect across the Benchmark Radar corpus, and jump from any topic into the filtered daily list.",
+    query: "view=map",
+  },
+};
+
+function applyViewSeo(view) {
+  const seo = VIEW_SEO[view] || VIEW_SEO.today;
+  document.title = seo.title;
+  const description = document.querySelector('meta[name="description"]');
+  if (description) description.setAttribute("content", seo.description);
+  const canonical = document.querySelector('link[rel="canonical"]');
+  if (canonical) {
+    const url = new URL(window.location.pathname, window.location.origin);
+    if (seo.query) url.search = seo.query;
+    else url.search = "";
+    canonical.setAttribute("href", url.href);
+  }
+}
+
 // `update` false is for restoring a view that is already in the URL (boot and
 // popstate), where writing history again would either duplicate the entry or
 // fight the entry being restored.
 function setView(view, update = true, mode = "push") {
+  applyViewSeo(view);
   if (view !== "leaderboard" && selectedFrontierPoint) {
     clearFrontierPointSelection();
   }

--- a/site/index.html
+++ b/site/index.html
@@ -30,6 +30,61 @@
       content="Benchmark Radar: the most-reported benchmarks across frontier model cards, led by GPQA Diamond, SWE-bench Verified, and LiveCodeBench."
     >
     <meta name="twitter:card" content="summary_large_image">
+    <!-- Mirrors og:image for consumers that read the Twitter namespace only
+         and do not fall back to the Open Graph tags. -->
+    <meta name="twitter:image" content="https://ktwu01.github.io/benchmark-radar/assets/og-card.png">
+
+    <!-- Issue #236. Every view is a query-string variant of this one path, so
+         each view restates its own canonical (VIEW_SEO in assets/app.js) and
+         filter permutations consolidate into these four clean URLs rather
+         than fragmenting ranking signals across every ?view=...&lq=... state.
+         The static default below is what crawlers fetch before any script
+         runs; app.js rewrites it per view on navigation. -->
+    <link rel="canonical" href="https://ktwu01.github.io/benchmark-radar/">
+
+    <!-- Structured data for the two things this project actually is: a
+         searchable site and a dataset. The SearchAction target is the real
+         search endpoint (the leaderboard's lq filter), not a pretend one, so
+         a search result lands on a page that answers it. -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        "name": "Benchmark Radar",
+        "url": "https://ktwu01.github.io/benchmark-radar/",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": {
+            "@type": "EntryPoint",
+            "urlTemplate": "https://ktwu01.github.io/benchmark-radar/?view=leaderboard&lq={search_term_string}"
+          },
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Dataset",
+        "name": "Benchmark Radar cumulative corpus",
+        "description": "A daily-updated machine-readable corpus of AI benchmark, evaluation, and dataset signals collected from arXiv, GitHub, Hugging Face, OpenAlex, OpenReview, Semantic Scholar, Hacker News, and first-party lab feeds.",
+        "url": "https://ktwu01.github.io/benchmark-radar/data/radar.json",
+        "license": "https://opensource.org/licenses/MIT",
+        "creator": {
+          "@type": "Person",
+          "name": "Koutian Wu",
+          "url": "https://github.com/ktwu01"
+        },
+        "sameAs": "https://github.com/ktwu01/benchmark-radar",
+        "distribution": [
+          {
+            "@type": "DataDownload",
+            "encodingFormat": "application/json",
+            "contentUrl": "https://ktwu01.github.io/benchmark-radar/data/radar.json"
+          }
+        ]
+      }
+    </script>
 
     <link rel="icon" href="icon.svg" type="image/svg+xml">
     <link rel="alternate" type="application/rss+xml" title="Benchmark Radar RSS" href="feed.xml">

--- a/site/index.html
+++ b/site/index.html
@@ -20,9 +20,9 @@
       property="og:description"
       content="A live ranking of the benchmarks reported in frontier model cards, system cards, and technical reports. Measures vendor reporting convention, not benchmark quality."
     >
-    <meta property="og:url" content="https://ktwu01.github.io/benchmark-radar/">
+    <meta property="og:url" content="https://koutian.is-a.dev/benchmark-radar/">
     <!-- Absolute, because Open Graph consumers do not resolve relative URLs. -->
-    <meta property="og:image" content="https://ktwu01.github.io/benchmark-radar/assets/og-card.png">
+    <meta property="og:image" content="https://koutian.is-a.dev/benchmark-radar/assets/og-card.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta
@@ -32,7 +32,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <!-- Mirrors og:image for consumers that read the Twitter namespace only
          and do not fall back to the Open Graph tags. -->
-    <meta name="twitter:image" content="https://ktwu01.github.io/benchmark-radar/assets/og-card.png">
+    <meta name="twitter:image" content="https://koutian.is-a.dev/benchmark-radar/assets/og-card.png">
 
     <!-- Issue #236. Every view is a query-string variant of this one path, so
          each view restates its own canonical (VIEW_SEO in assets/app.js) and
@@ -40,7 +40,7 @@
          than fragmenting ranking signals across every ?view=...&lq=... state.
          The static default below is what crawlers fetch before any script
          runs; app.js rewrites it per view on navigation. -->
-    <link rel="canonical" href="https://ktwu01.github.io/benchmark-radar/">
+    <link rel="canonical" href="https://koutian.is-a.dev/benchmark-radar/">
 
     <!-- Structured data for the two things this project actually is: a
          searchable site and a dataset. The SearchAction target is the real
@@ -51,12 +51,12 @@
         "@context": "https://schema.org",
         "@type": "WebSite",
         "name": "Benchmark Radar",
-        "url": "https://ktwu01.github.io/benchmark-radar/",
+        "url": "https://koutian.is-a.dev/benchmark-radar/",
         "potentialAction": {
           "@type": "SearchAction",
           "target": {
             "@type": "EntryPoint",
-            "urlTemplate": "https://ktwu01.github.io/benchmark-radar/?view=leaderboard&lq={search_term_string}"
+            "urlTemplate": "https://koutian.is-a.dev/benchmark-radar/?view=leaderboard&lq={search_term_string}"
           },
           "query-input": "required name=search_term_string"
         }
@@ -68,7 +68,7 @@
         "@type": "Dataset",
         "name": "Benchmark Radar cumulative corpus",
         "description": "A daily-updated machine-readable corpus of AI benchmark, evaluation, and dataset signals collected from arXiv, GitHub, Hugging Face, OpenAlex, OpenReview, Semantic Scholar, Hacker News, and first-party lab feeds.",
-        "url": "https://ktwu01.github.io/benchmark-radar/data/radar.json",
+        "url": "https://koutian.is-a.dev/benchmark-radar/data/radar.json",
         "license": "https://opensource.org/licenses/MIT",
         "creator": {
           "@type": "Person",
@@ -80,7 +80,7 @@
           {
             "@type": "DataDownload",
             "encodingFormat": "application/json",
-            "contentUrl": "https://ktwu01.github.io/benchmark-radar/data/radar.json"
+            "contentUrl": "https://koutian.is-a.dev/benchmark-radar/data/radar.json"
           }
         ]
       }

--- a/site/robots.txt
+++ b/site/robots.txt
@@ -1,0 +1,6 @@
+User-agent: *
+Allow: /
+
+# Regenerated on every dashboard build by src/benchmark_radar/site_seo.py,
+# so it can never list a view the deployed site does not serve.
+Sitemap: https://ktwu01.github.io/benchmark-radar/sitemap.xml

--- a/site/robots.txt
+++ b/site/robots.txt
@@ -1,6 +1,6 @@
 User-agent: *
 Allow: /
 
-# Regenerated on every dashboard build by src/benchmark_radar/site_seo.py,
-# so it can never list a view the deployed site does not serve.
-Sitemap: https://ktwu01.github.io/benchmark-radar/sitemap.xml
+# The sitemap is regenerated on every dashboard build, so it can never list a
+# view the deployed site does not serve.
+Sitemap: https://koutian.is-a.dev/benchmark-radar/sitemap.xml

--- a/src/benchmark_radar/feed.py
+++ b/src/benchmark_radar/feed.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any
 from xml.etree import ElementTree as ET
 
-SITE_URL = "https://ktwu01.github.io/benchmark-radar"
+SITE_URL = "https://koutian.is-a.dev/benchmark-radar"
 FEED_URL = f"{SITE_URL}/feed.xml"
 ATOM_NAMESPACE = "http://www.w3.org/2005/Atom"
 

--- a/src/benchmark_radar/site_seo.py
+++ b/src/benchmark_radar/site_seo.py
@@ -1,0 +1,75 @@
+"""Generate sitemap.xml for the published dashboard (issue #236).
+
+The dashboard is one HTML document whose views are query-string variants of a
+single path. Each view is still a page a reader can land on, link, and search,
+so each one is listed as its own indexable URL with a canonical that matches
+(see `VIEW_SEO` in assets/app.js). Filter permutations are deliberately left
+out: a sitemap should tell crawlers which doors exist, not enumerate every
+state behind them.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from xml.etree import ElementTree as ET
+
+from .feed import SITE_URL
+
+SITEMAP_NAMESPACE = "http://www.sitemaps.org/schemas/sitemap/0.9"
+
+# One entry per dashboard view, in nav order. logos.html is excluded on
+# purpose: it is a maintainer QA page carrying <meta name="robots"
+# content="noindex">, so listing it would contradict the page itself.
+INDEXABLE_VIEWS: tuple[tuple[str, str], ...] = (
+    ("Today", "/"),
+    ("Leaderboard", "/?view=leaderboard"),
+    ("Trends", "/?view=trends"),
+    ("Explore", "/?view=map"),
+)
+
+ET.register_namespace("sm", SITEMAP_NAMESPACE)
+
+
+def _lastmod_date(snapshots: list[dict[str, Any]]) -> str | None:
+    """Date of the newest snapshot, or None when there is no history yet.
+
+    Derived from the snapshots rather than the clock so two rebuilds over the
+    same history produce byte-identical output; feed.xml's lastBuildDate makes
+    the same choice.
+    """
+    if not snapshots:
+        return None
+    generated = max(
+        datetime.fromisoformat(str(snapshot["generated_at"]).replace("Z", "+00:00"))
+        for snapshot in snapshots
+    )
+    return generated.astimezone(UTC).date().isoformat()
+
+
+def _q(tag: str) -> str:
+    # Tags are written with the qualified name; register_namespace above makes
+    # the serializer emit the readable sm: prefix instead of ns0.
+    return f"{{{SITEMAP_NAMESPACE}}}{tag}"
+
+
+def sitemap_tree(snapshots: list[dict[str, Any]]) -> ET.ElementTree:
+    """Build one stable urlset covering every indexable view."""
+    root = ET.Element(_q("urlset"))
+    lastmod = _lastmod_date(snapshots)
+    for _, path in INDEXABLE_VIEWS:
+        url = ET.SubElement(root, _q("url"))
+        ET.SubElement(url, _q("loc")).text = SITE_URL + path
+        if lastmod:
+            ET.SubElement(url, _q("lastmod")).text = lastmod
+    return ET.ElementTree(root)
+
+
+def write_sitemap(snapshots: list[dict[str, Any]], output: Path) -> Path:
+    """Write a deterministic UTF-8 sitemap beside the published data."""
+    output.parent.mkdir(parents=True, exist_ok=True)
+    tree = sitemap_tree(snapshots)
+    ET.indent(tree, space="  ")
+    tree.write(output, encoding="utf-8", xml_declaration=True)
+    return output

--- a/src/benchmark_radar/snapshots.py
+++ b/src/benchmark_radar/snapshots.py
@@ -31,6 +31,7 @@ from .rubric import (
     v2_rubric_reference,
     v3_rubric_reference,
 )
+from .site_seo import write_sitemap
 
 SCHEMA_VERSION = 2
 SUPPORTED_SCHEMA_VERSIONS = {1, SCHEMA_VERSION}
@@ -1062,6 +1063,10 @@ def rebuild_dashboard(
     badge_path = output.parent / "records-badge.json"
     badge_path.parent.mkdir(parents=True, exist_ok=True)
     badge_path.write_text(records_badge(value), encoding="utf-8")
+    # The sitemap lives beside radar.json for the same reason the badge does:
+    # written per build, never committed, so it can only describe what this
+    # build actually published (issue #236).
+    write_sitemap(snapshots, output.parent / "sitemap.xml")
     if feed_output is not None:
         write_feed(snapshots, feed_output)
     return value

--- a/src/benchmark_radar/snapshots.py
+++ b/src/benchmark_radar/snapshots.py
@@ -1063,10 +1063,16 @@ def rebuild_dashboard(
     badge_path = output.parent / "records-badge.json"
     badge_path.parent.mkdir(parents=True, exist_ok=True)
     badge_path.write_text(records_badge(value), encoding="utf-8")
-    # The sitemap lives beside radar.json for the same reason the badge does:
-    # written per build, never committed, so it can only describe what this
-    # build actually published (issue #236).
-    write_sitemap(snapshots, output.parent / "sitemap.xml")
+    # The sitemap is a site-level discovery document, not dashboard data. When
+    # this build also publishes the site-level feed, put the sitemap beside it
+    # so robots.txt's /sitemap.xml URL resolves in the Pages artifact. Custom
+    # data-only builds retain the local beside-output behavior.
+    sitemap_output = (
+        feed_output.with_name("sitemap.xml")
+        if feed_output is not None
+        else output.parent / "sitemap.xml"
+    )
+    write_sitemap(snapshots, sitemap_output)
     if feed_output is not None:
         write_feed(snapshots, feed_output)
     return value

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -68,6 +68,8 @@ def test_default_dashboard_build_also_publishes_the_feed(monkeypatch, tmp_path):
 
     assert (tmp_path / "site" / "data" / "radar.json").exists()
     assert (tmp_path / "site" / "feed.xml").exists()
+    assert (tmp_path / "site" / "sitemap.xml").exists()
+    assert not (tmp_path / "site" / "data" / "sitemap.xml").exists()
 
 
 def test_custom_dashboard_does_not_overwrite_the_default_feed(monkeypatch, tmp_path):

--- a/tests/test_feed.py
+++ b/tests/test_feed.py
@@ -47,7 +47,7 @@ def test_feed_is_deterministic_valid_rss_with_one_item_per_snapshot(tmp_path):
         "Benchmark Radar — 2026-08-06",
     ]
     assert items[0].findtext("link") == (
-        "https://ktwu01.github.io/benchmark-radar/?date=2026-08-07"
+        "https://koutian.is-a.dev/benchmark-radar/?date=2026-08-07"
     )
     assert items[0].find("guid").attrib["isPermaLink"] == "true"
     assert "1 evidence observation from 1 source" in items[0].findtext("description")

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -855,7 +855,7 @@ def test_share_card_is_declared_with_an_absolute_url():
     # og:image silently yields the same blank grey card as no tag at all
     # (issue #88). The failure is invisible from inside the site.
     assert 'property="og:image"' in html
-    assert "https://ktwu01.github.io/benchmark-radar/assets/og-card.png" in html
+    assert "https://koutian.is-a.dev/benchmark-radar/assets/og-card.png" in html
     assert 'name="twitter:card" content="summary_large_image"' in html
     # Declared dimensions let a consumer reserve the large-image layout before
     # the file is fetched; without them some fall back to a small thumbnail.

--- a/tests/test_site_seo.py
+++ b/tests/test_site_seo.py
@@ -10,9 +10,7 @@ NS = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
 
 
 def test_sitemap_covers_every_indexable_view():
-    tree = sitemap_tree(
-        [{"generated_at": "2026-08-21T02:17:00+00:00", "date": "2026-08-21"}]
-    )
+    tree = sitemap_tree([{"generated_at": "2026-08-21T02:17:00+00:00", "date": "2026-08-21"}])
     root = tree.getroot()
     urls = [node.text for node in root.findall("sm:url/sm:loc", NS)]
     assert urls == [
@@ -60,9 +58,7 @@ def test_each_view_has_its_own_title_and_description():
 
 def test_write_sitemap_writes_valid_xml_beside_the_data(tmp_path):
     output = tmp_path / "site" / "sitemap.xml"
-    written = write_sitemap(
-        [{"generated_at": "2026-08-21T02:17:00+00:00"}], output
-    )
+    written = write_sitemap([{"generated_at": "2026-08-21T02:17:00+00:00"}], output)
     assert written == output
     parsed = ET.parse(output)
     assert parsed.getroot().tag == f"{{{NS['sm']}}}urlset"
@@ -74,7 +70,7 @@ def test_published_head_and_robots_match_the_generated_sitemap():
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
 
     # Canonical default in the static head; app.js restates it per view.
-    assert '<link rel="canonical" href="https://ktwu01.github.io/benchmark-radar/">' in html
+    assert f'<link rel="canonical" href="{SITE_URL}/">' in html
     assert 'link[rel="canonical"]' in script
 
     # The four canonical view URLs in app.js are exactly the ones the
@@ -86,6 +82,8 @@ def test_published_head_and_robots_match_the_generated_sitemap():
     # robots.txt points at the sitemap URL the build actually writes.
     sitemap_url = f"{SITE_URL}/sitemap.xml"
     assert sitemap_url in robots
+    assert "https://ktwu01.github.io/benchmark-radar" not in html
+    assert "https://ktwu01.github.io/benchmark-radar" not in robots
 
 
 def test_structured_data_describes_a_searchable_site_and_a_dataset():

--- a/tests/test_site_seo.py
+++ b/tests/test_site_seo.py
@@ -1,0 +1,111 @@
+import json
+import re
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+from benchmark_radar.feed import SITE_URL
+from benchmark_radar.site_seo import INDEXABLE_VIEWS, sitemap_tree, write_sitemap
+
+NS = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+
+
+def test_sitemap_covers_every_indexable_view():
+    tree = sitemap_tree(
+        [{"generated_at": "2026-08-21T02:17:00+00:00", "date": "2026-08-21"}]
+    )
+    root = tree.getroot()
+    urls = [node.text for node in root.findall("sm:url/sm:loc", NS)]
+    assert urls == [
+        f"{SITE_URL}/",
+        f"{SITE_URL}/?view=leaderboard",
+        f"{SITE_URL}/?view=trends",
+        f"{SITE_URL}/?view=map",
+    ]
+
+
+def test_sitemap_lastmod_is_derived_from_history_not_the_clock():
+    snapshots = [
+        {"generated_at": "2026-08-19T23:50:00+00:00"},
+        {"generated_at": "2026-08-21T02:17:00+00:00"},
+        {"generated_at": "2026-08-20T12:00:00+00:00"},
+    ]
+    root = sitemap_tree(snapshots).getroot()
+    lastmods = [node.text for node in root.findall("sm:url/sm:lastmod", NS)]
+    # One date per URL, the newest snapshot's, so two rebuilds over the same
+    # history are byte-identical.
+    assert lastmods == ["2026-08-21"] * len(INDEXABLE_VIEWS)
+
+
+def test_sitemap_without_snapshots_omits_lastmod():
+    root = sitemap_tree([]).getroot()
+    assert [node.text for node in root.findall("sm:url/sm:lastmod", NS)] == []
+    assert len(root.findall("sm:url", NS)) == len(INDEXABLE_VIEWS)
+
+
+def test_each_view_has_its_own_title_and_description():
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+    block = script.split("const VIEW_SEO = {", 1)[1].split("\n};", 1)[0]
+    titles = re.findall(r'title: "([^"]+)"', block)
+    descriptions = re.findall(r'description:\s*"([^"]+)"', block, flags=re.DOTALL)
+    assert len(titles) == len(INDEXABLE_VIEWS)
+    assert len(set(titles)) == len(INDEXABLE_VIEWS)
+    assert len(descriptions) == len(INDEXABLE_VIEWS)
+    assert len(set(descriptions)) == len(INDEXABLE_VIEWS)
+
+    # Wired inside setView, not beside it: boot, popstate, nav clicks, and
+    # fallbacks all route through one place.
+    set_view = script.split("function setView(", 1)[1].split("\nfunction ", 1)[0]
+    assert "applyViewSeo(view)" in set_view
+
+
+def test_write_sitemap_writes_valid_xml_beside_the_data(tmp_path):
+    output = tmp_path / "site" / "sitemap.xml"
+    written = write_sitemap(
+        [{"generated_at": "2026-08-21T02:17:00+00:00"}], output
+    )
+    assert written == output
+    parsed = ET.parse(output)
+    assert parsed.getroot().tag == f"{{{NS['sm']}}}urlset"
+
+
+def test_published_head_and_robots_match_the_generated_sitemap():
+    html = Path("site/index.html").read_text(encoding="utf-8")
+    robots = Path("site/robots.txt").read_text(encoding="utf-8")
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    # Canonical default in the static head; app.js restates it per view.
+    assert '<link rel="canonical" href="https://ktwu01.github.io/benchmark-radar/">' in html
+    assert 'link[rel="canonical"]' in script
+
+    # The four canonical view URLs in app.js are exactly the ones the
+    # generator publishes; a view added to one side must land on the other.
+    for _, path in INDEXABLE_VIEWS:
+        query = path.removeprefix("/?").removeprefix("/")
+        assert f'query: "{query}"' in script
+
+    # robots.txt points at the sitemap URL the build actually writes.
+    sitemap_url = f"{SITE_URL}/sitemap.xml"
+    assert sitemap_url in robots
+
+
+def test_structured_data_describes_a_searchable_site_and_a_dataset():
+    html = Path("site/index.html").read_text(encoding="utf-8")
+    blocks = [
+        json.loads(chunk.split(">", 1)[1].split("</script>", 1)[0])
+        for chunk in html.split('type="application/ld+json"')[1:]
+    ]
+    types = {block["@type"] for block in blocks}
+    assert {"WebSite", "Dataset"} <= types
+
+    website = next(block for block in blocks if block["@type"] == "WebSite")
+    target = website["potentialAction"]["target"]["urlTemplate"]
+    # The search endpoint is the leaderboard's real lq filter, not a pretend one.
+    assert "{search_term_string}" in target
+    assert "?view=leaderboard&lq={search_term_string}" in target
+    assert website["potentialAction"]["query-input"] == "required name=search_term_string"
+
+    dataset = next(block for block in blocks if block["@type"] == "Dataset")
+    assert dataset["url"].endswith("/data/radar.json")
+    distributions = [entry["contentUrl"] for entry in dataset["distribution"]]
+    assert dataset["url"] in distributions
+    assert dataset["license"].endswith("/MIT")

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -5,6 +5,7 @@ from xml.etree import ElementTree as ET
 
 import pytest
 
+from benchmark_radar.feed import SITE_URL
 from benchmark_radar.model_cards import ModelCardRegistryError
 from benchmark_radar.models import (
     AttentionObservation,
@@ -251,6 +252,28 @@ def test_rebuild_can_publish_the_feed_from_the_same_snapshot_history(tmp_path):
         "Benchmark Radar — 2026-07-27",
         "Benchmark Radar — 2026-07-26",
     ]
+
+
+def test_rebuild_writes_the_sitemap_beside_the_data(tmp_path):
+    """Issue #236: the sitemap is generated per build rather than committed,
+    so it can only ever describe views this build actually publishes."""
+    snapshot_dir = tmp_path / "snapshots"
+    write_snapshot(radar_run(27), snapshot_dir)
+    data_output = tmp_path / "site" / "data" / "radar.json"
+
+    rebuild_dashboard(snapshot_dir, data_output)
+
+    ns = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+    root = ET.parse(data_output.parent / "sitemap.xml").getroot()
+    urls = [node.text for node in root.findall("sm:url/sm:loc", ns)]
+    assert urls == [
+        f"{SITE_URL}/",
+        f"{SITE_URL}/?view=leaderboard",
+        f"{SITE_URL}/?view=trends",
+        f"{SITE_URL}/?view=map",
+    ]
+    lastmods = [node.text for node in root.findall("sm:url/sm:lastmod", ns)]
+    assert lastmods == ["2026-07-27"] * len(urls)
 
 
 def test_rescore_applies_a_new_category_to_older_snapshots(tmp_path):

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -254,17 +254,20 @@ def test_rebuild_can_publish_the_feed_from_the_same_snapshot_history(tmp_path):
     ]
 
 
-def test_rebuild_writes_the_sitemap_beside_the_data(tmp_path):
-    """Issue #236: the sitemap is generated per build rather than committed,
-    so it can only ever describe views this build actually publishes."""
+def test_rebuild_writes_the_sitemap_at_the_site_root(tmp_path):
+    """The Pages build must publish the URL advertised by robots.txt."""
     snapshot_dir = tmp_path / "snapshots"
     write_snapshot(radar_run(27), snapshot_dir)
     data_output = tmp_path / "site" / "data" / "radar.json"
+    feed_output = tmp_path / "site" / "feed.xml"
 
-    rebuild_dashboard(snapshot_dir, data_output)
+    rebuild_dashboard(snapshot_dir, data_output, feed_output=feed_output)
 
     ns = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
-    root = ET.parse(data_output.parent / "sitemap.xml").getroot()
+    sitemap_output = tmp_path / "site" / "sitemap.xml"
+    assert sitemap_output.exists()
+    assert not (data_output.parent / "sitemap.xml").exists()
+    root = ET.parse(sitemap_output).getroot()
     urls = [node.text for node in root.findall("sm:url/sm:loc", ns)]
     assert urls == [
         f"{SITE_URL}/",


### PR DESCRIPTION
## Summary

Implements the entire "Now: technical SEO" checklist of #236. No new content, no query targeting: the mechanical layer on existing pages.

- [x] `sitemap.xml`, generated rather than hand-written, covering every indexable view
- [x] `robots.txt`
- [x] Per-page `<title>` and meta description that differ from each other
- [x] Open Graph / Twitter card tags (OG already shipped; adds explicit `twitter:image`)
- [x] JSON-LD structured data (`Dataset` for the corpus; `WebSite` with `SearchAction`)
- [x] Canonical URLs

## How each item works

**Sitemap** — new `src/benchmark_radar/site_seo.py`. Written by `rebuild_dashboard` beside `radar.json`, exactly like `records-badge.json`: never committed, so it can only describe views this build actually publishes. Lists the four views (Today, Leaderboard, Trends, Explore); excludes `logos.html` because that page carries `noindex`. `lastmod` comes from snapshot history, not the clock, so rebuilds are byte-deterministic.

**Canonicals** — static default in the head; `app.js` restates title, description, and canonical on every view change via one `VIEW_SEO` map wired inside `setView` (covers boot, popstate, nav clicks, fallbacks). Canonicals carry only the view parameter, so filter permutations (`q`, `lq`, `lfrontier`, ...) consolidate into four clean URLs instead of fragmenting signals.

**JSON-LD** — `WebSite`+`SearchAction` targets `?view=leaderboard&lq={search_term_string}`, which is the leaderboard's real search filter, and `Dataset` describes `data/radar.json` with MIT license and a DataDownload entry.

## Verification

- Full suite green: 885 passed, 6 skipped; ruff clean
- New tests: `tests/test_site_seo.py` (sitemap coverage, deterministic lastmod, head/robots/JS consistency, structured-data parsing) + `test_snapshots.py` regression asserting the build writes the sitemap
- Generated artifact eyeballed end-to-end from the real committed snapshots

## Not in this PR (per the issue)

The outreach-list half of #236 stays open as separate work.

Closes #236