### PR TITLE
Fix missed arXiv benchmarks and expose card metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"

--- a/.github/workflows/daily-radar.yml
+++ b/.github/workflows/daily-radar.yml
@@ -2,13 +2,12 @@ name: Daily Benchmark Radar
 
 on:
   schedule:
-    # One run daily at 01:00 UTC = 09:00 Asia/Singapore (UTC+8, no DST), timed
-    # so the GPT briefing and Q&A read same-day insight over breakfast in
-    # Singapore. Supersedes the twice-daily Chicago-anchored schedule from
-    # issues #44/#104: that pair existed for same-day retry coverage against
-    # missed evidence, which this single run trades away for a predictable,
-    # once-a-day cadence.
-    - cron: "0 1 * * *"
+    # One run daily at 05:00 UTC = 13:00 Asia/Singapore (UTC+8, no DST).
+    # arXiv's category RSS bulletin is dated 04:00 UTC; the former 01:00 UTC
+    # run could finish before that day's feed was populated and miss a paper
+    # until the following scan (issue #379). Keep one predictable daily run,
+    # but place it after the source we promise to cover has published.
+    - cron: "0 5 * * *"
   workflow_dispatch:
     inputs:
       publish:

--- a/.github/workflows/weekly-jargon.yml
+++ b/.github/workflows/weekly-jargon.yml
@@ -2,10 +2,10 @@ name: Weekly Jargon Audit
 
 on:
   schedule:
-    # Mondays 02:00 UTC = 10:00 Asia/Singapore, an hour after the daily radar
-    # so the two never contend for the same runner. Weekly rather than daily
+    # Mondays 02:00 UTC = 10:00 Asia/Singapore. Weekly rather than daily
     # because the copy changes slowly and a report nobody has had time to act
-    # on is a report that gets skimmed (issue #241).
+    # on is a report that gets skimmed (issue #241). This audit is independent
+    # of the daily collection job and intentionally runs on its own schedule.
     - cron: "0 2 * * 1"
   workflow_dispatch:
 

--- a/config.yml
+++ b/config.yml
@@ -132,7 +132,10 @@ sources:
     # shared-IP quota. Use official category RSS feeds and filter locally.
     # Atom parsing remains available for deployments with a stable egress IP.
     atom_enabled: false
-    rss_categories: [cs.AI, cs.CL, cs.CV]
+    # Software-agent benchmarks can be primary cs.SE rather than cross-listed
+    # into the three general AI feeds. Include that first-party category so a
+    # named SWE benchmark is not dependent on a cross-list (issue #379).
+    rss_categories: [cs.AI, cs.CL, cs.CV, cs.SE]
     # "benchmark"/"evaluation"/"dataset" alone match most ML papers, since
     # almost every paper evaluates on some existing benchmark. cs.AI+cs.CL+cs.CV
     # publish 700+ papers a day, and the old bare-word list matched roughly two
@@ -141,6 +144,11 @@ sources:
     # merely using one, which cuts matches to about one in ten.
     rss_keywords:
       - benchmark for
+      # Named suites often end the title with "Bench:" and put the full word
+      # only after their name (for example SWE Refactor Bench). The leading
+      # space catches that form without matching compounds such as Workbench:
+      # or Test-Bench: (issue #379).
+      - " bench:"
       - new benchmark
       - novel benchmark
       - benchmark dataset

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -431,6 +431,15 @@ const I18N = {
     "Sort: New releases first, then Priority ↓": "排序:新发布优先,再按优先度 ↓",
     "Sort: Date, then new releases, then Priority ↓": "排序:日期,再新发布优先,再按优先度 ↓",
     "Sort: Date ↓": "排序:日期 ↓",
+    Stars: "Star 数",
+    Forks: "Fork 数",
+    Likes: "点赞数",
+    Downloads: "下载数",
+    Citations: "引用数",
+    "Influential citations": "高影响力引用数",
+    "Source metadata": "来源元数据",
+    "Activity counters": "活跃度数据",
+    "Not reported by this source": "该来源未报告",
     // --- Leaderboard ---------------------------------------------------------
     "Which benchmarks do model cards report?": "模型卡报告了哪些benchmark?",
     "What does this source record?": "这个来源记录了什么？",
@@ -1508,6 +1517,77 @@ function definition(label, value) {
     element("dt", { text: label }),
     element("dd", { text: value }),
   ]);
