### PR TITLE
Add bilingual issue template guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-model-card.yml
+++ b/.github/ISSUE_TEMPLATE/add-model-card.yml
@@ -1,5 +1,5 @@
-name: Tell us about a model card we missed
-description: Name a model card, system card, technical report, or release post the site has not read yet.
+name: Tell us about a model card we missed / 补充模型卡
+description: Name a model card, system card, technical report, or release post the site has not read yet. / 提交站点尚未收录的模型卡、系统卡、技术报告或发布文章。
 title: "Add model card: "
 labels: ["model-card", "good first issue"]
 body:
@@ -15,11 +15,14 @@ body:
         have to make the change yourself. If you would like to, see
         [CONTRIBUTING.md](https://github.com/ktwu01/benchmark-radar/blob/main/CONTRIBUTING.md).
 
+        中文也可以。请尽量回答三个问题：这个文档是什么、它报告了哪些
+        benchmark、为什么值得收录。链接和截图比长解释更有用。
+
   - type: input
     id: url
     attributes:
-      label: Link to the document
-      description: Where the scores are published. This is what lets anyone check the numbers later.
+      label: Link to the document / 文档链接
+      description: Where the scores are published. This is what lets anyone check the numbers later. / 分数发布在哪里；后续核对数字靠这个链接。
       placeholder: https://example.com/frontier-1-model-card
     validations:
       required: true
@@ -27,7 +30,7 @@ body:
   - type: input
     id: organization
     attributes:
-      label: Who released the model
+      label: Who released the model / 发布方
       placeholder: Acme
     validations:
       required: true
@@ -35,7 +38,7 @@ body:
   - type: input
     id: model
     attributes:
-      label: Model name
+      label: Model name / 模型名
       placeholder: Frontier-1
     validations:
       required: true
@@ -43,7 +46,7 @@ body:
   - type: dropdown
     id: document_type
     attributes:
-      label: What kind of document is it
+      label: What kind of document is it / 文档类型
       options:
         - Model card
         - System card
@@ -55,8 +58,8 @@ body:
   - type: input
     id: published
     attributes:
-      label: Date it was published (YYYY-MM-DD)
-      description: The date on the document itself. If the model was announced on a different day, use the document's date.
+      label: Date it was published (YYYY-MM-DD) / 发布日期
+      description: The date on the document itself. If the model was announced on a different day, use the document's date. / 用文档自己的日期；如果模型公告日期不同，也以文档日期为准。
       placeholder: "2026-05-14"
     validations:
       required: true
@@ -64,7 +67,7 @@ body:
   - type: textarea
     id: benchmarks
     attributes:
-      label: Which benchmarks does it report scores for
+      label: Which benchmarks does it report scores for / 报告了哪些 benchmark 分数
       description: |
         One per line. Write the names however the document writes them. We
         will match them to the names the site uses.
@@ -72,6 +75,9 @@ body:
         List what the document actually publishes a score for, not everything
         the model can do. A document that reports one benchmark three
         different ways still counts as reporting it once.
+
+        每行一个，按原文名称写即可。只列文档实际给出分数的 benchmark，
+        不要列模型“可能会做”的能力项。
       placeholder: |
         GPQA Diamond
         SWE-bench Verified
@@ -82,10 +88,13 @@ body:
   - type: textarea
     id: notes
     attributes:
-      label: Anything unusual about it
+      label: Anything unusual about it / 需要特别说明的地方
       description: |
         Optional. Worth mentioning if the document was edited after it went up
         and gained scores later, if it calls a benchmark by a name nobody else
         uses, or if it talks about a test without giving a score.
+
+        可选。如果文档后续补了分数、benchmark 名称很特殊，或只提到测试但
+        没有给分数，请写在这里。
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/report.yml
+++ b/.github/ISSUE_TEMPLATE/report.yml
@@ -1,11 +1,21 @@
-name: Report something
-description: Anything wrong, confusing, or missing on the site.
+name: Report something / 反馈问题
+description: Anything wrong, confusing, or missing on the site. / 反馈页面上错误、难懂或缺失的信息。
 labels: ["bug"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        English or Chinese is fine. The fastest useful report says: what you
+        saw, where it happened, what you expected, and why it matters to a
+        reader.
+
+        中文也可以。最有用的反馈通常包括：你看到了什么、发生在哪里、
+        你期待看到什么、以及为什么这会影响读者理解。
+
   - type: dropdown
     id: kind
     attributes:
-      label: What kind of problem is it
+      label: What kind of problem is it / 问题类型
       options:
         - Something looks wrong (layout, spacing, colours)
         - A logo is wrong, missing, or too small to read
@@ -21,8 +31,8 @@ body:
   - type: input
     id: where
     attributes:
-      label: Where did you see it
-      description: Paste the address of the page, or just name it.
+      label: Where did you see it / 在哪里看到的
+      description: Paste the address of the page, or just name it. / 贴页面地址，或直接写页面/区域名称。
       placeholder: https://koutian.is-a.dev/benchmark-radar/?view=leaderboard
     validations:
       required: true
@@ -30,9 +40,25 @@ body:
   - type: textarea
     id: what
     attributes:
-      label: What happened
+      label: What happened / 发生了什么
       description: |
         What you saw, and what you expected instead. A screenshot says it
         faster than words: you can paste one straight into this box.
+
+        写清楚你实际看到的内容，以及你原本期待看到什么。截图通常比长
+        描述更快，可以直接粘贴到这里。
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why is this worth fixing / 为什么值得修
+      description: |
+        Who is confused or blocked by this: a newcomer, an eval builder, a
+        benchmark author, or someone sharing the project?
+
+        这个问题会影响谁：第一次看的读者、做 eval 的人、benchmark 作者，
+        还是准备转发项目的人？
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/use-case.yml
+++ b/.github/ISSUE_TEMPLATE/use-case.yml
@@ -1,5 +1,5 @@
-name: Show how you use Benchmark Radar
-description: Share a project, paper, evaluation, or workflow that Benchmark Radar helped.
+name: Show how you use Benchmark Radar / 展示你的使用场景
+description: Share a project, paper, evaluation, or workflow that Benchmark Radar helped. / 分享 Benchmark Radar 帮到的项目、论文、评测或工作流。
 title: "Use case: "
 labels: ["use-case"]
 body:
@@ -9,10 +9,13 @@ body:
         Independent use is the best signal that this project is useful. A short
         note is enough, and a public link helps other eval builders learn from it.
 
+        中文也可以。请尽量写清楚：你在做什么、Benchmark Radar 帮你省了
+        哪一步、别人看完这个例子能学到什么。截图、链接或一句结论都很好。
+
   - type: input
     id: project
     attributes:
-      label: What are you building or researching?
+      label: What are you building or researching? / 你在做什么
       placeholder: An agent evaluation suite for customer-support workflows
     validations:
       required: true
@@ -20,16 +23,29 @@ body:
   - type: textarea
     id: use
     attributes:
-      label: How did Benchmark Radar help?
-      description: Name the page, dataset, benchmark, or decision that was useful.
+      label: How did Benchmark Radar help? / Benchmark Radar 怎么帮到你
+      description: Name the page, dataset, benchmark, or decision that was useful. / 写具体页面、数据集、benchmark 或它帮你做出的判断。
+    validations:
+      required: true
+
+  - type: textarea
+    id: worthy
+    attributes:
+      label: Why is this worth showing? / 为什么这个例子值得展示
+      description: |
+        What should another reader notice first: saved research time, a useful
+        benchmark choice, a surprising gap, or a shareable result?
+
+        另一个读者最应该先看到什么：省下的调研时间、一个有用的 benchmark
+        选择、一个意外缺口，还是一个方便传播的结果？
     validations:
       required: true
 
   - type: input
     id: link
     attributes:
-      label: Public link
-      description: Optional project, paper, post, repository, or evaluation link.
+      label: Public link / 公开链接
+      description: Optional project, paper, post, repository, or evaluation link. / 可选：项目、论文、帖子、仓库或评测链接。
       placeholder: https://example.com/my-eval-project
     validations:
       required: false
@@ -37,6 +53,6 @@ body:
   - type: textarea
     id: feedback
     attributes:
-      label: What would make it more useful?
+      label: What would make it more useful? / 还希望它改进什么
     validations:
       required: false


### PR DESCRIPTION
## Summary
- add Chinese guidance alongside English issue template copy
- prompt reporters to include what happened, where, expected behavior, and why it matters
- add use-case guidance for what is worth showing and sharing

Closes #356

## Test
- uv run --extra dev python -c "from pathlib import Path; import yaml; [yaml.safe_load(p.read_text()) for p in Path('.github/ISSUE_TEMPLATE').glob('*.yml')]; print('issue templates parse')"
- uv run --extra dev pytest tests/test_readme.py tests/test_site.py -q
- clean worktree: uv run --extra dev ruff check .
- clean worktree: uv run --extra dev ruff format --check .
- clean worktree: uv run --extra dev benchmark-radar normalize-external
- clean worktree: uv run --extra dev benchmark-radar classify
- clean worktree: uv run --extra dev pytest -q