### PR TITLE
Shorten issue template copy and add empty-state recovery checklist (#388, #386)

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-model-card.yml
+++ b/.github/ISSUE_TEMPLATE/add-model-card.yml
@@ -42,26 +42,3 @@ body:
         AIME 2025
     validations:
       required: true
-
-  - type: input
-    id: details
-    attributes:
-      label: Model and date (optional) / 模型与日期（可选）
-      description: Model name, publisher, and date if you have them. / 如有，填写模型名、发布方和日期。
-      placeholder: Frontier-1 by Acme — 2026-05-14
-    validations:
-      required: false
-
-  - type: textarea
-    id: notes
-    attributes:
-      label: Anything unusual about it / 需要特别说明的地方
-      description: |
-        Optional. Worth mentioning if the document was edited after it went up
-        and gained scores later, if it calls a benchmark by a name nobody else
-        uses, or if it talks about a test without giving a score.
-
-        可选。如果文档后续补了分数、benchmark 名称很特殊，或只提到测试但
-        没有给分数，请写在这里。
-    validations:
-      required: false

--- a/.github/ISSUE_TEMPLATE/add-model-card.yml
+++ b/.github/ISSUE_TEMPLATE/add-model-card.yml
@@ -4,24 +4,13 @@ labels: ["model-card", "good first issue"]
 body:
   - type: markdown
     attributes:
-      value: |
-        The [Model Card Adoption Rank](https://github.com/ktwu01/benchmark-radar#model-card-adoption-rank)
-        counts how many companies report each benchmark when they launch a
-        model. Every document in it was read by a person, so the site only
-        knows about the ones somebody has pointed at.
-
-        Naming one we missed is a real contribution on its own. You do not
-        have to make the change yourself. If you would like to, see
-        [CONTRIBUTING.md](https://github.com/ktwu01/benchmark-radar/blob/main/CONTRIBUTING.md).
-
-        中文也可以。请尽量回答三个问题：这个文档是什么、它报告了哪些
-        benchmark、为什么值得收录。链接和截图比长解释更有用。
+      value: "The [Model Card Adoption Rank](https://github.com/ktwu01/benchmark-radar#model-card-adoption-rank) only counts documents a person has pointed at, so naming one we missed is the whole contribution. / 排行榜只统计有人提交过的文档，指出我们漏掉的一份就已经是贡献。"
 
   - type: input
     id: url
     attributes:
       label: Link to the document / 文档链接
-      description: Where the scores are published. If you know the model name and date, include them here too. / 分数发布在哪里；如果知道模型名和发布日期也一并贴上，方便核对。
+      description: Where the scores are published. / 分数发布在哪里。
       placeholder: https://example.com/frontier-1-model-card
     validations:
       required: true
@@ -30,15 +19,27 @@ body:
     id: benchmarks
     attributes:
       label: Which benchmarks does it report scores for / 报告了哪些 benchmark 分数
-      description: |
-        One per line, names as the document writes them. We will match them
-        to the names the site uses. Only list what it actually publishes a
-        score for.
-
-        每行一个，按原文名称写即可。只列文档实际给出分数的 benchmark。
+      description: One per line, named as the document writes them. / 每行一个，按原文名称写即可。
       placeholder: |
         GPQA Diamond
         SWE-bench Verified
         AIME 2025
     validations:
       required: true
+
+  - type: input
+    id: details
+    attributes:
+      label: Model and date / 模型与日期
+      description: Optional. / 可选。
+      placeholder: Frontier-1 by Acme, 2026-05-14
+    validations:
+      required: false
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Anything unusual about it / 需要特别说明的地方
+      description: Optional. For example a benchmark it names differently than everyone else. / 可选：例如它给 benchmark 起了别处没有的名字。
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -26,19 +26,3 @@ body:
       description: Who would use it and what task it makes faster or possible. / 谁会用到，它能让哪项任务更快、更清楚或从无法完成变为可以完成。
     validations:
       required: true
-
-  - type: textarea
-    id: users
-    attributes:
-      label: Who would use it? / 谁会使用 (optional / 可选)
-      description: Optional. Name the readers, researchers, or eval builders who need it — you can also just mention them above. / 可选：说明哪些读者或研究者会用到，也可直接写在上一栏。
-    validations:
-      required: false
-
-  - type: textarea
-    id: example
-    attributes:
-      label: Example, sketch, or link / 示例、草图或链接
-      description: Optional. Paste a screenshot, mockup, related product, paper, or dataset. / 可选：粘贴截图、草图、相关产品、论文或数据集。
-    validations:
-      required: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -4,18 +4,13 @@ labels: ["new feature"]
 body:
   - type: markdown
     attributes:
-      value: |
-        English or Chinese is fine. Describe what you want Benchmark Radar to
-        add, who would use it, and how it would improve their work.
-
-        中文也可以。请写清楚希望 Benchmark Radar 增加什么、谁会使用，
-        以及它能如何改善现有工作。
+      value: "English or Chinese is fine. Say what to add and who it helps. / 中英文均可。写清楚要加什么、对谁有用。"
 
   - type: textarea
     id: feature
     attributes:
       label: What should Benchmark Radar add? / 希望 Benchmark Radar 增加什么
-      description: Describe the capability, data source, workflow, or interface change you want. / 描述你希望增加的能力、数据源、工作流或界面改动。
+      description: A capability, data source, workflow, or interface change. / 一项能力、数据源、工作流或界面改动。
     validations:
       required: true
 
@@ -23,6 +18,22 @@ body:
     id: value
     attributes:
       label: Why is it worth adding? / 为什么值得加入
-      description: Who would use it and what task it makes faster or possible. / 谁会用到，它能让哪项任务更快、更清楚或从无法完成变为可以完成。
+      description: What task it makes faster, clearer, or possible at all. / 它能让哪件事更快、更清楚，或从做不到变成做得到。
     validations:
       required: true
+
+  - type: textarea
+    id: users
+    attributes:
+      label: Who would use it? / 谁会使用
+      description: Optional. / 可选。
+    validations:
+      required: false
+
+  - type: textarea
+    id: example
+    attributes:
+      label: Example, sketch, or link / 示例、草图或链接
+      description: Optional screenshot, mockup, paper, or dataset. / 可选：截图、草图、论文或数据集。
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/report.yml
+++ b/.github/ISSUE_TEMPLATE/report.yml
@@ -4,25 +4,13 @@ labels: ["bug"]
 body:
   - type: markdown
     attributes:
-      value: |
-        English or Chinese is fine. The fastest useful report says: what you
-        saw, where it happened, what you expected, and why it matters to a
-        reader.
-
-        中文也可以。最有用的反馈通常包括：你看到了什么、发生在哪里、
-        你期待看到什么、以及为什么这会影响读者理解。
+      value: "English or Chinese is fine. Say what you saw and what you expected instead. / 中英文均可。写清楚看到了什么、原本期待看到什么。"
 
   - type: textarea
     id: what
     attributes:
       label: What happened / 发生了什么
-      description: |
-        What you saw, and what you expected instead. A screenshot says it
-        faster than words: you can paste one straight into this box. If you
-        remember the page address, include it here too.
-
-        写清楚你实际看到的内容，以及你原本期待看到什么。截图通常比长
-        描述更快，可以直接粘贴到这里；记得页面地址的话一并贴上。
+      description: A screenshot pasted straight into this box says it fastest. / 直接把截图粘贴到这里最快。
     validations:
       required: true
 
@@ -30,7 +18,7 @@ body:
     id: where
     attributes:
       label: Where did you see it / 在哪里看到的
-      description: Optional. Paste the page address or just name the area. / 可选：贴页面地址或写页面/区域名称。
+      description: Optional. The page address, or just the area. / 可选：页面地址，或写页面名称。
       placeholder: https://koutian.is-a.dev/benchmark-radar/?view=leaderboard
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/use-case.yml
+++ b/.github/ISSUE_TEMPLATE/use-case.yml
@@ -4,19 +4,14 @@ labels: ["use-case"]
 body:
   - type: markdown
     attributes:
-      value: |
-        Independent use is the best signal that this project is useful. A short
-        note is enough, and a public link helps other eval builders learn from it.
-
-        中文也可以。请尽量写清楚：你在做什么、Benchmark Radar 帮你省了
-        哪一步、别人看完这个例子能学到什么。截图、链接或一句结论都很好。
+      value: "A short note is enough. A public link helps other eval builders learn from it. / 简短说明即可；附上公开链接，别人更容易参考。"
 
   - type: textarea
     id: use
     attributes:
       label: How did Benchmark Radar help? / Benchmark Radar 怎么帮到你
-      description: What you are building and which page, dataset, or benchmark was useful. / 你在做什么，以及哪个页面、数据集或 benchmark 帮到了你。
-      placeholder: An agent evaluation suite for customer-support workflows — the leaderboard helped us pick ... / 面向客服工作流的 agent 评测套件，排行榜帮我们选了 ...
+      description: What you are building, and which page or dataset was useful. / 你在做什么，哪个页面或数据集帮到了你。
+      placeholder: "An agent evaluation suite for customer support: the leaderboard helped us pick ... / 面向客服的 agent 评测套件，排行榜帮我们选了 ..."
     validations:
       required: true
 
@@ -24,6 +19,23 @@ body:
     id: worthy
     attributes:
       label: Why is this worth sharing? / 为什么值得分享
-      description: What should another reader notice first. / 另一个读者最应该先看到什么。
+      description: What another reader should notice first. / 另一个读者最应该先看到什么。
     validations:
       required: true
+
+  - type: input
+    id: link
+    attributes:
+      label: Public link / 公开链接
+      description: Optional project, paper, post, or repository. / 可选：项目、论文、帖子或仓库。
+      placeholder: https://example.com/my-eval-project
+    validations:
+      required: false
+
+  - type: textarea
+    id: feedback
+    attributes:
+      label: What would make it more useful? / 还希望它改进什么
+      description: Optional. / 可选。
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/use-case.yml
+++ b/.github/ISSUE_TEMPLATE/use-case.yml
@@ -27,19 +27,3 @@ body:
       description: What should another reader notice first. / 另一个读者最应该先看到什么。
     validations:
       required: true
-
-  - type: input
-    id: link
-    attributes:
-      label: Public link / 公开链接
-      description: Optional project, paper, post, repository, or evaluation link. / 可选：项目、论文、帖子、仓库或评测链接。
-      placeholder: https://example.com/my-eval-project
-    validations:
-      required: false
-
-  - type: textarea
-    id: feedback
-    attributes:
-      label: What would make it more useful? / 还希望它改进什么
-    validations:
-      required: false

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -107,6 +107,41 @@ function zeroItemSources(day) {
 // Only speaks when the source filter alone is active. With a second filter
 // on, the source's own zero is no longer the whole story, and guessing which
 // of the two emptied the list would be a worse answer than the general one.
+// The generic "no filter matches" case gives the reader a short recovery
+// checklist instead of a single sentence: two ways to widen the view, and a
+// way to ask for a benchmark that is genuinely missing (issue #386).
+function noFilterMatchNodes() {
+  return [
+    element("div", { className: "empty-state" }, [
+      element("p", { text: t("No observations match these filters.") }),
+      element("p", { className: "empty-state-try", text: t("Try:") }),
+      element("ol", { className: "empty-state-steps" }, [
+        element("li", { text: t("Clear one or more filters to widen the view.") }),
+        element("li", { text: t('Reset the date to "all dates".') }),
+        element("li", {}, [
+          document.createTextNode(t("Add your wanted benchmark as an ")),
+          element("a", {
+            text: t("issue"),
+            attrs: {
+              href: "https://github.com/ktwu01/benchmark-radar/issues/",
+              target: "_blank",
+              rel: "noopener",
+            },
+          }),
+          document.createTextNode("."),
+        ]),
+      ]),
+    ]),
+  ];
+}
+
+function emptyTodayNodes(day, benchmarkMatches = 0) {
+  const message = emptyTodayMessage(day, benchmarkMatches);
+  if (message === null) return noFilterMatchNodes();
+  return [element("p", { className: "empty-state", text: message })];
+}
+
+
 function emptyTodayMessage(day, benchmarkMatches = 0) {
   // A search that found the benchmark but no daily coverage of it is not a
   // filter that is set too narrow, and telling the reader to widen it sends
@@ -137,12 +172,13 @@ function emptyTodayMessage(day, benchmarkMatches = 0) {
   }
   const others = [state.q.trim(), state.kind, state.category, state.event].filter(Boolean);
   if (!state.source || others.length) {
-    return t("No observations match these filters. Clear one or more filters to widen the view.");
+    // Generic case: emptyTodayNodes() renders the recovery checklist (#386).
+    return null;
   }
   const wanted = state.source.trim().toLowerCase();
   const gap = zeroItemSources(day).find((entry) => entry.name.toLowerCase() === wanted);
   if (!gap) {
-    return t("No observations match these filters. Clear one or more filters to widen the view.");
+    return null;
   }
   // The three states from issue #260, said in the second person because the
   // reader is standing in front of the empty list asking about this source.
@@ -511,6 +547,12 @@ const I18N = {
     "No briefing was recorded for this day.": "这一天没有记录简报。",
     "No observations match these filters. Clear one or more filters to widen the view.":
       "没有符合条件的记录。清除一个或多个筛选条件以扩大范围。",
+    "No observations match these filters.": "没有符合这些筛选条件的记录。",
+    "Clear one or more filters to widen the view.": "清除一个或多个筛选条件以扩大范围。",
+    "Try:": "试试:",
+    'Reset the date to "all dates".': "将日期重置为“全部日期”。",
+    "Add your wanted benchmark as an ": "把你想要的 benchmark 作为一个",
+    issue: "issue 提交",
     "Evidence: ": "证据: ",
     "Attention: active": "关注度:活跃",
     "No categorized records in this scan.": "本次扫描没有分类记录。",
@@ -2107,12 +2149,7 @@ function renderToday({ resultsOnly = false } = {}) {
     listHost,
     visibleObservations.length
       ? visibleObservations.map((item, offset) => observationCard(item, pageStart + offset))
-      : [
-          element("p", {
-            className: "empty-state",
-            text: emptyTodayMessage(day, benchmarkMatches),
-          }),
-        ],
+      : emptyTodayNodes(day, benchmarkMatches),
   );
   byId("today-page-status").textContent = t(
     "Page {page} of {pages} · showing {start}–{end} of {total}",

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -1968,6 +1968,22 @@ td a {
   text-align: center;
 }
 
+.empty-state-try {
+  margin-top: 0.75rem;
+  font-weight: 600;
+}
+
+.empty-state-steps {
+  display: inline-block;
+  margin: 0.35rem 0 0;
+  padding-left: 1.25rem;
+  text-align: left;
+}
+
+.empty-state-steps li {
+  margin: 0.2rem 0;
+}
+
 .map-summary {
   display: block;
   margin-top: 0.35rem;

--- a/tests/test_issue_templates.py
+++ b/tests/test_issue_templates.py
@@ -57,8 +57,18 @@ def test_feature_request_form_has_a_small_required_core() -> None:
     fields = {field.get("id"): field for field in form["body"] if field.get("id")}
 
     assert form["labels"] == ["new feature"]
-    assert set(fields) == {"feature", "users", "value", "example"}
-    required_ids = ("feature", "value")
-    assert all(fields[field_id]["validations"]["required"] for field_id in required_ids)
-    assert fields["users"]["validations"]["required"] is False
-    assert fields["example"]["validations"]["required"] is False
+    # Issue #388: keep the form to two fields, both required, so it never asks
+    # for a third or fourth item.
+    assert set(fields) == {"feature", "value"}
+    assert all(fields[field_id]["validations"]["required"] for field_id in fields)
+
+
+def test_issue_forms_ask_for_at_most_two_fields() -> None:
+    # Issue #388: every form should collect at most two input fields, so a
+    # contributor never faces three or four boxes to fill.
+    for path in FORM_PATHS:
+        if path.name == "config.yml":
+            continue
+        form = load_yaml(path)
+        field_ids = [field.get("id") for field in form["body"] if field.get("id")]
+        assert len(field_ids) <= 2, f"{path.name} has {len(field_ids)} fields"

--- a/tests/test_issue_templates.py
+++ b/tests/test_issue_templates.py
@@ -57,18 +57,37 @@ def test_feature_request_form_has_a_small_required_core() -> None:
     fields = {field.get("id"): field for field in form["body"] if field.get("id")}
 
     assert form["labels"] == ["new feature"]
-    # Issue #388: keep the form to two fields, both required, so it never asks
-    # for a third or fourth item.
-    assert set(fields) == {"feature", "value"}
-    assert all(fields[field_id]["validations"]["required"] for field_id in fields)
+    assert set(fields) == {"feature", "users", "value", "example"}
+    required_ids = ("feature", "value")
+    assert all(fields[field_id]["validations"]["required"] for field_id in required_ids)
+    assert fields["users"]["validations"]["required"] is False
+    assert fields["example"]["validations"]["required"] is False
 
 
-def test_issue_forms_ask_for_at_most_two_fields() -> None:
-    # Issue #388: every form should collect at most two input fields, so a
-    # contributor never faces three or four boxes to fill.
+def test_issue_forms_keep_their_copy_short_and_on_one_line() -> None:
+    """Issue #388: the forms read as too much work to fill in.
+
+    The count of boxes was not the problem: two of the four were already
+    optional. The wall of prose above and beside them was. Block scalars are
+    how that prose grew, because a paragraph costs the same to write as a
+    sentence once the copy is already wrapped across lines, so every string a
+    contributor reads stays on one line and under a cap.
+    """
     for path in FORM_PATHS:
         if path.name == "config.yml":
             continue
+
         form = load_yaml(path)
-        field_ids = [field.get("id") for field in form["body"] if field.get("id")]
-        assert len(field_ids) <= 2, f"{path.name} has {len(field_ids)} fields"
+        for field in form["body"]:
+            attributes = field["attributes"]
+            if field["type"] == "markdown":
+                value = attributes["value"].strip()
+                where = f"{path.name}: markdown introduction"
+                assert "\n" not in value, f"{where} is wrapped across lines"
+                assert len(value) <= 260, f"{where} is {len(value)} chars"
+                continue
+
+            if description := attributes.get("description", "").strip():
+                where = f"{path.name}: {field['id']} description"
+                assert "\n" not in description, f"{where} is wrapped across lines"
+                assert len(description) <= 120, f"{where} is {len(description)} chars"

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1810,7 +1810,7 @@ def test_an_empty_source_filter_says_why_instead_of_blaming_the_filter():
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
 
     # The empty list asks the helper rather than hardcoding one sentence.
-    assert "text: emptyTodayMessage(day, benchmarkMatches)," in script
+    assert "emptyTodayNodes(day, benchmarkMatches)" in script
     assert "function emptyTodayMessage(day" in script
 
     # It reuses issue #260's three states rather than inventing a fourth
@@ -1827,13 +1827,27 @@ def test_an_empty_source_filter_says_why_instead_of_blaming_the_filter():
     # second filter on, which one did it is a guess.
     assert "others.length" in helper
 
-    # Every sentence it can print is translated, including the general one,
-    # which shipped untranslated before this change.
+    # Every source-specific sentence it can print is translated: the English
+    # key the call site passes and the zh value it looks up.
     for phrase in (
-        "No observations match these filters. Clear one or more filters to widen the view.",
+        "{source} could not be reached on this day, so nothing was collected from it.",
         "Try another date, or clear the filter.",
     ):
         assert script.count(f'"{phrase}"') >= 2, phrase
+
+    # The generic "too narrow" case (issue #386) no longer prints one sentence.
+    # It returns null so emptyTodayNodes() can render a recovery checklist: two
+    # ways to widen the view and a link to open an issue for a missing benchmark.
+    assert "function emptyTodayNodes(day" in script
+    assert "function noFilterMatchNodes()" in script
+    for phrase in (
+        "No observations match these filters.",
+        "Clear one or more filters to widen the view.",
+        'Reset the date to "all dates".',
+        "Add your wanted benchmark as an ",
+    ):
+        assert script.count(f'"{phrase}"') >= 2 or script.count(f"'{phrase}'") >= 2, phrase
+    assert "github.com/ktwu01/benchmark-radar/issues/" in script
 
 
 def test_a_benchmark_name_search_reaches_the_registry_not_only_the_daily_feed():


### PR DESCRIPTION
Closes #388, closes #386.

## #388 — issue forms felt like too much work

The number of boxes was not the problem: two of the four were already optional. The prose around them was. Every label, description, and intro is now one line, with no wrapped block scalars, which is what let the copy grow in the first place.

All input boxes are kept as they were.

| Form | Boxes | Copy a contributor reads |
| --- | --- | --- |
| `add-model-card` | 4 (2 required) | 1185 → 457 chars (-61%) |
| `report` | 2 (1 required) | 516 → 240 chars (-53%) |
| `feature-request` | 4 (2 required) | 619 → 324 chars (-48%) |
| `use-case` | 4 (2 required) | 469 → 320 chars (-32%) |

A test holds the line: prose stays on one line and under a length cap, so a future paragraph fails CI.

## #386 — empty "no matches" state

The generic case now shows a short recovery checklist instead of one sentence:

1. Clear one or more filters to widen the view.
2. Reset the date to "all dates".
3. Add your wanted benchmark as an [issue](https://github.com/ktwu01/benchmark-radar/issues/).

"issue" is a real link. Chinese translations, CSS, and tests included; verified in the browser in both languages.

The date-as-a-filter idea from the issue notes is a larger UX change, left for a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
