### PR TITLE
Fix contributor image workflow for protected main

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: contributors-image
@@ -32,13 +33,15 @@ jobs:
           avatarSize: 42
           excludeBots: "true"
 
-      - name: Commit updated image
-        run: |
-          if git diff --quiet -- assets/contributors.svg; then
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add assets/contributors.svg
-          git commit -m "chore: update contributors image"
-          git push
+      - name: Propose updated image
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          branch: automation/update-contributors-image
+          delete-branch: true
+          commit-message: "chore: update contributors image"
+          title: "chore: update contributors image"
+          body: |
+            Updates the generated contributor profile image.
+
+            This pull request was opened automatically by the contributors workflow.
+          base: main


### PR DESCRIPTION
## Summary

- open automated contributor-image updates as pull requests
- avoid direct pushes to protected `main`
- grant the workflow permission to create pull requests

Fixes the post-merge workflow failure for #396.

## Validation

- workflow YAML validation
- `ruff check .`
- `ruff format --check .`
- `pytest -q` (990 passed)