### PR TITLE
Simplify README badge labels and clarify UI guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,33 +18,34 @@ any report, launch note, TLDR, screenshot, GIF, demo, dashboard, or UI surface.
   screenshots, short GIFs, and compact summaries that make the work easy to
   scan, review, forward, or explain upward.
 
-### Preserve visual identity during simplification
+### Example: simplify badge copy and keep its style
 
-- Separate redundant text from visual identity. You may remove a person's name
-  or handle when the destination already identifies that person. Keep the
-  platform logo, brand treatment, badge shape, and platform label that help a
-  reader recognize the link.
-- Preserve the component type and its established style. Do not turn a badge,
-  icon, or other visual affordance into a plain text link unless the task asks
-  for that redesign.
-- Keep destination specificity in the link target. A generic platform label
-  may link to a specific person's profile; the visible label does not need to
-  repeat the person's identity.
-- Before deleting an element, classify its role: content, visual identity,
-  interaction, or destination. Remove redundant content only. Keep the visual
-  identity, interaction, and destination intact unless the request says to
-  change them.
+Before:
 
-Examples:
+```html
+<p align="center">
+  <a href="https://koutian.is-a.dev/benchmark-radar/"><img alt="Benchmark records collected" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fkoutian.is-a.dev%2Fbenchmark-radar%2Fdata%2Frecords-badge.json&amp;style=for-the-badge"></a>
+  <a href="https://koutian.is-a.dev/benchmark-radar/data/radar.json"><img alt="Download dataset" src="https://img.shields.io/badge/Dataset-download%20JSON-2f81f7?style=for-the-badge&amp;logo=json&amp;logoColor=white"></a>
+  <a href="https://x.com/ktwu01"><img alt="X" src="https://img.shields.io/badge/X-%40ktwu01-000000?style=for-the-badge&amp;logo=x&amp;logoColor=white"></a>
+  <a href="https://www.linkedin.com/in/ktwu01"><img alt="LinkedIn" src="https://img.shields.io/badge/LinkedIn-Koutian%20Wu-0A66C2?style=for-the-badge&amp;logo=linkedin&amp;logoColor=white"></a>
+  <a href="https://scholar.google.com/citations?user=s9w1k-cAAAAJ&amp;hl=en"><img alt="Google Scholar" src="https://img.shields.io/badge/Google%20Scholar-Koutian%20Wu-4285F4?style=for-the-badge&amp;logo=googlescholar&amp;logoColor=white"></a>
+</p>
+```
 
-- X: keep the original X badge and link it to `https://x.com/ktwu01`. Do not
-  replace the badge with the plain handle `@ktwu01` or the person's name.
-- LinkedIn: keep the original LinkedIn badge with the visible label `LinkedIn`
-  and link it to the specific profile. Do not put `Koutian Wu` in the badge or
-  use badge text such as `LinkedIn-Koutian%20Wu`.
-- Google Scholar: keep the badge label `Google Scholar` and link it to the
-  specific Scholar profile. Do not use badge text such as
-  `Google%20Scholar-Koutian%20Wu`.
+After:
+
+```html
+<p align="center">
+  <a href="https://koutian.is-a.dev/benchmark-radar/"><img alt="Benchmark records collected" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fkoutian.is-a.dev%2Fbenchmark-radar%2Fdata%2Frecords-badge.json&amp;style=for-the-badge"></a>
+  <a href="https://koutian.is-a.dev/benchmark-radar/data/radar.json"><img alt="Download dataset" src="https://img.shields.io/badge/Dataset-download%20JSON-2f81f7?style=for-the-badge&amp;logo=json&amp;logoColor=white"></a>
+  <a href="https://x.com/ktwu01"><img alt="X" src="https://img.shields.io/badge/X-000000?style=for-the-badge&amp;logo=x&amp;logoColor=white"></a>
+  <a href="https://www.linkedin.com/in/ktwu01"><img alt="LinkedIn" src="https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge&amp;logo=linkedin&amp;logoColor=white"></a>
+  <a href="https://scholar.google.com/citations?user=s9w1k-cAAAAJ&amp;hl=en"><img alt="Google Scholar" src="https://img.shields.io/badge/Google%20Scholar-4285F4?style=for-the-badge&amp;logo=googlescholar&amp;logoColor=white"></a>
+</p>
+```
+
+The after example removes the handle or name from three badge labels. It keeps
+the five-badge layout, badge styles, logos, colors, and profile URLs.
 
 ## Glob rule: Benchmark Radar audience
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,33 +18,34 @@ any report, launch note, TLDR, screenshot, GIF, demo, dashboard, or UI surface.
   screenshots, short GIFs, and compact summaries that make the work easy to
   scan, review, forward, or explain upward.
 
