### PR TITLE
Simplify issue templates to at most two required fields

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-model-card.yml
+++ b/.github/ISSUE_TEMPLATE/add-model-card.yml
@@ -21,45 +21,8 @@ body:
     id: url
     attributes:
       label: Link to the document / 文档链接
-      description: Where the scores are published. This is what lets anyone check the numbers later. / 分数发布在哪里；后续核对数字靠这个链接。
+      description: Where the scores are published. If you know the model name and date, include them here too. / 分数发布在哪里；如果知道模型名和发布日期也一并贴上，方便核对。
       placeholder: https://example.com/frontier-1-model-card
-    validations:
-      required: true
-
-  - type: input
-    id: organization
-    attributes:
-      label: Who released the model / 发布方
-      placeholder: Acme
-    validations:
-      required: true
-
-  - type: input
-    id: model
-    attributes:
-      label: Model name / 模型名
-      placeholder: Frontier-1
-    validations:
-      required: true
-
-  - type: dropdown
-    id: document_type
-    attributes:
-      label: What kind of document is it / 文档类型
-      options:
-        - Model card / 模型卡
-        - System card / 系统卡
-        - Technical report / 技术报告
-        - Release post or blog / 发布文章或博客
-    validations:
-      required: true
-
-  - type: input
-    id: published
-    attributes:
-      label: Date it was published (YYYY-MM-DD) / 发布日期
-      description: The date on the document itself. If the model was announced on a different day, use the document's date. / 用文档自己的日期；如果模型公告日期不同，也以文档日期为准。
-      placeholder: "2026-05-14"
     validations:
       required: true
 
@@ -68,21 +31,26 @@ body:
     attributes:
       label: Which benchmarks does it report scores for / 报告了哪些 benchmark 分数
       description: |
-        One per line. Write the names however the document writes them. We
-        will match them to the names the site uses.
+        One per line, names as the document writes them. We will match them
+        to the names the site uses. Only list what it actually publishes a
+        score for.
 
-        List what the document actually publishes a score for, not everything
-        the model can do. A document that reports one benchmark three
-        different ways still counts as reporting it once.
-
-        每行一个，按原文名称写即可。只列文档实际给出分数的 benchmark，
-        不要列模型“可能会做”的能力项。
+        每行一个，按原文名称写即可。只列文档实际给出分数的 benchmark。
       placeholder: |
         GPQA Diamond
         SWE-bench Verified
         AIME 2025
     validations:
       required: true
+
+  - type: input
+    id: details
+    attributes:
+      label: Model and date (optional) / 模型与日期（可选）
+      description: Model name, publisher, and date if you have them. / 如有，填写模型名、发布方和日期。
+      placeholder: Frontier-1 by Acme — 2026-05-14
+    validations:
+      required: false
 
   - type: textarea
     id: notes

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -20,18 +20,10 @@ body:
       required: true
 
   - type: textarea
-    id: users
-    attributes:
-      label: Who would use it? / 谁会使用
-      description: Name the readers, researchers, benchmark authors, or eval builders who need it. / 说明哪些读者、研究者、benchmark 作者或 eval 开发者会用到它。
-    validations:
-      required: true
-
-  - type: textarea
     id: value
     attributes:
       label: Why is it worth adding? / 为什么值得加入
-      description: Name the task it would make faster, clearer, or possible. / 说明它能让哪项任务更快、更清楚，或从无法完成变为可以完成。
+      description: Who would use it and what task it makes faster or possible. / 谁会用到，它能让哪项任务更快、更清楚或从无法完成变为可以完成。
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -28,6 +28,14 @@ body:
       required: true
 
   - type: textarea
+    id: users
+    attributes:
+      label: Who would use it? / 谁会使用 (optional / 可选)
+      description: Optional. Name the readers, researchers, or eval builders who need it — you can also just mention them above. / 可选：说明哪些读者或研究者会用到，也可直接写在上一栏。
+    validations:
+      required: false
+
+  - type: textarea
     id: example
     attributes:
       label: Example, sketch, or link / 示例、草图或链接

--- a/.github/ISSUE_TEMPLATE/report.yml
+++ b/.github/ISSUE_TEMPLATE/report.yml
@@ -12,19 +12,17 @@ body:
         中文也可以。最有用的反馈通常包括：你看到了什么、发生在哪里、
         你期待看到什么、以及为什么这会影响读者理解。
 
-  - type: dropdown
-    id: kind
+  - type: textarea
+    id: what
     attributes:
