### PR TITLE
Update README showcase to SWE-bench Verified

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ web. It pulls evidence from arXiv, GitHub, Hugging Face, OpenAlex, OpenReview,
 first-party lab feeds, Brave Search, Semantic Scholar, Hacker News, and more
 every day, and keeps updating.
 
-**Click the image to watch how reported AIME 2025 scores saturated over time.**
+**Find a benchmark in seconds, then see how model scores change over time. Click
+the GIF below to watch SWE-bench Verified move toward saturation.**
 
-<a href="https://koutian.is-a.dev/benchmark-radar/?view=leaderboard&lfrontier=llm-stats-aime-2025">
-  <img src="assets/aime-2025-leaderboard.png" alt="AIME 2025 leaderboard frontier chart, plotting every reported score against each model's release date" width="720" />
+<a href="https://koutian.is-a.dev/benchmark-radar/?view=leaderboard&lfrontier=swe_bench_verified">
+  <img src="assets/swe-bench-verified.gif" alt="Animated demo of searching for SWE-bench Verified and viewing its model scores over time" width="720" />
 </a>
 
 ## Use it
@@ -59,9 +60,9 @@ Scan the QR code to join the WeChat group for daily benchmark updates and eval d
 
 ## Acknowledgements
 
-The frontier-model score layer (including the AIME 2025 chart above) is built on
-benchmark data collected by [LLM Stats](https://llm-stats.com). Thank you for
-keeping that data open.
+The frontier-model score layer, including the SWE-bench Verified timeline above,
+is built on benchmark data collected by [LLM Stats](https://llm-stats.com).
+Thank you for keeping that data open.
 
 ## Citation
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -19,10 +19,11 @@
 做 benchmark 研究的时候发现新东西太多了，所以我搞了这个持续爬虫，每天自动从全网抓新的 benchmark 相关信息。它目前每天从 arXiv、GitHub、Hugging Face、OpenAlex、OpenReview、各家实验室官方 feed、Brave Search、Semantic Scholar、Hacker News 等来源采集，并持续更新。你如果需要寻找 related work 或找到适合eval自己的agent 的 bench 或者关注最新的 eval 进展，可以看这里哈哈哈：
 github.com/ktwu01/benchmark-radar，每天更新，并支持一键导出数据
 
-**点击图片即可查看 AIME 2025 报告分数随时间逐渐饱和的过程。**
+**几秒找到一个 benchmark，再看模型成绩如何随时间变化。点击下面的动图，查看
+SWE-bench Verified 的 saturation 过程。**
 
-<a href="https://koutian.is-a.dev/benchmark-radar/?view=leaderboard&lfrontier=llm-stats-aime-2025">
-  <img src="assets/aime-2025-leaderboard.png" alt="AIME 2025 模型报告分数随发布日期变化的前沿图" width="720" />
+<a href="https://koutian.is-a.dev/benchmark-radar/?view=leaderboard&lfrontier=swe_bench_verified">
+  <img src="assets/swe-bench-verified.gif" alt="搜索 SWE-bench Verified 并查看模型成绩随时间变化的动画演示" width="720" />
 </a>
 
 ## 使用方法
@@ -54,7 +55,7 @@ github.com/ktwu01/benchmark-radar，每天更新，并支持一键导出数据
 
 ## 感谢
 
-前沿模型分数层（包括上方的 AIME 2025 图表）基于 [LLM Stats](https://llm-stats.com) 采集的 benchmark 数据构建，感谢他们把这些数据公开出来。
+前沿模型分数层（包括上方的 SWE-bench Verified 时间线）基于 [LLM Stats](https://llm-stats.com) 采集的 benchmark 数据构建，感谢他们把这些数据公开出来。
 
 ## 引用
 

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -40,8 +40,10 @@ def test_readmes_offer_free_data_and_an_earned_star_request():
     assert "[README.zh-CN.md](README.zh-CN.md)" not in english
     assert '<div align="left">' in chinese.split("# Benchmark Radar")[0]
     assert "[English](README.md)" in chinese
-    assert "Click the image" in english
-    assert "点击图片" in chinese
+    assert "Click" in english and "the GIF below" in english
+    assert "点击下面的动图" in chinese
+    assert "assets/swe-bench-verified.gif" in english
+    assert "assets/swe-bench-verified.gif" in chinese
     assert "data/radar.json" in english and "no crawler or contact required" in english
     assert "data/radar.json" in chinese and "无需爬虫或联系作者" in chinese
     assert "star the repository" in english


### PR DESCRIPTION
## Summary

- replace the removed AIME 2025 image with the SWE-bench Verified GIF in both READMEs
- add bilingual saturation copy and update the LLM Stats acknowledgements
- update the README regression test for the new showcase

## Testing

- `ruff check .`
- `ruff format --check .`
- `benchmark-radar normalize-external`
- `benchmark-radar classify`
- `pytest -q` (939 passed)