### PR TITLE
Add bilingual feature request form

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-model-card.yml
+++ b/.github/ISSUE_TEMPLATE/add-model-card.yml
@@ -1,6 +1,5 @@
 name: Tell us about a model card we missed / 补充模型卡
 description: Name a model card, system card, technical report, or release post the site has not read yet. / 提交站点尚未收录的模型卡、系统卡、技术报告或发布文章。
-title: "Add model card: "
 labels: ["model-card", "good first issue"]
 body:
   - type: markdown
@@ -48,10 +47,10 @@ body:
     attributes:
       label: What kind of document is it / 文档类型
       options:
-        - Model card
-        - System card
-        - Technical report
-        - Release post or blog
+        - Model card / 模型卡
+        - System card / 系统卡
+        - Technical report / 技术报告
+        - Release post or blog / 发布文章或博客
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
-  - name: See the ranking first
+  - name: See the ranking first / 提交前先看排行榜
     url: https://ktwu01.github.io/benchmark-radar/?view=leaderboard
-    about: The live ranking. Worth a look before reporting something as missing or wrong.
-  - name: How the ranking is built
+    about: The live ranking. Check it before reporting missing or incorrect data. / 实时排行榜；提交数据缺失或错误前请先查看。
+  - name: How the ranking is built / 排名如何生成
     url: https://github.com/ktwu01/benchmark-radar/blob/main/CONTRIBUTING.md
