### PR TITLE
docs: update citation metadata for v0.8.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,8 @@ authors:
 repository-code: "https://github.com/ktwu01/benchmark-radar"
 url: "https://koutian.is-a.dev/benchmark-radar/"
 license: MIT
-version: 0.3.0
+version: 0.8.0
+date-released: 2026-08-23
 abstract: >-
   A daily evidence-first radar and machine-readable corpus for AI benchmarks,
   evaluations, datasets, model-card reporting, and data quality.


### PR DESCRIPTION
## Summary

- update CITATION.cff from v0.3.0 to v0.8.0
- record the v0.8.0 release date

## Verification

- ruff check .
- ruff format --check .
- pytest -q (870 passed, 26 skipped)
- benchmark-radar classify

All checks ran in a fresh detached worktree at commit 5c0fc9c.