+}
+
+const RECORD_METRIC_LABELS = {
+  stars: "Stars",
+  forks: "Forks",
+  likes: "Likes",
+  downloads: "Downloads",
+  citations: "Citations",
+  influential_citations: "Influential citations",
+};
+
+function compactNames(values, limit = 2) {
+  const names = [...new Set((values || []).map((value) => String(value).trim()).filter(Boolean))];
+  if (!names.length) return "";
+  const shown = names.slice(0, limit).join(", ");
+  return names.length > limit ? `${shown} +${names.length - limit}` : shown;
+}
+
+// Source facts are different from score components. A counter appears only
+// when its connector supplied that field; an absent counter is labelled as
+// unreported rather than rendered as zero. This lets a reader audit Adoption 0
+// for sources that publish activity counters while making sources without
+// those counters explicit (issue #361).
+function recordFactEntries(item) {
+  const facts = [];
+  const organizations = compactNames(item.organizations);
+  const authors = compactNames(item.authors);
+  if (organizations) facts.push([t("Organizations"), organizations]);
+  if (authors) facts.push([t("Authors"), authors]);
+  const metrics = item.metrics || {};
+  let metricCount = 0;
+  Object.entries(RECORD_METRIC_LABELS).forEach(([key, label]) => {
+    if (!Object.hasOwn(metrics, key)) return;
+    const rawValue = metrics[key];
+    const value = Number(rawValue);
+    if (rawValue === null || rawValue === undefined || !Number.isFinite(value)) return;
+    const locale = getLang() === "zh" ? "zh-CN" : "en-US";
+    facts.push([t(label), value.toLocaleString(locale)]);
+    metricCount += 1;
+  });
+  if (!metricCount) facts.push([t("Activity counters"), t("Not reported by this source")]);
+  return facts;
+}
+
+function recordDateEntries(item) {
+  const entries = [];
+  if (item.published_at) {
+    entries.push([t("Published"), formatDate(item.published_at, { dateStyle: "medium" })]);
+  }
+  if (item.updated_at && item.updated_at !== item.published_at) {
+    entries.push([t("Updated"), formatDate(item.updated_at, { dateStyle: "medium" })]);
+  }
+  return entries;
+}
+
+function recordFacts(item) {
+  const facts = recordFactEntries(item);
+  if (!facts.length) return null;
+  return element(
+    "div",
+    {
+      className: "record-facts",
+      attrs: { role: "group", "aria-label": t("Source metadata") },
+    },
+    facts.map(([label, value]) =>
+      element("span", {}, [
+        element("strong", { text: label }),
+        document.createTextNode(`: ${value}`),
+      ]),
+    ),
+  );
 }
 
 function safeHttpUrl(value) {
@@ -3217,6 +3297,8 @@ function openRubric(item = null, versionOverride = null) {
 function expandedRecord(item, teaser) {
   const isAttention = item.observation_kind === "attention";
   const primaryArtifact = item.primary_artifact_url || item.artifact_urls?.[0];
+  const sourceFacts = recordFactEntries(item);
+  const sourceDates = recordDateEntries(item);
   const scoreEntries = isAttention
     ? [
         [
@@ -3235,6 +3317,8 @@ function expandedRecord(item, teaser) {
         // Adoption is weighted into the total, so hiding it here left the
         // four shown components unable to explain the priority above them.
         [t("Adoption"), Number(item.adoption_score || 0).toFixed(2)],
+        ...sourceDates,
+        ...sourceFacts,
       ];
   const rationale = element(
     "ul",
@@ -7417,6 +7501,10 @@ function observationCard(item, index) {
       // instead of classifying the item before it is named (issue #248).
       element("h3", { text: item.title }),
       metadata,
+      // Attention rows already show their source-specific points, comments,
+      // and submissions in attentionActivity; the generic facts helper does
+      // not understand those counters and would incorrectly call them absent.
+      isAttention ? null : recordFacts(item),
       ...(item.watchlist && item.watchlist_note
         ? [element("p", { className: "signal-tldr", text: item.watchlist_note })]
         : []),

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -1116,6 +1116,24 @@ input {
   font-weight: 600;
 }
 
+/* Raw source facts sit on their own quiet line. They are visible before a
+   card is opened because they are the evidence behind the derived Adoption
+   score, but they stay typographically below the title and provenance. */
+.record-facts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.2rem 0.85rem;
+  margin: 0 0 0.65rem;
+  color: var(--muted);
+  font-family: var(--utility);
+  font-size: 0.75rem;
+}
+
+.record-facts strong {
+  color: var(--ink);
+  font-weight: 600;
+}
+
 /* The one line saying why a tracked artifact matters, ahead of upstream prose. */
 .signal-tldr {
   margin-bottom: 0.35rem;

--- a/src/benchmark_radar/models.py
+++ b/src/benchmark_radar/models.py
@@ -20,6 +20,7 @@ class RadarItem:
     summary: str = ""
     event_kind: str = "discovered"
     authors: list[str] = field(default_factory=list)
+    organizations: list[str] = field(default_factory=list)
     artifact_urls: list[str] = field(default_factory=list)
     metrics: dict[str, float] = field(default_factory=dict)
     raw: dict[str, Any] = field(default_factory=dict, repr=False)

--- a/src/benchmark_radar/pipeline.py
+++ b/src/benchmark_radar/pipeline.py
@@ -98,6 +98,9 @@ def deduplicate(items: list[RadarItem]) -> list[RadarItem]:
             for author in item.authors:
                 if author not in existing.authors:
                     existing.authors.append(author)
+            for organization in item.organizations:
+                if organization not in existing.organizations:
+                    existing.organizations.append(organization)
             # A record with no description loses nothing by adopting one that
             # has it; a record that already has one keeps its own.
             if not existing.summary.strip() and item.summary.strip():

--- a/src/benchmark_radar/sources.py
+++ b/src/benchmark_radar/sources.py
@@ -950,6 +950,14 @@ def fetch_openalex(
                 authorship.get("author", {}).get("display_name", "")
                 for authorship in row.get("authorships", [])
             ]
+            organizations = list(
+                dict.fromkeys(
+                    str(institution.get("display_name") or "").strip()
+                    for authorship in row.get("authorships", [])
+                    for institution in (authorship.get("institutions") or [])
+                    if str(institution.get("display_name") or "").strip()
+                )
+            )
             primary = row.get("primary_location") or {}
             url = row.get("doi") or primary.get("landing_page_url") or row["id"]
             # OpenAlex publishes a date, not a timestamp, so an exact cutoff
@@ -985,6 +993,7 @@ def fetch_openalex(
                 published_at=published,
                 event_kind="released",
                 authors=[author for author in authors if author],
+                organizations=organizations,
                 metrics={"citations": float(row.get("cited_by_count") or 0)},
                 raw=row,
                 parser_version="openalex-works/1",

--- a/tests/record_facts_harness.mjs
+++ b/tests/record_facts_harness.mjs
@@ -1,0 +1,52 @@
+// Execute the real metadata helpers from app.js so the test proves missing
+// versus zero behavior rather than matching implementation source strings.
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(here, "..", "site", "assets", "app.js"), "utf8");
+const start = source.indexOf("const RECORD_METRIC_LABELS");
+const end = source.indexOf("\nfunction safeHttpUrl", start);
+if (start < 0 || end < 0) throw new Error("Record metadata helpers not found");
+
+globalThis.t = (value) => value;
+globalThis.getLang = () => "en";
+globalThis.formatDate = (value) => `date:${value}`;
+globalThis.document = { createTextNode: (text) => ({ text }) };
+globalThis.element = (tag, props = {}, children = []) => ({ tag, props, children });
+const harness = `${source.slice(start, end)}
+globalThis.__recordFactEntries = recordFactEntries;
+globalThis.__recordDateEntries = recordDateEntries;
+globalThis.__recordFacts = recordFacts;`;
+new Function(harness)();
+
+const reportedItem = {
+  organizations: ["OpenAI"],
+  authors: ["Alice", "Bob", "Carol"],
+  metrics: { stars: 0, forks: null },
+};
+const reported = globalThis.__recordFactEntries(reportedItem);
+const unreported = globalThis.__recordFactEntries({
+  authors: ["Deyao Hong"],
+  metrics: {},
+});
+const dates = globalThis.__recordDateEntries({
+  published_at: "2026-08-24T17:59:04Z",
+  updated_at: "2026-08-25T17:59:04Z",
+});
+const rendered = globalThis.__recordFacts(reportedItem);
+
+console.log(
+  JSON.stringify({
+    reported,
+    unreported,
+    dates,
+    rendered: {
+      tag: rendered.tag,
+      className: rendered.props.className,
+      role: rendered.props.attrs.role,
+      ariaLabel: rendered.props.attrs["aria-label"],
+    },
+  }),
+);

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -409,6 +409,19 @@ def test_daily_radar_yml_enables_and_requires_questions_in_production():
     assert str(env.get("OPENAI_QUESTIONS_REQUIRED")).lower() == "true"
 
 
+def test_daily_radar_runs_after_the_arxiv_rss_bulletin():
+    """Issue #379: a 01:00 UTC run could precede arXiv's 04:00 UTC feed."""
+    workflow_path = Path(".github/workflows/daily-radar.yml")
+    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    trigger = workflow.get("on", workflow.get(True))
+
+    schedules = trigger["schedule"]
+    assert len(schedules) == 1
+    minute, hour, *_ = schedules[0]["cron"].split()
+    assert minute == "0"
+    assert int(hour) >= 5
+
+
 def test_pages_rebuilds_when_any_package_module_changes():
     """Dashboard output depends on transitive package imports, not snapshots.py alone."""
     workflow_path = Path(".github/workflows/pages.yml")

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -982,6 +982,7 @@ def test_dedupe_preserves_authors_and_summary_from_the_absorbed_copy():
         title="Same Long Title For Merge Testing Purposes",
         url="https://github.com/org/repo2",
         authors=["Alice"],
+        organizations=["Example Lab"],
         summary="A real card.",
     )
     bare = item(
@@ -990,11 +991,13 @@ def test_dedupe_preserves_authors_and_summary_from_the_absorbed_copy():
         source_id="9999.1111",
         summary="",
         authors=["Bob"],
+        organizations=["Example University"],
         published_at=datetime(2026, 7, 27, 6, tzinfo=UTC),
     )
     merged = deduplicate([described, bare])[0]
 
     assert set(merged.authors) == {"Alice", "Bob"}
+    assert set(merged.organizations) == {"Example Lab", "Example University"}
     assert merged.summary == "A real card."
 
 

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -443,6 +443,47 @@ def test_attention_signals_use_activity_metrics_not_quality_scores():
     assert "evidence_score: 0" not in script
 
 
+def test_evidence_cards_show_fetched_source_metadata_without_inventing_zeroes():
+    """Issue #361: raw facts must be visible beside the derived score."""
+    import json
+    import shutil
+    import subprocess
+
+    styles = Path("site/assets/styles.css").read_text(encoding="utf-8")
+
+    node = shutil.which("node")
+    assert node is not None, "Node.js is required for the site behavior tests"
+    result = subprocess.run(
+        [node, "tests/record_facts_harness.mjs"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=True,
+    )
+    facts = json.loads(result.stdout)
+
+    assert facts["reported"] == [
+        ["Organizations", "OpenAI"],
+        ["Authors", "Alice, Bob +1"],
+        ["Stars", "0"],
+    ]
+    assert facts["unreported"] == [
+        ["Authors", "Deyao Hong"],
+        ["Activity counters", "Not reported by this source"],
+    ]
+    assert facts["dates"] == [
+        ["Published", "date:2026-08-24T17:59:04Z"],
+        ["Updated", "date:2026-08-25T17:59:04Z"],
+    ]
+    assert facts["rendered"] == {
+        "tag": "div",
+        "className": "record-facts",
+        "role": "group",
+        "ariaLabel": "Source metadata",
+    }
+    assert ".record-facts" in styles
+
+
 def test_main_filters_use_persisted_attention_and_snapshot_dates():
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
     html = Path("site/index.html").read_text(encoding="utf-8")

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,7 +1,9 @@
 from datetime import UTC, datetime
+from pathlib import Path
 from urllib.error import HTTPError
 
 import pytest
+import yaml
 
 from benchmark_radar.http import RequestError
 from benchmark_radar.models import RadarItem
@@ -157,6 +159,24 @@ Abstract: A benchmark recovered from the official category feed.</description>
 </rss>
 """
 
+SWE_REFACTOR_RSS = """\
+<rss xmlns:arxiv="http://arxiv.org/schemas/atom"
+     xmlns:dc="http://purl.org/dc/elements/1.1/" version="2.0">
+  <channel>
+    <item>
+      <title>SWE Refactor Bench: Can Coding Agents Complete a Long-Horizon Migration?</title>
+      <link>https://arxiv.org/abs/2608.23564</link>
+      <description>arXiv:2608.23564v1 Announce Type: new
+Abstract: We introduce SWE Refactor Bench, a benchmark comprising 20 migrations.</description>
+      <guid isPermaLink="false">oai:arXiv.org:2608.23564v1</guid>
+      <pubDate>Wed, 26 Aug 2026 00:00:00 -0400</pubDate>
+      <arxiv:announce_type>new</arxiv:announce_type>
+      <dc:creator>Deyao Hong, Yizhe Chi</dc:creator>
+    </item>
+  </channel>
+</rss>
+"""
+
 
 def test_arxiv_uses_overlap_and_updated_timestamp(monkeypatch):
     calls = []
@@ -233,6 +253,69 @@ def test_arxiv_can_use_official_rss_as_primary(monkeypatch):
     )
 
     assert [item.source_id for item in items] == ["2607.54321"]
+
+
+def test_arxiv_config_keeps_named_bench_releases(monkeypatch):
+    """Issue #379: `SWE Refactor Bench:` used no configured exact phrase."""
+    config = yaml.safe_load(Path("config.yml").read_text(encoding="utf-8"))["sources"]["arxiv"]
+    requested = []
+
+    def fake_get_text(url, params=None):
+        assert params is None
+        requested.append(url)
+        if url == "https://rss.arxiv.org/rss/cs.SE":
+            return SWE_REFACTOR_RSS
+        return "<rss version='2.0'><channel /></rss>"
+
+    monkeypatch.setattr("benchmark_radar.sources.get_text", fake_get_text)
+
+    items = fetch_arxiv(config, datetime(2026, 8, 26, 5, tzinfo=UTC), 10)
+
+    assert [item.source_id for item in items] == ["2608.23564"]
+    assert requested == [
+        "https://rss.arxiv.org/rss/cs.AI",
+        "https://rss.arxiv.org/rss/cs.CL",
+        "https://rss.arxiv.org/rss/cs.CV",
+        "https://rss.arxiv.org/rss/cs.SE",
+    ]
+
+
+def test_openalex_carries_author_institutions(monkeypatch):
+    monkeypatch.setenv("OPENALEX_API_KEY", "key")
+    monkeypatch.setattr(
+        "benchmark_radar.sources.get_json",
+        lambda url, params: {
+            "results": [
+                {
+                    "id": "https://openalex.org/W1",
+                    "display_name": "Institution-backed benchmark",
+                    "publication_date": "2026-08-26",
+                    "primary_location": {"landing_page_url": "https://example.com/w1"},
+                    "authorships": [
+                        {
+                            "author": {"display_name": "Radar Author"},
+                            "institutions": [
+                                {"display_name": "Example University"},
+                                {"display_name": "Example University"},
+                                {"display_name": "Example Lab"},
+                            ],
+                        }
+                    ],
+                    "cited_by_count": 0,
+                }
+            ]
+        },
+    )
+
+    items = fetch_openalex(
+        {"searches": ["benchmark"]},
+        datetime(2026, 8, 25, tzinfo=UTC),
+        10,
+        now=datetime(2026, 8, 26, 12, tzinfo=UTC),
+    )
+
+    assert items[0].authors == ["Radar Author"]
+    assert items[0].organizations == ["Example University", "Example Lab"]
 
 
 def test_arxiv_rejects_incompatible_empty_rss_document(monkeypatch):


### PR DESCRIPTION
## What this fixes

- Catches named `Bench:` arXiv releases, includes the `cs.SE` feed, and runs collection after the 04:00 UTC arXiv bulletin so daily submissions are not one scan late.
- Shows source-provided authors, organizations, publication dates, and activity counters directly on benchmark cards.
- Keeps a real zero distinct from a missing counter and labels unavailable activity data honestly.
- Carries OpenAlex affiliations through collection and deduplication.

## Why it matters

SWE Refactor Bench (`arXiv:2608.23564`) was missing from the radar, and readers could not inspect the source facts behind a card adoption score. These changes make discovery timely and the score inputs visible at a glance.

## Verification

- Clean checkout: `ruff check .`
- Clean checkout: `ruff format --check .`
- Clean checkout: `benchmark-radar normalize-external`
- Clean checkout: `benchmark-radar classify`
- Clean checkout: `pytest -q` — 943 passed
- Chrome local preview verified in English and Chinese with no console warnings or errors

Closes #361
Closes #379