### PR TITLE
i18n: missing zh entries; SEO: single H1, og:title, internal links

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -7260,7 +7260,10 @@ function bindEvents() {
   const langToggle = byId("lang-toggle");
   if (langToggle) langToggle.addEventListener("click", toggleLang);
   document.querySelectorAll("[data-view]").forEach((button) => {
-    button.addEventListener("click", async () => {
+    button.addEventListener("click", async (event) => {
+      // View nav entries are anchors so crawlers can follow them; keep the
+      // navigation client-side instead of a full page reload.
+      if (event.target.closest("a")) event.preventDefault();
       const view = button.dataset.view;
       try {
         if (["trends", "map"].includes(view)) await ensureFullData();

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -760,7 +760,7 @@ const I18N = {
     Discord: "Discord",
     "The complete dataset is free to download. If it saves you research time, star the repository so other eval builders can find it.":
       "完整数据集可以免费下载。如果它帮你节省了研究时间，请给仓库点个 Star，让更多评测开发者找到它。",
-    "Download the dataset": "下载数据集",
+    Download: "下载",
     "Star the repository": "给仓库点 Star",
     "Free dataset. No crawler needed.": "免费数据集，无需爬虫。",
     "If this saved you research time, cite the work, star the repo and help other eval builders find it.":
@@ -769,7 +769,7 @@ const I18N = {
     "Share Benchmark Radar": "分享 Benchmark Radar",
     Share: "分享",
     Copied: "已复制",
-    "contact the author": "联系作者",
+    Contact: "联系作者",
     "for a one-click export.": "即可一键导出。",
     // --- Remaining dynamic strings ------------------------------------------
     " on a": " 以",
@@ -7224,7 +7224,7 @@ function openContact(updateUrl = true) {
       }),
       element("a", {
         className: "primary-link",
-        text: t("Download the dataset"),
+        text: t("Download"),
         attrs: { href: "data/radar.json" },
       }),
       element("a", {
@@ -7442,7 +7442,7 @@ function bindEvents() {
   // before they trust any single row.
   byId("rubric-nav").addEventListener("click", () => openRubric());
   byId("badge-contact").addEventListener("click", openContact);
-  // The footer's "contact the author" opens the same sheet as the header
+  // The footer's "Contact" button opens the same sheet as the header
   // badge (issue #311): one contact surface, two doors.
   byId("footer-contact").addEventListener("click", openContact);
   byId("contact-close").addEventListener("click", () => byId("contact-dialog").close());

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -767,7 +767,7 @@ const I18N = {
       "如果它帮你节省了研究时间，请引用这项工作、给仓库点 Star，让更多评测开发者找到它。",
     Cite: "引用",
     "Share Benchmark Radar": "分享 Benchmark Radar",
-    "Copy link": "复制链接",
+    Share: "分享",
     Copied: "已复制",
     "contact the author": "联系作者",
     "for a one-click export.": "即可一键导出。",
@@ -7464,7 +7464,7 @@ function bindEvents() {
       if (navigator.share) await navigator.share(shareData);
       else await navigator.clipboard.writeText(shareData.url);
       button.textContent = t("Copied");
-      setTimeout(() => { button.textContent = t("Copy link"); }, 1600);
+      setTimeout(() => { button.textContent = t("Share"); }, 1600);
     } catch (error) {
       if (error?.name !== "AbortError") console.error(error);
     }

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -916,6 +916,37 @@ const I18N = {
     datasets: "数据集",
     evaluations: "评测",
     "times found": "次发现",
+    // --- Coverage for dynamic t() call sites ---------------------------------
+    "or above marks the item as recommended; it does not control inclusion. Watchlisted artifacts are also retained.":
+      "及以上分数表示该条目被推荐；该分数不决定是否收录。观察名单中的工件同样会保留。",
+    "not scored": "未评分",
+    "data quality": "数据质量",
+    "no scores collected": "未采集到分数",
+    "{shown} of {total} matches": "共 {total} 条匹配，已显示 {shown} 条",
+    "No benchmark matches that name": "没有匹配该名称的基准",
+    "Benchmark search is unavailable right now": "基准搜索暂时不可用",
+    "not recorded": "未记录",
+    "The source declares a maximum of {max} but carries values above it, so that bound is not a scale.":
+      "来源声明的满分是 {max}，但存在超过它的数值，因此这个上限并不是一个统一的量表。",
+    "same benchmark, other source": "同一基准，其他来源",
+    "related split": "相关子集",
+    "same framework": "同一框架",
+    "introduced in the same paper": "出自同一篇论文",
+    "has a related variant": "存在相关变体",
+    "Related records": "相关记录",
+    "External benchmark": "外部基准",
+    "Loading benchmark details…": "正在加载基准详情…",
+    "Could not load details for this benchmark.": "无法加载该基准的详情。",
+    "Ranked by how many curated model cards report each benchmark, which measures vendor reporting convention rather than benchmark quality. A crawled score count answers a different question: AIME 2025 carries 115 crawled scores and GPQA Diamond 26 model cards, and those are different measures rather than competing ones.":
+      "排名依据是每个基准被多少张精选模型卡报告，衡量的是厂商的报告惯例而非基准质量。爬取到的分数数量回答的是另一个问题：AIME 2025 有 115 个爬取到的分数，GPQA Diamond 有 26 张模型卡，两者是不同的度量而不是互相竞争的指标。",
+    "points to the {bound}-point bound of this metric": "指向该指标 {bound} 分的上限",
+    "across {domains}{listed}.": "覆盖 {domains}{listed}。",
+    " · {count} released in the newest 18-month window already appear across three or more dated organizations. Follow their trajectories before reading the raw rank.":
+      " · 最近 18 个月窗口内发布的 {count} 项已经出现在三家及以上有明确日期的机构中。在解读原始排名之前，先看它们的轨迹变化。",
+    "Show all {count} benchmarks": "显示全部 {count} 个基准",
+    "Star this repository on GitHub. {count} stars": "在 GitHub 上给这个仓库点 Star。{count} 个 star",
+    "Fork this repository on GitHub. {count} forks": "在 GitHub 上 fork 这个仓库。{count} 个 fork",
+    "Open a new issue on GitHub. {count} issues open": "在 GitHub 上提交新 issue。当前有 {count} 个 open issue",
   },
 };
 

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -394,16 +394,14 @@ main {
   padding-top: clamp(1.25rem, 2vw, 1.75rem);
 }
 
-/* These two headings are semantically h2 now (the page keeps one h1), but
-   they must render exactly as they did as h1s, so this restates the global
-   h1 treatment they used to inherit. */
+/* View headings are h2s under the page's single h1, and they share the
+   quiet leaderboard-heading scale rather than the display scale the old
+   per-view h1s used. */
 .view-heading h2 {
-  max-width: 800px;
-  margin-bottom: 0;
-  font-size: clamp(1.9rem, 4vw, 3rem);
-  line-height: 1;
-  letter-spacing: -0.015em;
-  text-transform: uppercase;
+  margin: 0;
+  max-width: none;
+  font-size: clamp(1.25rem, 2vw, 1.5rem);
+  line-height: 1.2;
 }
 
 .view-heading {
@@ -3586,7 +3584,10 @@ dialog::backdrop {
 
 .detail-title {
   padding-right: 2rem;
-  font-size: clamp(2rem, 5vw, 3.4rem);
+  /* Same quiet scale as the view headings; the old display-scale title
+     outweighed the detail content it named. */
+  font-size: clamp(1.25rem, 2vw, 1.5rem);
+  line-height: 1.2;
 }
 
 .detail-summary {
@@ -4097,11 +4098,7 @@ footer {
     width: 100%;
   }
 
-  /* The view headings were h1s when this rule was written; the selectors
-     follow them so their mobile sizing is unchanged. */
-  h1,
-  .view-heading h2,
-  .error-state h2 {
+  h1 {
     max-width: 100%;
     overflow-wrap: anywhere;
     font-size: clamp(1.7rem, 7vw, 2.3rem);

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -3831,17 +3831,6 @@ dialog::backdrop {
   cursor: pointer;
 }
 
-.footer-views {
-  display: flex;
-  gap: 1rem;
-  font-family: var(--utility);
-  font-size: 0.75rem;
-}
-
-.footer-views a {
-  color: var(--ink);
-}
-
 .footer-dataset {
   display: grid;
   gap: 0.55rem;

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -117,6 +117,7 @@ footer {
 .brand small,
 .eyebrow,
 .section-title span,
+#today-view .section-title h1,
 #today-view .section-title h2,
 .heading-note,
 .date-control,
@@ -497,15 +498,20 @@ input {
   border-bottom: 1px solid var(--ink);
 }
 
+.section-title h1,
 .section-title h2 {
   margin-bottom: 0;
 }
 
 /* The results heading reads as a caption for the list beneath it, so it
    carries the regular weight rather than the display h2 weight (issue #248). */
+#today-view .section-title h1,
 #today-view .section-title h2 {
   color: var(--muted);
   font-weight: 400;
+  font-size: clamp(1.25rem, 2vw, 1.5rem);
+  text-transform: none;
+  letter-spacing: -0.01em;
 }
 
 .section-title span {
@@ -2324,7 +2330,8 @@ td a {
    hundreds of pixels away in empty space with no anchor. At this size the
    heading fits one line, so the toggle sits immediately after its last
    glyph, and wrap keeps that true on narrow screens by stacking instead. */
-.leaderboard-top-heading h1 {
+.leaderboard-top-heading h1,
+.leaderboard-top-heading h2 {
   margin: 0;
   max-width: none;
   font-size: clamp(1.25rem, 2vw, 1.5rem);
@@ -3804,6 +3811,17 @@ dialog::backdrop {
   cursor: pointer;
 }
 
+.footer-views {
+  display: flex;
+  gap: 1rem;
+  font-family: var(--utility);
+  font-size: 0.75rem;
+}
+
+.footer-views a {
+  color: var(--ink);
+}
+
 .footer-dataset {
   display: grid;
   gap: 0.55rem;
@@ -3898,7 +3916,8 @@ button.stale-banner-action {
   padding: 7rem 0;
 }
 
-.error-state h1 {
+.error-state h1,
+.error-state h2 {
   margin-bottom: 2rem;
   font-size: clamp(2.5rem, 7vw, 5.5rem);
 }

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -3823,6 +3823,10 @@ dialog::backdrop {
 }
 
 .footer-dataset {
+  /* The footer is a space-between flex row (build meta left, view links
+     middle, this card last); order moves the card to the leading edge so it
+     is always the left-most item without changing the DOM order. */
+  order: -1;
   display: grid;
   gap: 0.55rem;
   margin: 0.7rem 0 0;

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -515,18 +515,13 @@ input {
 
 /* The results heading reads as a caption for the list beneath it, so it
    carries the regular weight rather than the display h2 weight (issue #248).
-   The heading is semantically an h1 now, but it must render exactly as it
-   did as an h2: undo the global h1 treatment (uppercase transform, 800px
-   width cap, single-line height) and keep the UA h2 size (1.5em) and the
-   shared display-face letter-spacing (-0.025em) untouched. */
+   The heading is semantically an h1, but it renders exactly like the counts
+   caption beside it: same utility face, same 0.72rem size, inherited from
+   the shared small-caps group above. */
 #today-view .section-title h1,
 #today-view .section-title h2 {
   color: var(--muted);
   font-weight: 400;
-  font-size: 1.5em;
-  line-height: normal;
-  text-transform: none;
-  max-width: none;
 }
 
 .section-title span {
@@ -542,6 +537,9 @@ input {
   align-items: baseline;
   justify-content: flex-end;
   text-align: right;
+  /* Counts read as plain data, not a label; the small-caps transform the
+     section-title group applies to spans is dropped here. */
+  text-transform: none;
 }
 
 #today-sort {
@@ -3950,7 +3948,11 @@ button.stale-banner-action {
 
 footer {
   display: flex;
-  justify-content: space-between;
+  /* Everything hugs the leading edge: dataset card (order -1), then the
+     updated stamp, then the view links. */
+  justify-content: flex-start;
+  gap: 1.5rem;
+  align-items: baseline;
   padding: 1.5rem 0 3rem;
   border-top: 1px solid var(--ink);
   color: var(--muted);

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -538,7 +538,11 @@ input {
   justify-content: flex-end;
   text-align: right;
   /* Counts read as plain data, not a label; the small-caps transform the
-     section-title group applies to spans is dropped here. */
+     section-title group applies to these spans directly is dropped here. */
+  text-transform: none;
+}
+
+.results-meta span {
   text-transform: none;
 }
 
@@ -3839,10 +3843,6 @@ dialog::backdrop {
 }
 
 .footer-dataset {
-  /* The footer is a space-between flex row (build meta left, view links
-     middle, this card last); order moves the card to the leading edge so it
-     is always the left-most item without changing the DOM order. */
-  order: -1;
   display: grid;
   gap: 0.55rem;
   margin: 0.7rem 0 0;
@@ -3947,12 +3947,12 @@ button.stale-banner-action {
 }
 
 footer {
+  /* One left-aligned column: updated stamp, view links, then the dataset
+     card underneath them. */
   display: flex;
-  /* Everything hugs the leading edge: dataset card (order -1), then the
-     updated stamp, then the view links. */
-  justify-content: flex-start;
-  gap: 1.5rem;
-  align-items: baseline;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.9rem;
   padding: 1.5rem 0 3rem;
   border-top: 1px solid var(--ink);
   color: var(--muted);

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -394,6 +394,18 @@ main {
   padding-top: clamp(1.25rem, 2vw, 1.75rem);
 }
 
+/* These two headings are semantically h2 now (the page keeps one h1), but
+   they must render exactly as they did as h1s, so this restates the global
+   h1 treatment they used to inherit. */
+.view-heading h2 {
+  max-width: 800px;
+  margin-bottom: 0;
+  font-size: clamp(1.9rem, 4vw, 3rem);
+  line-height: 1;
+  letter-spacing: -0.015em;
+  text-transform: uppercase;
+}
+
 .view-heading {
   display: flex;
   gap: 2rem;
@@ -504,14 +516,19 @@ input {
 }
 
 /* The results heading reads as a caption for the list beneath it, so it
-   carries the regular weight rather than the display h2 weight (issue #248). */
+   carries the regular weight rather than the display h2 weight (issue #248).
+   The heading is semantically an h1 now, but it must render exactly as it
+   did as an h2: undo the global h1 treatment (uppercase transform, 800px
+   width cap, single-line height) and keep the UA h2 size (1.5em) and the
+   shared display-face letter-spacing (-0.025em) untouched. */
 #today-view .section-title h1,
 #today-view .section-title h2 {
   color: var(--muted);
   font-weight: 400;
-  font-size: clamp(1.25rem, 2vw, 1.5rem);
+  font-size: 1.5em;
+  line-height: normal;
   text-transform: none;
-  letter-spacing: -0.01em;
+  max-width: none;
 }
 
 .section-title span {
@@ -3923,7 +3940,11 @@ button.stale-banner-action {
 .error-state h1,
 .error-state h2 {
   margin-bottom: 2rem;
+  /* Restates the global h1 treatment the heading carried as an h1. */
   font-size: clamp(2.5rem, 7vw, 5.5rem);
+  line-height: 1;
+  letter-spacing: -0.015em;
+  text-transform: uppercase;
 }
 
 footer {
@@ -4076,7 +4097,11 @@ footer {
     width: 100%;
   }
 
-  h1 {
+  /* The view headings were h1s when this rule was written; the selectors
+     follow them so their mobile sizing is unchanged. */
+  h1,
+  .view-heading h2,
+  .error-state h2 {
     max-width: 100%;
     overflow-wrap: anywhere;
     font-size: clamp(1.7rem, 7vw, 2.3rem);

--- a/site/index.html
+++ b/site/index.html
@@ -761,7 +761,7 @@
       <div class="footer-dataset">
         <strong data-i18n="Free dataset. No crawler needed.">Free dataset. No crawler needed.</strong>
         <span class="footer-dataset-actions">
-          <a href="data/radar.json" data-i18n="Download the dataset">Download the dataset</a>
+          <a href="data/radar.json" data-i18n="Download">Download</a>
           <a
             href="https://github.com/ktwu01/benchmark-radar"
             target="_blank"
@@ -772,8 +772,8 @@
             type="button"
             class="footer-contact-link"
             id="footer-contact"
-            data-i18n="contact the author"
-          >contact the author</button>
+            data-i18n="Contact"
+          >Contact</button>
         </span>
       </div>
     </footer>

--- a/site/index.html
+++ b/site/index.html
@@ -354,8 +354,8 @@
                   rel="noopener noreferrer"
                   data-i18n="Star the repository"
                 >Star the repository</a>
-                <button type="button" class="secondary-link" id="share-radar" data-i18n="Copy link">
-                  Copy link
+                <button type="button" class="secondary-link" id="share-radar" data-i18n="Share">
+                  Share
                 </button>
               </span>
             </aside>
@@ -758,14 +758,6 @@
 
     <footer>
       <p id="build-meta">Updated —</p>
-      <!-- Crawlable internal links: the view switcher above is buttons, which
-         search engines cannot follow, so the footer restates the views as
-         real anchors pointing at the canonical per-view URLs. -->
-      <nav class="footer-views" aria-label="Site views">
-        <a href="?view=leaderboard" data-i18n="Leaderboard">Leaderboard</a>
-        <a href="?view=trends" data-i18n="Trends">Trends</a>
-        <a href="?view=map" data-i18n="Explore">Explore</a>
-      </nav>
       <div class="footer-dataset">
         <strong data-i18n="Free dataset. No crawler needed.">Free dataset. No crawler needed.</strong>
         <span class="footer-dataset-actions">

--- a/site/index.html
+++ b/site/index.html
@@ -15,7 +15,10 @@
          shows the current top rows rather than a static logo. -->
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Benchmark Radar">
-    <meta property="og:title" content="Which benchmarks do frontier labs actually report?">
+    <meta
+      property="og:title"
+      content="Benchmark Radar"
+    >
     <meta
       property="og:description"
       content="A live ranking of the benchmarks reported in frontier model cards, system cards, and technical reports. Measures vendor reporting convention, not benchmark quality."
@@ -315,7 +318,7 @@
         <div class="content-grid">
           <div>
             <div class="section-title">
-              <h2 data-i18n="Today's radar">Today's radar</h2>
+              <h1 class="today-heading" data-i18n="Today's radar">Today's radar</h1>
               <div class="results-meta" aria-live="polite">
                 <span id="today-breakdown"></span>
                 <span id="today-sort"></span>
@@ -410,7 +413,7 @@
              name, and the (i) beside it carries the caveat. -->
         <section class="leaderboard-top" aria-labelledby="leaderboard-heading">
           <div class="leaderboard-top-heading">
-            <h1 id="leaderboard-heading" data-i18n="Most reported benchmarks in model cards">Most reported benchmarks in model cards</h1>
+            <h2 id="leaderboard-heading" data-i18n="Most reported benchmarks in model cards">Most reported benchmarks in model cards</h2>
             <span id="leaderboard-top-info"></span>
             <!-- Written but not shown: the visible copy is in the (i). A screen
                  reader announces it with the heading. -->
@@ -610,7 +613,7 @@
         <header class="view-heading">
           <div>
             <p class="eyebrow" data-i18n="Big picture">Big picture</p>
-            <h1 id="map-heading" data-i18n="What we found">What we found</h1>
+            <h2 id="map-heading" data-i18n="What we found">What we found</h2>
           </div>
           <p class="heading-note" data-i18n="map.heading.note">
             See what shows up most often and where it came from. Open the connections view
@@ -654,7 +657,7 @@
         <header class="view-heading">
           <div>
             <p class="eyebrow" data-i18n="Recent activity">Recent activity</p>
-            <h1 id="trends-heading" data-i18n="Signals over time">Signals over time</h1>
+            <h2 id="trends-heading" data-i18n="Signals over time">Signals over time</h2>
           </div>
           <p class="heading-note" data-i18n="trends.heading.note">Counts describe discovery volume, not scientific quality.</p>
         </header>
@@ -727,7 +730,7 @@
 
       <section class="error-state" id="error-state" hidden>
         <p class="eyebrow" data-i18n="Dashboard unavailable">Dashboard unavailable</p>
-        <h1 data-i18n="The validated data file could not be loaded.">The validated data file could not be loaded.</h1>
+        <h2 data-i18n="The validated data file could not be loaded.">The validated data file could not be loaded.</h2>
         <p data-i18n="error.note">Try refreshing, or inspect the latest daily Issue while the dashboard rebuilds.</p>
         <a href="https://github.com/ktwu01/benchmark-radar/issues?q=is%3Aissue+label%3Adaily-radar" data-i18n="Open daily Issues">Open daily Issues ↗</a>
       </section>
@@ -755,6 +758,14 @@
 
     <footer>
       <p id="build-meta">Updated —</p>
+      <!-- Crawlable internal links: the view switcher above is buttons, which
+         search engines cannot follow, so the footer restates the views as
+         real anchors pointing at the canonical per-view URLs. -->
+      <nav class="footer-views" aria-label="Site views">
+        <a href="?view=leaderboard" data-i18n="Leaderboard">Leaderboard</a>
+        <a href="?view=trends" data-i18n="Trends">Trends</a>
+        <a href="?view=map" data-i18n="Explore">Explore</a>
+      </nav>
       <div class="footer-dataset">
         <strong data-i18n="Free dataset. No crawler needed.">Free dataset. No crawler needed.</strong>
         <span class="footer-dataset-actions">

--- a/site/index.html
+++ b/site/index.html
@@ -73,6 +73,7 @@
         "description": "A daily-updated machine-readable corpus of AI benchmark, evaluation, and dataset signals collected from arXiv, GitHub, Hugging Face, OpenAlex, OpenReview, Semantic Scholar, Hacker News, and first-party lab feeds.",
         "url": "https://koutian.is-a.dev/benchmark-radar/data/radar.json",
         "license": "https://opensource.org/licenses/MIT",
+        "isAccessibleForFree": true,
         "creator": {
           "@type": "Person",
           "name": "Koutian Wu",
@@ -88,6 +89,16 @@
         ]
       }
     </script>
+
+    <!-- Machine-readable citation hints: Highwire tags are the convention
+         academic indexers and reference managers look for; cite-as points at
+         the canonical thing to cite (the repo, which carries CITATION.cff
+         and the BibTeX entry in both READMEs). -->
+    <meta name="citation_title" content="Benchmark Radar">
+    <meta name="citation_author" content="Wu, Koutian">
+    <meta name="citation_publication_date" content="2026">
+    <meta name="citation_dataset_url" content="https://koutian.is-a.dev/benchmark-radar/data/radar.json">
+    <link rel="cite-as" href="https://github.com/ktwu01/benchmark-radar">
 
     <link rel="icon" href="icon.svg" type="image/svg+xml">
     <link rel="alternate" type="application/rss+xml" title="Benchmark Radar RSS" href="feed.xml">

--- a/site/index.html
+++ b/site/index.html
@@ -229,11 +229,15 @@
 
     <nav class="view-nav" aria-label="Dashboard views" data-i18n-aria="Dashboard views">
       <button type="button" data-view="today" aria-controls="today-view" data-i18n="Today">Today</button>
-      <button type="button" data-view="leaderboard" aria-controls="leaderboard-view" data-i18n="Leaderboard">
+      <!-- The three non-default views are real anchors, not buttons: crawlers
+         do not follow buttons, and without hrefs the site reported zero
+         internal links. app.js intercepts the click so navigation stays
+         client-side; the href is the same canonical URL the view writes. -->
+      <a href="?view=leaderboard" data-view="leaderboard" aria-controls="leaderboard-view" data-i18n="Leaderboard">
         Leaderboard
-      </button>
-      <button type="button" data-view="trends" aria-controls="trends-view" data-i18n="Trends">Trends</button>
-      <button type="button" data-view="map" aria-controls="map-view" data-i18n="Explore">Explore</button>
+      </a>
+      <a href="?view=trends" data-view="trends" aria-controls="trends-view" data-i18n="Trends">Trends</a>
+      <a href="?view=map" data-view="map" aria-controls="map-view" data-i18n="Explore">Explore</a>
       <button type="button" id="rubric-nav" aria-haspopup="dialog" data-i18n="Rubric">Rubric</button>
     </nav>
 

--- a/tests/test_leaderboard_workbench.py
+++ b/tests/test_leaderboard_workbench.py
@@ -1042,16 +1042,15 @@ def test_issue_313_the_title_is_half_size_and_its_info_is_anchored():
     styles = source("site/assets/styles.css")
     html = source("site/index.html")
 
-    rule = styles.split(".leaderboard-top-heading h1 {", 1)[1].split("}", 1)[0]
+    rule = styles.split(".leaderboard-top-heading h2 {", 1)[1].split("}", 1)[0]
     assert "font-size: clamp(1.25rem, 2vw, 1.5rem);" in rule
     assert "margin: 0;" in rule
     # The global h1 caps its width at 800px; the heading is a flex item, so that
     # cap is what let the title's box stretch and strand the (i). Reset it here
     # so the title is content-sized and the toggle anchors to its last glyph.
     assert "max-width: none;" in rule
-    # The old dead h2 selector (markup is <h1> since #256) is gone, not left to
-    # rot beside the rule that replaced it.
-    assert ".leaderboard-top-heading h2" not in styles
+    # The heading is an <h2>: the page keeps a single <h1> ("Today's radar"),
+    # so crawlers see one document outline instead of four competing titles.
 
     heading = styles.split(".leaderboard-top-heading {", 1)[1].split("}", 1)[0]
     assert "flex-wrap: wrap;" in heading

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -520,7 +520,7 @@ def test_corpus_view_progressively_discloses_the_complete_relationship_map():
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
 
     assert 'data-view="map"' in html
-    assert 'data-i18n="Explore">Explore</button>' in html
+    assert 'data-i18n="Explore">Explore</a>' in html
     assert 'id="map-insights"' in html
     assert '<details class="relationship-explorer" id="relationship-explorer">' in html
     assert "renderMapInsights(corpus)" in script

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1990,3 +1990,53 @@ def test_issue_311_the_today_list_loads_one_page_at_a_time():
     assert "The complete dataset is free to download" in contact
     assert 'href: "data/radar.json"' in contact
     assert 'className: "contact-dataset"' in contact
+
+
+def _css_rule(styles: str, selector: str) -> str:
+    """Return the body of the first rule whose selector matches exactly."""
+    assert selector in styles, f"missing selector: {selector}"
+    return styles.split(selector, 1)[1].split("}", 1)[0]
+
+
+def test_heading_outline_and_scale_stay_quiet():
+    """Regression guard for the single-h1 retagging and its typography.
+
+    The page keeps one document h1 ("Today's radar"), rendered as the muted
+    caption it always was; every other view heading is an h2 at the compact
+    leaderboard scale. Before this rule existed the per-view headings carried
+    the display-scale h1 treatment (3rem uppercase), which drowned the content
+    they named.
+    """
+    html = Path("site/index.html").read_text(encoding="utf-8")
+    styles = Path("site/assets/styles.css").read_text(encoding="utf-8")
+
+    # One h1 in the static document, and it is the today view's caption.
+    assert html.count("<h1") == 1
+    assert '<h1 class="today-heading" data-i18n="Today\'s radar">' in html
+    for old_h1_id in ("leaderboard-heading", "map-heading", "trends-heading"):
+        assert f'<h2 id="{old_h1_id}"' in html
+
+    # The h1 keeps the v0.7.0 caption rendering despite the tag change. The
+    # marker appears twice (a shared font-family list earlier in the file),
+    # so take the rule after the last occurrence.
+    marker = "#today-view .section-title h1,"
+    today_rule = styles.split(marker)[-1].split("}", 1)[0]
+    assert "font-size: 1.5em;" in today_rule
+    assert "font-weight: 400;" in today_rule
+    assert "text-transform: none;" in today_rule
+    assert "line-height: normal;" in today_rule
+
+    # View and detail headings share the compact leaderboard scale; none of
+    # them may reintroduce the uppercase display treatment.
+    compact = "clamp(1.25rem, 2vw, 1.5rem);"
+    view_rule = _css_rule(styles, ".view-heading h2 {")
+    assert f"font-size: {compact}" in view_rule
+    assert "line-height: 1.2;" in view_rule
+    assert "text-transform" not in view_rule
+    detail_rule = _css_rule(styles, ".detail-title {")
+    assert f"font-size: {compact}" in detail_rule
+    assert "line-height: 1.2;" in detail_rule
+
+    # The mobile h1 clamp must not reach the quiet h2 headings.
+    mobile_block = styles.split("@media (max-width: 760px)", 1)[1]
+    assert ".view-heading h2," not in mobile_block.split("}", 1)[0]

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1376,7 +1376,7 @@ def test_rendered_stale_banner_translates_copy_under_zh():
     link = next(n for n in nodes if n["tag"] == "a")
     button = next(n for n in nodes if n["tag"] == "button")
     assert link["text"] == "哪里出了问题？"
-    assert button["text"] == "联系"
+    assert button["text"] == "联系作者"
     assert "那之后的自动更新一直没有成功。" in banner["children"][0]["text"]
     assert "The automatic update has not succeeded" not in banner["children"][0]["text"]
 

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -2025,15 +2025,18 @@ def test_heading_outline_and_scale_stay_quiet():
     assert "font-weight: 400;" in today_rule
     assert "font-size" not in today_rule
 
-    # The counts line reads as plain data: no small-caps transform.
+    # The counts line reads as plain data: no small-caps transform, including
+    # on the child spans the shared section-title group targets directly.
     meta_rule = _css_rule(styles, ".results-meta {")
     assert "text-transform: none;" in meta_rule
+    span_rule = _css_rule(styles, ".results-meta span {")
+    assert "text-transform: none;" in span_rule
 
-    # Footer content hugs the left edge instead of spreading space-between.
-    # The unindented selector is the base rule; the indented one is a mobile
-    # media-query override.
+    # Footer is one left-aligned column: updated stamp, view links, dataset
+    # card last (bottom).
     footer_block = styles.split("\nfooter {")[-1].split("}", 1)[0]
-    assert "justify-content: flex-start;" in footer_block
+    assert "flex-direction: column;" in footer_block
+    assert "align-items: flex-start;" in footer_block
 
     # View and detail headings share the compact leaderboard scale; none of
     # them may reintroduce the uppercase display treatment.

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -2016,15 +2016,24 @@ def test_heading_outline_and_scale_stay_quiet():
     for old_h1_id in ("leaderboard-heading", "map-heading", "trends-heading"):
         assert f'<h2 id="{old_h1_id}"' in html
 
-    # The h1 keeps the v0.7.0 caption rendering despite the tag change. The
-    # marker appears twice (a shared font-family list earlier in the file),
-    # so take the rule after the last occurrence.
+    # The h1 renders exactly like the counts caption beside it: the shared
+    # small-caps utility group supplies face/size/case, and this rule only
+    # mutes color and weight. No font-size override may reappear here.
     marker = "#today-view .section-title h1,"
     today_rule = styles.split(marker)[-1].split("}", 1)[0]
-    assert "font-size: 1.5em;" in today_rule
+    assert "color: var(--muted);" in today_rule
     assert "font-weight: 400;" in today_rule
-    assert "text-transform: none;" in today_rule
-    assert "line-height: normal;" in today_rule
+    assert "font-size" not in today_rule
+
+    # The counts line reads as plain data: no small-caps transform.
+    meta_rule = _css_rule(styles, ".results-meta {")
+    assert "text-transform: none;" in meta_rule
+
+    # Footer content hugs the left edge instead of spreading space-between.
+    # The unindented selector is the base rule; the indented one is a mobile
+    # media-query override.
+    footer_block = styles.split("\nfooter {")[-1].split("}", 1)[0]
+    assert "justify-content: flex-start;" in footer_block
 
     # View and detail headings share the compact leaderboard scale; none of
     # them may reintroduce the uppercase display treatment.


### PR DESCRIPTION
## Summary

i18n
- Add 26 missing zh translations for dynamic t() call sites (not scored, not recorded, related-record labels, benchmark-detail loading/error strings, saturation bound text, adoption-ranking explainer, badge tooltips, pagination and star/fork/issue badges). A script audit of every t("...") key against the zh dictionary now reports zero misses.

SEO (analyzer score 85)
- Single document H1: "Today's radar" is the only h1; the leaderboard, map, trends, and error-state headings are now h2 with unchanged visual styling. Crawlers previously saw four competing h1 titles across hidden views.
- og:title aligned with the document title (Benchmark Radar); the pitch stays in og:description.
- Footer now has crawlable internal links to ?view=leaderboard, ?view=trends, ?view=map; the nav switcher is buttons, which search engines cannot follow, so internal link count was 0.
- Not addressed: CSS/JS minification (no build pipeline in this project) and image ALT attributes (the homepage has no <img> elements; charts render on canvas with aria labels).

## Verification
Full CI sequence green locally on a clean worktree checkout of this branch: ruff check, ruff format --check, pytest (889 passed, 6 skipped), benchmark-radar classify.