-      label: What kind of problem is it / 问题类型
-      options:
-        - Something looks wrong (layout, spacing, colours) / 页面显示有问题（布局、间距、颜色）
-        - A logo is wrong, missing, or too small to read / Logo 错误、缺失或太小看不清
-        - A number looks wrong / 数字可能有误
-        - Wording is confusing or too technical / 文案难懂或过于技术化
-        - Something is missing that should be there / 缺少本应显示的内容
-        - A button or link does not work / 按钮或链接无法使用
-        - The page is slow or does not load / 页面加载缓慢或无法打开
-        - Something else / 其他问题
+      label: What happened / 发生了什么
+      description: |
+        What you saw, and what you expected instead. A screenshot says it
+        faster than words: you can paste one straight into this box. If you
+        remember the page address, include it here too.
+
+        写清楚你实际看到的内容，以及你原本期待看到什么。截图通常比长
+        描述更快，可以直接粘贴到这里；记得页面地址的话一并贴上。
     validations:
       required: true
 
@@ -32,33 +30,7 @@ body:
     id: where
     attributes:
       label: Where did you see it / 在哪里看到的
-      description: Paste the address of the page, or just name it. / 贴页面地址，或直接写页面/区域名称。
+      description: Optional. Paste the page address or just name the area. / 可选：贴页面地址或写页面/区域名称。
       placeholder: https://koutian.is-a.dev/benchmark-radar/?view=leaderboard
     validations:
-      required: true
-
-  - type: textarea
-    id: what
-    attributes:
-      label: What happened / 发生了什么
-      description: |
-        What you saw, and what you expected instead. A screenshot says it
-        faster than words: you can paste one straight into this box.
-
-        写清楚你实际看到的内容，以及你原本期待看到什么。截图通常比长
-        描述更快，可以直接粘贴到这里。
-    validations:
-      required: true
-
-  - type: textarea
-    id: why
-    attributes:
-      label: Why is this worth fixing / 为什么值得修
-      description: |
-        Who is confused or blocked by this: a newcomer, an eval builder, a
-        benchmark author, or someone sharing the project?
-
-        这个问题会影响谁：第一次看的读者、做 eval 的人、benchmark 作者，
-        还是准备转发项目的人？
-    validations:
-      required: true
+      required: false

--- a/.github/ISSUE_TEMPLATE/use-case.yml
+++ b/.github/ISSUE_TEMPLATE/use-case.yml
@@ -11,32 +11,20 @@ body:
         中文也可以。请尽量写清楚：你在做什么、Benchmark Radar 帮你省了
         哪一步、别人看完这个例子能学到什么。截图、链接或一句结论都很好。
 
-  - type: input
-    id: project
-    attributes:
-      label: What are you building or researching? / 你在做什么
-      placeholder: An agent evaluation suite for customer-support workflows / 面向客服工作流的 agent 评测套件
-    validations:
-      required: true
-
   - type: textarea
     id: use
     attributes:
       label: How did Benchmark Radar help? / Benchmark Radar 怎么帮到你
-      description: Name the page, dataset, benchmark, or decision that was useful. / 写具体页面、数据集、benchmark 或它帮你做出的判断。
+      description: What you are building and which page, dataset, or benchmark was useful. / 你在做什么，以及哪个页面、数据集或 benchmark 帮到了你。
+      placeholder: An agent evaluation suite for customer-support workflows — the leaderboard helped us pick ... / 面向客服工作流的 agent 评测套件，排行榜帮我们选了 ...
     validations:
       required: true
 
   - type: textarea
     id: worthy
     attributes:
-      label: Why is this worth showing? / 为什么这个例子值得展示
-      description: |
-        What should another reader notice first: saved research time, a useful
-        benchmark choice, a surprising gap, or a shareable result?
-
-        另一个读者最应该先看到什么：省下的调研时间、一个有用的 benchmark
-        选择、一个意外缺口，还是一个方便传播的结果？
+      label: Why is this worth sharing? / 为什么值得分享
+      description: What should another reader notice first. / 另一个读者最应该先看到什么。
     validations:
       required: true
 

--- a/tests/test_issue_templates.py
+++ b/tests/test_issue_templates.py
@@ -58,6 +58,7 @@ def test_feature_request_form_has_a_small_required_core() -> None:
 
     assert form["labels"] == ["new feature"]
     assert set(fields) == {"feature", "users", "value", "example"}
-    required_ids = ("feature", "users", "value")
+    required_ids = ("feature", "value")
     assert all(fields[field_id]["validations"]["required"] for field_id in required_ids)
+    assert fields["users"]["validations"]["required"] is False
     assert fields["example"]["validations"]["required"] is False


### PR DESCRIPTION
Fixes #388.

Each template now has at most two required fields so filing takes seconds:

- **Report**: 1 required (what happened, incl. optional page address inline) + 1 optional where field. Removed kind dropdown and why-worth-fixing.
- **Feature request**: 2 required (what to add + why worth adding, merged who-uses into why).
- **Use case**: 2 required (how it helped incl. what you are building + why worth sharing).
- **Model card**: 2 required (link + benchmarks) + 1 optional combined model/date/publisher field. Removed separate org/model/type/date required fields.

Motto: 能填两项就不要填三项。