### PR TITLE
Remove donor jargon from dashboard copy

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -730,8 +730,8 @@ const I18N = {
     "modality not established": "模态尚未确定",
     "No paper, repository, dataset or site link established.":
       "尚未确定论文、代码仓库、数据集或站点链接。",
-    "Identity below is inherited from the {donor} card for a reviewed equivalent benchmark; scores are unchanged.":
-      "以下基本信息继承自 {donor} 中经人工核对为同一基准的记录；分数不受影响。",
+    "Identity below comes from the {source} card after review matched it to the same benchmark; scores are unchanged.":
+      "以下基本信息来自 {source} 卡片；人工核对确认它指向同一个基准，分数不受影响。",
     Openness: "开放性",
     "openness not established": "开放性尚未确定",
     open: "开放",
@@ -4246,12 +4246,12 @@ function externalFactList(facts) {
 function externalInheritanceNote(detail) {
   const inheritance = detail.identity_inheritance;
   if (!inheritance) return null;
-  const donorName = externalSourceMeta(inheritance.donor_source).name;
+  const sourceName = externalSourceMeta(inheritance.donor_source).name;
   return element("p", {
     className: "external-inherited",
     text: t(
-      "Identity below is inherited from the {donor} card for a reviewed equivalent benchmark; scores are unchanged.",
-      { donor: donorName },
+      "Identity below comes from the {source} card after review matched it to the same benchmark; scores are unchanged.",
+      { source: sourceName },
     ),
   });
 }

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -293,7 +293,7 @@ def test_issue_316_benchmark_detail_labels_are_translated():
     # the value rather than a single-line "key": "value" pair.
     assert "尚未确定论文、代码仓库、数据集或站点链接。" in script
     # The #262 inheritance note also wraps onto its own line.
-    assert "中经人工核对为同一基准的记录" in script
+    assert "人工核对确认它指向同一个基准" in script
 
 
 def test_language_toggle_click_handler_is_wired():


### PR DESCRIPTION
## Summary
- replace the user-facing identity inheritance note so it says the information comes from the matched source card instead of a donor card
- update the Chinese translation with the same reader-facing framing
- refresh the site translation assertion for the revised copy

Closes #340

## Test
- uv run --extra dev python scripts/audit_jargon.py
- uv run --extra dev pytest tests/test_site.py -q
- clean worktree: uv run --extra dev ruff check .
- clean worktree: uv run --extra dev ruff format --check .
- clean worktree: uv run --extra dev benchmark-radar normalize-external
- clean worktree: uv run --extra dev benchmark-radar classify
- clean worktree: uv run --extra dev pytest -q