### PR TITLE
Show one latest sighting per record in All dates

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -2897,6 +2897,31 @@ function allObservations() {
   return state.observations;
 }
 
+// All dates is a record finder, not a replay of every overlapping crawl
+// window. Keep the newest matching sighting for each source record there while
+// leaving individual daily scans untouched. Source stays in the key because
+// two independent providers can describe the same identifier without being
+// interchangeable evidence; attention uses its producer-assigned observation
+// ID when available for the same reason.
+function observationRecordKey(item) {
+  if (item.observation_kind === "attention") {
+    return `attention\u0000${item.observation_id || `${item.source}\u0000${item.source_id}`}`;
+  }
+  return `evidence\u0000${item.source}\u0000${item.source_id}`;
+}
+
+function latestObservationsByRecord(observations) {
+  const latest = new Map();
+  observations.forEach((item) => {
+    const key = observationRecordKey(item);
+    const current = latest.get(key);
+    if (!current || String(item.snapshot_date) > String(current.snapshot_date)) {
+      latest.set(key, item);
+    }
+  });
+  return observations.filter((item) => latest.get(observationRecordKey(item)) === item);
+}
+
 function populateSelect(target, values, label, selected) {
   replaceChildren(target, [
     option("", `All ${label}`),
@@ -2967,7 +2992,7 @@ function closeFiltersDrawer() {
 function filteredObservations() {
   const query = state.q.trim().toLowerCase();
   const sourceLower = state.source.trim().toLowerCase();
-  return allObservations().filter((item) => {
+  const matches = allObservations().filter((item) => {
     const haystack = `${item.title} ${item.summary} ${item.source}`.toLowerCase();
     return (
       (state.todayDate === "all" || item.snapshot_date === state.todayDate) &&
@@ -2979,6 +3004,7 @@ function filteredObservations() {
       (!query || haystack.includes(query))
     );
   });
+  return state.todayDate === "all" ? latestObservationsByRecord(matches) : matches;
 }
 
 // When a record is supplied, the rubric is rendered with that record's own

--- a/tests/deduplicate_observations_harness.mjs
+++ b/tests/deduplicate_observations_harness.mjs
@@ -1,0 +1,59 @@
+// Execute the real All dates deduplication helpers from app.js without
+// copying their implementation into the test.
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(here, "..", "site", "assets", "app.js"), "utf8");
+const start = source.indexOf("function observationRecordKey(");
+const end = source.indexOf("\nfunction populateSelect(", start);
+if (start < 0 || end < 0) throw new Error("All dates deduplication helpers not found");
+
+const harness = `${source.slice(start, end)}\nglobalThis.__latest = latestObservationsByRecord;`;
+new Function(harness)();
+
+const rows = [
+  {
+    observation_kind: "evidence",
+    source: "GitHub Release",
+    source_id: "modelscope/evalscope@v1.11.0",
+    snapshot_date: "2026-08-25",
+    total_score: 65.2,
+  },
+  {
+    observation_kind: "evidence",
+    source: "GitHub Release",
+    source_id: "modelscope/evalscope@v1.11.0",
+    snapshot_date: "2026-08-26",
+    total_score: 55.15,
+  },
+  {
+    observation_kind: "evidence",
+    source: "GitHub",
+    source_id: "modelscope/evalscope@v1.11.0",
+    snapshot_date: "2026-08-25",
+  },
+  {
+    observation_kind: "attention",
+    observation_id: "hacker-news:123",
+    source: "Hacker News",
+    source_id: "123",
+    snapshot_date: "2026-08-25",
+  },
+  {
+    observation_kind: "attention",
+    observation_id: "hacker-news:123",
+    source: "Hacker News",
+    source_id: "123",
+    snapshot_date: "2026-08-26",
+  },
+  {
+    observation_kind: "evidence",
+    source: "arXiv",
+    source_id: "2608.00001",
+    snapshot_date: "2026-08-24",
+  },
+];
+
+console.log(JSON.stringify(globalThis.__latest(rows)));

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -454,6 +454,36 @@ def test_main_filters_use_persisted_attention_and_snapshot_dates():
     assert "explorer-view" not in html
 
 
+def test_all_dates_keeps_only_the_latest_matching_sighting_per_source_record():
+    import json
+    import shutil
+    import subprocess
+
+    import pytest
+
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+    assert 'state.todayDate === "all" ? latestObservationsByRecord(matches) : matches' in script
+
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is not installed")
+    result = subprocess.run(
+        [node, "tests/deduplicate_observations_harness.mjs"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=True,
+    )
+    rows = json.loads(result.stdout)
+
+    assert [(row["source"], row["source_id"], row["snapshot_date"]) for row in rows] == [
+        ("GitHub Release", "modelscope/evalscope@v1.11.0", "2026-08-26"),
+        ("GitHub", "modelscope/evalscope@v1.11.0", "2026-08-25"),
+        ("Hacker News", "123", "2026-08-26"),
+        ("arXiv", "2608.00001", "2026-08-24"),
+    ]
+
+
 def test_records_expand_inline_without_an_exclusive_accordion_or_record_modal():
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
     html = Path("site/index.html").read_text(encoding="utf-8")


### PR DESCRIPTION
## Result

“All dates” now shows one latest matching sighting per source record instead of replaying the same record from every overlapping daily scan.

For the reported example, `modelscope/evalscope@v1.11.0` appears once using its August 26 sighting rather than twice for August 25 and 26.

## Boundaries

- Individual date views remain unchanged.
- Daily snapshots and trend calculations retain the complete observation history.
- Records from different sources remain separate evidence.

## Validation

Clean checkout, in CI order:

- `ruff check .`
- `ruff format --check .`
- `benchmark-radar normalize-external`
- `benchmark-radar classify`
- `pytest -q` — 936 passed