### PR TITLE
Backfill bare GitHub release titles

### DIFF
--- a/data/snapshots/2026-08-14.json
+++ b/data/snapshots/2026-08-14.json
@@ -9416,7 +9416,7 @@
       "metrics": {
         "downloads": 10.0
       },
-      "parser_version": "github-releases/1",
+      "parser_version": "github-releases/2",
       "published_at": "2026-08-13T17:37:13+00:00",
       "rationale": [
         "Also found via GitHub Release",
@@ -9434,7 +9434,7 @@
       "source_id": "embeddings-benchmark/mteb@2.18.20",
       "summary": "2.18.20 (2026-08-13) Ci ci: Revert copilot dataset pr review (#5177) Delete .github/workflows/copilot dataset review.yml Delete .github/instructions directory (`57dbbfc`) Fix fix: cap retrieval top-k search depth to available results (#5180) (`246abdc`) Unknown dataset: add RAVENEA cultural image-to-text retrieval (#5135) dataset: add RAVENEA retrieval fix: address RAVENEA review feedback test: remove RAVENEA task tests (`68c25a0`)",
       "suppression_reasons": [],
-      "title": "2.18.20",
+      "title": "embeddings-benchmark/mteb 2.18.20",
       "total_score": 45.87,
       "updated_at": "2026-08-13T17:37:13+00:00",
       "url": "https://github.com/embeddings-benchmark/mteb/releases/tag/2.18.20",

--- a/data/snapshots/2026-08-19.json
+++ b/data/snapshots/2026-08-19.json
@@ -13332,7 +13332,7 @@
       "metrics": {
         "downloads": 14.0
       },
-      "parser_version": "github-releases/1",
+      "parser_version": "github-releases/2",
       "published_at": "2026-08-18T05:06:28+00:00",
       "rationale": [
         "Also found via GitHub Release",
@@ -13350,7 +13350,7 @@
       "source_id": "embeddings-benchmark/mteb@2.19.5",
       "summary": "2.19.5 (2026-08-18) Fix fix: break p-MRR rank ties by doc id to match the other retrieval metrics (#5241) fix: break p-MRR rank ties by doc id to match the other retrieval metrics test: cover p-MRR tie-break order-independence (`00616c7`) Unknown dataset: add FSDKaggle2018 (#5235) dataset: add FSDKaggle2018 Add FSDKaggle2018 preparation script (`0adc124`)",
       "suppression_reasons": [],
-      "title": "2.19.5",
+      "title": "embeddings-benchmark/mteb 2.19.5",
       "total_score": 41.78,
       "updated_at": "2026-08-18T05:06:28+00:00",
       "url": "https://github.com/embeddings-benchmark/mteb/releases/tag/2.19.5",

--- a/data/snapshots/2026-08-20.json
+++ b/data/snapshots/2026-08-20.json
@@ -13861,7 +13861,7 @@
       "metrics": {
         "downloads": 5.0
       },
-      "parser_version": "github-releases/1",
+      "parser_version": "github-releases/2",
       "published_at": "2026-08-18T05:06:28+00:00",
       "rationale": [
         "Matched: dataset",
@@ -13878,7 +13878,7 @@
       "source_id": "embeddings-benchmark/mteb@2.19.5",
       "summary": "2.19.5 (2026-08-18) Fix fix: break p-MRR rank ties by doc id to match the other retrieval metrics (#5241) fix: break p-MRR rank ties by doc id to match the other retrieval metrics test: cover p-MRR tie-break order-independence (`00616c7`) Unknown dataset: add FSDKaggle2018 (#5235) dataset: add FSDKaggle2018 Add FSDKaggle2018 preparation script (`0adc124`)",
       "suppression_reasons": [],
-      "title": "2.19.5",
+      "title": "embeddings-benchmark/mteb 2.19.5",
       "total_score": 29.8,
       "updated_at": "2026-08-18T05:06:28+00:00",
       "url": "https://github.com/embeddings-benchmark/mteb/releases/tag/2.19.5",

--- a/data/snapshots/2026-08-21.json
+++ b/data/snapshots/2026-08-21.json
@@ -11973,7 +11973,7 @@
       "metrics": {
         "downloads": 16.0
       },
-      "parser_version": "github-releases/1",
+      "parser_version": "github-releases/2",
       "published_at": "2026-08-20T20:31:21+00:00",
       "rationale": [
         "Also found via GitHub Release",
@@ -11991,7 +11991,7 @@
       "source_id": "embeddings-benchmark/mteb@2.20.0",
       "summary": "2.20.0 (2026-08-20) Feature feat: Add sparse encoder (#5087) add sparse encoder make sparse models on all tasks improve tests improve max sim fix typing simplify comments Update mteb/models/sentence transformer wrapper.py Co-authored-by: Kenneth Enevoldsen &lt;kennethcenevoldsen@gmail.com&gt; Update mteb/models/sentence transformer wrapper.py Co-authored-by: Kenneth Enevoldsen &lt;kennethcenevoldsen@gmail.com&gt; Potential fix for pull request finding Co-authored-by: Copilot Autofix powered by AI &lt;175728472+Copilot@users.noreply.github.com&gt; lint Co-authored-by: Kenneth Enevoldsen &lt;kennethcenevoldsen@gmail.com&gt; Co-authored-by: Copilot Autofix powered by AI &lt;175728472+Copilot@users.noreply.github.com&gt; (`44f4bed`) Unknown dataset: add MMEdit audio editing retrieval (#5246) (`dc9ec0f`) Add UEmbed implementation. (#5200) Add UEmbed implementation. Signed-off-by: sighingsnow &lt;songtingyu220@gmail.com&gt; Fix implementation. Signed-off-by: sighingsnow &lt;songtingyu220@gmail.com&gt; Signed-off-by: sighingsnow &lt;songtingyu220@gmail.com&gt; (`82edbff`)",
       "suppression_reasons": [],
-      "title": "2.20.0",
+      "title": "embeddings-benchmark/mteb 2.20.0",
       "total_score": 40.68,
       "updated_at": "2026-08-20T20:31:21+00:00",
       "url": "https://github.com/embeddings-benchmark/mteb/releases/tag/2.20.0",

--- a/data/snapshots/2026-08-22.json
+++ b/data/snapshots/2026-08-22.json
@@ -10308,7 +10308,7 @@
       "metrics": {
         "downloads": 16.0
       },
-      "parser_version": "github-releases/1",
+      "parser_version": "github-releases/2",
       "published_at": "2026-08-20T20:31:21+00:00",
       "rationale": [
         "Also found via GitHub Release",
@@ -10326,7 +10326,7 @@
       "source_id": "embeddings-benchmark/mteb@2.20.0",
       "summary": "2.20.0 (2026-08-20) Feature feat: Add sparse encoder (#5087) add sparse encoder make sparse models on all tasks improve tests improve max sim fix typing simplify comments Update mteb/models/sentence transformer wrapper.py Co-authored-by: Kenneth Enevoldsen &lt;kennethcenevoldsen@gmail.com&gt; Update mteb/models/sentence transformer wrapper.py Co-authored-by: Kenneth Enevoldsen &lt;kennethcenevoldsen@gmail.com&gt; Potential fix for pull request finding Co-authored-by: Copilot Autofix powered by AI &lt;175728472+Copilot@users.noreply.github.com&gt; lint Co-authored-by: Kenneth Enevoldsen &lt;kennethcenevoldsen@gmail.com&gt; Co-authored-by: Copilot Autofix powered by AI &lt;175728472+Copilot@users.noreply.github.com&gt; (`44f4bed`) Unknown dataset: add MMEdit audio editing retrieval (#5246) (`dc9ec0f`) Add UEmbed implementation. (#5200) Add UEmbed implementation. Signed-off-by: sighingsnow &lt;songtingyu220@gmail.com&gt; Fix implementation. Signed-off-by: sighingsnow &lt;songtingyu220@gmail.com&gt; Signed-off-by: sighingsnow &lt;songtingyu220@gmail.com&gt; (`82edbff`)",
       "suppression_reasons": [],
-      "title": "2.20.0",
+      "title": "embeddings-benchmark/mteb 2.20.0",
       "total_score": 38.5,
       "updated_at": "2026-08-20T20:31:21+00:00",
       "url": "https://github.com/embeddings-benchmark/mteb/releases/tag/2.20.0",

--- a/data/snapshots/2026-08-24.json
+++ b/data/snapshots/2026-08-24.json
@@ -9692,7 +9692,7 @@
       "metrics": {
         "downloads": 9.0
       },
-      "parser_version": "github-releases/1",
+      "parser_version": "github-releases/2",
       "published_at": "2026-08-23T08:33:18+00:00",
       "rationale": [
         "Matched: dataset",
@@ -9709,7 +9709,7 @@
       "source_id": "embeddings-benchmark/mteb@2.20.1",
       "summary": "2.20.1 (2026-08-23) Fix fix: repair Memotion retrieval dataset (#5266) (`75c3624`) Unknown model: Add LanguageBind video and audio model wrapper (#4557) model: add LanguageBind video, audio, and image wrappers with compatibility patches feat: HF mirror auto-download for LanguageBind + extras group for reproducibility wip: phase 1 review fixes for GPU testing refactor: trim LanguageBind compat shims to the two that are required Tested each of the five compatibility patches individually on GPU against the pinned transformers 4.45.2 / torchvision 0.20.1 / torchaudio 2.5.1: clip loss: transformers already defines it; the hasattr guard never fires -&gt; removed torchaudio.set audio backend: still present as a no-op; guard never fires -&gt; removed expand mask: LanguageBind hard-imports it from modeling clip -&gt; kept torchvision.transforms.functional tensor: pytorchvideo hard-imports it -&gt; kept tokenizer init shim: kept defensively (not triggered under the pinned versions, but guards against transformers load-path drift) Added inline comments documenting why the two retained shims are required. refactor: apply compat shims in the loader instead of at module import Move the patch compatibility() call into ensure languagebind source() so the shims only run when a LanguageBind model is actually loaded, rather than globally at module import time. refactor: move LanguageBind compat fixes into the pinned source snapshot Instead of monkey-patching transformers/torchvision/torchaudio at runtime from the MTEB wrapper, the compatibility fixes now live in the vendored LanguageBind source itself (pinned HF revision d2d0f6f): expand mask / clip loss: vendored into the modeling files (removed from transformers in the attention-mask refactor, before 4.40) tokenizer init : pass args to CLIPTokenizer.",
       "suppression_reasons": [],
-      "title": "2.20.1",
+      "title": "embeddings-benchmark/mteb 2.20.1",
       "total_score": 42.31,
       "updated_at": "2026-08-23T08:33:18+00:00",
       "url": "https://github.com/embeddings-benchmark/mteb/releases/tag/2.20.1",

--- a/data/snapshots/2026-08-25.json
+++ b/data/snapshots/2026-08-25.json
@@ -7239,7 +7239,7 @@
       "metrics": {
         "downloads": 0.0
       },
-      "parser_version": "github-releases/1",
+      "parser_version": "github-releases/2",
       "published_at": "2026-08-24T12:24:27+00:00",
       "rationale": [
         "Matched: agent~bench, benchmark, dataset, evaluat",
@@ -7256,7 +7256,7 @@
       "source_id": "modelscope/evalscope@v1.11.0",
       "summary": "中文版 基准测试数据集 多模态评测：新增 PerceptionBench、ScreenSpot-Pro、PMC-VQA、LogicVista、CC-OCR-V2、SLAKE、olmOCR-Bench、CountQA 等视觉、多模态与文档理解基准。 推理与专业能力评测：新增 HiPhO 高中物理奥赛、PhyX 物理推理（选择题与开放题）、PLawBench 法律实践能力评测。 多语言评测：新增 Milu、ARC-Indic、GSM8K-Indic、IndicBoolQ、TriviaQA-Indic、IndicPara、Sanskriti、Hindi HellaSwag，以及 BhashaBench / BhashaBench-Multi 的金融、法律、农业和阿育吠陀子集。 功能增强 评测版本管理：新增原生评测版本与缓存身份校验，并支持确定性的选择题选项打乱，避免语义变更后复用不兼容缓存。 Judge 评测：统一 LLM Judge 的 JSON 输出契约；格式不合法或 [ERROR] 回复将从指标统计中排除。 自定义数据集： general vmcq 统一支持图片、视频、音频输入，并支持 Parquet 和二进制媒体字段； general vqa 新增媒体占位符支持。 指标与报告：统一指标语义和评测报告展示，优化 Agent Trace 的步骤分组及工具调用与结果关联。 服务与 Web：评测界面支持 Sandbox 配置；优化报告列表元数据读取和条件请求。 文档优化 更新文本生成图像任务的指标选择说明。 修复 API 消息、工具调用和 Tau-bench pass^k 等文档说明问题。 问题修复 修复 IFBench NLTK 英文词性标注模型下载、ACEBench 官方评分协议对齐、IFEval 与 GPQA 结果可复现性等问题。 修复多选题括号答案和多答案场景下的标签提取问题。 修复 TaskConfig 未知字段被静默忽略的问题，提供相近字段建议；同时修复 reasoning effort 参数透传。 修复 CMMMU 等视觉基准的媒体输入归一化、OmniDocBench 重复加载、VQA 信息读取等问题。 修复终端评测非法 reward 与未完成运行的结果报告问题，以及 BFCL 空工具调用丢失问题。 修复性能测试中的流式 usage 统计、空 content、请求构建失败、缺失 chat template 和插件返回空数据集等问题。 修复 Web 报告中的本地媒体渲染、空 reasoning tokens 与后端空值处理问题。 English Version Benchmark Datasets Multimodal Evaluation: Added PerceptionBench, ScreenSpot-Pro, PMC-VQA, LogicVista, CC-OCR-V2, SLAKE, olmOCR-Bench, CountQA, and other vision, multimodal, and document-understanding benchmarks. Reasoning and Domain Evaluation: Added HiPhO for high-school physics Olympiad problems, PhyX for multiple-choice and open-ended physical reasoning, and PLawBench for legal practice evaluation. Multilingual Evaluation: Added Milu, ARC-Indic, GSM8K-Indic, IndicBoolQ, TriviaQA-Indic, IndicPara, Sanskriti, Hindi HellaSwag, and BhashaBench / BhashaBench-Multi finance, legal, agriculture, and Ayurveda subsets. Feature Enhancements Evaluation Versioning: Added native evaluation versioning, cache identity checks, and deterministic choice shuffling to prevent incompatible cached predictions from being reused.",
       "suppression_reasons": [],
-      "title": "v1.11.0",
+      "title": "modelscope/evalscope v1.11.0",
       "total_score": 65.2,
       "updated_at": "2026-08-24T12:24:27+00:00",
       "url": "https://github.com/modelscope/evalscope/releases/tag/v1.11.0",
@@ -14948,7 +14948,7 @@
       "metrics": {
         "downloads": 9.0
       },
-      "parser_version": "github-releases/1",
+      "parser_version": "github-releases/2",
       "published_at": "2026-08-23T08:33:18+00:00",
       "rationale": [
         "Matched: dataset",
@@ -14965,7 +14965,7 @@
       "source_id": "embeddings-benchmark/mteb@2.20.1",
       "summary": "2.20.1 (2026-08-23) Fix fix: repair Memotion retrieval dataset (#5266) (`75c3624`) Unknown model: Add LanguageBind video and audio model wrapper (#4557) model: add LanguageBind video, audio, and image wrappers with compatibility patches feat: HF mirror auto-download for LanguageBind + extras group for reproducibility wip: phase 1 review fixes for GPU testing refactor: trim LanguageBind compat shims to the two that are required Tested each of the five compatibility patches individually on GPU against the pinned transformers 4.45.2 / torchvision 0.20.1 / torchaudio 2.5.1: clip loss: transformers already defines it; the hasattr guard never fires -&gt; removed torchaudio.set audio backend: still present as a no-op; guard never fires -&gt; removed expand mask: LanguageBind hard-imports it from modeling clip -&gt; kept torchvision.transforms.functional tensor: pytorchvideo hard-imports it -&gt; kept tokenizer init shim: kept defensively (not triggered under the pinned versions, but guards against transformers load-path drift) Added inline comments documenting why the two retained shims are required. refactor: apply compat shims in the loader instead of at module import Move the patch compatibility() call into ensure languagebind source() so the shims only run when a LanguageBind model is actually loaded, rather than globally at module import time. refactor: move LanguageBind compat fixes into the pinned source snapshot Instead of monkey-patching transformers/torchvision/torchaudio at runtime from the MTEB wrapper, the compatibility fixes now live in the vendored LanguageBind source itself (pinned HF revision d2d0f6f): expand mask / clip loss: vendored into the modeling files (removed from transformers in the attention-mask refactor, before 4.40) tokenizer init : pass args to CLIPTokenizer.",
       "suppression_reasons": [],
-      "title": "2.20.1",
+      "title": "embeddings-benchmark/mteb 2.20.1",
       "total_score": 32.34,
       "updated_at": "2026-08-23T08:33:18+00:00",
       "url": "https://github.com/embeddings-benchmark/mteb/releases/tag/2.20.1",

--- a/data/snapshots/2026-08-26.json
+++ b/data/snapshots/2026-08-26.json
@@ -8384,7 +8384,7 @@
       "metrics": {
         "downloads": 0.0
       },
-      "parser_version": "github-releases/1",
+      "parser_version": "github-releases/2",
       "published_at": "2026-08-24T12:24:27+00:00",
       "rationale": [
         "Matched: agent~bench, benchmark, dataset, evaluat",
@@ -8401,7 +8401,7 @@
       "source_id": "modelscope/evalscope@v1.11.0",
       "summary": "中文版 基准测试数据集 多模态评测：新增 PerceptionBench、ScreenSpot-Pro、PMC-VQA、LogicVista、CC-OCR-V2、SLAKE、olmOCR-Bench、CountQA 等视觉、多模态与文档理解基准。 推理与专业能力评测：新增 HiPhO 高中物理奥赛、PhyX 物理推理（选择题与开放题）、PLawBench 法律实践能力评测。 多语言评测：新增 Milu、ARC-Indic、GSM8K-Indic、IndicBoolQ、TriviaQA-Indic、IndicPara、Sanskriti、Hindi HellaSwag，以及 BhashaBench / BhashaBench-Multi 的金融、法律、农业和阿育吠陀子集。 功能增强 评测版本管理：新增原生评测版本与缓存身份校验，并支持确定性的选择题选项打乱，避免语义变更后复用不兼容缓存。 Judge 评测：统一 LLM Judge 的 JSON 输出契约；格式不合法或 [ERROR] 回复将从指标统计中排除。 自定义数据集： general vmcq 统一支持图片、视频、音频输入，并支持 Parquet 和二进制媒体字段； general vqa 新增媒体占位符支持。 指标与报告：统一指标语义和评测报告展示，优化 Agent Trace 的步骤分组及工具调用与结果关联。 服务与 Web：评测界面支持 Sandbox 配置；优化报告列表元数据读取和条件请求。 文档优化 更新文本生成图像任务的指标选择说明。 修复 API 消息、工具调用和 Tau-bench pass^k 等文档说明问题。 问题修复 修复 IFBench NLTK 英文词性标注模型下载、ACEBench 官方评分协议对齐、IFEval 与 GPQA 结果可复现性等问题。 修复多选题括号答案和多答案场景下的标签提取问题。 修复 TaskConfig 未知字段被静默忽略的问题，提供相近字段建议；同时修复 reasoning effort 参数透传。 修复 CMMMU 等视觉基准的媒体输入归一化、OmniDocBench 重复加载、VQA 信息读取等问题。 修复终端评测非法 reward 与未完成运行的结果报告问题，以及 BFCL 空工具调用丢失问题。 修复性能测试中的流式 usage 统计、空 content、请求构建失败、缺失 chat template 和插件返回空数据集等问题。 修复 Web 报告中的本地媒体渲染、空 reasoning tokens 与后端空值处理问题。 English Version Benchmark Datasets Multimodal Evaluation: Added PerceptionBench, ScreenSpot-Pro, PMC-VQA, LogicVista, CC-OCR-V2, SLAKE, olmOCR-Bench, CountQA, and other vision, multimodal, and document-understanding benchmarks. Reasoning and Domain Evaluation: Added HiPhO for high-school physics Olympiad problems, PhyX for multiple-choice and open-ended physical reasoning, and PLawBench for legal practice evaluation. Multilingual Evaluation: Added Milu, ARC-Indic, GSM8K-Indic, IndicBoolQ, TriviaQA-Indic, IndicPara, Sanskriti, Hindi HellaSwag, and BhashaBench / BhashaBench-Multi finance, legal, agriculture, and Ayurveda subsets. Feature Enhancements Evaluation Versioning: Added native evaluation versioning, cache identity checks, and deterministic choice shuffling to prevent incompatible cached predictions from being reused.",
       "suppression_reasons": [],
-      "title": "v1.11.0",
+      "title": "modelscope/evalscope v1.11.0",
       "total_score": 55.15,
       "updated_at": "2026-08-24T12:24:27+00:00",
       "url": "https://github.com/modelscope/evalscope/releases/tag/v1.11.0",
@@ -12245,7 +12245,7 @@
       "metrics": {
         "downloads": 8.0
       },
-      "parser_version": "github-releases/1",
+      "parser_version": "github-releases/2",
       "published_at": "2026-08-25T13:45:10+00:00",
       "rationale": [
         "Matched: dataset",
@@ -12262,7 +12262,7 @@
       "source_id": "embeddings-benchmark/mteb@2.20.2",
       "summary": "2.20.2 (2026-08-25) Ci ci: fix dataset loading workflow hang by replacing uv sync with uv pip install (#5290) ci: isolate uv cache to diagnose dataset loading hang ci: trigger dataset loading workflow on changes to itself ci: add venv creation diagnostics and restore pre-created venv workaround ci: install Python before diagnostic step ci: add trace logging and --no-install-project isolation test ci: scope RUST LOG to uv= to reduce trace volume ci: replace uv sync with pip install to fix hang uv sync hangs indefinitely because it must parse uv.lock (54 MB, 19k lines) before doing anything else. Rust serde deserialization of this file likely exhausts the runner&#39;s available memory, causing the process to stall. The dataset-loading test only needs mteb, pytest, and pytest-rerunfailures, so we bypass the lockfile entirely with a direct pip install. ci: use uv pip install instead of uv sync to avoid lockfile parsing ci: add --system flag to uv pip install ci: create venv via python -m venv then uv pip install ci: add bibtexparser dependency ci: add gitpython dependency (`8df869d`) ci: use minimal deps and fallback venv for dataset loading workflow (#5289) (`f5f504b`) ci: use Python 3.10 in dataset loading workflow (#5286) ci: use Python 3.10 in dataset loading workflow to share uv cache with lint ci: add 30m timeout and verbose output to dataset loading install step (`526cd73`) ci: use --frozen flag in dataset loading and lint install steps (#5277) ci: use --frozen flag in dataset loading and lint install steps Bypasses dependency resolution in CI where the lockfile should always be used as-is, speeding up the install step.",
       "suppression_reasons": [],
-      "title": "2.20.2",
+      "title": "embeddings-benchmark/mteb 2.20.2",
       "total_score": 44.23,
       "updated_at": "2026-08-25T13:45:10+00:00",
       "url": "https://github.com/embeddings-benchmark/mteb/releases/tag/2.20.2",

--- a/src/benchmark_radar/snapshots.py
+++ b/src/benchmark_radar/snapshots.py
@@ -32,6 +32,7 @@ from .rubric import (
     v3_rubric_reference,
 )
 from .site_seo import write_sitemap
+from .sources import GITHUB_RELEASE_PARSER_VERSION, github_release_title
 
 SCHEMA_VERSION = 2
 SUPPORTED_SCHEMA_VERSIONS = {1, SCHEMA_VERSION}
@@ -1232,7 +1233,9 @@ def migrate_snapshot_history(config: dict[str, Any], snapshot_dir: Path) -> list
     for path in paths:
         raw = json.loads(path.read_text(encoding="utf-8"))
         versions.append(int(raw.get("schema_version") or 0))
-        snapshots.append(normalize_snapshot(raw, source=str(path)))
+        snapshot = normalize_snapshot(raw, source=str(path))
+        _backfill_github_release_titles(snapshot)
+        snapshots.append(snapshot)
     if snapshots and versions[-1] == 1:
         latest = snapshots[-1]
         observed_at = _validate_time(
@@ -1258,3 +1261,25 @@ def migrate_snapshot_history(config: dict[str, Any], snapshot_dir: Path) -> list
         validate_snapshot(snapshot, source=str(path))
         _write_json(path, snapshot)
     return snapshots
+
+
+def _backfill_github_release_titles(snapshot: dict[str, Any]) -> int:
+    """Reparse persisted bare-tag release titles with the current connector."""
+    changed = 0
+    for record in snapshot.get("evidence_items") or []:
+        if record.get("source") != "GitHub Release":
+            continue
+        source_id = str(record.get("source_id") or "")
+        if "@" not in source_id:
+            continue
+        repository, tag = source_id.rsplit("@", 1)
+        if not repository or not tag:
+            continue
+        current = str(record.get("title") or "").strip()
+        corrected = github_release_title(repository, tag, current)
+        if corrected == current:
+            continue
+        record["title"] = corrected
+        record["parser_version"] = GITHUB_RELEASE_PARSER_VERSION
+        changed += 1
+    return changed

--- a/src/benchmark_radar/sources.py
+++ b/src/benchmark_radar/sources.py
@@ -18,6 +18,7 @@ class ConnectorPayloadError(ValueError):
 
 
 FUTURE_TIMESTAMP_TOLERANCE = timedelta(minutes=5)
+GITHUB_RELEASE_PARSER_VERSION = "github-releases/2"
 
 
 def _xml_local_name(tag: str) -> str:
@@ -757,7 +758,7 @@ def fetch_semantic_scholar(
     return sorted(found.values(), key=lambda item: item.published_at, reverse=True)[:limit]
 
 
-def _release_title(repository: str, tag: str, name: str) -> str:
+def github_release_title(repository: str, tag: str, name: str) -> str:
     """Build a release title that never degrades to the bare tag.
 
     Some repositories (modelscope/evalscope among them) name each release
@@ -867,7 +868,7 @@ def fetch_github_releases(
                 found[f"{repository}@{tag}"] = RadarItem(
                     source="GitHub Release",
                     source_id=f"{repository}@{tag}",
-                    title=_release_title(repository, tag, str(row.get("name") or "")),
+                    title=github_release_title(repository, tag, str(row.get("name") or "")),
                     url=url,
                     published_at=published,
                     updated_at=published,
@@ -889,7 +890,7 @@ def fetch_github_releases(
                         )
                     },
                     raw=row,
-                    parser_version="github-releases/1",
+                    parser_version=GITHUB_RELEASE_PARSER_VERSION,
                 )
             if len(payload) < min(page_size, limit - len(found)) or (
                 oldest is not None and oldest < since

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -25,6 +25,7 @@ from benchmark_radar.snapshots import (
     validate_snapshot,
     write_snapshot,
 )
+from benchmark_radar.sources import GITHUB_RELEASE_PARSER_VERSION
 
 
 def radar_run(day: int = 27, *, title: str = "A New Evaluation Benchmark") -> RadarRun:
@@ -765,6 +766,42 @@ def test_migrate_does_not_refetch_attention_for_schema_two(tmp_path, monkeypatch
     migrated = migrate_snapshot_history({}, tmp_path)
 
     assert migrated[0]["schema_version"] == 2
+
+
+def test_migrate_backfills_bare_github_release_titles_idempotently(tmp_path):
+    snapshot_dir = tmp_path / "snapshots"
+    snapshot_dir.mkdir()
+    snapshot = snapshot_for_run(radar_run())
+    record = snapshot["evidence_items"][0]
+    record.update(
+        {
+            "source": "GitHub Release",
+            "source_id": "modelscope/evalscope@v1.11.0",
+            "title": "v1.11.0",
+            "url": "https://github.com/modelscope/evalscope/releases/tag/v1.11.0",
+            "parser_version": "github-releases/1",
+        }
+    )
+    original_hash = record["raw_payload_hash"]
+    path = snapshot_dir / "2026-07-27.json"
+    path.write_text(json.dumps(snapshot), encoding="utf-8")
+
+    migrate_snapshot_history({}, snapshot_dir)
+    first_pass = path.read_text(encoding="utf-8")
+    dashboard = rebuild_dashboard(snapshot_dir, tmp_path / "site" / "radar.json")
+
+    migrated = json.loads(first_pass)["evidence_items"][0]
+    assert migrated["title"] == "modelscope/evalscope v1.11.0"
+    assert migrated["parser_version"] == GITHUB_RELEASE_PARSER_VERSION
+    assert migrated["raw_payload_hash"] == original_hash
+    assert dashboard["days"][0]["evidence_items"][0]["title"] == ("modelscope/evalscope v1.11.0")
+    artifact = next(
+        entity for entity in dashboard["corpus"]["entities"] if entity["type"] == "artifact"
+    )
+    assert artifact["label"] == "modelscope/evalscope v1.11.0"
+
+    migrate_snapshot_history({}, snapshot_dir)
+    assert path.read_text(encoding="utf-8") == first_pass
 
 
 def test_cumulative_counts_one_artifact_reported_by_two_sources_once(tmp_path):

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -6,6 +6,7 @@ import pytest
 from benchmark_radar.http import RequestError
 from benchmark_radar.models import RadarItem
 from benchmark_radar.sources import (
+    GITHUB_RELEASE_PARSER_VERSION,
     ConnectorPayloadError,
     collection_method,
     fetch_arxiv,
@@ -17,6 +18,7 @@ from benchmark_radar.sources import (
     fetch_openalex,
     fetch_openreview,
     fetch_semantic_scholar,
+    github_release_title,
 )
 
 FIRST_PARTY_RSS = """\
@@ -564,7 +566,7 @@ def test_github_releases_success_uses_release_notes(monkeypatch):
     assert items[0].title == "Benchmark 2.0"
     assert items[0].summary == "The upstream release notes."
     assert items[0].metrics["downloads"] == 7
-    assert items[0].parser_version == "github-releases/1"
+    assert items[0].parser_version == GITHUB_RELEASE_PARSER_VERSION
 
 
 def test_github_releases_issue_362_title_never_degrades_to_the_bare_tag(
@@ -602,14 +604,14 @@ def test_github_releases_issue_362_title_never_degrades_to_the_bare_tag(
     assert [item.title for item in items] == ["modelscope/evalscope v1.11.0"]
 
     # The same guard covers an empty name and a v-prefix mismatch.
-    from benchmark_radar.sources import _release_title
-
-    assert _release_title("modelscope/evalscope", "v1.11.0", "") == ("modelscope/evalscope v1.11.0")
-    assert _release_title("modelscope/evalscope", "1.11.0", "v1.11.0") == (
+    assert github_release_title("modelscope/evalscope", "v1.11.0", "") == (
+        "modelscope/evalscope v1.11.0"
+    )
+    assert github_release_title("modelscope/evalscope", "1.11.0", "v1.11.0") == (
         "modelscope/evalscope 1.11.0"
     )
     # A real release name still wins.
-    assert _release_title("example/benchmark", "v2.0.0", "Benchmark 2.0") == "Benchmark 2.0"
+    assert github_release_title("example/benchmark", "v2.0.0", "Benchmark 2.0") == "Benchmark 2.0"
 
 
 def test_github_releases_isolates_one_repository_failure(monkeypatch):


### PR DESCRIPTION
## Result

Backfills the 10 persisted bare-tag GitHub Release titles that remained after #383, covering six EvalScope and MTEB releases across eight daily snapshots.

## Implementation

- Reuses the connector title normalizer from the explicit `benchmark-radar migrate` path.
- Stamps corrected and future records with `github-releases/2`.
- Retains the original raw-payload hashes.
- Adds an idempotency and rebuild-level regression test.

Follow-up to #383 and #362.

## Validation

Clean checkout, in CI order:

- `ruff check .`
- `ruff format --check .`
- `benchmark-radar normalize-external`
- `benchmark-radar classify`
- `pytest -q` — 935 passed