### PR TITLE
Add README badges and star history chart

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -1,0 +1,19 @@
+name: Update star history chart
+
+on:
+  schedule:
+    - cron: "30 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: xpzouying/star-history@8b1f26dc5e9a17caa75da9351b688509ef312811 # v1
+        with:
+          branch: star-history

--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -1,8 +1,15 @@
 name: Update star history chart
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/star-history.yml"
+      - "scripts/generate_star_history.py"
+  watch:
+    types: [started]
   schedule:
-    - cron: "30 4 * * 1"
+    - cron: "17 5 * * *"
   workflow_dispatch:
 
 permissions:
@@ -14,6 +21,19 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: xpzouying/star-history@8b1f26dc5e9a17caa75da9351b688509ef312811 # v1
-        with:
-          branch: star-history
+      - name: Generate charts
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python scripts/generate_star_history.py \
+            --repo "$GITHUB_REPOSITORY" \
+            --token "$GITHUB_TOKEN"
+      - name: Publish chart assets
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout --orphan __star_history_publish
+          git reset -q
+          git add -f assets/star-history.svg assets/star-history-dark.svg
+          git commit -q -m "chore: update star history chart"
+          git push -f origin HEAD:refs/heads/star-history

--- a/README.md
+++ b/README.md
@@ -10,7 +10,13 @@
 every collection, so it states what the project actually holds rather than a
 hand-edited number (issue #197). -->
 
-[![benchmark records collected](https://img.shields.io/endpoint?url=https%3A%2F%2Fkoutian.is-a.dev%2Fbenchmark-radar%2Fdata%2Frecords-badge.json)](https://koutian.is-a.dev/benchmark-radar/)
+<p align="center">
+  <a href="https://koutian.is-a.dev/benchmark-radar/"><img alt="Benchmark records collected" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fkoutian.is-a.dev%2Fbenchmark-radar%2Fdata%2Frecords-badge.json&amp;style=for-the-badge"></a>
+  <a href="https://koutian.is-a.dev/benchmark-radar/data/radar.json"><img alt="Download dataset" src="https://img.shields.io/badge/Dataset-download%20JSON-2f81f7?style=for-the-badge&amp;logo=json&amp;logoColor=white"></a>
+  <a href="https://x.com/ktwu01"><img alt="X" src="https://img.shields.io/badge/X-%40ktwu01-000000?style=for-the-badge&amp;logo=x&amp;logoColor=white"></a>
+  <a href="https://www.linkedin.com/in/ktwu01"><img alt="LinkedIn" src="https://img.shields.io/badge/LinkedIn-Koutian%20Wu-0A66C2?style=for-the-badge&amp;logo=linkedin&amp;logoColor=white"></a>
+  <a href="https://scholar.google.com/citations?user=s9w1k-cAAAAJ&amp;hl=en"><img alt="Google Scholar" src="https://img.shields.io/badge/Google%20Scholar-Koutian%20Wu-4285F4?style=for-the-badge&amp;logo=googlescholar&amp;logoColor=white"></a>
+</p>
 
 I kept running into new benchmarks while doing benchmark research, so I built a
 crawler that continuously collects benchmark-related signals from across the
@@ -72,3 +78,12 @@ If Benchmark Radar supports your research or evaluation work, please cite it:
 ```
 
 See [`CITATION.cff`](CITATION.cff) for machine-readable citation metadata.
+
+## Star History
+
+<a href="https://www.star-history.com/#ktwu01/benchmark-radar&Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ktwu01/benchmark-radar/star-history/assets/star-history-dark.svg" />
+    <img alt="Benchmark Radar star history chart" src="https://raw.githubusercontent.com/ktwu01/benchmark-radar/star-history/assets/star-history.svg" />
+  </picture>
+</a>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,7 +8,13 @@
 
 <!-- 记录数 badge 由数据驱动：每次采集都会根据语料重新生成，因此它反映的是项目实际收集到的数据量 -->
 
-[![已收集 benchmark 记录](https://img.shields.io/endpoint?url=https%3A%2F%2Fkoutian.is-a.dev%2Fbenchmark-radar%2Fdata%2Frecords-badge.json)](https://koutian.is-a.dev/benchmark-radar/)
+<p align="center">
+  <a href="https://koutian.is-a.dev/benchmark-radar/"><img alt="已收集的 benchmark 记录" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fkoutian.is-a.dev%2Fbenchmark-radar%2Fdata%2Frecords-badge.json&amp;style=for-the-badge"></a>
+  <a href="https://koutian.is-a.dev/benchmark-radar/data/radar.json"><img alt="下载数据集" src="https://img.shields.io/badge/Dataset-download%20JSON-2f81f7?style=for-the-badge&amp;logo=json&amp;logoColor=white"></a>
+  <a href="https://x.com/ktwu01"><img alt="X" src="https://img.shields.io/badge/X-%40ktwu01-000000?style=for-the-badge&amp;logo=x&amp;logoColor=white"></a>
+  <a href="https://www.linkedin.com/in/ktwu01"><img alt="LinkedIn" src="https://img.shields.io/badge/LinkedIn-Koutian%20Wu-0A66C2?style=for-the-badge&amp;logo=linkedin&amp;logoColor=white"></a>
+  <a href="https://scholar.google.com/citations?user=s9w1k-cAAAAJ&amp;hl=en"><img alt="Google Scholar" src="https://img.shields.io/badge/Google%20Scholar-Koutian%20Wu-4285F4?style=for-the-badge&amp;logo=googlescholar&amp;logoColor=white"></a>
+</p>
 
 做 benchmark 研究的时候发现新东西太多了，所以我搞了这个持续爬虫，每天自动从全网抓新的 benchmark 相关信息。它目前每天从 arXiv、GitHub、Hugging Face、OpenAlex、OpenReview、各家实验室官方 feed、Brave Search、Semantic Scholar、Hacker News 等来源采集，并持续更新。你如果需要寻找 related work 或找到适合eval自己的agent 的 bench 或者关注最新的 eval 进展，可以看这里哈哈哈：
 github.com/ktwu01/benchmark-radar，每天更新，并支持一键导出数据
@@ -65,3 +71,12 @@ github.com/ktwu01/benchmark-radar，每天更新，并支持一键导出数据
 ```
 
 机器可读的引用元数据见 [`CITATION.cff`](CITATION.cff)。
+
+## Star 历史
+
+<a href="https://www.star-history.com/#ktwu01/benchmark-radar&Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ktwu01/benchmark-radar/star-history/assets/star-history-dark.svg" />
+    <img alt="Benchmark Radar Star 历史图" src="https://raw.githubusercontent.com/ktwu01/benchmark-radar/star-history/assets/star-history.svg" />
+  </picture>
+</a>

--- a/scripts/generate_star_history.py
+++ b/scripts/generate_star_history.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Generate repository-owned light and dark star-history SVGs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from collections import Counter
+from datetime import date, datetime, timedelta
+from html import escape
+from pathlib import Path
+from urllib.request import Request, urlopen
+
+GRAPHQL_URL = "https://api.github.com/graphql"
+QUERY = """
+query StarHistory($owner: String!, $name: String!, $cursor: String) {
+  repository(owner: $owner, name: $name) {
+    stargazers(first: 100, after: $cursor, orderBy: {field: STARRED_AT, direction: ASC}) {
+      edges { starredAt }
+      pageInfo { hasNextPage endCursor }
+    }
+  }
+}
+"""
+
+
+def fetch_star_dates(repo: str, token: str) -> list[date]:
+    """Read every stargazer timestamp through the repository's own token."""
+    owner, name = repo.split("/", 1)
+    cursor: str | None = None
+    dates: list[date] = []
+
+    while True:
+        body = json.dumps(
+            {
+                "query": QUERY,
+                "variables": {"owner": owner, "name": name, "cursor": cursor},
+            }
+        ).encode()
+        request = Request(
+            GRAPHQL_URL,
+            data=body,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+                "User-Agent": "benchmark-radar-star-history",
+            },
+        )
+        with urlopen(request, timeout=30) as response:  # noqa: S310 - fixed GitHub endpoint
+            payload = json.load(response)
+        if errors := payload.get("errors"):
+            raise RuntimeError(f"GitHub GraphQL error: {errors[0]['message']}")
+
+        connection = payload["data"]["repository"]["stargazers"]
+        dates.extend(
+            datetime.fromisoformat(edge["starredAt"].replace("Z", "+00:00")).date()
+            for edge in connection["edges"]
+        )
+        page = connection["pageInfo"]
+        if not page["hasNextPage"]:
+            return dates
+        cursor = page["endCursor"]
+
+
+def cumulative_points(star_dates: list[date]) -> list[tuple[date, int]]:
+    """Collapse individual stars into a cumulative daily series."""
+    counts = Counter(star_dates)
+    total = 0
+    points = []
+    for day in sorted(counts):
+        total += counts[day]
+        points.append((day, total))
+    return points
+
+
+def _ticks(start: date, end: date, count: int = 5) -> list[date]:
+    span = (end - start).days
+    if span == 0:
+        return [start]
+    return [start + timedelta(days=round(span * index / (count - 1))) for index in range(count)]
+
+
+def render_svg(repo: str, points: list[tuple[date, int]], *, dark: bool) -> str:
+    """Render a dependency-free, theme-specific SVG chart."""
+    width, height = 800, 480
+    left, right, top, bottom = 72, 28, 72, 62
+    plot_width = width - left - right
+    plot_height = height - top - bottom
+    colors = {
+        "background": "#0d1117" if dark else "#ffffff",
+        "text": "#e6edf3" if dark else "#1f2328",
+        "muted": "#8b949e" if dark else "#656d76",
+        "grid": "#30363d" if dark else "#d8dee4",
+        "line": "#58a6ff" if dark else "#0969da",
+        "area": "#1f6feb" if dark else "#54aeff",
+    }
+
+    if not points:
+        message = '<text x="400" y="245" text-anchor="middle" font-size="20">No stars yet</text>'
+        plot = message
+        subtitle = "0 stars"
+    else:
+        first_day, last_day = points[0][0], points[-1][0]
+        max_stars = points[-1][1]
+        span = max((last_day - first_day).days, 1)
+
+        def x(day: date) -> float:
+            return left + (day - first_day).days / span * plot_width
+
+        def y(stars: int) -> float:
+            return top + plot_height - stars / max_stars * plot_height
+
+        coordinates = [(x(day), y(stars)) for day, stars in points]
+        if first_day == last_day:
+            coordinates = [(left, y(max_stars)), (left + plot_width, y(max_stars))]
+        line_path = " ".join(
+            f"{'M' if index == 0 else 'L'} {px:.1f} {py:.1f}"
+            for index, (px, py) in enumerate(coordinates)
+        )
+        area_path = (
+            f"M {coordinates[0][0]:.1f} {top + plot_height:.1f} "
+            + " ".join(f"L {px:.1f} {py:.1f}" for px, py in coordinates)
+            + f" L {coordinates[-1][0]:.1f} {top + plot_height:.1f} Z"
+        )
+
+        y_step = max(1, math.ceil(max_stars / 4))
+        y_values = sorted({0, max_stars, *(min(max_stars, y_step * i) for i in range(1, 4))})
+        grid = []
+        for value in y_values:
+            py = y(value)
+            grid.append(
+                f'<line x1="{left}" y1="{py:.1f}" x2="{left + plot_width}" y2="{py:.1f}" />'
+            )
+            grid.append(f'<text x="{left - 12}" y="{py + 5:.1f}" text-anchor="end">{value}</text>')
+        date_ticks = _ticks(first_day, last_day)
+        for index, day in enumerate(date_ticks):
+            px = x(day)
+            anchor = "start" if index == 0 else "end" if index == len(date_ticks) - 1 else "middle"
+            grid.append(
+                f'<text x="{px:.1f}" y="{height - 28}" text-anchor="{anchor}">{day:%Y-%m-%d}</text>'
+            )
+
+        plot = (
+            f'<g class="grid">{"".join(grid)}</g>'
+            f'<path d="{area_path}" fill="{colors["area"]}" opacity="0.18" />'
+            f'<path d="{line_path}" fill="none" stroke="{colors["line"]}" stroke-width="3" '
+            'stroke-linecap="round" stroke-linejoin="round" />'
+            f'<circle cx="{coordinates[-1][0]:.1f}" cy="{coordinates[-1][1]:.1f}" '
+            f'r="5" fill="{colors["line"]}" />'
+        )
+        subtitle = f"{max_stars:,} stars · {first_day:%Y-%m-%d} – {last_day:%Y-%m-%d}"
+
+    return f'''<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width} {height}"
+  role="img" aria-labelledby="title description">
+  <title id="title">{escape(repo)} star history</title>
+  <desc id="description">{escape(subtitle)}</desc>
+  <rect width="{width}" height="{height}" rx="12" fill="{colors["background"]}" />
+  <style>
+    text {{
+      fill: {colors["text"]};
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }}
+    .grid line {{ stroke: {colors["grid"]}; stroke-width: 1; }}
+    .grid text {{ fill: {colors["muted"]}; font-size: 12px; }}
+  </style>
+  <text x="{left}" y="34" font-size="22" font-weight="600">{escape(repo)} Star History</text>
+  <text x="{left}" y="56" font-size="13" fill="{colors["muted"]}">{escape(subtitle)}</text>
+  {plot}
+</svg>
+'''
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", required=True, help="GitHub repository as owner/name")
+    parser.add_argument("--token", required=True, help="GitHub token that can read stargazers")
+    parser.add_argument("--output-dir", type=Path, default=Path("assets"))
+    args = parser.parse_args()
+
+    points = cumulative_points(fetch_star_dates(args.repo, args.token))
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    (args.output_dir / "star-history.svg").write_text(
+        render_svg(args.repo, points, dark=False), encoding="utf-8"
+    )
+    (args.output_dir / "star-history-dark.svg").write_text(
+        render_svg(args.repo, points, dark=True), encoding="utf-8"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_generate_star_history.py
+++ b/tests/test_generate_star_history.py
@@ -1,0 +1,34 @@
+import sys
+from datetime import date
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from generate_star_history import cumulative_points, render_svg  # noqa: E402
+
+
+def test_cumulative_points_groups_stars_by_day():
+    assert cumulative_points([date(2026, 8, 2), date(2026, 8, 1), date(2026, 8, 2)]) == [
+        (date(2026, 8, 1), 1),
+        (date(2026, 8, 2), 3),
+    ]
+
+
+def test_render_svg_is_theme_aware_and_escapes_repository_name():
+    points = [(date(2026, 8, 1), 1), (date(2026, 8, 3), 4)]
+
+    light = render_svg("owner/repo&chart", points, dark=False)
+    dark = render_svg("owner/repo&chart", points, dark=True)
+
+    assert "owner/repo&amp;chart Star History" in light
+    assert "4 stars · 2026-08-01 – 2026-08-03" in light
+    assert 'fill="#ffffff"' in light
+    assert 'fill="#0d1117"' in dark
+    assert "<path" in light
+
+
+def test_render_svg_handles_an_empty_repository():
+    svg = render_svg("owner/repo", [], dark=False)
+
+    assert "No stars yet" in svg
+    assert "0 stars" in svg


### PR DESCRIPTION
## Summary

- add a prominent JSON dataset-download badge plus Koutian Wu’s X, LinkedIn, and Google Scholar badges
- keep the English and Chinese READMEs in sync
- add a theme-aware Star History chart generated entirely by this repository’s own Python script
- refresh immediately on merge and every new star, with manual dispatch and a daily fallback

The initial 57-star chart is already published on the repository-owned `star-history` branch, so the README preview does not wait for a scheduled run.

Closes #351

## Validation

- generated both real SVGs from GitHub’s GraphQL data and visually checked the light chart
- `ruff check .`
- `ruff format --check .`
- `benchmark-radar normalize-external`
- `benchmark-radar classify`
- `pytest -q` (919 passed)
- repeated the repository-note sequence: `ruff check .`, `ruff format --check .`, `pytest -q`, `benchmark-radar classify`