-    about: What gets counted, what is left out on purpose, and how to add a document.
+    about: What gets counted, what is excluded, and how to add a document. / 查看统计范围、排除内容和文档添加方法。

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,44 @@
+name: Suggest a new feature / 建议新功能
+description: Propose a capability, data source, workflow, or interface improvement. / 建议新能力、数据源、工作流或界面改进。
+labels: ["new feature"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        English or Chinese is fine. Describe what you want Benchmark Radar to
+        add, who would use it, and how it would improve their work.
+
+        中文也可以。请写清楚希望 Benchmark Radar 增加什么、谁会使用，
+        以及它能如何改善现有工作。
+
+  - type: textarea
+    id: feature
+    attributes:
+      label: What should Benchmark Radar add? / 希望 Benchmark Radar 增加什么
+      description: Describe the capability, data source, workflow, or interface change you want. / 描述你希望增加的能力、数据源、工作流或界面改动。
+    validations:
+      required: true
+
+  - type: textarea
+    id: users
+    attributes:
+      label: Who would use it? / 谁会使用
+      description: Name the readers, researchers, benchmark authors, or eval builders who need it. / 说明哪些读者、研究者、benchmark 作者或 eval 开发者会用到它。
+    validations:
+      required: true
+
+  - type: textarea
+    id: value
+    attributes:
+      label: Why is it worth adding? / 为什么值得加入
+      description: Name the task it would make faster, clearer, or possible. / 说明它能让哪项任务更快、更清楚，或从无法完成变为可以完成。
+    validations:
+      required: true
+
+  - type: textarea
+    id: example
+    attributes:
+      label: Example, sketch, or link / 示例、草图或链接
+      description: Optional. Paste a screenshot, mockup, related product, paper, or dataset. / 可选：粘贴截图、草图、相关产品、论文或数据集。
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/report.yml
+++ b/.github/ISSUE_TEMPLATE/report.yml
@@ -17,14 +17,14 @@ body:
     attributes:
       label: What kind of problem is it / 问题类型
       options:
-        - Something looks wrong (layout, spacing, colours)
-        - A logo is wrong, missing, or too small to read
-        - A number looks wrong
-        - Wording is confusing or too technical
-        - Something is missing that should be there
-        - A button or link does not work
-        - The page is slow or does not load
-        - Something else
+        - Something looks wrong (layout, spacing, colours) / 页面显示有问题（布局、间距、颜色）
+        - A logo is wrong, missing, or too small to read / Logo 错误、缺失或太小看不清
+        - A number looks wrong / 数字可能有误
+        - Wording is confusing or too technical / 文案难懂或过于技术化
+        - Something is missing that should be there / 缺少本应显示的内容
+        - A button or link does not work / 按钮或链接无法使用
+        - The page is slow or does not load / 页面加载缓慢或无法打开
+        - Something else / 其他问题
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/use-case.yml
+++ b/.github/ISSUE_TEMPLATE/use-case.yml
@@ -1,6 +1,5 @@
 name: Show how you use Benchmark Radar / 展示你的使用场景
 description: Share a project, paper, evaluation, or workflow that Benchmark Radar helped. / 分享 Benchmark Radar 帮到的项目、论文、评测或工作流。
-title: "Use case: "
 labels: ["use-case"]
 body:
   - type: markdown
@@ -16,7 +15,7 @@ body:
     id: project
     attributes:
       label: What are you building or researching? / 你在做什么
-      placeholder: An agent evaluation suite for customer-support workflows
+      placeholder: An agent evaluation suite for customer-support workflows / 面向客服工作流的 agent 评测套件
     validations:
       required: true
 

--- a/tests/test_issue_templates.py
+++ b/tests/test_issue_templates.py
@@ -1,0 +1,63 @@
+import re
+from pathlib import Path
+
+import yaml
+
+TEMPLATE_DIR = Path(__file__).parents[1] / ".github" / "ISSUE_TEMPLATE"
+FORM_PATHS = sorted(TEMPLATE_DIR.glob("*.yml"))
+CHINESE_RE = re.compile(r"[\u4e00-\u9fff]")
+ENGLISH_RE = re.compile(r"[A-Za-z]")
+
+
+def load_yaml(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def assert_bilingual(value: str, location: str) -> None:
+    assert ENGLISH_RE.search(value), f"{location} has no English copy"
+    assert CHINESE_RE.search(value), f"{location} has no Chinese copy"
+
+
+def test_issue_forms_keep_user_facing_copy_bilingual() -> None:
+    for path in FORM_PATHS:
+        if path.name == "config.yml":
+            continue
+
+        form = load_yaml(path)
+        assert_bilingual(form["name"], f"{path.name}: name")
+        assert_bilingual(form["description"], f"{path.name}: description")
+
+        if title := form.get("title"):
+            assert_bilingual(title, f"{path.name}: title")
+
+        for field in form["body"]:
+            attributes = field["attributes"]
+            if field["type"] == "markdown":
+                assert_bilingual(attributes["value"], f"{path.name}: markdown introduction")
+                continue
+
+            assert_bilingual(attributes["label"], f"{path.name}: {field['id']} label")
+            if description := attributes.get("description"):
+                assert_bilingual(description, f"{path.name}: {field['id']} description")
+            for option in attributes.get("options", []):
+                assert_bilingual(option, f"{path.name}: {field['id']} option")
+
+
+def test_issue_chooser_has_no_english_only_blank_issue() -> None:
+    config = load_yaml(TEMPLATE_DIR / "config.yml")
+
+    assert config["blank_issues_enabled"] is False
+    for link in config["contact_links"]:
+        assert_bilingual(link["name"], f"contact link {link['url']}: name")
+        assert_bilingual(link["about"], f"contact link {link['url']}: about")
+
+
+def test_feature_request_form_has_a_small_required_core() -> None:
+    form = load_yaml(TEMPLATE_DIR / "feature-request.yml")
+    fields = {field.get("id"): field for field in form["body"] if field.get("id")}
+
+    assert form["labels"] == ["new feature"]
+    assert set(fields) == {"feature", "users", "value", "example"}
+    required_ids = ("feature", "users", "value")
+    assert all(fields[field_id]["validations"]["required"] for field_id in required_ids)
+    assert fields["example"]["validations"]["required"] is False


### PR DESCRIPTION
## Summary
- add a bilingual feature-request form with three required questions, one optional example field, and the existing `new feature` label
- finish bilingual repository-controlled copy across chooser links, dropdown options, and form titles
- disable the built-in English-only blank issue card; the general report form remains the catch-all
- add regression tests for bilingual issue-form copy and the feature form contract

GitHub-owned interface text such as `Create new issue` continues to follow each viewer’s GitHub language setting.

Closes #372
Closes #356

## Test
- clean worktree: `uv run --extra dev ruff check .`
- clean worktree: `uv run --extra dev ruff format --check .`
- clean worktree: `uv run --extra dev benchmark-radar normalize-external`
- clean worktree: `uv run --extra dev benchmark-radar classify`
- clean worktree: `uv run --extra dev pytest -q` (`933 passed`)