-### Preserve visual identity during simplification
+### Example: simplify badge copy and keep its style
 
-- Separate redundant text from visual identity. You may remove a person's name
-  or handle when the destination already identifies that person. Keep the
-  platform logo, brand treatment, badge shape, and platform label that help a
-  reader recognize the link.
-- Preserve the component type and its established style. Do not turn a badge,
-  icon, or other visual affordance into a plain text link unless the task asks
-  for that redesign.
-- Keep destination specificity in the link target. A generic platform label
-  may link to a specific person's profile; the visible label does not need to
-  repeat the person's identity.
-- Before deleting an element, classify its role: content, visual identity,
-  interaction, or destination. Remove redundant content only. Keep the visual
-  identity, interaction, and destination intact unless the request says to
-  change them.
+Before:
 
-Examples:
+```html
+<p align="center">
+  <a href="https://koutian.is-a.dev/benchmark-radar/"><img alt="Benchmark records collected" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fkoutian.is-a.dev%2Fbenchmark-radar%2Fdata%2Frecords-badge.json&amp;style=for-the-badge"></a>
+  <a href="https://koutian.is-a.dev/benchmark-radar/data/radar.json"><img alt="Download dataset" src="https://img.shields.io/badge/Dataset-download%20JSON-2f81f7?style=for-the-badge&amp;logo=json&amp;logoColor=white"></a>
+  <a href="https://x.com/ktwu01"><img alt="X" src="https://img.shields.io/badge/X-%40ktwu01-000000?style=for-the-badge&amp;logo=x&amp;logoColor=white"></a>
+  <a href="https://www.linkedin.com/in/ktwu01"><img alt="LinkedIn" src="https://img.shields.io/badge/LinkedIn-Koutian%20Wu-0A66C2?style=for-the-badge&amp;logo=linkedin&amp;logoColor=white"></a>
+  <a href="https://scholar.google.com/citations?user=s9w1k-cAAAAJ&amp;hl=en"><img alt="Google Scholar" src="https://img.shields.io/badge/Google%20Scholar-Koutian%20Wu-4285F4?style=for-the-badge&amp;logo=googlescholar&amp;logoColor=white"></a>
+</p>
+```
 
-- X: keep the original X badge and link it to `https://x.com/ktwu01`. Do not
-  replace the badge with the plain handle `@ktwu01` or the person's name.
-- LinkedIn: keep the original LinkedIn badge with the visible label `LinkedIn`
-  and link it to the specific profile. Do not put `Koutian Wu` in the badge or
-  use badge text such as `LinkedIn-Koutian%20Wu`.
-- Google Scholar: keep the badge label `Google Scholar` and link it to the
-  specific Scholar profile. Do not use badge text such as
-  `Google%20Scholar-Koutian%20Wu`.
+After:
+
+```html
+<p align="center">
+  <a href="https://koutian.is-a.dev/benchmark-radar/"><img alt="Benchmark records collected" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fkoutian.is-a.dev%2Fbenchmark-radar%2Fdata%2Frecords-badge.json&amp;style=for-the-badge"></a>
+  <a href="https://koutian.is-a.dev/benchmark-radar/data/radar.json"><img alt="Download dataset" src="https://img.shields.io/badge/Dataset-download%20JSON-2f81f7?style=for-the-badge&amp;logo=json&amp;logoColor=white"></a>
+  <a href="https://x.com/ktwu01"><img alt="X" src="https://img.shields.io/badge/X-000000?style=for-the-badge&amp;logo=x&amp;logoColor=white"></a>
+  <a href="https://www.linkedin.com/in/ktwu01"><img alt="LinkedIn" src="https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge&amp;logo=linkedin&amp;logoColor=white"></a>
+  <a href="https://scholar.google.com/citations?user=s9w1k-cAAAAJ&amp;hl=en"><img alt="Google Scholar" src="https://img.shields.io/badge/Google%20Scholar-4285F4?style=for-the-badge&amp;logo=googlescholar&amp;logoColor=white"></a>
+</p>
+```
+
+The after example removes the handle or name from three badge labels. It keeps
+the five-badge layout, badge styles, logos, colors, and profile URLs.
 
 ## Glob rule: Benchmark Radar audience
 

