### PR TITLE
Show the Today and Leaderboard pages in both READMEs (#357)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,22 @@ the GIF below to watch SWE-bench Verified move toward saturation.**
   <img src="assets/swe-bench-verified.gif" alt="Animated demo of searching for SWE-bench Verified and viewing its model scores over time" width="720" />
 </a>
 
+## See the dashboard
+
+**Today: everything that showed up in the last 24 hours, scored and ranked, plus
+a short daily briefing that says what changed and links the evidence it used.**
+
+<a href="https://koutian.is-a.dev/benchmark-radar/">
+  <img src="assets/intro-today-page.gif" alt="Animated tour of the Today page: the ranked feed of newly found benchmarks and the daily briefing with its cited evidence" width="720" />
+</a>
+
+**Leaderboard: which benchmarks labs actually report in their model cards, and
+how scores on each one climb until there is almost no headroom left.**
+
+<a href="https://koutian.is-a.dev/benchmark-radar/?view=leaderboard">
+  <img src="assets/intro-leaderboard-page.gif" alt="Animated tour of the Leaderboard page: benchmarks ranked by model-card adoption, a scores-over-time chart, and remaining-headroom cards" width="720" />
+</a>
+
 ## Use it
 
 - **[Open the dashboard](https://koutian.is-a.dev/benchmark-radar/)** — today's insights, trends, popular benchmarks, model-card adoption, and more

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -26,6 +26,22 @@ SWE-bench Verified 的 saturation 过程。**
   <img src="assets/swe-bench-verified.gif" alt="搜索 SWE-bench Verified 并查看模型成绩随时间变化的动画演示" width="720" />
 </a>
 
+## 看看这个 dashboard
+
+**Today：过去 24 小时新出现的东西，全部打分排序，再配一段每日简报，说明发生了
+什么变化，并附上它引用的证据。**
+
+<a href="https://koutian.is-a.dev/benchmark-radar/">
+  <img src="assets/intro-today-page.gif" alt="Today 页面动画演示：新发现 benchmark 的排序信息流，以及附带证据引用的每日简报" width="720" />
+</a>
+
+**Leaderboard：各家模型卡到底最常报告哪些 benchmark，以及每个 benchmark 的成绩
+如何一路上涨，直到几乎没有提升空间。**
+
+<a href="https://koutian.is-a.dev/benchmark-radar/?view=leaderboard">
+  <img src="assets/intro-leaderboard-page.gif" alt="Leaderboard 页面动画演示：按模型卡采用度排序的 benchmark、成绩随时间变化的图表，以及剩余提升空间卡片" width="720" />
+</a>
+
 ## 使用方法
 
 - **[打开 dashboard](https://koutian.is-a.dev/benchmark-radar/)** — 每日洞察、趋势、热门 benchmark、模型卡采用排名等


### PR DESCRIPTION
Closes #357.

Both READMEs showed one GIF (SWE-bench Verified saturation). This adds a
**See the dashboard** section using the two GIFs already committed in `assets/`:

- `assets/intro-today-page.gif` — the ranked daily feed plus the daily briefing and its cited evidence, linked to the live dashboard.
- `assets/intro-leaderboard-page.gif` — benchmarks ranked by model-card adoption, the scores-over-time chart, and the remaining-headroom cards, linked to `?view=leaderboard`.

Each GIF gets a one-line caption above it so a reader knows what the page is for
before the animation loops. English and Chinese copy are kept in sync.

Local CI passed in a clean worktree: `ruff check`, `ruff format --check`,
`normalize-external`, `classify`, then `pytest -q` (939 passed).

Please merge with a merge commit, not a squash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)