### PR TITLE
Fix silent radar pipeline data errors

### DIFF
--- a/src/benchmark_radar/corpus.py
+++ b/src/benchmark_radar/corpus.py
@@ -49,7 +49,8 @@ def _arxiv_id(path: str) -> str | None:
     match = re.search(r"/(?:abs|pdf)/([^/?#]+)", path, flags=re.IGNORECASE)
     if not match:
         return None
-    return re.sub(r"v\d+$", "", match.group(1), flags=re.IGNORECASE).lower()
+    identifier = re.sub(r"\.pdf$", "", match.group(1), flags=re.IGNORECASE)
+    return re.sub(r"v\d+$", "", identifier, flags=re.IGNORECASE).lower()
 
 
 def _exact_candidates(item: dict[str, Any]) -> list[tuple[int, str]]:

--- a/src/benchmark_radar/pipeline.py
+++ b/src/benchmark_radar/pipeline.py
@@ -72,6 +72,37 @@ def dedupe_keys(item: RadarItem) -> list[str]:
 
 
 def deduplicate(items: list[RadarItem]) -> list[RadarItem]:
+    def merge_into(target: RadarItem, duplicate: RadarItem) -> None:
+        if duplicate.url != target.url and duplicate.url not in target.artifact_urls:
+            target.artifact_urls.append(duplicate.url)
+        target.metrics.update(
+            {
+                metric: max(value, target.metrics.get(metric, 0))
+                for metric, value in duplicate.metrics.items()
+            }
+        )
+        # The merged copy is dropped, so keep the corroboration it carried:
+        # a cross-source link is exactly what the evidence component reads.
+        for url in duplicate.artifact_urls:
+            if url != target.url and url not in target.artifact_urls:
+                target.artifact_urls.append(url)
+        for author in duplicate.authors:
+            if author not in target.authors:
+                target.authors.append(author)
+        for organization in duplicate.organizations:
+            if organization not in target.organizations:
+                target.organizations.append(organization)
+        # A record with no description loses nothing by adopting one that has
+        # it; a record that already has one keeps its own.
+        if not target.summary.strip() and duplicate.summary.strip():
+            target.summary = duplicate.summary
+        for rationale in duplicate.rationale:
+            if rationale not in target.rationale:
+                target.rationale.append(rationale)
+        note = f"Also found via {duplicate.source}"
+        if note not in target.rationale:
+            target.rationale.append(note)
+
     kept: dict[str, RadarItem] = {}
     order: list[RadarItem] = []
     for item in sorted(
@@ -80,43 +111,31 @@ def deduplicate(items: list[RadarItem]) -> list[RadarItem]:
         reverse=True,
     ):
         keys = dedupe_keys(item)
-        existing = next((kept[key] for key in keys if key in kept), None)
-        if existing:
-            if item.url not in existing.artifact_urls:
-                existing.artifact_urls.append(item.url)
-            existing.metrics.update(
-                {
-                    metric: max(value, existing.metrics.get(metric, 0))
-                    for metric, value in item.metrics.items()
-                }
-            )
-            # The merged copy is dropped, so keep the corroboration it carried:
-            # a cross-source link is exactly what the evidence component reads.
-            for url in item.artifact_urls:
-                if url not in existing.artifact_urls:
-                    existing.artifact_urls.append(url)
-            for author in item.authors:
-                if author not in existing.authors:
-                    existing.authors.append(author)
-            for organization in item.organizations:
-                if organization not in existing.organizations:
-                    existing.organizations.append(organization)
-            # A record with no description loses nothing by adopting one that
-            # has it; a record that already has one keeps its own.
-            if not existing.summary.strip() and item.summary.strip():
-                existing.summary = item.summary
-            note = f"Also found via {item.source}"
-            if note not in existing.rationale:
-                existing.rationale.append(note)
-            # The absorbed record's identities now point at the survivor, so a
-            # third copy sharing only the arXiv id or only the title still lands
-            # on the same artifact.
-            target = existing
+        matches: list[RadarItem] = []
+        for key in keys:
+            match = kept.get(key)
+            if match is not None and not any(match is candidate for candidate in matches):
+                matches.append(match)
+        if matches:
+            # A bridge can connect two clusters that already exist: for example,
+            # a DOI-plus-repository record arriving after DOI-only and repo-only
+            # observations. Keep the first (newest) cluster and absorb every
+            # other match so identity remains genuinely transitive.
+            positions = {id(candidate): index for index, candidate in enumerate(order)}
+            matches.sort(key=lambda candidate: positions[id(candidate)])
+            target = matches[0]
+            merge_into(target, item)
+            for absorbed in matches[1:]:
+                merge_into(target, absorbed)
+                order = [candidate for candidate in order if candidate is not absorbed]
+                for known_key, known_target in list(kept.items()):
+                    if known_target is absorbed:
+                        kept[known_key] = target
         else:
             target = item
             order.append(item)
         for key in keys:
-            kept.setdefault(key, target)
+            kept[key] = target
     # One record is registered under several keys, so dict values repeat.
     # Insertion order is preserved to keep the output deterministic.
     return order
