### PR TITLE
docs: README polish, LLM Stats acknowledgement, citation section, homepage cite button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-# Benchmark Radar
+<div align="right">
 
-**简体中文:** [README.zh-CN.md](README.zh-CN.md)
+[中文](README.zh-CN.md)
+
+</div>
+
+# Benchmark Radar
 
 <!-- The record-count badge is data-driven: it is regenerated from the corpus on
 every collection, so it states what the project actually holds rather than a
@@ -10,8 +14,8 @@ hand-edited number (issue #197). -->
 
 I kept running into new benchmarks while doing benchmark research, so I built a
 crawler that continuously collects benchmark-related signals from across the
-web. It pulls evidence from **arXiv, GitHub, Hugging Face, OpenAlex, OpenReview,
-first-party lab feeds, Brave Search, Semantic Scholar, Hacker News, and more**
+web. It pulls evidence from arXiv, GitHub, Hugging Face, OpenAlex, OpenReview,
+first-party lab feeds, Brave Search, Semantic Scholar, Hacker News, and more
 every day, and keeps updating.
 
 **Click the image to watch how reported AIME 2025 scores saturated over time.**
@@ -46,3 +50,25 @@ If Benchmark Radar saves you research time, **[star the repository](https://gith
 Scan the QR code to join the WeChat group for daily benchmark updates and eval discussions:
 
 <img src="assets/wechat-group-qr.jpg" alt="WeChat group QR code" width="280" />
+
+## Acknowledgements
+
+The frontier-model score layer (including the AIME 2025 chart above) is built on
+benchmark data collected by [LLM Stats](https://llm-stats.com). Thank you for
+keeping that data open.
+
+## Citation
+
+If Benchmark Radar supports your research or evaluation work, please cite it:
+
+```bibtex
+@misc{wu2026benchmarkradar,
+  title        = {Benchmark Radar: A Daily, Evidence-First Radar and Machine-Readable Corpus for AI Benchmarks},
+  author       = {Wu, Koutian},
+  year         = {2026},
+  howpublished = {\url{https://github.com/ktwu01/benchmark-radar}},
+  note         = {Daily benchmark radar and open dataset}
+}
+```
+
+See [`CITATION.cff`](CITATION.cff) for machine-readable citation metadata.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,12 +1,16 @@
-# Benchmark Radar
+<div align="right">
 
-**English:** [README.md](README.md)
+[English](README.md)
+
+</div>
+
+# Benchmark Radar
 
 <!-- 记录数 badge 由数据驱动：每次采集都会根据语料重新生成，因此它反映的是项目实际收集到的数据量 -->
 
 [![已收集 benchmark 记录](https://img.shields.io/endpoint?url=https%3A%2F%2Fkoutian.is-a.dev%2Fbenchmark-radar%2Fdata%2Frecords-badge.json)](https://koutian.is-a.dev/benchmark-radar/)
 
-做 benchmark 研究的时候发现新东西太多了，所以我搞了这个持续爬虫，每天自动从全网抓新的 benchmark 相关信息。它目前每天从 **arXiv、GitHub、Hugging Face、OpenAlex、OpenReview、各家实验室官方 feed、Brave Search、Semantic Scholar、Hacker News** 等来源采集，并持续更新。你如果需要寻找 related work 或找到适合eval自己的agent 的 bench 或者关注最新的 eval 进展，可以看这里哈哈哈：
+做 benchmark 研究的时候发现新东西太多了，所以我搞了这个持续爬虫，每天自动从全网抓新的 benchmark 相关信息。它目前每天从 arXiv、GitHub、Hugging Face、OpenAlex、OpenReview、各家实验室官方 feed、Brave Search、Semantic Scholar、Hacker News 等来源采集，并持续更新。你如果需要寻找 related work 或找到适合eval自己的agent 的 bench 或者关注最新的 eval 进展，可以看这里哈哈哈：
 github.com/ktwu01/benchmark-radar，每天更新，并支持一键导出数据
 
 **点击图片即可查看 AIME 2025 报告分数随时间逐渐饱和的过程。**
@@ -41,3 +45,23 @@ github.com/ktwu01/benchmark-radar，每天更新，并支持一键导出数据
 扫码加入微信群，获取每日 benchmark 更新、交流评测相关话题：
 
 <img src="assets/wechat-group-qr.jpg" alt="微信群二维码" width="280" />
+
+## 感谢
+
+前沿模型分数层（包括上方的 AIME 2025 图表）基于 [LLM Stats](https://llm-stats.com) 采集的基准数据构建，感谢他们把这些数据公开出来。
+
+## 引用
+
+如果 Benchmark Radar 对你的研究或评测工作有帮助，欢迎引用：
+
+```bibtex
+@misc{wu2026benchmarkradar,
+  title        = {Benchmark Radar: A Daily, Evidence-First Radar and Machine-Readable Corpus for AI Benchmarks},
+  author       = {Wu, Koutian},
+  year         = {2026},
+  howpublished = {\url{https://github.com/ktwu01/benchmark-radar}},
+  note         = {Daily benchmark radar and open dataset}
+}
+```
+
+机器可读的引用元数据见 [`CITATION.cff`](CITATION.cff)。

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -763,8 +763,9 @@ const I18N = {
     "Download the dataset": "下载数据集",
     "Star the repository": "给仓库点 Star",
     "Free dataset. No crawler needed.": "免费数据集，无需爬虫。",
-    "If this saved you research time, star the repository and help other eval builders find it.":
-      "如果它帮你节省了研究时间，请给仓库点 Star，让更多评测开发者找到它。",
+    "If this saved you research time, cite the work, star the repo and help other eval builders find it.":
+      "如果它帮你节省了研究时间，请引用这项工作、给仓库点 Star，让更多评测开发者找到它。",
+    Cite: "引用",
     "Share Benchmark Radar": "分享 Benchmark Radar",
     "Copy link": "复制链接",
     Copied: "已复制",

--- a/site/index.html
+++ b/site/index.html
@@ -333,10 +333,17 @@
               <button type="button" id="today-page-next" data-i18n="Next">Next</button>
             </nav>
             <aside class="adoption-cta" aria-label="Support Benchmark Radar">
-              <p data-i18n="If this saved you research time, star the repository and help other eval builders find it.">
-                If this saved you research time, star the repository and help other eval builders find it.
+              <p data-i18n="If this saved you research time, cite the work, star the repo and help other eval builders find it.">
+                If this saved you research time, cite the work, star the repo and help other eval builders find it.
               </p>
               <span class="adoption-actions">
+                <a
+                  class="primary-link"
+                  href="https://github.com/ktwu01/benchmark-radar/blob/main/CITATION.cff"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  data-i18n="Cite"
+                >Cite</a>
                 <a
                   class="primary-link"
                   href="https://github.com/ktwu01/benchmark-radar"

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -86,10 +86,12 @@ def test_chinese_readme_mirrors_the_english_one():
     if not README_ZH.exists():  # pragma: no cover
         return
     zh = README_ZH.read_text(encoding="utf-8")
-    en = README.read_text(encoding="utf-8")
 
     url = "https://koutian.is-a.dev/benchmark-radar/data/records-badge.json"
     quoted = quote(url, safe="")
     assert f"https://img.shields.io/endpoint?url={quoted}" in zh
-    assert "[README.md](README.md)" in zh
-    assert "[README.zh-CN.md](README.zh-CN.md)" in en
+    assert "[English](README.md)" in zh
+    # The language switch sits at the top-right, above the title, with a plain
+    # language label rather than a filename.
+    assert '<div align="right">' in zh.split("# Benchmark Radar")[0]
+    assert "[README.md](README.md)" not in zh

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -34,8 +34,12 @@ def test_readmes_offer_free_data_and_an_earned_star_request():
     english = Path("README.md").read_text(encoding="utf-8")
     chinese = Path("README.zh-CN.md").read_text(encoding="utf-8")
 
-    assert "[README.zh-CN.md](README.zh-CN.md)" in english
-    assert "[README.md](README.md)" in chinese
+    # Language switch sits top-right above the title with a plain label.
+    assert '<div align="right">' in english.split("# Benchmark Radar")[0]
+    assert "[中文](README.zh-CN.md)" in english
+    assert "[README.zh-CN.md](README.zh-CN.md)" not in english
+    assert '<div align="right">' in chinese.split("# Benchmark Radar")[0]
+    assert "[English](README.md)" in chinese
     assert "Click the image" in english
     assert "点击图片" in chinese
     assert "data/radar.json" in english and "no crawler or contact required" in english


### PR DESCRIPTION
## Summary
- Move the language-switch link to the top-right above the title in both READMEs, with a plain label ([中文](README.zh-CN.md) / [English](README.md)) instead of a filename-style link.
- Remove bold styling from the source-list sentence in both READMEs.
- Add an Acknowledgements/感谢 section crediting LLM Stats as the frontier-score data source (the AIME 2025 chart is built on llm-stats.com data).
- Add a BibTeX citation block at the end of both READMEs (Wu 2026), pointing at CITATION.cff for machine-readable metadata.
- Homepage: update the support card copy to mention citing the work and add a Cite button linking to CITATION.cff; update the zh i18n strings.

## Verification
Full CI sequence green locally on a clean worktree checkout of this branch: ruff check, ruff format --check, pytest (889 passed, 6 skipped). README tests updated to assert the new top-right link format.