### PR TITLE
Restore the leaderboard score chart and unbreak CI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,3 +4,22 @@
 
 - Do not squash-merge pull requests.
 - Merge pull requests with a merge commit so Git preserves branch ancestry and recognizes the branch as merged.
+
+## Before opening a pull request
+
+- Run the full CI sequence locally and get it passing before opening a PR. Do
+  not open one against a red local run.
+- Run it against a clean checkout (`git worktree add --detach <tmp> <branch>`),
+  not your working copy. Generated files such as `site/data/radar.json` and
+  `site/data/radar-bootstrap.json` are gitignored and absent on a fresh CI
+  runner, so a working copy that happens to have them on disk passes tests that
+  CI fails.
+- The sequence is the one in `.github/workflows/ci.yml`, in order:
+
+      ruff check .
+      ruff format --check .
+      pytest -q
+      benchmark-radar classify
+
+- All four must pass. `ruff format --check` runs before the tests, so a
+  formatting slip fails the run before a single test executes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,3 +4,22 @@
 
 - Do not squash-merge pull requests.
 - Merge pull requests with a merge commit so Git preserves branch ancestry and recognizes the branch as merged.
+
+## Before opening a pull request
+
+- Run the full CI sequence locally and get it passing before opening a PR. Do
+  not open one against a red local run.
+- Run it against a clean checkout (`git worktree add --detach <tmp> <branch>`),
+  not your working copy. Generated files such as `site/data/radar.json` and
+  `site/data/radar-bootstrap.json` are gitignored and absent on a fresh CI
+  runner, so a working copy that happens to have them on disk passes tests that
+  CI fails.
+- The sequence is the one in `.github/workflows/ci.yml`, in order:
+
+      ruff check .
+      ruff format --check .
+      pytest -q
+      benchmark-radar classify
+
+- All four must pass. `ruff format --check` runs before the tests, so a
+  formatting slip fails the run before a single test executes.

--- a/src/benchmark_radar/snapshots.py
+++ b/src/benchmark_radar/snapshots.py
@@ -1044,10 +1044,14 @@ def dashboard_bootstrap(dashboard: dict[str, Any]) -> dict[str, Any]:
 
     The full bundle contains every historical observation and every corpus
     entity.  Today and the model-card leaderboard need neither: they use the
-    latest day, the curated leaderboard, and corpus aggregate counts.  Keep the
-    public ``radar.json`` export intact for researchers, while giving the
-    browser a much smaller default document and letting history-heavy views
-    fetch the full bundle only when opened.
+    latest day, the curated leaderboard, its score progression, and corpus
+    aggregate counts.  Keep the public ``radar.json`` export intact for
+    researchers, while giving the browser a much smaller default document and
+    letting history-heavy views fetch the full bundle only when opened.
+
+    The score progression stays in this payload.  It is what the leaderboard's
+    score panel reads, and no view upgrades to the full bundle on the reader's
+    way to that panel, so dropping it left the panel permanently empty.
     """
     corpus = dashboard.get("corpus") or {}
     return {
@@ -1055,10 +1059,6 @@ def dashboard_bootstrap(dashboard: dict[str, Any]) -> dict[str, Any]:
         "bootstrap": True,
         "days": (dashboard.get("days") or [])[-1:],
         "corpus": {"aggregates": corpus.get("aggregates") or {}},
-        # This history is only consumed alongside the full multi-day payload.
-        # Omitting it removes another sizeable block without changing Today or
-        # the leaderboard's first paint.
-        "benchmark_score_progression": {},
     }
 
 

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -570,7 +570,10 @@ def test_static_html_references_existing_local_assets():
     # Pages generates these from validated source data before upload. Their
     # generators and rendered structure have dedicated tests, while this check
     # remains about static assets that must exist in a clean checkout.
-    generated_assets = {"feed.xml"}
+    # radar.json is the dashboard bundle the "Download the dataset" link points
+    # at. Pages writes it during the build, before the artifact upload, so the
+    # published link resolves; it is absent from a clean checkout by design.
+    generated_assets = {"feed.xml", "data/radar.json"}
     missing = []
     for reference in parser.local_refs:
         path = urlsplit(reference).path

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -252,10 +252,7 @@ def test_rebuild_writes_a_small_latest_day_bootstrap(tmp_path):
     assert bootstrap["corpus"] == {"aggregates": dashboard["corpus"]["aggregates"]}
     # The leaderboard's score panel renders straight off this payload and
     # nothing upgrades it to the full bundle first, so the progression ships.
-    assert (
-        bootstrap["benchmark_score_progression"]
-        == dashboard["benchmark_score_progression"]
-    )
+    assert bootstrap["benchmark_score_progression"] == dashboard["benchmark_score_progression"]
     assert bootstrap_path.stat().st_size < output.stat().st_size
 
 

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -250,7 +250,12 @@ def test_rebuild_writes_a_small_latest_day_bootstrap(tmp_path):
     assert [day["date"] for day in bootstrap["days"]] == ["2026-07-27"]
     assert bootstrap["facets"]["dates"] == ["2026-07-26", "2026-07-27"]
     assert bootstrap["corpus"] == {"aggregates": dashboard["corpus"]["aggregates"]}
-    assert bootstrap["benchmark_score_progression"] == {}
+    # The leaderboard's score panel renders straight off this payload and
+    # nothing upgrades it to the full bundle first, so the progression ships.
+    assert (
+        bootstrap["benchmark_score_progression"]
+        == dashboard["benchmark_score_progression"]
+    )
     assert bootstrap_path.stat().st_size < output.stat().st_size
 
 


### PR DESCRIPTION
## Leaderboard score panel

The Leaderboard's "Scores over time" panel showed "No benchmark in this registry has a score read from a document yet." on every visit, on the live site.

`dashboard_bootstrap()` blanked `benchmark_score_progression` out of the first-paint payload on the grounds that the history "is only consumed alongside the full multi-day payload." It isn't: `scoreRecord()` (`site/assets/app.js:4973`) reads exactly that block, and `stateNeedsFullData()` upgrades to `radar.json` only for the trends, map, and historical-today views, never for the leaderboard. The panel read a block that had been emptied and could never be refilled.

The progression now ships in the bootstrap payload. It is 274 KB of the 42 MB bundle; the alternative is fetching all 42 MB when someone opens Leaderboard.

## CI

`tests/test_site.py::test_static_html_references_existing_local_assets` has failed on every run since the dataset download link landed. `site/index.html` links `data/radar.json`, which Pages writes during the build before the artifact upload, so the published link resolves, but a clean checkout has no such file and the check only allowlisted `feed.xml`. Added the bundle to the allowlist.

The check passes locally on a working copy that already has the generated bundle on disk, which is why it went unnoticed. `CLAUDE.md` and `AGENTS.md` now require running the CI sequence against a clean checkout before opening a PR.

## Verification

Full `ci.yml` sequence against a detached clean worktree with no generated files:

| step | result |
|---|---|
| `ruff check .` | passed |
| `ruff format --check .` | 99 files already formatted |
| `pytest -q` | 889 passed, 6 skipped |
| `benchmark-radar classify` | exit 0, bootstrap carries 59 scored benchmarks |

Browser check on the built site: chart renders with 24 plotted points, benchmark picker (738 options) redraws on change, `?lfrontier=swe_bench_verified` resolves to its own track, no console errors.

Merge with a merge commit, not a squash, per the repository instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)