@@ -516,7 +535,7 @@ def _score_and_select(
     suppressed_low_value = sum(
         1
         for item in scored
-        if [reason for reason in item.suppression_reasons if reason != rubric.SELF_REFERENCE_LABEL]
+        if rubric.SELF_REFERENCE_LABEL not in item.suppression_reasons and item.suppression_reasons
     )
     uncategorized = sum(
         1
@@ -524,6 +543,7 @@ def _score_and_select(
         if not item.suppression_reasons and not item.watchlist and not item.categories
     )
     recommended = sum(1 for item in selected if item.recommended)
+    merged_as_duplicate = len(titled) - len(unique)
     selection = {
         "fetched": fetched_count,
         # arXiv records already seen in a previous run, dropped before dedupe.
@@ -535,6 +555,8 @@ def _score_and_select(
         # connector regresses, so a non-zero value here is the signal that one
         # has, rather than an unexplained gap between fetched and deduplicated.
         "suppressed_untitled": untitled_count,
+        # Multiple source observations absorbed into one surviving artifact.
+        "merged_as_duplicate": merged_as_duplicate,
         "deduplicated": len(unique),
         "scored": len(scored),
         "eligible": len(selected),
@@ -656,7 +678,7 @@ def simulate_backfill(
     for simulated_now in dates:
         since = simulated_now - timedelta(hours=lookback_hours)
         visible = [
-            item
+            deepcopy(item)
             for item in pool
             if since <= (item.updated_at or item.published_at) <= simulated_now
         ]

--- a/src/benchmark_radar/report.py
+++ b/src/benchmark_radar/report.py
@@ -42,11 +42,13 @@ def _item_block(index: int, item: RadarItem) -> str:
         # restate the source and event line directly above.
         lines.extend(["_No description published at the source._", ""])
     details = [
-        f"Published/updated: `{item.published_at.date().isoformat()}`",
+        f"Published: `{item.published_at.date().isoformat()}`",
         f"Evidence: `{item.evidence_score:.2f}`",
         f"Relevance: `{item.relevance_score:.2f}`",
         f"Recency: `{item.recency_score:.2f}`",
     ]
+    if item.updated_at and item.updated_at != item.published_at:
+        details.insert(1, f"Updated: `{item.updated_at.date().isoformat()}`")
     if authors:
         details.append(f"Authors: {_escape(authors)}")
     if signals:
@@ -271,6 +273,7 @@ def render_markdown(
         suppressed = int(selection.get("suppressed_as_seen") or 0)
         suppressed_future = int(selection.get("suppressed_future_dated") or 0)
         suppressed_untitled = int(selection.get("suppressed_untitled") or 0)
+        merged_as_duplicate = int(selection.get("merged_as_duplicate") or 0)
         suppressed_low_value = int(selection.get("suppressed_low_value") or 0)
         # Absent from snapshots written before scoring v4, where self-records
         # were simply ranked; `or 0` keeps those funnels rendering unchanged.
@@ -301,6 +304,11 @@ def render_markdown(
                 + (
                     f"**{suppressed_untitled}** untitled records dropped → "
                     if suppressed_untitled
+                    else ""
+                )
+                + (
+                    f"**{merged_as_duplicate}** duplicate observations merged → "
+                    if merged_as_duplicate
                     else ""
                 )
                 + f"**{selection.get('deduplicated', 0)}** after dedupe → "

--- a/src/benchmark_radar/snapshots.py
+++ b/src/benchmark_radar/snapshots.py
@@ -476,16 +476,28 @@ def merge_snapshots(existing: dict[str, Any], incoming: dict[str, Any]) -> dict[
     pass and not the other. Widening the window would not recover them; only
     unioning the passes on write does.
 
-    Item identity is `exact_artifact_key`, the same exact-identifier rule daily
+    Item identity uses every exact identifier transitively, the same rule daily
     dedup and the cumulative corpus already use. On a collision the incoming
     (newer) record wins: it observed the artifact more recently, so its metrics
     and scores are the fresher reading.
     """
+    # A delayed retry can arrive after a newer pass. All "incoming wins"
+    # decisions below must mean chronologically newer, not merely whichever
+    # value happened to be passed as the second argument.
+    existing_generated = _validate_time(
+        existing["generated_at"], source="existing snapshot", field="generated_at"
+    )
+    incoming_generated = _validate_time(
+        incoming["generated_at"], source="incoming snapshot", field="generated_at"
+    )
+    if incoming_generated < existing_generated:
+        existing, incoming = incoming, existing
+
+    all_items = [*existing["evidence_items"], *incoming["evidence_items"]]
+    aliases = artifact_alias_map(all_items)
     merged_items: dict[str, Any] = {}
-    for item in existing["evidence_items"]:
-        merged_items[exact_artifact_key(item)] = item
-    for item in incoming["evidence_items"]:
-        merged_items[exact_artifact_key(item)] = item
+    for item in all_items:
+        merged_items[aliases[exact_artifact_key(item)]] = item
     evidence_items = list(merged_items.values())
 
     # Attention collection normally carries the previous pass forward, but a

--- a/src/benchmark_radar/sources.py
+++ b/src/benchmark_radar/sources.py
@@ -84,10 +84,16 @@ def fetch_first_party_feeds(config: dict[str, Any], since: datetime, limit: int)
     feeds = config.get("feeds") or []
     if not isinstance(feeds, list):
         raise ConnectorPayloadError("First-party feeds must be an array")
-    found: dict[str, RadarItem] = {}
+    validated_feeds: list[dict[str, Any]] = []
     for feed in feeds:
         if not isinstance(feed, dict) or not feed.get("name") or not feed.get("url"):
             raise ConnectorPayloadError("First-party feed is missing name or url")
+        validated_feeds.append(feed)
+
+    found: dict[str, RadarItem] = {}
+    failures: list[Exception] = []
+    healthy_feeds = 0
+    for feed in validated_feeds:
         name = str(feed["name"]).strip()
         feed_url = str(feed["url"]).strip()
         # Broad publisher feeds carry unrelated engineering posts that still hit a
@@ -96,49 +102,61 @@ def fetch_first_party_feeds(config: dict[str, Any], since: datetime, limit: int)
         require_any = [
             str(value).casefold() for value in (feed.get("require_any") or []) if str(value).strip()
         ]
-        root = ET.fromstring(get_text(feed_url, **_request_options(config)))
-        root_name = _xml_local_name(root.tag)
-        if root_name == "rss":
-            channel = _feed_child(root, "channel")
-            entries = (
-                []
-                if channel is None
-                else [child for child in channel if _xml_local_name(child.tag) == "item"]
-            )
-        elif root_name == "feed":
-            entries = [child for child in root if _xml_local_name(child.tag) == "entry"]
-        else:
-            raise ConnectorPayloadError(f"{name} returned an incompatible feed document")
-        for entry in entries:
-            title = _feed_text(entry, "title")
-            summary = clean_card_text(_feed_text(entry, "description", "summary", "content"))
-            haystack = f"{title} {summary}".casefold()
-            if not title or (keywords and not any(keyword in haystack for keyword in keywords)):
-                continue
-            if require_any and not any(keyword in haystack for keyword in require_any):
-                continue
-            url = _feed_link(entry)
-            source_id = _feed_text(entry, "id", "guid") or url
-            published = _feed_date(_feed_text(entry, "published", "pubDate", "date"))
-            updated = _feed_date(_feed_text(entry, "updated")) or published
-            activity = updated or published
-            if not url or not source_id or published is None or activity is None:
-                raise ConnectorPayloadError(f"{name} feed item is missing required fields")
-            identity = f"{name}:{source_id}"
-            if activity < since or _reject_future(config, identity, published, updated):
-                continue
-            found[identity] = RadarItem(
-                source="First-party feed",
-                source_id=identity,
-                title=title,
-                url=url,
-                published_at=published,
-                updated_at=updated,
-                summary=summary,
-                event_kind="updated" if updated > published else "released",
-                raw={"xml": ET.tostring(entry, encoding="unicode")},
-                parser_version="first-party-rss-atom/1",
-            )
+        feed_found: dict[str, RadarItem] = {}
+        try:
+            root = ET.fromstring(get_text(feed_url, **_request_options(config)))
+            root_name = _xml_local_name(root.tag)
+            if root_name == "rss":
+                channel = _feed_child(root, "channel")
+                entries = (
+                    []
+                    if channel is None
+                    else [child for child in channel if _xml_local_name(child.tag) == "item"]
+                )
+            elif root_name == "feed":
+                entries = [child for child in root if _xml_local_name(child.tag) == "entry"]
+            else:
+                raise ConnectorPayloadError(f"{name} returned an incompatible feed document")
+            for entry in entries:
+                title = _feed_text(entry, "title")
+                summary = clean_card_text(_feed_text(entry, "description", "summary", "content"))
+                haystack = f"{title} {summary}".casefold()
+                if not title or (keywords and not any(keyword in haystack for keyword in keywords)):
+                    continue
+                if require_any and not any(keyword in haystack for keyword in require_any):
+                    continue
+                url = _feed_link(entry)
+                source_id = _feed_text(entry, "id", "guid") or url
+                published = _feed_date(_feed_text(entry, "published", "pubDate", "date"))
+                updated = _feed_date(_feed_text(entry, "updated")) or published
+                activity = updated or published
+                if not url or not source_id or published is None or activity is None:
+                    raise ConnectorPayloadError(f"{name} feed item is missing required fields")
+                identity = f"{name}:{source_id}"
+                if activity < since or _reject_future(config, identity, published, updated):
+                    continue
+                feed_found[identity] = RadarItem(
+                    source="First-party feed",
+                    source_id=identity,
+                    title=title,
+                    url=url,
+                    published_at=published,
+                    updated_at=updated,
+                    summary=summary,
+                    event_kind="updated" if updated > published else "released",
+                    organizations=[name],
+                    raw={"xml": ET.tostring(entry, encoding="unicode")},
+                    parser_version="first-party-rss-atom/1",
+                )
+        except Exception as error:
+            warnings = config.setdefault("_source_warnings", [])
+            warnings.append(f"{name}: {type(error).__name__}: {error}")
+            failures.append(error)
+            continue
+        healthy_feeds += 1
+        found.update(feed_found)
+    if validated_feeds and healthy_feeds == 0:
+        raise failures[0]
     return sorted(
         found.values(),
         key=lambda item: (item.updated_at or item.published_at, item.source_id),
@@ -217,21 +235,15 @@ def _optional_date(value: str | None) -> datetime | None:
     if not value:
         return None
     try:
-        return datetime.fromisoformat(str(value).replace("Z", "+00:00")).astimezone(UTC)
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        # Date-only API values are naive. Calling astimezone() on one otherwise
+        # interprets it in the runner's local timezone, so the same record moves
+        # by several hours between a laptop and GitHub's UTC runner.
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=UTC)
+        return parsed.astimezone(UTC)
     except (TypeError, ValueError):
         return None
-
-
-def _date(value: str | None) -> datetime:
-    """Parse a timestamp, substituting the current time when it is missing.
-
-    Callers that feed a recency score must use :func:`_optional_date` instead: a
-    missing timestamp resolved to "now" is indistinguishable from a genuinely
-    fresh record, so the substitution silently awards maximum recency to a
-    record whose age is unknown.
-    """
-    parsed = _optional_date(value)
-    return datetime.now(UTC) if parsed is None else parsed
 
 
 def _arxiv_source_id(value: str) -> str:
@@ -352,15 +364,25 @@ def fetch_arxiv(config: dict[str, Any], since: datetime, limit: int) -> list[Rad
                         "http:", "https:"
                     )
                     source_id = _arxiv_source_id(url)
-                    published = _date(entry.findtext("atom:published", namespaces=namespace))
-                    updated = _date(entry.findtext("atom:updated", namespaces=namespace))
+                    title = " ".join(
+                        (entry.findtext("atom:title", namespaces=namespace) or "").split()
+                    )
+                    published = _optional_date(
+                        entry.findtext("atom:published", namespaces=namespace)
+                    )
+                    updated = _optional_date(entry.findtext("atom:updated", namespaces=namespace))
+                    if (
+                        not url
+                        or not source_id
+                        or not title
+                        or published is None
+                        or updated is None
+                    ):
+                        raise ConnectorPayloadError("arXiv Atom item is missing required fields")
                     if max(published, updated) < overlap_since or _reject_future(
                         config, source_id, published, updated
                     ):
                         continue
-                    title = " ".join(
-                        (entry.findtext("atom:title", namespaces=namespace) or "").split()
-                    )
                     summary = " ".join(
                         (entry.findtext("atom:summary", namespaces=namespace) or "").split()
                     )
@@ -428,20 +450,21 @@ def fetch_huggingface(config: dict[str, Any], since: datetime, limit: int) -> li
                 # An undated repo is skipped rather than dated "now": the
                 # substitution both invented freshness and slipped past the
                 # `since` check below, which is what it was meant to enforce.
-                changed = _optional_date(row.get("lastModified") or row.get("createdAt"))
+                created = _optional_date(row.get("createdAt"))
+                changed = _optional_date(row.get("lastModified")) or created
                 if (
                     changed is None
                     or changed < since
-                    or _reject_future(config, str(item_id), changed)
+                    or _reject_future(config, str(item_id), created, changed)
                 ):
                     continue
-                created = _optional_date(row.get("createdAt"))
                 found[item_id] = RadarItem(
                     source="Hugging Face",
                     source_id=item_id,
                     title=item_id,
                     url=f"https://huggingface.co/{kind}/{item_id}",
-                    published_at=changed,
+                    published_at=created or changed,
+                    updated_at=changed,
                     # Never synthesize prose here: `score_item` reads `summary`,
                     # so a template would let the pipeline score itself on its
                     # own words. "" means the repo shipped no card.
@@ -460,7 +483,9 @@ def fetch_huggingface(config: dict[str, Any], since: datetime, limit: int) -> li
     # search, so the union could reach kinds x searches x limit. Trimming to the
     # most recently changed keeps the source's reported count comparable with
     # every other connector's.
-    return sorted(found.values(), key=lambda item: item.published_at, reverse=True)[:limit]
+    return sorted(
+        found.values(), key=lambda item: item.updated_at or item.published_at, reverse=True
+    )[:limit]
 
 
 def fetch_github(config: dict[str, Any], since: datetime, limit: int) -> list[RadarItem]:
@@ -512,17 +537,27 @@ def fetch_github(config: dict[str, Any], since: datetime, limit: int) -> list[Ra
             rows = _payload_rows(payload, "items", "GitHub Search")
             for row in rows:
                 full_name = row["full_name"]
-                changed = _date(row.get("pushed_at") or row.get("updated_at"))
-                if changed < since or _reject_future(config, full_name, changed):
+                created = _optional_date(row.get("created_at"))
+                changed = _optional_date(row.get("pushed_at")) or _optional_date(
+                    row.get("updated_at")
+                )
+                if (
+                    changed is None
+                    or changed < since
+                    or _reject_future(config, full_name, created, changed)
+                ):
                     continue
                 found[full_name] = RadarItem(
                     source="GitHub",
                     source_id=full_name,
                     title=full_name,
                     url=row["html_url"],
-                    published_at=changed,
+                    published_at=created or changed,
+                    updated_at=changed,
                     summary=github_summary(row),
-                    event_kind=("released" if _date(row.get("created_at")) >= since else "updated"),
+                    event_kind=(
+                        "released" if created is not None and created >= since else "updated"
+                    ),
                     metrics={
                         "stars": float(row.get("stargazers_count") or 0),
                         "forks": float(row.get("forks_count") or 0),
@@ -537,7 +572,9 @@ def fetch_github(config: dict[str, Any], since: datetime, limit: int) -> list[Ra
     # Round-robin can overshoot the per-source cap on its final sweep, since
     # every query contributes before the total is known. Trim to the most
     # recently active repositories so `max_items_per_source` stays honest.
-    return sorted(found.values(), key=lambda item: item.published_at, reverse=True)[:limit]
+    return sorted(
+        found.values(), key=lambda item: item.updated_at or item.published_at, reverse=True
+    )[:limit]
 
 
 def fetch_openreview(
@@ -565,6 +602,8 @@ def fetch_openreview(
     venues = [str(value) for value in config.get("venues", []) if str(value).strip()]
     budget = max(1, int(config.get("max_requests", len(venues) or 1)))
     requests_made = 0
+    failures: list[Exception] = []
+    healthy_venues = 0
 
     for venue in venues:
         if requests_made >= budget or len(found) >= limit:
@@ -572,76 +611,87 @@ def fetch_openreview(
 
         # Map venue to submission invitation ID (e.g., "ICLR.cc/2026/Conference/-/Submission")
         invitation = f"{venue}/-/Submission"
-
+        venue_found: dict[str, RadarItem] = {}
+        requests_made += 1
         try:
             notes = client.get_notes(invitation=invitation, limit=min(1000, limit - len(found)))
-        except openreview.openreview.OpenReviewException as e:
-            error_data = e.args[0] if e.args else {}
+            if not isinstance(notes, list):
+                raise ConnectorPayloadError(f"{venue} returned an incompatible notes payload")
+            for note in notes:
+                content = note.content
+                if not isinstance(content, dict):
+                    continue
+
+                note_id = str(note.forum or note.id or "").strip()
+                title = str(_openreview_content(content, "title", "")).strip()
+                created = _milliseconds(note.cdate or note.pdate)
+                modified = _milliseconds(note.mdate) or created
+                activity = modified or created
+
+                if not note_id or not title or not created or not activity:
+                    continue
+                if activity < since or _reject_future(config, note_id, activity):
+                    continue
+
+                abstract = str(_openreview_content(content, "abstract", "")).strip()
+
+                authors = _openreview_content(content, "authors", [])
+                if isinstance(authors, str):
+                    authors = [authors]
+                if not isinstance(authors, list):
+                    authors = []
+
+                artifact_urls = []
+                for key in ("code", "dataset", "project", "supplementary_material"):
+                    value = _openreview_content(content, key, [])
+                    values = value if isinstance(value, list) else [value]
+                    artifact_urls.extend(
+                        str(url)
+                        for url in values
+                        if isinstance(url, str) and url.startswith(("https://", "http://"))
+                    )
+
+                venue_found[note_id] = RadarItem(
+                    source="OpenReview",
+                    source_id=note_id,
+                    title=title,
+                    url=f"https://openreview.net/forum?id={note_id}",
+                    published_at=created,
+                    updated_at=modified,
+                    summary=abstract,
+                    event_kind="updated" if modified and modified > created else "released",
+                    authors=[str(author) for author in authors if str(author).strip()],
+                    artifact_urls=sorted(set(artifact_urls)),
+                    raw={
+                        "id": note.id,
+                        "forum": note.forum,
+                        "cdate": note.cdate,
+                        "mdate": note.mdate,
+                        "content": note.content,
+                    },
+                    parser_version="openreview-api-v2/1",
+                )
+        except openreview.openreview.OpenReviewException as error:
+            error_data = error.args[0] if error.args else {}
             if isinstance(error_data, dict) and error_data.get("name") == "ChallengeRequiredError":
                 raise ConnectorPayloadError(
                     "OpenReview authentication failed: ChallengeRequiredError. "
                     "Check OPENREVIEW_USERNAME/OPENREVIEW_PASSWORD credentials."
-                ) from e
-            raise
-
-        requests_made += 1
-        if not notes:
+                ) from error
+            warnings = config.setdefault("_source_warnings", [])
+            warnings.append(f"{venue}: {type(error).__name__}: {error}")
+            failures.append(error)
             continue
+        except Exception as error:
+            warnings = config.setdefault("_source_warnings", [])
+            warnings.append(f"{venue}: {type(error).__name__}: {error}")
+            failures.append(error)
+            continue
+        healthy_venues += 1
+        found.update(venue_found)
 
-        for note in notes:
-            content = note.content
-            if not isinstance(content, dict):
-                continue
-
-            note_id = str(note.forum or note.id or "").strip()
-            title = str(_openreview_content(content, "title", "")).strip()
-            created = _milliseconds(note.cdate or note.pdate)
-            modified = _milliseconds(note.mdate) or created
-            activity = modified or created
-
-            if not note_id or not title or not created or not activity:
-                continue
-            if activity < since or _reject_future(config, note_id, activity):
-                continue
-
-            abstract = str(_openreview_content(content, "abstract", "")).strip()
-
-            authors = _openreview_content(content, "authors", [])
-            if isinstance(authors, str):
-                authors = [authors]
-            if not isinstance(authors, list):
-                authors = []
-
-            artifact_urls = []
-            for key in ("code", "dataset", "project", "supplementary_material"):
-                value = _openreview_content(content, key, [])
-                values = value if isinstance(value, list) else [value]
-                artifact_urls.extend(
-                    str(url)
-                    for url in values
-                    if isinstance(url, str) and url.startswith(("https://", "http://"))
-                )
-
-            found[note_id] = RadarItem(
-                source="OpenReview",
-                source_id=note_id,
-                title=title,
-                url=f"https://openreview.net/forum?id={note_id}",
-                published_at=created,
-                updated_at=modified,
-                summary=abstract,
-                event_kind="updated" if modified and modified > created else "released",
-                authors=[str(author) for author in authors if str(author).strip()],
-                artifact_urls=sorted(set(artifact_urls)),
-                raw={
-                    "id": note.id,
-                    "forum": note.forum,
-                    "cdate": note.cdate,
-                    "mdate": note.mdate,
-                    "content": note.content,
-                },
-                parser_version="openreview-api-v2/1",
-            )
+    if venues and healthy_venues == 0 and failures:
+        raise failures[0]
 
     return sorted(
         found.values(),
@@ -703,8 +753,10 @@ def fetch_semantic_scholar(
                 published_text = row.get("publicationDate")
                 if not paper_id or not title or not published_text:
                     continue
-                published = _date(str(published_text))
-                if published < since or _reject_future(config, paper_id, published):
+                published = _optional_date(str(published_text))
+                if published is None:
+                    continue
+                if published.date() < since.date() or _reject_future(config, paper_id, published):
                     continue
                 external = row.get("externalIds") or {}
                 if not isinstance(external, dict):
@@ -848,7 +900,9 @@ def fetch_github_releases(
                 published_text = row.get("published_at") or row.get("created_at")
                 if not published_text:
                     continue
-                published = _date(str(published_text))
+                published = _optional_date(str(published_text))
+                if published is None:
+                    continue
                 oldest = min(oldest or published, published)
                 if published < since:
                     continue
@@ -946,15 +1000,22 @@ def fetch_openalex(
         # with no matching works.
         for row in _payload_rows(payload, "results", "OpenAlex"):
             source_id = row["id"].rsplit("/", 1)[-1]
+            authorships = row.get("authorships") or []
+            if not isinstance(authorships, list) or not all(
+                isinstance(authorship, dict) for authorship in authorships
+            ):
+                raise ConnectorPayloadError("OpenAlex authorships must be an array")
             authors = [
-                authorship.get("author", {}).get("display_name", "")
-                for authorship in row.get("authorships", [])
+                (authorship.get("author") or {}).get("display_name", "")
+                for authorship in authorships
+                if isinstance(authorship.get("author") or {}, dict)
             ]
             organizations = list(
                 dict.fromkeys(
                     str(institution.get("display_name") or "").strip()
-                    for authorship in row.get("authorships", [])
+                    for authorship in authorships
                     for institution in (authorship.get("institutions") or [])
+                    if isinstance(institution, dict)
                     if str(institution.get("display_name") or "").strip()
                 )
             )

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -47,6 +47,14 @@ def test_exact_primary_identifier_wins_over_secondary_record_and_repo_links():
     assert exact_artifact_key(record) == "artifact:arxiv:2607.12345"
 
 
+def test_arxiv_pdf_and_abstract_urls_share_one_identity():
+    abstract = item(url="https://arxiv.org/abs/2608.12345")
+    pdf = item(url="https://arxiv.org/pdf/2608.12345v2.pdf")
+
+    assert exact_artifact_key(abstract) == "artifact:arxiv:2608.12345"
+    assert exact_artifact_key(pdf) == exact_artifact_key(abstract)
+
+
 def test_every_identifier_of_the_same_kind_is_preserved():
     record = item(
         artifact_urls=[

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -960,6 +960,52 @@ def test_dedupe_matches_on_a_weaker_shared_identifier():
     assert len(deduplicate([paper, repo])) == 1
 
 
+def test_dedupe_transitively_absorbs_clusters_joined_by_a_later_bridge():
+    paper = item(
+        source_id="2608.12345",
+        title="A Paper Record With Its Own Distinct Name",
+        url="https://arxiv.org/abs/2608.12345",
+        published_at=datetime(2026, 8, 5, 12, tzinfo=UTC),
+        authors=["Alice"],
+    )
+    repo = item(
+        source="GitHub",
+        source_id="example/eval-suite",
+        title="Example Evaluation Suite Repository",
+        url="https://github.com/example/eval-suite",
+        published_at=datetime(2026, 8, 5, 11, tzinfo=UTC),
+        organizations=["Example Lab"],
+    )
+    bridge = item(
+        source="Semantic Scholar",
+        source_id="S2-bridge",
+        title="A Third Source With Different Metadata",
+        url="https://www.semanticscholar.org/paper/S2-bridge",
+        artifact_urls=[
+            "https://arxiv.org/abs/2608.12345",
+            "https://github.com/example/eval-suite",
+        ],
+        published_at=datetime(2026, 8, 5, 10, tzinfo=UTC),
+        authors=["Bob"],
+    )
+    repo_followup = item(
+        source="Hugging Face",
+        source_id="example/eval-suite-mirror",
+        title="A Later Mirror With Yet Another Distinct Name",
+        url="https://huggingface.co/datasets/example/eval-suite-mirror",
+        artifact_urls=["https://github.com/example/eval-suite"],
+        published_at=datetime(2026, 8, 5, 9, tzinfo=UTC),
+        authors=["Carol"],
+    )
+
+    merged = deduplicate([paper, repo, bridge, repo_followup])
+
+    assert len(merged) == 1
+    assert set(merged[0].authors) == {"Alice", "Bob", "Carol"}
+    assert merged[0].organizations == ["Example Lab"]
+    assert "https://github.com/example/eval-suite" in merged[0].artifact_urls
+
+
 def test_dedupe_keeps_unrelated_records_apart():
     first = item(
         source_id="1111.2222",
@@ -1064,6 +1110,36 @@ def test_simulate_backfill_fetches_each_source_once_for_every_date(monkeypatch):
     assert all(
         item_.title.startswith("A benchmark repository") for run in runs for item_ in run.items
     )
+
+
+def test_simulate_backfill_keeps_each_days_items_independent(monkeypatch):
+    source_item = item(
+        source="GitHub",
+        source_id="org/repo",
+        title="A benchmark repository for evaluation",
+        url="https://github.com/org/repo",
+        published_at=datetime(2026, 7, 10, tzinfo=UTC),
+    )
+    monkeypatch.setitem(
+        __import__("benchmark_radar.pipeline", fromlist=["SOURCE_FETCHERS"]).SOURCE_FETCHERS,
+        "github",
+        lambda config, since, limit: [source_item],
+    )
+    monkeypatch.setitem(
+        __import__("benchmark_radar.pipeline", fromlist=["SOURCE_FETCHERS"]).SOURCE_FETCHERS,
+        "huggingface",
+        lambda config, since, limit: [],
+    )
+    dates = [datetime(2026, 7, 11, tzinfo=UTC), datetime(2026, 7, 12, tzinfo=UTC)]
+
+    runs = simulate_backfill(_backfill_config(), dates)
+
+    first = runs[0].items[0]
+    second = runs[1].items[0]
+    assert first is not second
+    assert first.discovered_at == dates[0]
+    assert second.discovered_at == dates[1]
+    assert first.recency_score > second.recency_score
 
 
 def test_simulate_backfill_excludes_items_published_after_the_simulated_date(monkeypatch):
@@ -1227,6 +1303,32 @@ def test_the_eligibility_counters_sum_to_the_drop():
     assert gap == 1
 
 
+def test_the_fetch_funnel_accounts_for_merged_duplicate_observations():
+    first = _fresh(
+        source_id="paper",
+        title="The Same Benchmark Observation Across Two Sources",
+        url="https://arxiv.org/abs/2608.12345",
+    )
+    second = _fresh(
+        source="GitHub",
+        source_id="org/repo",
+        title="The Same Benchmark Observation Across Two Sources",
+        url="https://github.com/org/repo",
+    )
+
+    selection = _select([first, second])
+
+    assert selection["merged_as_duplicate"] == 1
+    assert selection["deduplicated"] == 1
+    assert selection["fetched"] == (
+        selection["suppressed_as_seen"]
+        + selection["suppressed_future_dated"]
+        + selection["suppressed_untitled"]
+        + selection["merged_as_duplicate"]
+        + selection["deduplicated"]
+    )
+
+
 def test_score_threshold_only_marks_recommendation():
     high = _fresh(source_id="high", title="A New Benchmark Dataset For Evaluation")
     low = _fresh(source_id="low", title="benchmark", summary="")
@@ -1354,6 +1456,28 @@ def test_this_repository_is_excluded_from_its_own_ranking():
     assert selection["suppressed_self_reference"] == 1
     # Billed to its own counter, not to the taxonomy's low-value deductions.
     assert selection["suppressed_low_value"] == 0
+
+
+def test_self_exclusion_takes_precedence_over_other_suppression_reasons():
+    us = _fresh(
+        source="GitHub",
+        source_id="ktwu01/benchmark-radar",
+        url="https://github.com/ktwu01/benchmark-radar",
+        title="Benchmark Radar results dump and dataset index",
+    )
+
+    retained, selection = _score_and_select(
+        [us],
+        _funnel_config(),
+        now=FUNNEL_NOW,
+        fetched_count=1,
+        suppressed_count=0,
+    )
+
+    assert retained == []
+    assert selection["suppressed_self_reference"] == 1
+    assert selection["suppressed_low_value"] == 0
+    assert selection["scored"] - selection["eligible"] == 1
 
 
 def test_self_exclusion_matches_the_repository_not_the_name():

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -31,6 +31,24 @@ def test_report_contains_evidence_and_health():
     assert "Source health" in report
 
 
+def test_report_distinguishes_release_and_update_dates():
+    record = RadarItem(
+        source="GitHub",
+        source_id="org/repo",
+        title="Updated benchmark suite",
+        url="https://github.com/org/repo",
+        published_at=datetime(2026, 6, 1, tzinfo=UTC),
+        updated_at=datetime(2026, 7, 27, tzinfo=UTC),
+        categories=["benchmark"],
+    )
+
+    report = render_markdown(_run([record]))
+
+    assert "Published: `2026-06-01`" in report
+    assert "Updated: `2026-07-27`" in report
+    assert "Published/updated" not in report
+
+
 def test_source_health_names_each_connectors_collection_method():
     # Issue #174: every row of the Source health table looked the same at a
     # glance, so a stalled RSS feed and a broken search API read as identical
@@ -166,6 +184,21 @@ def test_report_accounts_for_future_dated_quarantine_in_the_funnel():
 
     assert "**2** fetched → **1** future-dated records quarantined" in report
     assert "→ **1** after dedupe" in report
+
+
+def test_report_names_duplicate_observations_merged_by_dedupe():
+    run = _run([_record(1)])
+    run.selection = {
+        "fetched": 3,
+        "merged_as_duplicate": 2,
+        "deduplicated": 1,
+        "eligible": 1,
+        "published": 1,
+    }
+
+    report = render_markdown(run)
+
+    assert "**2** duplicate observations merged → **1** after dedupe" in report
 
 
 def test_funnel_excludes_watchlist_bypasses_from_the_threshold_count():

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -180,6 +180,45 @@ def test_same_utc_day_prefers_the_newer_record_on_collision(tmp_path):
     assert merged["evidence_items"][0]["metrics"] == {"citations": 9}
 
 
+def test_same_utc_day_rejects_stale_retry_metadata_as_the_newest_pass(tmp_path):
+    newer = radar_run(title="Newer reading")
+    newer.generated_at = datetime(2026, 7, 27, 18, tzinfo=UTC)
+    newer.selection = {"fetched": 80, "published": 1}
+    newer.items[0].metrics = {"citations": 9}
+    stale_retry = radar_run(title="Stale retry")
+    stale_retry.generated_at = datetime(2026, 7, 27, 6, tzinfo=UTC)
+    stale_retry.selection = {"fetched": 40, "published": 1}
+
+    write_snapshot(newer, tmp_path)
+    write_snapshot(stale_retry, tmp_path)
+
+    merged = load_snapshots(tmp_path)[0]
+    assert merged["generated_at"] == newer.generated_at.isoformat()
+    assert merged["selection"]["fetched"] == 80
+    assert merged["evidence_items"][0]["title"] == "Newer reading"
+    assert merged["evidence_items"][0]["metrics"] == {"citations": 9}
+
+
+def test_same_utc_day_joins_records_through_any_exact_identifier(tmp_path):
+    first = radar_run(title="DOI and arXiv observation")
+    first.items[0].source = "Semantic Scholar"
+    first.items[0].source_id = "S2-bridge"
+    first.items[0].url = "https://www.semanticscholar.org/paper/S2-bridge"
+    first.items[0].artifact_urls = [
+        "https://doi.org/10.1000/radar",
+        "https://arxiv.org/abs/2607.0027",
+    ]
+    second = radar_run(title="Fresh arXiv observation")
+    second.generated_at = first.generated_at + timedelta(hours=6)
+
+    write_snapshot(first, tmp_path)
+    write_snapshot(second, tmp_path)
+
+    merged = load_snapshots(tmp_path)[0]
+    assert len(merged["evidence_items"]) == 1
+    assert merged["evidence_items"][0]["title"] == "Fresh arXiv observation"
+
+
 def test_a_pass_that_fetched_nothing_keeps_the_day_and_reports_an_honest_funnel(tmp_path):
     # A source outage can hand us a pass with no items at all. Merging it must
     # keep the day's existing records, and must not leave the file claiming it

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -85,6 +85,7 @@ def test_first_party_feeds_parse_rss_and_atom_and_filter_noise(monkeypatch):
     assert items[0].event_kind == "updated"
     assert items[0].source == "First-party feed"
     assert items[0].source_id == "Lab Atom:tag:lab.example,2026:leaderboard"
+    assert items[0].organizations == ["Lab Atom"]
 
 
 def test_first_party_feeds_require_any_narrows_broad_publishers(monkeypatch):
@@ -126,6 +127,28 @@ def test_first_party_feeds_reject_non_feed_documents(monkeypatch):
             datetime(2026, 8, 8, 0, tzinfo=UTC),
             10,
         )
+
+
+def test_first_party_feeds_isolate_one_broken_feed(monkeypatch):
+    def fake_get_text(url, attempts=3, timeout=30):
+        if url.endswith("/broken"):
+            raise RequestError("HTTP 503 from https://lab.example/broken")
+        return FIRST_PARTY_RSS
+
+    monkeypatch.setattr("benchmark_radar.sources.get_text", fake_get_text)
+    config = {
+        "feeds": [
+            {"name": "Broken Lab", "url": "https://lab.example/broken"},
+            {"name": "Healthy Lab", "url": "https://lab.example/healthy"},
+        ]
+    }
+
+    items = fetch_first_party_feeds(config, datetime(2026, 8, 8, 0, tzinfo=UTC), 10)
+
+    assert [item.title for item in items] == ["A new agent evaluation benchmark"]
+    assert config["_source_warnings"] == [
+        "Broken Lab: RequestError: HTTP 503 from https://lab.example/broken"
+    ]
 
 
 ARXIV_XML = """\
@@ -233,6 +256,21 @@ def test_arxiv_falls_back_to_official_rss_when_atom_is_rate_limited(monkeypatch)
     assert items[0].event_kind == "released"
 
 
+def test_arxiv_atom_rejects_missing_dates_instead_of_inventing_now(monkeypatch):
+    malformed = ARXIV_XML.replace("<updated>2026-07-26T18:00:00Z</updated>", "")
+    monkeypatch.setattr(
+        "benchmark_radar.sources.get_text",
+        lambda url, params=None: malformed,
+    )
+
+    with pytest.raises(ConnectorPayloadError, match="arXiv Atom item is missing required fields"):
+        fetch_arxiv(
+            {"queries": ["all:benchmark"], "rss_categories": []},
+            datetime(2026, 7, 25, 12, tzinfo=UTC),
+            10,
+        )
+
+
 def test_arxiv_can_use_official_rss_as_primary(monkeypatch):
     def fake_get_text(url, params=None):
         assert url == "https://rss.arxiv.org/rss/cs.AI"
@@ -316,6 +354,35 @@ def test_openalex_carries_author_institutions(monkeypatch):
 
     assert items[0].authors == ["Radar Author"]
     assert items[0].organizations == ["Example University", "Example Lab"]
+
+
+def test_openalex_accepts_explicitly_null_authorships(monkeypatch):
+    monkeypatch.setenv("OPENALEX_API_KEY", "key")
+    monkeypatch.setattr(
+        "benchmark_radar.sources.get_json",
+        lambda url, params: {
+            "results": [
+                {
+                    "id": "https://openalex.org/W1",
+                    "display_name": "Benchmark without authorship metadata",
+                    "publication_date": "2026-08-26",
+                    "primary_location": {"landing_page_url": "https://example.com/w1"},
+                    "authorships": None,
+                    "cited_by_count": 0,
+                }
+            ]
+        },
+    )
+
+    items = fetch_openalex(
+        {"searches": ["benchmark"]},
+        datetime(2026, 8, 25, tzinfo=UTC),
+        10,
+        now=datetime(2026, 8, 26, 12, tzinfo=UTC),
+    )
+
+    assert items[0].authors == []
+    assert items[0].organizations == []
 
 
 def test_arxiv_rejects_incompatible_empty_rss_document(monkeypatch):
@@ -508,6 +575,26 @@ def test_github_respects_the_per_source_limit_after_round_robin(monkeypatch):
     assert len(items) == 150
 
 
+def test_github_preserves_creation_and_update_times(monkeypatch):
+    row = _github_row(1)
+    row["created_at"] = "2026-06-01T00:00:00Z"
+    row["pushed_at"] = "2026-07-27T12:00:00Z"
+    monkeypatch.setattr(
+        "benchmark_radar.sources.get_json",
+        lambda url, params=None, headers=None: {"items": [row]},
+    )
+
+    items = fetch_github(
+        {"queries": ["benchmark"], "request_delay_seconds": 0},
+        datetime(2026, 7, 26, tzinfo=UTC),
+        10,
+    )
+
+    assert items[0].published_at == datetime(2026, 6, 1, tzinfo=UTC)
+    assert items[0].updated_at == datetime(2026, 7, 27, 12, tzinfo=UTC)
+    assert items[0].event_kind == "updated"
+
+
 def test_openreview_success_uses_only_upstream_abstract(monkeypatch):
     timestamp = int(datetime(2026, 7, 27, 12, tzinfo=UTC).timestamp() * 1000)
 
@@ -558,6 +645,41 @@ def test_openreview_success_uses_only_upstream_abstract(monkeypatch):
     assert items[0].authors == ["Ada Radar"]
     assert items[0].parser_version == "openreview-api-v2/1"
     assert items[0].raw["forum"] == "stable-forum"
+
+
+def test_openreview_isolates_one_failed_venue(monkeypatch):
+    timestamp = int(datetime(2026, 7, 27, 12, tzinfo=UTC).timestamp() * 1000)
+
+    class MockNote:
+        id = "healthy-note"
+        forum = "healthy-forum"
+        cdate = timestamp
+        mdate = timestamp
+        content = {
+            "title": {"value": "A Healthy Venue Benchmark"},
+            "abstract": {"value": "A real benchmark abstract."},
+        }
+
+    import openreview.api
+
+    class MockClient:
+        def get_notes(self, invitation, limit):
+            if invitation.startswith("Broken.cc"):
+                raise openreview.openreview.OpenReviewException(
+                    {"name": "Error", "message": "HTTP 500", "status": 500}
+                )
+            return [MockNote()]
+
+    monkeypatch.setattr(openreview.api, "OpenReviewClient", lambda **kwargs: MockClient())
+    monkeypatch.setenv("OPENREVIEW_USERNAME", "test@example.com")
+    monkeypatch.setenv("OPENREVIEW_PASSWORD", "testpass")
+    config = {"venues": ["Broken.cc/2026/Conference", "Healthy.cc/2026/Conference"]}
+
+    items = fetch_openreview(config, datetime(2026, 7, 26, tzinfo=UTC), 10)
+
+    assert [item.source_id for item in items] == ["healthy-forum"]
+    assert len(config["_source_warnings"]) == 1
+    assert config["_source_warnings"][0].startswith("Broken.cc/2026/Conference:")
 
 
 def test_semantic_scholar_success_preserves_external_ids(monkeypatch):
@@ -957,6 +1079,93 @@ def test_new_connectors_never_synthesize_missing_summary(monkeypatch, fetcher, c
     assert items and items[0].summary == ""
 
 
+def test_semantic_scholar_skips_malformed_dates(monkeypatch):
+    monkeypatch.setattr(
+        "benchmark_radar.sources.get_json",
+        lambda url, **kwargs: {
+            "data": [
+                {
+                    "paperId": "paper",
+                    "title": "Malformed date benchmark",
+                    "publicationDate": "not-a-date",
+                    "authors": [],
+                }
+            ]
+        },
+    )
+
+    assert (
+        fetch_semantic_scholar({"searches": ["benchmark"]}, datetime(2026, 7, 26, tzinfo=UTC), 10)
+        == []
+    )
+
+
+def test_semantic_scholar_date_only_values_are_utc_on_every_machine(monkeypatch):
+    monkeypatch.setattr(
+        "benchmark_radar.sources.get_json",
+        lambda url, **kwargs: {
+            "data": [
+                {
+                    "paperId": "paper",
+                    "title": "Date-only benchmark",
+                    "publicationDate": "2026-07-27",
+                    "authors": [],
+                }
+            ]
+        },
+    )
+
+    items = fetch_semantic_scholar(
+        {"searches": ["benchmark"]}, datetime(2026, 7, 26, tzinfo=UTC), 10
+    )
+
+    assert items[0].published_at == datetime(2026, 7, 27, tzinfo=UTC)
+
+
+def test_semantic_scholar_keeps_the_date_granular_lookback_boundary(monkeypatch):
+    monkeypatch.setattr(
+        "benchmark_radar.sources.get_json",
+        lambda url, **kwargs: {
+            "data": [
+                {
+                    "paperId": "boundary-paper",
+                    "title": "Boundary-day benchmark",
+                    "publicationDate": "2026-07-26",
+                    "authors": [],
+                }
+            ]
+        },
+    )
+
+    items = fetch_semantic_scholar(
+        {"searches": ["benchmark"]}, datetime(2026, 7, 26, 12, tzinfo=UTC), 10
+    )
+
+    assert [item.source_id for item in items] == ["boundary-paper"]
+
+
+def test_github_releases_skip_malformed_dates(monkeypatch):
+    monkeypatch.setattr(
+        "benchmark_radar.sources.get_json",
+        lambda url, **kwargs: [
+            {
+                "tag_name": "v1",
+                "html_url": "https://github.com/example/benchmark/releases/tag/v1",
+                "published_at": "not-a-date",
+            }
+        ],
+    )
+
+    assert (
+        fetch_github_releases(
+            {"repositories": ["example/benchmark"]},
+            datetime(2026, 7, 26, tzinfo=UTC),
+            10,
+        )
+        == []
+    )
+
+
 def test_openalex_rejects_a_shapeless_payload(monkeypatch):
     # `payload.get("results", [])` made a `{}` reply indistinguishable from a
     # genuine zero-result day, so a broken response reported as healthy.
@@ -1157,6 +1366,29 @@ def test_huggingface_skips_undated_repositories(monkeypatch):
     assert [item.source_id for item in items] == ["org/dated"]
 
 
+def test_huggingface_preserves_creation_and_update_times(monkeypatch):
+    monkeypatch.setattr(
+        "benchmark_radar.sources.get_json",
+        lambda url, params: [
+            {
+                "id": "org/benchmark",
+                "createdAt": "2026-06-01T00:00:00Z",
+                "lastModified": "2026-07-27T12:00:00Z",
+            }
+        ],
+    )
+
+    items = fetch_huggingface(
+        {"kinds": ["datasets"], "searches": ["benchmark"]},
+        datetime(2026, 7, 26, tzinfo=UTC),
+        10,
+    )
+
+    assert items[0].published_at == datetime(2026, 6, 1, tzinfo=UTC)
+    assert items[0].updated_at == datetime(2026, 7, 27, 12, tzinfo=UTC)
+    assert items[0].event_kind == "updated"
+
+
 def test_huggingface_filters_future_rows_before_the_local_cap(monkeypatch):
     seen_limit = []
 
@@ -1182,6 +1414,27 @@ def test_huggingface_filters_future_rows_before_the_local_cap(monkeypatch):
 
     assert seen_limit == [51, 51]
     assert [item.source_id for item in items] == ["org/current"]
+    assert config["_future_rejections"] == 1
+
+
+def test_huggingface_rejects_a_future_creation_date_even_when_modified_now(monkeypatch):
+    monkeypatch.setattr(
+        "benchmark_radar.sources.get_json",
+        lambda url, params: [
+            {
+                "id": "org/future-created",
+                "createdAt": "2050-01-01T00:00:00Z",
+                "lastModified": "2026-07-27T12:00:00Z",
+            }
+        ],
+    )
+    config = {
+        "kinds": ["datasets"],
+        "searches": ["benchmark"],
+        "_collection_now": datetime(2026, 7, 28, tzinfo=UTC),
+    }
+
+    assert fetch_huggingface(config, datetime(2026, 7, 26, tzinfo=UTC), 10) == []
     assert config["_future_rejections"] == 1
 
 


### PR DESCRIPTION
## What this fixes

- preserves distinct creation and update timestamps for GitHub and Hugging Face records
- rejects malformed and future timestamps without inventing freshness, and parses date-only values consistently as UTC
- isolates individual first-party feeds and OpenReview venues so one failure does not erase healthy results
- makes daily dedup and same-day snapshot identity genuinely transitive
- preserves newer same-day pass metadata when a stale retry arrives later
- fixes arXiv PDF identity, Semantic Scholar boundary-day loss, and backfill cross-day mutation
- makes self-reference and duplicate-merge funnel accounting reconcile cleanly
- reports publication and update dates separately

The 2026-08-26 snapshot contains 98 GitHub or Hugging Face update records with update time stored as publication time, confirming the timestamp issue affected real output.

## Independent audit

A user-requested read-only Claude CLI review examined the pipeline after the first fix pass. Its six contained findings were independently reproduced and fixed here. One broader identity-model question remains deliberately out of scope: multi-valued related links can over-collapse distinct artifacts and needs a schema decision about same-as versus related-to edges.

## Validation

Ran from a fresh detached worktree, in repository-required order:

- ruff check .
- ruff format --check .
- benchmark-radar normalize-external
- benchmark-radar classify
- pytest -q: 963 passed