--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ instead of a hand-edited README number (issue #197). -->
 
 [Download dataset](https://koutian.is-a.dev/benchmark-radar/data/radar.json) ·
 [Open dashboard](https://koutian.is-a.dev/benchmark-radar/) ·
-[GitHub](https://github.com/ktwu01/benchmark-radar) ·
-[LinkedIn](https://www.linkedin.com/in/ktwu01) ·
-[Scholar](https://scholar.google.com/citations?user=s9w1k-cAAAAJ&hl=en) ·
-[@ktwu01](https://x.com/ktwu01)
+[GitHub](https://github.com/ktwu01/benchmark-radar)
+
+[![X](https://img.shields.io/badge/X-000000?style=for-the-badge&logo=x&logoColor=white)](https://x.com/ktwu01)
+[![LinkedIn](https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/ktwu01)
+[![Google Scholar](https://img.shields.io/badge/Google%20Scholar-4285F4?style=for-the-badge&logo=googlescholar&logoColor=white)](https://scholar.google.com/citations?user=s9w1k-cAAAAJ&hl=en)
 
 I kept running into new benchmarks while doing benchmark research, so I built a
 crawler that continuously collects benchmark-related signals from across the

--- a/README.md
+++ b/README.md
@@ -6,17 +6,18 @@
 
 # Benchmark Radar
 
-<!-- The record-count badge is data-driven: it is regenerated from the corpus on
-every collection, so it states what the project actually holds rather than a
-hand-edited number (issue #197). -->
+<!-- The corpus badge is data-driven and regenerated from the published
+dashboard bundle on every collection, so it stays tied to the actual corpus
+instead of a hand-edited README number (issue #197). -->
 
-<p align="center">
-  <a href="https://koutian.is-a.dev/benchmark-radar/"><img alt="Benchmark records collected" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fkoutian.is-a.dev%2Fbenchmark-radar%2Fdata%2Frecords-badge.json&amp;style=for-the-badge"></a>
-  <a href="https://koutian.is-a.dev/benchmark-radar/data/radar.json"><img alt="Download dataset" src="https://img.shields.io/badge/Dataset-download%20JSON-2f81f7?style=for-the-badge&amp;logo=json&amp;logoColor=white"></a>
-  <a href="https://x.com/ktwu01"><img alt="X" src="https://img.shields.io/badge/X-%40ktwu01-000000?style=for-the-badge&amp;logo=x&amp;logoColor=white"></a>
-  <a href="https://www.linkedin.com/in/ktwu01"><img alt="LinkedIn" src="https://img.shields.io/badge/LinkedIn-Koutian%20Wu-0A66C2?style=for-the-badge&amp;logo=linkedin&amp;logoColor=white"></a>
-  <a href="https://scholar.google.com/citations?user=s9w1k-cAAAAJ&amp;hl=en"><img alt="Google Scholar" src="https://img.shields.io/badge/Google%20Scholar-Koutian%20Wu-4285F4?style=for-the-badge&amp;logo=googlescholar&amp;logoColor=white"></a>
-</p>
+[![Benchmark records collected](https://img.shields.io/endpoint?url=https%3A%2F%2Fkoutian.is-a.dev%2Fbenchmark-radar%2Fdata%2Frecords-badge.json)](https://koutian.is-a.dev/benchmark-radar/)
+
+[Download dataset](https://koutian.is-a.dev/benchmark-radar/data/radar.json) ·
+[Open dashboard](https://koutian.is-a.dev/benchmark-radar/) ·
+[GitHub](https://github.com/ktwu01/benchmark-radar) ·
+[LinkedIn](https://www.linkedin.com/in/ktwu01) ·
+[Scholar](https://scholar.google.com/citations?user=s9w1k-cAAAAJ&hl=en) ·
+[@ktwu01](https://x.com/ktwu01)
 
 I kept running into new benchmarks while doing benchmark research, so I built a
 crawler that continuously collects benchmark-related signals from across the

--- a/README.md
+++ b/README.md
@@ -6,19 +6,17 @@
 
 # Benchmark Radar
 
-<!-- The corpus badge is data-driven and regenerated from the published
-dashboard bundle on every collection, so it stays tied to the actual corpus
-instead of a hand-edited README number (issue #197). -->
+<!-- The record-count badge is data-driven: it is regenerated from the corpus on
+every collection, so it states what the project actually holds rather than a
+hand-edited number (issue #197). -->
 
-[![Benchmark records collected](https://img.shields.io/endpoint?url=https%3A%2F%2Fkoutian.is-a.dev%2Fbenchmark-radar%2Fdata%2Frecords-badge.json)](https://koutian.is-a.dev/benchmark-radar/)
-
-[Download dataset](https://koutian.is-a.dev/benchmark-radar/data/radar.json) ·
-[Open dashboard](https://koutian.is-a.dev/benchmark-radar/) ·
-[GitHub](https://github.com/ktwu01/benchmark-radar)
-
-[![X](https://img.shields.io/badge/X-000000?style=for-the-badge&logo=x&logoColor=white)](https://x.com/ktwu01)
-[![LinkedIn](https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/ktwu01)
-[![Google Scholar](https://img.shields.io/badge/Google%20Scholar-4285F4?style=for-the-badge&logo=googlescholar&logoColor=white)](https://scholar.google.com/citations?user=s9w1k-cAAAAJ&hl=en)
+<p align="center">
+  <a href="https://koutian.is-a.dev/benchmark-radar/"><img alt="Benchmark records collected" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fkoutian.is-a.dev%2Fbenchmark-radar%2Fdata%2Frecords-badge.json&amp;style=for-the-badge"></a>
+  <a href="https://koutian.is-a.dev/benchmark-radar/data/radar.json"><img alt="Download dataset" src="https://img.shields.io/badge/Dataset-download%20JSON-2f81f7?style=for-the-badge&amp;logo=json&amp;logoColor=white"></a>
+  <a href="https://x.com/ktwu01"><img alt="X" src="https://img.shields.io/badge/X-000000?style=for-the-badge&amp;logo=x&amp;logoColor=white"></a>
+  <a href="https://www.linkedin.com/in/ktwu01"><img alt="LinkedIn" src="https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge&amp;logo=linkedin&amp;logoColor=white"></a>
+  <a href="https://scholar.google.com/citations?user=s9w1k-cAAAAJ&amp;hl=en"><img alt="Google Scholar" src="https://img.shields.io/badge/Google%20Scholar-4285F4?style=for-the-badge&amp;logo=googlescholar&amp;logoColor=white"></a>
+</p>
 
 I kept running into new benchmarks while doing benchmark research, so I built a
 crawler that continuously collects benchmark-related signals from across the

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,17 +6,15 @@
 
 # Benchmark Radar
 
-<!-- 记录数 badge 由已发布 dashboard bundle 重新生成，因此它反映的是项目实际收集到的数据量，而不是手写数字。 -->
+<!-- 记录数 badge 由数据驱动：每次采集都会根据语料重新生成，因此它反映的是项目实际收集到的数据量 -->
 
-[![已收集的 benchmark 记录](https://img.shields.io/endpoint?url=https%3A%2F%2Fkoutian.is-a.dev%2Fbenchmark-radar%2Fdata%2Frecords-badge.json)](https://koutian.is-a.dev/benchmark-radar/)
-
-[下载数据集](https://koutian.is-a.dev/benchmark-radar/data/radar.json) ·
-[打开 dashboard](https://koutian.is-a.dev/benchmark-radar/) ·
-[GitHub](https://github.com/ktwu01/benchmark-radar)
-
-[![X](https://img.shields.io/badge/X-000000?style=for-the-badge&logo=x&logoColor=white)](https://x.com/ktwu01)
-[![LinkedIn](https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/ktwu01)
-[![Google Scholar](https://img.shields.io/badge/Google%20Scholar-4285F4?style=for-the-badge&logo=googlescholar&logoColor=white)](https://scholar.google.com/citations?user=s9w1k-cAAAAJ&hl=en)
+<p align="center">
+  <a href="https://koutian.is-a.dev/benchmark-radar/"><img alt="已收集的 benchmark 记录" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fkoutian.is-a.dev%2Fbenchmark-radar%2Fdata%2Frecords-badge.json&amp;style=for-the-badge"></a>
+  <a href="https://koutian.is-a.dev/benchmark-radar/data/radar.json"><img alt="下载数据集" src="https://img.shields.io/badge/Dataset-download%20JSON-2f81f7?style=for-the-badge&amp;logo=json&amp;logoColor=white"></a>
+  <a href="https://x.com/ktwu01"><img alt="X" src="https://img.shields.io/badge/X-000000?style=for-the-badge&amp;logo=x&amp;logoColor=white"></a>
+  <a href="https://www.linkedin.com/in/ktwu01"><img alt="LinkedIn" src="https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge&amp;logo=linkedin&amp;logoColor=white"></a>
+  <a href="https://scholar.google.com/citations?user=s9w1k-cAAAAJ&amp;hl=en"><img alt="Google Scholar" src="https://img.shields.io/badge/Google%20Scholar-4285F4?style=for-the-badge&amp;logo=googlescholar&amp;logoColor=white"></a>
+</p>
 
 做 benchmark 研究的时候发现新东西太多了，所以我搞了这个持续爬虫，每天自动从全网抓新的 benchmark 相关信息。它目前每天从 arXiv、GitHub、Hugging Face、OpenAlex、OpenReview、各家实验室官方 feed、Brave Search、Semantic Scholar、Hacker News 等来源采集，并持续更新。你如果需要寻找 related work 或找到适合eval自己的agent 的 bench 或者关注最新的 eval 进展，可以看这里哈哈哈：
 github.com/ktwu01/benchmark-radar，每天更新，并支持一键导出数据

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,15 +6,16 @@
 
 # Benchmark Radar
 
-<!-- 记录数 badge 由数据驱动：每次采集都会根据语料重新生成，因此它反映的是项目实际收集到的数据量 -->
+<!-- 记录数 badge 由已发布 dashboard bundle 重新生成，因此它反映的是项目实际收集到的数据量，而不是手写数字。 -->
 
-<p align="center">
-  <a href="https://koutian.is-a.dev/benchmark-radar/"><img alt="已收集的 benchmark 记录" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fkoutian.is-a.dev%2Fbenchmark-radar%2Fdata%2Frecords-badge.json&amp;style=for-the-badge"></a>
-  <a href="https://koutian.is-a.dev/benchmark-radar/data/radar.json"><img alt="下载数据集" src="https://img.shields.io/badge/Dataset-download%20JSON-2f81f7?style=for-the-badge&amp;logo=json&amp;logoColor=white"></a>
-  <a href="https://x.com/ktwu01"><img alt="X" src="https://img.shields.io/badge/X-%40ktwu01-000000?style=for-the-badge&amp;logo=x&amp;logoColor=white"></a>
-  <a href="https://www.linkedin.com/in/ktwu01"><img alt="LinkedIn" src="https://img.shields.io/badge/LinkedIn-Koutian%20Wu-0A66C2?style=for-the-badge&amp;logo=linkedin&amp;logoColor=white"></a>
-  <a href="https://scholar.google.com/citations?user=s9w1k-cAAAAJ&amp;hl=en"><img alt="Google Scholar" src="https://img.shields.io/badge/Google%20Scholar-Koutian%20Wu-4285F4?style=for-the-badge&amp;logo=googlescholar&amp;logoColor=white"></a>
-</p>
+[![已收集的 benchmark 记录](https://img.shields.io/endpoint?url=https%3A%2F%2Fkoutian.is-a.dev%2Fbenchmark-radar%2Fdata%2Frecords-badge.json)](https://koutian.is-a.dev/benchmark-radar/)
+
+[下载数据集](https://koutian.is-a.dev/benchmark-radar/data/radar.json) ·
+[打开 dashboard](https://koutian.is-a.dev/benchmark-radar/) ·
+[GitHub](https://github.com/ktwu01/benchmark-radar) ·
+[LinkedIn](https://www.linkedin.com/in/ktwu01) ·
+[Scholar](https://scholar.google.com/citations?user=s9w1k-cAAAAJ&hl=en) ·
+[@ktwu01](https://x.com/ktwu01)
 
 做 benchmark 研究的时候发现新东西太多了，所以我搞了这个持续爬虫，每天自动从全网抓新的 benchmark 相关信息。它目前每天从 arXiv、GitHub、Hugging Face、OpenAlex、OpenReview、各家实验室官方 feed、Brave Search、Semantic Scholar、Hacker News 等来源采集，并持续更新。你如果需要寻找 related work 或找到适合eval自己的agent 的 bench 或者关注最新的 eval 进展，可以看这里哈哈哈：
 github.com/ktwu01/benchmark-radar，每天更新，并支持一键导出数据

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -12,10 +12,11 @@
 
 [下载数据集](https://koutian.is-a.dev/benchmark-radar/data/radar.json) ·
 [打开 dashboard](https://koutian.is-a.dev/benchmark-radar/) ·
-[GitHub](https://github.com/ktwu01/benchmark-radar) ·
-[LinkedIn](https://www.linkedin.com/in/ktwu01) ·
-[Scholar](https://scholar.google.com/citations?user=s9w1k-cAAAAJ&hl=en) ·
-[@ktwu01](https://x.com/ktwu01)
+[GitHub](https://github.com/ktwu01/benchmark-radar)
+
+[![X](https://img.shields.io/badge/X-000000?style=for-the-badge&logo=x&logoColor=white)](https://x.com/ktwu01)
+[![LinkedIn](https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/ktwu01)
+[![Google Scholar](https://img.shields.io/badge/Google%20Scholar-4285F4?style=for-the-badge&logo=googlescholar&logoColor=white)](https://scholar.google.com/citations?user=s9w1k-cAAAAJ&hl=en)
 
 做 benchmark 研究的时候发现新东西太多了，所以我搞了这个持续爬虫，每天自动从全网抓新的 benchmark 相关信息。它目前每天从 arXiv、GitHub、Hugging Face、OpenAlex、OpenReview、各家实验室官方 feed、Brave Search、Semantic Scholar、Hacker News 等来源采集，并持续更新。你如果需要寻找 related work 或找到适合eval自己的agent 的 bench 或者关注最新的 eval 进展，可以看这里哈哈哈：
 github.com/ktwu01/benchmark-radar，每天更新，并支持一键导出数据


### PR DESCRIPTION
## Summary
- keep the centered five-badge README header and its existing badge styles
- remove the handle or name from the X, LinkedIn, and Google Scholar badge labels while preserving their specific profile links
- mirror the badge-label changes in the Chinese README
- follow up on #366 by replacing abstract visual-identity rules with a complete before/after badge example in AGENTS.md and CLAUDE.md

Closes #353

## Test
- uv run --extra dev pytest tests/test_readme.py -q
- clean worktree: uv run --extra dev ruff check .
- clean worktree: uv run --extra dev ruff format --check .
- clean worktree: uv run --extra dev benchmark-radar normalize-external
- clean worktree: uv run --extra dev benchmark-radar classify
- clean worktree: uv run --extra dev pytest -q