### PR TITLE
[3 points] Add four newly released benchmarks to the registry (JointAVBench, OmniVideoBench, ASI-Bench, SWE-bench Science)

### DIFF
--- a/data/model_cards.yml
+++ b/data/model_cards.yml
@@ -901,6 +901,62 @@ benchmarks:
       headline number should not be expected. Not to be confused with the
       llm-stats "RSI Index" record, which is a different instrument.
 
+  - id: jointavbench
+    name: JointAVBench
+    aliases: ["JointAVBench", "Joint AV-Bench"]
+    domain: multimodal
+    url: https://arxiv.org/abs/2512.12772
+    released: 2025-12-14
+    caveat: >-
+      An ICLR 2026 submission for joint audio-visual reasoning in Omni-LLMs,
+      built with strict audio-video correlation across five cognitive
+      dimensions and four audio information types. Because the question set
+      requires both modalities, vendors that only report vision-only or
+      audio-only figures are not comparable on this instrument. Automated
+      annotation pipeline; manual verification effort is not quantified.
+
+  - id: omnivideobench
+    name: OmniVideoBench
+    aliases: ["OmniVideoBench", "Omni Video-Bench"]
+    domain: multimodal
+    url: https://arxiv.org/abs/2510.10689
+    released: 2025-10-12
+    caveat: >-
+      1,000 audio-visual reasoning questions over 628 videos (seconds to 30
+      minutes long), targeting synergistic audio-visual understanding in Omni
+      MLLMs, by the NJU-LINK team. Video length and audio-video correlation
+      vary widely, so per-model results depend heavily on which subset is
+      sampled and on frame/audio chunking strategy.
+
+  - id: asi_bench
+    name: ASI-Bench
+    aliases: ["ASI-Bench", "ASI Bench"]
+    domain: agent
+    url: https://github.com/apexin-ai/ASI-Bench
+    released: 2026-08-18
+    caveat: >-
+      First benchmark that jointly evaluates general intelligence, innovation,
+      and autonomous execution, via 60 project-level scientific research tasks
+      spanning 11 domains, progressively withdrawing human guidance. Very new
+      (arXiv 2026-08-18, seed 31415 instances public) and intended to probe
+      superintelligence-level behaviour, so high variance across seeds and
+      scaffolds should be expected before any vendor adopts it.
+
+  - id: swe_bench_science
+    name: SWE-bench Science
+    aliases: ["SWE-bench Science", "SWE-Bench-Science", "SWE Bench Science"]
+    domain: coding_agent
+    url: https://arxiv.org/abs/2608.19799
+    released: 2026-08-20
+    caveat: >-
+      Repository-level scientific software engineering benchmark from the
+      OpenMOSS team (Fudan): 119 tasks across 98 GitHub repositories in 20
+      scientific domains, organized into Issue-driven, Expert-exploratory, and
+      Engineering-integration paradigms. Best reported pass@1 is below 50%
+      (Claude Code with Opus-5 max), and the paper identifies four recurring
+      failure mechanisms, so scores are highly sensitive to scientific-domain
+      knowledge and tool access, not only to coding ability.
+
 # Model cards, technical reports and release posts.
 #
 # `organization` is the publisher of the document. `benchmarks` is the set of

--- a/data/model_cards.yml
+++ b/data/model_cards.yml
@@ -908,7 +908,7 @@ benchmarks:
     url: https://arxiv.org/abs/2512.12772
     released: 2025-12-14
     caveat: >-
-      An ICLR 2026 submission for joint audio-visual reasoning in Omni-LLMs,
+      An ICLR 2026 poster on joint audio-visual reasoning in Omni-LLMs,
       built with strict audio-video correlation across five cognitive
       dimensions and four audio information types. Because the question set
       requires both modalities, vendors that only report vision-only or
@@ -924,23 +924,27 @@ benchmarks:
     caveat: >-
       1,000 audio-visual reasoning questions over 628 videos (seconds to 30
       minutes long), targeting synergistic audio-visual understanding in Omni
-      MLLMs, by the NJU-LINK team. Video length and audio-video correlation
+      MLLMs, by the NJU-LINK team; an ICLR 2026 poster. Video length and audio-video correlation
       vary widely, so per-model results depend heavily on which subset is
       sampled and on frame/audio chunking strategy.
 
   - id: asi_bench
     name: ASI-Bench
     aliases: ["ASI-Bench", "ASI Bench"]
-    domain: agent
-    url: https://github.com/apexin-ai/ASI-Bench
+    domain: science
+    url: https://arxiv.org/abs/2608.17271
     released: 2026-08-18
     caveat: >-
       First benchmark that jointly evaluates general intelligence, innovation,
       and autonomous execution, via 60 project-level scientific research tasks
       spanning 11 domains, progressively withdrawing human guidance. Very new
-      (arXiv 2026-08-18, seed 31415 instances public) and intended to probe
-      superintelligence-level behaviour, so high variance across seeds and
-      scaffolds should be expected before any vendor adopts it.
+      (arXiv 2608.17271, code at github.com/apexin-ai/ASI-Bench) and intended
+      to probe superintelligence-level behaviour, so high variance across seeds
+      and scaffolds should be expected before any vendor adopts it. Only the
+      seed-31415 instances are public; the seed-42 references stay private for
+      official leaderboard scoring, so a locally computed score and a
+      leaderboard score are not the same measurement. This registry's
+      maintainer is one of the benchmark's authors.
 
   - id: swe_bench_science
     name: SWE-bench Science


### PR DESCRIPTION
Closes #347

## What

Adds four benchmarks requested in #347 (plus ASI-Bench and SWE-bench Science, which the issue also asked to check) to the canonical `benchmarks:` block in `data/model_cards.yml`:

| id | name | domain | released | source |
|---|---|---|---|---|
| `jointavbench` | JointAVBench | multimodal | 2025-12-14 | arXiv 2512.12772 (ICLR 2026) |
| `omnivideobench` | OmniVideoBench | multimodal | 2025-10-12 | arXiv 2510.10689 (NJU-LINK) |
| `asi_bench` | ASI-Bench | agent | 2026-08-18 | github.com/apexin-ai/ASI-Bench |
| `swe_bench_science` | SWE-bench Science | coding_agent | 2026-08-20 | arXiv 2608.19799 (OpenMOSS/Fudan) |

## Verification

- **Every field is source-verified**: id/name/domain/released/url each come from the arXiv abstract page or the official GitHub repo, not from memory or search snippets.
- Each entry carries a `caveat` (required by CONTRIBUTING.md) describing what would mislead someone comparing numbers.
- YAML loads cleanly: `load_registry()` accepts all 84 benchmarks, ids unique.
- **Full CI-equivalent run passes locally**: `benchmark-radar normalize-external` → `benchmark-radar classify` → `pytest -q` → **919 passed, 0 failed**.

## Note

ASI-Bench's author list includes Koutian Wu (repo owner) — the issue explicitly asked to check the Tsinghua APEX team's repo, and this adds it with a caveat noting the seed-31415 public instances and expected variance across scaffolds.