### PR TITLE
Ranking v5: fix release adoption and update recency

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -310,6 +310,10 @@ sources:
     # Invalid future-dated rows may consume a page slot. Replacement requests
     # use a separate cap so they cannot steal the first request from later repos.
     future_replacement_requests: 2
+    # Popularity comes from a separate repository endpoint. These requests run
+    # only after release collection and use their own cap, so they cannot reduce
+    # release coverage when the shared release-page budget is exhausted.
+    repository_metadata_requests: 8
     attempts: 3
     timeout_seconds: 30
 

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -426,10 +426,12 @@ const I18N = {
     Previous: "上一页",
     Next: "下一页",
     "normal": "正常",
-    "Sort: Priority ↓": "排序:优先度 ↓",
-    "Sort: Date, then Priority ↓": "排序:日期,再按优先度 ↓",
-    "Sort: New releases first, then Priority ↓": "排序:新发布优先,再按优先度 ↓",
-    "Sort: Date, then new releases, then Priority ↓": "排序:日期,再新发布优先,再按优先度 ↓",
+    "Sort: Recency ↓, then Priority ↓": "排序:新鲜度 ↓,再按优先度 ↓",
+    "Sort: Date, then Recency ↓, then Priority ↓": "排序:日期,再按新鲜度 ↓,再按优先度 ↓",
+    "Sort: New releases first, then Recency ↓, then Priority ↓":
+      "排序:新发布优先,再按新鲜度 ↓,再按优先度 ↓",
+    "Sort: Date, then new releases, then Recency ↓, then Priority ↓":
+      "排序:日期,再新发布优先,再按新鲜度 ↓,再按优先度 ↓",
     "Sort: Date ↓": "排序:日期 ↓",
     Stars: "Star 数",
     Forks: "Fork 数",
@@ -2206,12 +2208,9 @@ function renderToday({ resultsOnly = false } = {}) {
   // describes the ordering the reader is paging through, and page one of a
   // release-led day is all releases even when later pages are not.
   //
-  // The caption stops at "new releases first" and does not promise a recency
-  // order. Releases are grouped into age tiers and ordered by priority inside
-  // each one, so the strongest true statement is that releases lead. Saying
-  // "newest first" would read as a strict sort and the rows would contradict
-  // it: the freshest tier opens with an 11.9-hour-old row above a 2.4-hour-old
-  // one, because priority separates them.
+  // The caption stops at "new releases first" rather than claiming a strict
+  // timestamp order across release tiers. Inside each tier, scored recency now
+  // leads priority so v5's event-kind discount changes the visible order.
   const priorityScored = visibleObservations.some((item) => Number(item.total_score) > 0);
   const releases = observations.filter(isRelease).length;
   const releasesLead = releases > 0 && releases < observations.length;
@@ -2219,11 +2218,11 @@ function renderToday({ resultsOnly = false } = {}) {
     ? t("Sort: Date ↓")
     : showingAllDates
       ? releasesLead
-        ? t("Sort: Date, then new releases, then Priority ↓")
-        : t("Sort: Date, then Priority ↓")
+        ? t("Sort: Date, then new releases, then Recency ↓, then Priority ↓")
+        : t("Sort: Date, then Recency ↓, then Priority ↓")
       : releasesLead
-        ? t("Sort: New releases first, then Priority ↓")
-        : t("Sort: Priority ↓");
+        ? t("Sort: New releases first, then Recency ↓, then Priority ↓")
+        : t("Sort: Recency ↓, then Priority ↓");
   const listHost = byId("today-list");
   replaceChildren(
     listHost,
@@ -2940,12 +2939,10 @@ const RELEASE_RECENT_HOURS = 72;
 // not a release at all. `event_kind` is set by the pipeline to "released" /
 // "updated" on evidence rows and "discussed" on attention rows.
 //
-// The tiers exist because a flat release group is ordered by priority, and
-// priority knows nothing about time: a release 2.4 hours old sat below one 11.9
-// hours old, and a 39.8-hour-old row still made page one. Crawl lag already
-// spreads a single day's releases across roughly 72 hours of real time, so
-// "today's releases" was never one moment -- these tiers make that spread
-// visible instead of leaving it to the priority score to scramble.
+// The tiers keep a new release ahead of an update. Scored recency then orders
+// within a tier, making v5's update/prerelease discount visible before priority
+// breaks ties. Crawl lag already spreads a single day's releases across roughly
+// 72 hours of real time, so "today's releases" was never one moment.
 function releaseRank(item) {
   if (item.event_kind !== "released") return 3;
   const hours = releaseAgeHours(item);
@@ -3000,10 +2997,12 @@ function allObservations() {
     // had months. Ranking the day purely by score therefore buries the one
     // thing a reader opens this page to find: on 2026-08-24 the top eight rows
     // were all `updated` and the highest-scoring actual release sat at rank
-    // nine (issue #332). Priority still orders within each tier -- it is a
-    // real quality signal, just not a substitute for recency.
+    // nine (issue #332). Scored recency orders within each tier, then priority
+    // breaks ties; a quality signal is not a substitute for recency.
     const releaseOrder = releaseRank(a) - releaseRank(b);
     if (releaseOrder) return releaseOrder;
+    const recencyOrder = Number(b.recency_score || 0) - Number(a.recency_score || 0);
+    if (recencyOrder) return recencyOrder;
     const scoreOrder = Number(b.total_score || 0) - Number(a.total_score || 0);
     if (scoreOrder) return scoreOrder;
     // Attention rows carry no priority, so within a day they order by the

--- a/src/benchmark_radar/pipeline.py
+++ b/src/benchmark_radar/pipeline.py
@@ -218,6 +218,20 @@ def is_self_reference(item: RadarItem) -> bool:
     return len(parts) >= 2 and "/".join(parts[:2]) == rubric.SELF_REPOSITORY
 
 
+def _has_structural_value(value: Any) -> bool:
+    if isinstance(value, str):
+        return bool(value.strip())
+    return bool(value)
+
+
+def _matches_structural_signal(item: RadarItem, signal: dict[str, Any]) -> bool:
+    fields = tuple(str(field) for field in signal["fields"])
+    values = [_has_structural_value(getattr(item, field, None)) for field in fields]
+    if signal["condition"] == "all_missing":
+        return not any(values)
+    raise ValueError(f"unknown structural signal condition: {signal['condition']}")
+
+
 def score_item(
     item: RadarItem,
     taxonomy: dict[str, Any],
@@ -251,11 +265,15 @@ def score_item(
         rubric.RELEVANCE_PER_CATEGORY * len(categories)
         + rubric.RELEVANCE_PER_TERM * len(matched_terms),
     )
-    deductions = [
+    text_deductions = [
         signal
         for signal in rubric.LOW_VALUE_SIGNALS
         if re.search(str(signal["pattern"]), haystack, flags=re.IGNORECASE)
     ]
+    structural_deductions = [
+        signal for signal in rubric.STRUCTURAL_SIGNALS if _matches_structural_signal(item, signal)
+    ]
+    deductions = [*text_deductions, *structural_deductions]
     deduction = min(
         rubric.MAX_LOW_VALUE_DEDUCTION,
         sum(float(signal["deduction"]) for signal in deductions),
@@ -286,6 +304,8 @@ def score_item(
         0.0,
         rubric.SCORE_MAX * (1.0 - age_hours / lookback_hours),
     )
+    recency_factor = rubric.RECENCY_EVENT_FACTORS.get(item.event_kind, 1.0)
+    item.recency_score *= recency_factor
 
     # Each counter is scored on its own log curve against its own saturation
     # point, then the strongest one wins. Counters that accumulate without a
@@ -320,14 +340,30 @@ def score_item(
     item.rationale = [
         reason
         for reason in item.rationale
-        if not reason.startswith(("Matched:", "Demoted:", "Primary record:"))
+        if not reason.startswith(
+            (
+                "Matched:",
+                "Demoted:",
+                "Structural demotion:",
+                "Structural gate:",
+                "Recency discount:",
+                "Primary record:",
+            )
+        )
     ]
     if matched_terms:
         item.rationale.append(f"Matched: {', '.join(sorted(set(matched_terms)))}")
-    for signal in deductions:
+    for signal in text_deductions:
         item.rationale.append(
             f"Demoted: {signal['label']} (-{float(signal['deduction']):g} relevance)"
         )
+    for signal in structural_deductions:
+        prefix = "Structural gate" if signal["action"] == "suppress" else "Structural demotion"
+        item.rationale.append(
+            f"{prefix}: {signal['label']} (-{float(signal['deduction']):g} relevance)"
+        )
+    if recency_factor < 1.0:
+        item.rationale.append(f"Recency discount: {item.event_kind} event ×{recency_factor:g}")
     item.rationale.append(f"Primary record: {item.source}")
     return item
 

--- a/src/benchmark_radar/rubric.py
+++ b/src/benchmark_radar/rubric.py
@@ -12,7 +12,7 @@ import hashlib
 import json
 from typing import Any
 
-SCORING_VERSION = 4
+SCORING_VERSION = 5
 SCORE_MAX = 100.0
 DEFAULT_LOOKBACK_HOURS = 48.0
 
@@ -25,6 +25,18 @@ WEIGHTS: dict[str, float] = {
     "evidence": 0.20,
     "recency": 0.20,
     "adoption": 0.25,
+}
+
+# A repository touch or paper replacement is current activity, but it is not
+# the same event as a first announcement. Prereleases retain more credit than
+# ordinary updates because they still introduce a new, if provisional, release.
+# Unknown event kinds keep full credit so a new connector is not silently
+# penalized before its semantics have been reviewed.
+RECENCY_EVENT_FACTORS: dict[str, float] = {
+    "released": 1.0,
+    "discovered": 1.0,
+    "prereleased": 0.75,
+    "updated": 0.50,
 }
 
 # Evidence is explicit and additive on a 0-100 scale.
@@ -101,6 +113,37 @@ LOW_VALUE_SIGNALS: tuple[dict[str, Any], ...] = (
     },
 )
 MAX_LOW_VALUE_DEDUCTION = 60.0
+
+# Field-only provenance checks stay separate from LOW_VALUE_SIGNALS, which are
+# regular expressions over title + summary. These rules deliberately make no
+# semantic claim about whether an artifact is a good or novel benchmark. They
+# only detect records that cannot lead a reader to their source or that arrived
+# with no supporting metadata beyond a title and URL.
+STRUCTURAL_SIGNALS: tuple[dict[str, Any], ...] = (
+    {
+        "label": "missing primary source URL",
+        "fields": ("url",),
+        "condition": "all_missing",
+        "description": "no primary source URL",
+        "deduction": 30.0,
+        "action": "suppress",
+    },
+    {
+        "label": "title-only provenance",
+        "fields": ("summary", "authors", "organizations", "artifact_urls", "metrics"),
+        "condition": "all_missing",
+        "description": ("no source description, attribution, artifact link, or public counter"),
+        "deduction": 15.0,
+        "action": "demote",
+    },
+)
+
+V5_LIMITS = (
+    "Update-driven recency is discounted from first announcements using the source's "
+    "event kind. This cannot distinguish a material GitHub release from a packaging bump.",
+    "Structural checks use only missing or populated record fields as a provenance signal. "
+    "They do not judge benchmark quality, novelty, or validity.",
+)
 
 # Adoption reaches the top of its scale at a documented, source-appropriate
 # public counter.  The strongest available counter is used because adding
@@ -205,6 +248,7 @@ def _components(*, lookback_hours: float) -> list[dict[str, Any]]:
                     + ("; suppressed" if signal["action"] == "suppress" else "")
                     for signal in LOW_VALUE_SIGNALS
                 ],
+                *_structural_bands(),
                 f"Total deductions capped at {MAX_LOW_VALUE_DEDUCTION:.0f}",
                 f"Clamped to 0-{SCORE_MAX:.0f}",
             ],
@@ -238,10 +282,12 @@ def _components(*, lookback_hours: float) -> list[dict[str, Any]]:
                 "this scan's configured collection window."
             ),
             "bands": [
-                f"{SCORE_MAX:.0f} at publication or update time",
-                f"Decays linearly across the configured {lookback_hours:g}-hour lookback",
-                f"Reaches 0 at {lookback_hours:g} hours",
-            ],
+                f"{SCORE_MAX:.0f} at release or first-discovery time",
+                f"Age-based credit decays linearly across the configured "
+                f"{lookback_hours:g}-hour lookback",
+                f"Age-based credit reaches 0 at {lookback_hours:g} hours",
+            ]
+            + _recency_event_bands(),
         },
         {
             "key": "adoption",
@@ -262,6 +308,29 @@ def _components(*, lookback_hours: float) -> list[dict[str, Any]]:
             ]
             + ["Uses the strongest available normalized counter", "Clamped to 0-100"],
         },
+    ]
+
+
+def _structural_bands() -> list[str]:
+    return [
+        f"-{signal['deduction']:.0f} for {signal['label']}: {signal['description']}"
+        + ("; suppressed" if signal["action"] == "suppress" else "")
+        for signal in STRUCTURAL_SIGNALS
+    ]
+
+
+def _recency_event_bands() -> list[str]:
+    return [
+        f"{event} events retain {factor * 100:g}% of their age-based recency"
+        for event, factor in RECENCY_EVENT_FACTORS.items()
+    ]
+
+
+def _v4_recency_bands(*, lookback_hours: float) -> list[str]:
+    return [
+        f"{SCORE_MAX:.0f} at publication or update time",
+        f"Decays linearly across the configured {lookback_hours:g}-hour lookback",
+        f"Reaches 0 at {lookback_hours:g} hours",
     ]
 
 
@@ -295,20 +364,25 @@ def rubric_reference(
             "Attention observations are shown separately and are never quality-scored.",
             "Watchlisted artifacts are retained whatever they score and sort first. Their "
             "rank reflects that request, not a higher score.",
+            *V5_LIMITS,
         ],
         "lookback_hours": float(lookback_hours),
     }
     return value
 
 
-def v2_rubric_reference(*, lookback_hours: float = DEFAULT_LOOKBACK_HOURS) -> dict[str, Any]:
-    """Describe v2 without retroactively granting its records the v3 feed tier."""
+def v4_rubric_reference(*, lookback_hours: float = DEFAULT_LOOKBACK_HOURS) -> dict[str, Any]:
+    """Describe v4 without retroactively applying v5's event and structure rules."""
     value = rubric_reference(lookback_hours=lookback_hours)
-    value["scoring_version"] = 2
+    value["scoring_version"] = 4
     for component in value["components"]:
-        if component["key"] != "evidence":
-            continue
-        component["bands"] = [band.replace(", First-party feed", "") for band in component["bands"]]
+        if component["key"] == "relevance":
+            component["bands"] = [
+                band for band in component["bands"] if band not in _structural_bands()
+            ]
+        elif component["key"] == "recency":
+            component["bands"] = _v4_recency_bands(lookback_hours=lookback_hours)
+    value["limits"] = [limit for limit in value["limits"] if limit not in V5_LIMITS]
     return value
 
 
@@ -320,7 +394,7 @@ def v3_rubric_reference(*, lookback_hours: float = DEFAULT_LOOKBACK_HOURS) -> di
     numbers with v4's bands would claim the run did something it did not, which
     is the relabelling #32 forbids.
     """
-    value = rubric_reference(lookback_hours=lookback_hours)
+    value = v4_rubric_reference(lookback_hours=lookback_hours)
     value["scoring_version"] = 3
     for component in value["components"]:
         if component["key"] != "adoption":
@@ -334,6 +408,17 @@ def v3_rubric_reference(*, lookback_hours: float = DEFAULT_LOOKBACK_HOURS) -> di
         for limit in value["limits"]
         if not limit.startswith("This project's own repository")
     ]
+    return value
+
+
+def v2_rubric_reference(*, lookback_hours: float = DEFAULT_LOOKBACK_HOURS) -> dict[str, Any]:
+    """Describe v2 without retroactively granting its records the v3 feed tier."""
+    value = v3_rubric_reference(lookback_hours=lookback_hours)
+    value["scoring_version"] = 2
+    for component in value["components"]:
+        if component["key"] != "evidence":
+            continue
+        component["bands"] = [band.replace(", First-party feed", "") for band in component["bands"]]
     return value
 
 

--- a/src/benchmark_radar/snapshots.py
+++ b/src/benchmark_radar/snapshots.py
@@ -30,6 +30,7 @@ from .rubric import (
     taxonomy_version,
     v2_rubric_reference,
     v3_rubric_reference,
+    v4_rubric_reference,
 )
 from .site_seo import write_sitemap
 from .sources import GITHUB_RELEASE_PARSER_VERSION, github_release_title
@@ -1003,6 +1004,11 @@ def dashboard_data(
                 ),
             ),
             "3": v3_rubric_reference(
+                lookback_hours=(
+                    (days[-1].get("selection") or {}).get("lookback_hours") or 48 if days else 48
+                ),
+            ),
+            "4": v4_rubric_reference(
                 lookback_hours=(
                     (days[-1].get("selection") or {}).get("lookback_hours") or 48 if days else 48
                 ),

--- a/src/benchmark_radar/sources.py
+++ b/src/benchmark_radar/sources.py
@@ -18,7 +18,7 @@ class ConnectorPayloadError(ValueError):
 
 
 FUTURE_TIMESTAMP_TOLERANCE = timedelta(minutes=5)
-GITHUB_RELEASE_PARSER_VERSION = "github-releases/2"
+GITHUB_RELEASE_PARSER_VERSION = "github-releases/3"
 
 
 def _xml_local_name(tag: str) -> str:
@@ -855,6 +855,7 @@ def fetch_github_releases(
     max_pages = max(1, int(config.get("max_pages_per_repository", 2)))
     budget = max(1, int(config.get("max_requests", len(repositories) or 1)))
     replacement_budget = max(0, int(config.get("future_replacement_requests", 2)))
+    metadata_budget = max(0, int(config.get("repository_metadata_requests", 8)))
     regular_requests = 0
     replacement_requests = 0
     found: dict[str, RadarItem] = {}
@@ -958,6 +959,40 @@ def fetch_github_releases(
     warnings = config.get("_source_warnings") or []
     if repositories and len(warnings) == len(repositories):
         raise failures[0]
+
+    # Popularity lives on the repository resource, not the release resource.
+    # Enrich only after release pagination has finished and under a separate
+    # request cap, so a metadata request can never consume the budget needed to
+    # discover a later repository's releases.
+    released_repositories = {
+        item.source_id.split("@", 1)[0] for item in found.values() if "@" in item.source_id
+    }
+    metadata_requests = 0
+    for repository in repositories:
+        if repository not in released_repositories or metadata_requests >= metadata_budget:
+            continue
+        metadata_requests += 1
+        try:
+            repository_payload = get_json(
+                f"https://api.github.com/repos/{repository}",
+                params={},
+                headers=headers,
+                **_request_options(config),
+            )
+            if not isinstance(repository_payload, dict):
+                raise ConnectorPayloadError("GitHub repository metadata was not an object")
+            stars = float(repository_payload.get("stargazers_count") or 0)
+            forks = float(repository_payload.get("forks_count") or 0)
+        except Exception as error:
+            config.setdefault("_source_warnings", []).append(
+                f"{repository} metadata: {type(error).__name__}: {error}"
+            )
+            continue
+        for item in found.values():
+            if not item.source_id.startswith(f"{repository}@"):
+                continue
+            item.metrics.update({"stars": stars, "forks": forks})
+            item.raw = {"release": item.raw, "repository": repository_payload}
     return sorted(found.values(), key=lambda item: item.published_at, reverse=True)[:limit]
 
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -346,6 +346,47 @@ def test_sponsor_bait_resource_listing_is_suppressed():
     assert "sponsor-bait resource listing" in spam.suppression_reasons
 
 
+def test_structural_signals_demote_thin_provenance_without_semantic_guessing():
+    taxonomy = {"benchmark": ["benchmark"], "evaluation": ["evaluation"]}
+    thin = score_item(
+        item(summary="", authors=[], organizations=[], artifact_urls=[], metrics={}),
+        taxonomy,
+        datetime(2026, 7, 27, 1, tzinfo=UTC),
+    )
+    described = score_item(
+        item(summary="A source-authored benchmark description."),
+        taxonomy,
+        datetime(2026, 7, 27, 1, tzinfo=UTC),
+    )
+
+    assert described.relevance_score - thin.relevance_score == 15
+    assert thin.suppression_reasons == []
+    assert any("Structural demotion: title-only provenance" in reason for reason in thin.rationale)
+
+
+def test_structural_gate_sets_a_suppression_reason_and_is_counted_by_the_funnel():
+    no_source_url = item(url="")
+    published, selection = _score_and_select(
+        [no_source_url],
+        {
+            "radar": {
+                "lookback_hours": 48,
+                "max_items_per_source": 10,
+                "minimum_score": 0,
+            },
+            "taxonomy": {"benchmark": ["benchmark"]},
+        },
+        now=datetime(2026, 7, 27, 1, tzinfo=UTC),
+        fetched_count=1,
+        suppressed_count=0,
+    )
+
+    assert published == []
+    assert no_source_url.suppression_reasons == ["missing primary source URL"]
+    assert selection["suppressed_low_value"] == 1
+    assert selection["eligible"] == 0
+
+
 def test_recency_uses_the_configured_collection_window():
     taxonomy = {"benchmark": ["benchmark"]}
     published = datetime(2026, 7, 27, tzinfo=UTC)
@@ -365,6 +406,29 @@ def test_recency_uses_the_configured_collection_window():
 
     assert halfway.recency_score == 50
     assert expired.recency_score == 0
+
+
+def test_update_driven_recency_is_discounted_and_rescore_is_idempotent():
+    taxonomy = {"benchmark": ["benchmark"]}
+    now = datetime(2026, 7, 27, 12, tzinfo=UTC)
+    activity_at = now - timedelta(hours=12)
+    announcement = score_item(
+        item(published_at=activity_at, event_kind="released"),
+        taxonomy,
+        now,
+        lookback_hours=48,
+    )
+    replacement = item(
+        published_at=activity_at - timedelta(days=30),
+        updated_at=activity_at,
+        event_kind="updated",
+    )
+    score_item(replacement, taxonomy, now, lookback_hours=48)
+    score_item(replacement, taxonomy, now, lookback_hours=48)
+
+    assert announcement.recency_score == 75
+    assert replacement.recency_score == 37.5
+    assert replacement.rationale.count("Recency discount: updated event ×0.5") == 1
 
 
 def test_visualization_companion_is_suppressed_from_pipeline(monkeypatch):

--- a/tests/test_rubric.py
+++ b/tests/test_rubric.py
@@ -208,3 +208,22 @@ def test_v3_reference_is_not_relabelled_with_v4_arithmetic():
     assert v3["scoring_version"] == 3
     assert not any("capped at" in band for band in adoption["bands"])
     assert not any(rubric.SELF_REPOSITORY in limit for limit in v3["limits"])
+
+
+def test_v4_reference_is_not_relabelled_with_v5_bands_or_limits():
+    current = rubric.rubric_reference()
+    v4 = rubric.v4_rubric_reference()
+    current_relevance = next(c for c in current["components"] if c["key"] == "relevance")
+    current_recency = next(c for c in current["components"] if c["key"] == "recency")
+    v4_relevance = next(c for c in v4["components"] if c["key"] == "relevance")
+    v4_recency = next(c for c in v4["components"] if c["key"] == "recency")
+
+    assert v4["scoring_version"] == 4
+    assert any("title-only provenance" in band for band in current_relevance["bands"])
+    assert not any("title-only provenance" in band for band in v4_relevance["bands"])
+    assert any("updated events retain 50%" in band for band in current_recency["bands"])
+    assert not any("updated events retain 50%" in band for band in v4_recency["bands"])
+    assert "100 at release or first-discovery time" in current_recency["bands"]
+    assert "100 at publication or update time" in v4_recency["bands"]
+    assert all(limit in current["limits"] for limit in rubric.V5_LIMITS)
+    assert all(limit not in v4["limits"] for limit in rubric.V5_LIMITS)

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -2201,28 +2201,33 @@ def test_issue_332_a_release_outranks_a_same_day_update():
     )[0]
     # Date still leads: the archive is a chronology before it is a ranking.
     assert sort_body.index("const dateOrder") < sort_body.index("const releaseOrder")
-    # Then releases, and only then priority.
+    # Then releases, scored recency, and only then priority. The v5 event-kind
+    # discount has to participate in the visible order instead of changing only
+    # the number printed on the card.
     assert sort_body.index("const releaseOrder") < sort_body.index("const scoreOrder")
+    assert sort_body.index("const releaseOrder") < sort_body.index("const recencyOrder")
+    assert sort_body.index("const recencyOrder") < sort_body.index("const scoreOrder")
     assert "releaseRank(a) - releaseRank(b)" in sort_body
+    assert "Number(b.recency_score || 0) - Number(a.recency_score || 0)" in sort_body
 
     # The caption names the order the reader is looking at, and only claims the
     # release tie-break when the result set actually contains both kinds.
-    assert 't("Sort: New releases first, then Priority ↓")' in script
-    assert 't("Sort: Date, then new releases, then Priority ↓")' in script
+    assert 't("Sort: New releases first, then Recency ↓, then Priority ↓")' in script
+    assert 't("Sort: Date, then new releases, then Recency ↓, then Priority ↓")' in script
     # "Is a release" is its own predicate now that releaseRank grades by age:
     # reading it as `=== 0` would have counted only the freshest tier.
     assert "const releases = observations.filter(isRelease).length;" in script
     assert 'return item.event_kind === "released";' in script
     assert "releases > 0 && releases < observations.length" in script
-    # The caption stops at "new releases first". Releases are ordered by
-    # priority inside each age tier, so promising a recency sort would be
-    # contradicted by the rows underneath it.
+    # The caption stops at "new releases first" rather than claiming a strict
+    # timestamp sort across release tiers; it then names the scored-recency
+    # order that v5 applies inside a tier.
     assert "Sort: Newest releases first" not in script
 
     # Both captions are translated; an untranslated string would render as
     # English inside an otherwise Chinese page.
-    assert "排序:新发布优先,再按优先度 ↓" in script
-    assert "排序:日期,再新发布优先,再按优先度 ↓" in script
+    assert "排序:新发布优先,再按新鲜度 ↓,再按优先度 ↓" in script
+    assert "排序:日期,再新发布优先,再按新鲜度 ↓,再按优先度 ↓" in script
 
 
 def test_issue_333_the_page_never_scrolls_sideways():

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -5,6 +5,7 @@ from xml.etree import ElementTree as ET
 
 import pytest
 
+from benchmark_radar import rubric
 from benchmark_radar.feed import SITE_URL
 from benchmark_radar.model_cards import ModelCardRegistryError
 from benchmark_radar.models import (
@@ -553,6 +554,10 @@ def test_dashboard_keeps_legacy_scores_on_their_original_rubric(tmp_path):
     assert published["score_max"] == 4
     assert data["rubrics"]["1"]["score_max"] == 4
     assert data["rubrics"]["2"]["score_max"] == 100
+    assert data["rubrics"]["4"]["scoring_version"] == 4
+    assert data["rubrics"][str(rubric.SCORING_VERSION)]["scoring_version"] == (
+        rubric.SCORING_VERSION
+    )
 
 
 def test_dashboard_without_snapshots_publishes_no_cutoff(tmp_path):

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -7,6 +7,7 @@ import yaml
 
 from benchmark_radar.http import RequestError
 from benchmark_radar.models import RadarItem
+from benchmark_radar.pipeline import score_item
 from benchmark_radar.sources import (
     GITHUB_RELEASE_PARSER_VERSION,
     ConnectorPayloadError,
@@ -772,6 +773,115 @@ def test_github_releases_success_uses_release_notes(monkeypatch):
     assert items[0].summary == "The upstream release notes."
     assert items[0].metrics["downloads"] == 7
     assert items[0].parser_version == GITHUB_RELEASE_PARSER_VERSION
+
+
+def test_github_release_popularity_comes_from_repository_metadata(monkeypatch):
+    release = {
+        "tag_name": "v2.0.0",
+        "name": "Benchmark 2.0",
+        "html_url": "https://github.com/example/benchmark/releases/tag/v2.0.0",
+        "published_at": "2026-07-27T12:00:00Z",
+        "body": "A benchmark evaluation release.",
+        "draft": False,
+        "prerelease": False,
+        "assets": [],
+    }
+    repository = {"stargazers_count": 7_000, "forks_count": 420}
+    calls = []
+
+    def fake_get_json(url, **kwargs):
+        calls.append(url)
+        return [release] if url.endswith("/releases") else repository
+
+    monkeypatch.setattr("benchmark_radar.sources.get_json", fake_get_json)
+    config = {
+        "repositories": ["example/benchmark"],
+        "max_requests": 1,
+        "repository_metadata_requests": 1,
+    }
+    radar_item = fetch_github_releases(
+        config,
+        datetime(2026, 7, 26, tzinfo=UTC),
+        10,
+    )[0]
+
+    assert calls == [
+        "https://api.github.com/repos/example/benchmark/releases",
+        "https://api.github.com/repos/example/benchmark",
+    ]
+    assert radar_item.metrics == {"downloads": 0.0, "stars": 7_000.0, "forks": 420.0}
+    assert radar_item.raw == {"release": release, "repository": repository}
+    score_item(
+        radar_item,
+        {"benchmark": ["benchmark"], "evaluation": ["evaluation"]},
+        radar_item.published_at,
+    )
+    assert radar_item.adoption_score > 0
+
+
+def test_github_release_repository_counters_are_covered_by_raw_hash(monkeypatch):
+    stars = 7_000
+
+    def fake_get_json(url, **kwargs):
+        if url.endswith("/releases"):
+            return [
+                {
+                    "tag_name": "v2.0.0",
+                    "html_url": "https://github.com/example/benchmark/releases/tag/v2.0.0",
+                    "published_at": "2026-07-27T12:00:00Z",
+                    "assets": [],
+                }
+            ]
+        return {"stargazers_count": stars, "forks_count": 420}
+
+    monkeypatch.setattr("benchmark_radar.sources.get_json", fake_get_json)
+    config = {
+        "repositories": ["example/benchmark"],
+        "max_requests": 1,
+        "repository_metadata_requests": 1,
+    }
+    first = fetch_github_releases(config, datetime(2026, 7, 26, tzinfo=UTC), 10)[0]
+    first_hash = first.to_dict()["raw_payload_hash"]
+
+    stars += 1
+    second = fetch_github_releases(config, datetime(2026, 7, 26, tzinfo=UTC), 10)[0]
+    second_hash = second.to_dict()["raw_payload_hash"]
+
+    assert first_hash != second_hash
+
+
+def test_github_release_metadata_budget_cannot_reduce_release_coverage(monkeypatch):
+    calls = []
+
+    def fake_get_json(url, **kwargs):
+        calls.append(url)
+        repository = url.split("/repos/", 1)[1].split("/releases", 1)[0]
+        if url.endswith("/releases"):
+            return [
+                {
+                    "tag_name": "v1",
+                    "html_url": f"https://github.com/{repository}/releases/tag/v1",
+                    "published_at": "2026-07-27T12:00:00Z",
+                    "assets": [],
+                }
+            ]
+        raise RequestError("metadata unavailable")
+
+    monkeypatch.setattr("benchmark_radar.sources.get_json", fake_get_json)
+    config = {
+        "repositories": ["org/first", "org/second"],
+        "max_requests": 2,
+        "repository_metadata_requests": 1,
+    }
+
+    items = fetch_github_releases(config, datetime(2026, 7, 26, tzinfo=UTC), 10)
+
+    assert [item.source_id for item in items] == ["org/first@v1", "org/second@v1"]
+    assert calls[:2] == [
+        "https://api.github.com/repos/org/first/releases",
+        "https://api.github.com/repos/org/second/releases",
+    ]
+    assert calls[2:] == ["https://api.github.com/repos/org/first"]
 
 
 def test_github_releases_issue_362_title_never_degrades_to_the_bare_tag(


### PR DESCRIPTION
## Why

GitHub Release records currently score adoption from release-asset downloads only, so a widely used repository with no binary assets appears to have zero adoption. Updates also receive the same recency credit as first announcements, and prose-only low-value rules cannot express field-based provenance checks or true suppression.

## What changed

- enrich collected GitHub releases with repository stars and forks after pagination, under a separate request cap
- include repository metadata in the raw payload hash and bump the release parser to `github-releases/3`
- publish rubric v5 with full recency for releases/discoveries, 75% for prereleases, and 50% for updates
- add idempotent recency rationale plus narrow field-only structural demotion/suppression rules
- order the dashboard by release tier, then scored recency, then priority
- preserve rubric v4 with its original bands and limits for historical records
- add regressions for request isolation, adoption, hashing, recency, suppression, ordering, and versioned rubric publication

The material-release heuristic, catalog cross-link, and semantic benchmark judgement remain deferred as scoped in the revised issue.

## Verification

Clean checkout, in CI order:

- [x] `ruff check .`
- [x] `ruff format --check .`
- [x] `benchmark-radar normalize-external`
- [x] `benchmark-radar classify`
- [x] `pytest -q` — 970 passed

Browser QA also confirmed the v5 sort caption and rubric, historical v4 isolation, and no console warnings or errors.

Closes #371
