### PR TITLE
Fix active navigation state across every tab

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -1278,6 +1278,26 @@ function applyViewSeo(view) {
   }
 }
 
+// Every navigation item uses one visual active state, even though the four
+// views use aria-current while Rubric is a dialog trigger with aria-expanded.
+// Keeping that distinction in ARIA and normalizing it here prevents element
+// type (button versus anchor) from deciding which item looks selected.
+function syncNavState() {
+  const rubricActive = Boolean(state.rubric);
+  document.querySelectorAll("[data-view]").forEach((item) => {
+    const active = !rubricActive && item.dataset.view === state.view;
+    item.classList.toggle("nav-active", active);
+    if (active) {
+      item.setAttribute("aria-current", "page");
+    } else {
+      item.removeAttribute("aria-current");
+    }
+  });
+  const rubricNav = byId("rubric-nav");
+  rubricNav.classList.toggle("nav-active", rubricActive);
+  rubricNav.setAttribute("aria-expanded", String(rubricActive));
+}
+
 // `update` false is for restoring a view that is already in the URL (boot and
 // popstate), where writing history again would either duplicate the entry or
 // fight the entry being restored.
@@ -1290,13 +1310,7 @@ function setView(view, update = true, mode = "push") {
   document.querySelectorAll(".view").forEach((section) => {
     section.hidden = section.id !== `${view}-view`;
   });
-  document.querySelectorAll("[data-view]").forEach((button) => {
-    if (button.dataset.view === view) {
-      button.setAttribute("aria-current", "page");
-    } else {
-      button.removeAttribute("aria-current");
-    }
-  });
+  syncNavState();
   if (update) writeUrl(mode);
 }
 
@@ -2993,6 +3007,7 @@ function openRubric(item = null, versionOverride = null) {
   const isLegacy = version !== current;
   state.contact = false;
   state.rubric = isLegacy ? String(version) : "current";
+  syncNavState();
   writeUrl();
   const header = [
     element("p", {
@@ -7650,6 +7665,7 @@ function bindEvents() {
   // cleared from the URL no matter how the reader dismisses the dialog.
   byId("rubric-dialog").addEventListener("close", () => {
     state.rubric = "";
+    syncNavState();
     writeUrl();
   });
   // Reachable without a record in hand, for a reader who wants the method

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -400,14 +400,14 @@ button.repo-badge svg {
   text-decoration: none;
 }
 
-.view-nav button[aria-current="page"] {
+.view-nav .nav-active {
   background: var(--ink);
   color: white;
 }
 
-/* Opens a dialog rather than switching views, so it never carries the
-   aria-current treatment the view tabs use. */
-#rubric-nav {
+/* Rubric is a dialog trigger rather than a page link, so its inactive blue is
+   kept separate from the shared active treatment above. */
+#rubric-nav:not(.nav-active) {
   color: var(--blue-deep);
 }
 
@@ -415,7 +415,7 @@ button.repo-badge svg {
   content: " ⓘ";
 }
 
-#rubric-nav:hover {
+#rubric-nav:not(.nav-active):hover {
   background: var(--panel);
 }
 
@@ -4837,11 +4837,11 @@ footer {
   border-radius: var(--radius-sm);
 }
 
-/* The selected view tab is the only solid dark block on the page, so leaving it
-   square made it the one hard-cornered shape among rounded ones. Rounded at the
-   top only: it sits on the nav's bottom rule and reads as a tab attached to the
-   page below it, not as a floating chip. */
-.view-nav button[aria-current="page"] {
+/* The selected navigation item is the only solid dark block on the page, so
+   leaving it square made it the one hard-cornered shape among rounded ones.
+   Rounded at the top only: it sits on the nav's bottom rule and reads as a tab
+   attached to the page below it, not as a floating chip. */
+.view-nav .nav-active {
   border-radius: var(--radius-sm) var(--radius-sm) 0 0;
 }
 

--- a/site/index.html
+++ b/site/index.html
@@ -249,7 +249,16 @@
       </a>
       <a href="?view=trends" data-view="trends" aria-controls="trends-view" data-i18n="Trends">Trends</a>
       <a href="?view=map" data-view="map" aria-controls="map-view" data-i18n="Explore">Explore</a>
-      <button type="button" id="rubric-nav" aria-haspopup="dialog" data-i18n="Rubric">Rubric</button>
+      <button
+        type="button"
+        id="rubric-nav"
+        aria-haspopup="dialog"
+        aria-controls="rubric-dialog"
+        aria-expanded="false"
+        data-i18n="Rubric"
+      >
+        Rubric
+      </button>
     </nav>
 
     <main id="main-content" tabindex="-1">

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -74,6 +74,25 @@ def test_priority_score_is_reachably_explained():
     assert "How is this scored?" in script
 
 
+def test_every_navigation_item_uses_the_same_active_state():
+    html = Path("site/index.html").read_text(encoding="utf-8")
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+    styles = Path("site/assets/styles.css").read_text(encoding="utf-8")
+
+    # Today is a button, the three routed views are anchors, and Rubric opens a
+    # dialog. Their element types and ARIA semantics must not change the visual
+    # selected state.
+    assert 'aria-controls="rubric-dialog"' in html
+    assert 'aria-expanded="false"' in html
+    assert "function syncNavState()" in script
+    assert 'item.classList.toggle("nav-active", active);' in script
+    assert 'rubricNav.classList.toggle("nav-active", rubricActive);' in script
+    assert 'rubricNav.setAttribute("aria-expanded", String(rubricActive));' in script
+    assert script.count("syncNavState();") >= 3
+    assert ".view-nav .nav-active {" in styles
+    assert '.view-nav button[aria-current="page"]' not in styles
+
+
 def test_recommendation_threshold_does_not_gate_inclusion_and_rows_carry_no_badge():
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- use one shared active class for Today, Leaderboard, Trends, Explore, and Rubric
- preserve correct ARIA semantics for routed views and the Rubric dialog
- restore the underlying view state when Rubric closes
- add regression coverage for anchors, buttons, and dialog state

## Verification
- Browser QA across all five navigation items
- `ruff check .`
- `ruff format --check .`
- `benchmark-radar normalize-external`
- `benchmark-radar classify`
- `pytest -q` (916 passed)