### PR TITLE
docs(readme): simplify intro source count and move internal docs to foldable section

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
 
 <!-- The record-count badge is data-driven: it is regenerated from the corpus on
 every collection, so it states what the project actually holds rather than a
-hand-edited number (issue #197). -->
+hand-edited number (issue #197). The source count in the intro below is
+manually maintained: update it when `config.yml` adds or removes a collection
+connector or first-party feed. -->
 
 <p align="center">
   <a href="https://benchmark-radar.org/"><img alt="Benchmarks collected" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fbenchmark-radar.org%2Fdata%2Frecords-badge.json&amp;style=for-the-badge"></a>
@@ -20,9 +22,7 @@ hand-edited number (issue #197). -->
 
 I kept running into new benchmarks while doing benchmark research, so I built a
 crawler that continuously collects benchmark-related signals from across the
-web. It pulls evidence from arXiv, GitHub, Hugging Face, OpenAlex, OpenReview,
-first-party lab feeds, Brave Search, Semantic Scholar, Hacker News, and more
-every day, and keeps updating.
+web. It pulls evidence from 37 public sources every day, and keeps updating.
 
 **Find a benchmark in seconds, then see how model scores change over time. Click
 the GIF below to watch SWE-bench Verified move toward saturation.**
@@ -131,12 +131,11 @@ maintainer/CI build commands. End users update with `sync`, not with the normali
 
 ## More
 
-- **SEO and indexing:** [`docs/seo-indexing-guide.md`](docs/seo-indexing-guide.md)
-- **Scoring rubric:** [`src/benchmark_radar/rubric.py`](src/benchmark_radar/rubric.py)
-- **Model-card adoption data:** [`data/model_cards.yml`](data/model_cards.yml)
-- **Public corpus schema:** [`docs/cumulative-corpus.schema.json`](docs/cumulative-corpus.schema.json)
-- **Citation metadata:** [`CITATION.cff`](CITATION.cff)
-- **Configuration:** [`config.yml`](config.yml)
+- [Scoring rubric](src/benchmark_radar/rubric.py)
+- [Model-card adoption data](data/model_cards.yml)
+- [Public corpus schema](docs/cumulative-corpus.schema.json)
+- [Citation metadata](CITATION.cff)
+- [Configuration](config.yml)
 - **Developer setup:** `python -m pip install -e '.[dev]' && benchmark-radar normalize-external`
 - **Support / bugs:** [open an issue](https://github.com/ktwu01/benchmark-radar/issues)
 - **Contact:** [@ktwu01](https://github.com/ktwu01)
@@ -149,6 +148,28 @@ Scan the QR code to join the WeChat group for daily benchmark updates and eval d
 <img src="assets/wechat-group-qr.jpg" alt="WeChat group QR code" width="280" />
 
 ## Acknowledgements
+
+The daily evidence feed is built on public data from [arXiv](https://arxiv.org),
+[GitHub Search](https://github.com/search), [GitHub organizations](https://github.com),
+[GitHub Releases](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases),
+[Hugging Face datasets and Spaces](https://huggingface.co), [Hugging Face Papers](https://huggingface.co/papers),
+[OpenAlex](https://openalex.org), [OpenReview](https://openreview.net),
+[Kaggle datasets](https://www.kaggle.com/datasets), [Zenodo](https://zenodo.org),
+[Semantic Scholar](https://www.semanticscholar.org), [Brave Search](https://search.brave.com),
+and [Hacker News](https://news.ycombinator.com), plus first-party lab feeds from
+[OpenAI](https://openai.com/news), [Google AI](https://blog.google/technology/ai/),
+[Google DeepMind](https://deepmind.google/blog/), [Google Research](https://research.google/blog/),
+[Meta Research](https://research.facebook.com), [Microsoft Research](https://www.microsoft.com/en-us/research/),
+[AWS Machine Learning](https://aws.amazon.com/blogs/machine-learning/),
+[Apple Machine Learning Research](https://machinelearning.apple.com),
+[NVIDIA AI Blog](https://blogs.nvidia.com), [NVIDIA Developer](https://developer.nvidia.com/blog/),
+[Hugging Face Blog](https://huggingface.co/blog), [Ai2](https://allenai.org),
+[Mistral AI](https://mistral.ai/news), [Together AI](https://www.together.ai/blog),
+[Sakana AI](https://sakana.ai), [Qwen](https://qwenlm.github.io/blog/),
+[Ollama](https://ollama.com/blog), [Stability AI](https://stability.ai),
+[Nomic AI](https://www.nomic.ai), [Replicate](https://replicate.com/blog),
+[IBM Research](https://research.ibm.com), [Databricks](https://www.databricks.com),
+[LangChain](https://www.langchain.com/blog), and [Meituan Engineering](https://tech.meituan.com).
 
 The frontier-model score layer, including the SWE-bench Verified timeline above,
 is built on benchmark data collected by [LLM Stats](https://llm-stats.com).
@@ -186,3 +207,11 @@ See [`CITATION.cff`](CITATION.cff) for machine-readable citation metadata.
     <img alt="Benchmark Radar star history chart" src="https://raw.githubusercontent.com/ktwu01/benchmark-radar/star-history/assets/star-history.svg" />
   </picture>
 </a>
+
+<details>
+<summary>Internal documentation</summary>
+
+- [SEO and indexing guide](docs/seo-indexing-guide.md)
+- [Benchmark logo gallery](https://benchmark-radar.org/logos.html)
+
+</details>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 every collection, so it states what the project actually holds rather than a
 hand-edited number (issue #197). The source count in the intro below is
 manually maintained: update it when `config.yml` adds or removes a collection
-connector or first-party feed. -->
+connector, a first-party feed, or the Hacker News attention source. -->
 
 <p align="center">
   <a href="https://benchmark-radar.org/"><img alt="Benchmarks collected" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fbenchmark-radar.org%2Fdata%2Frecords-badge.json&amp;style=for-the-badge"></a>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,7 +6,7 @@
 
 # Benchmark Radar
 
-<!-- 记录数 badge 由数据驱动：每次采集都会根据语料重新生成，因此它反映的是项目实际收集到的数据量；下方开头的来源数量是手工维护的，修改 `config.yml` 中的采集 connector 或 first-party feed 时需要同步更新该数字 -->
+<!-- 记录数 badge 由数据驱动：每次采集都会根据语料重新生成，因此它反映的是项目实际收集到的数据量；下方开头的来源数量是手工维护的，当 `config.yml` 增删采集 connector、first-party feed 或 Hacker News attention 来源时，需要同步更新该数字 -->
 
 <p align="center">
   <a href="https://benchmark-radar.org/"><img alt="已收集的 benchmark 记录" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fbenchmark-radar.org%2Fdata%2Frecords-badge.json&amp;style=for-the-badge"></a>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,7 +6,7 @@
 
 # Benchmark Radar
 
-<!-- 记录数 badge 由数据驱动：每次采集都会根据语料重新生成，因此它反映的是项目实际收集到的数据量 -->
+<!-- 记录数 badge 由数据驱动：每次采集都会根据语料重新生成，因此它反映的是项目实际收集到的数据量；下方开头的来源数量是手工维护的，修改 `config.yml` 中的采集 connector 或 first-party feed 时需要同步更新该数字 -->
 
 <p align="center">
   <a href="https://benchmark-radar.org/"><img alt="已收集的 benchmark 记录" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fbenchmark-radar.org%2Fdata%2Frecords-badge.json&amp;style=for-the-badge"></a>
@@ -16,7 +16,7 @@
   <a href="https://scholar.google.com/citations?user=s9w1k-cAAAAJ&amp;hl=en"><img alt="Google Scholar" src="https://img.shields.io/badge/Google%20Scholar-4285F4?style=for-the-badge&amp;logo=googlescholar&amp;logoColor=white"></a>
 </p>
 
-做 benchmark 研究的时候发现新东西太多了，所以我搞了这个持续爬虫，每天自动从全网抓新的 benchmark 相关信息。它目前每天从 arXiv、GitHub、Hugging Face、OpenAlex、OpenReview、各家实验室官方 feed、Brave Search、Semantic Scholar、Hacker News 等来源采集，并持续更新。你如果需要寻找 related work 或找到适合eval自己的agent 的 bench 或者关注最新的 eval 进展，可以看这里哈哈哈：
+做 benchmark 研究的时候发现新东西太多了，所以我搞了这个持续爬虫，每天自动从全网抓新的 benchmark 相关信息。它目前每天从 37 个公开来源采集，并持续更新。你如果需要寻找 related work 或找到适合eval自己的agent 的 bench 或者关注最新的 eval 进展，可以看这里哈哈哈：
 github.com/ktwu01/benchmark-radar，每天更新，并支持一键导出数据
 
 **几秒找到一个 benchmark，再看模型成绩如何随时间变化。点击下面的动图，查看
@@ -117,11 +117,11 @@ curl 'http://127.0.0.1:8765/api/v1/search?q=agent%20benchmark&scope=all'
 
 ## 更多
 
-- **评分规则：** [`src/benchmark_radar/rubric.py`](src/benchmark_radar/rubric.py)
-- **模型卡采用数据：** [`data/model_cards.yml`](data/model_cards.yml)
-- **公开语料 schema：** [`docs/cumulative-corpus.schema.json`](docs/cumulative-corpus.schema.json)
-- **引用信息：** [`CITATION.cff`](CITATION.cff)
-- **配置：** [`config.yml`](config.yml)
+- [评分规则](src/benchmark_radar/rubric.py)
+- [模型卡采用数据](data/model_cards.yml)
+- [公开语料 schema](docs/cumulative-corpus.schema.json)
+- [引用信息](CITATION.cff)
+- [配置](config.yml)
 - **开发环境：** `python -m pip install -e '.[dev]' && benchmark-radar normalize-external`
 - **支持 / 反馈：** [提交 issue](https://github.com/ktwu01/benchmark-radar/issues)
 - **联系：** [@ktwu01](https://github.com/ktwu01)
@@ -134,6 +134,8 @@ curl 'http://127.0.0.1:8765/api/v1/search?q=agent%20benchmark&scope=all'
 <img src="assets/wechat-group-qr.jpg" alt="微信群二维码" width="280" />
 
 ## 感谢
+
+每日信息流基于以下公开来源：[arXiv](https://arxiv.org)、[GitHub Search](https://github.com/search)、[GitHub organizations](https://github.com)、[GitHub Releases](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases)、[Hugging Face datasets and Spaces](https://huggingface.co)、[Hugging Face Papers](https://huggingface.co/papers)、[OpenAlex](https://openalex.org)、[OpenReview](https://openreview.net)、[Kaggle datasets](https://www.kaggle.com/datasets)、[Zenodo](https://zenodo.org)、[Semantic Scholar](https://www.semanticscholar.org)、[Brave Search](https://search.brave.com)、[Hacker News](https://news.ycombinator.com)，以及各家 first-party lab feed：[OpenAI](https://openai.com/news)、[Google AI](https://blog.google/technology/ai/)、[Google DeepMind](https://deepmind.google/blog/)、[Google Research](https://research.google/blog/)、[Meta Research](https://research.facebook.com)、[Microsoft Research](https://www.microsoft.com/en-us/research/)、[AWS Machine Learning](https://aws.amazon.com/blogs/machine-learning/)、[Apple Machine Learning Research](https://machinelearning.apple.com)、[NVIDIA AI Blog](https://blogs.nvidia.com)、[NVIDIA Developer](https://developer.nvidia.com/blog/)、[Hugging Face Blog](https://huggingface.co/blog)、[Ai2](https://allenai.org)、[Mistral AI](https://mistral.ai/news)、[Together AI](https://www.together.ai/blog)、[Sakana AI](https://sakana.ai)、[Qwen](https://qwenlm.github.io/blog/)、[Ollama](https://ollama.com/blog)、[Stability AI](https://stability.ai)、[Nomic AI](https://www.nomic.ai)、[Replicate](https://replicate.com/blog)、[IBM Research](https://research.ibm.com)、[Databricks](https://www.databricks.com)、[LangChain](https://www.langchain.com/blog)、[Meituan Engineering](https://tech.meituan.com)。
 
 前沿模型分数层（包括上方的 SWE-bench Verified 时间线）基于 [LLM Stats](https://llm-stats.com) 采集的 benchmark 数据构建，感谢他们把这些数据公开出来。
 
@@ -169,3 +171,11 @@ curl 'http://127.0.0.1:8765/api/v1/search?q=agent%20benchmark&scope=all'
     <img alt="Benchmark Radar Star 历史图" src="https://raw.githubusercontent.com/ktwu01/benchmark-radar/star-history/assets/star-history.svg" />
   </picture>
 </a>
+
+<details>
+<summary>内部文档</summary>
+
+- [SEO 与索引指南](docs/seo-indexing-guide.md)
+- [Benchmark logo 图库](https://benchmark-radar.org/logos.html)
+
+</details>


### PR DESCRIPTION
## What

Fixes #430.

Four README changes in both `README.md` and `README.zh-CN.md`:

1. **Intro source count.** Replaces the long enumeration ("arXiv, GitHub, Hugging Face, OpenAlex, OpenReview, first-party lab feeds, Brave Search, Semantic Scholar, Hacker News, and more") with a single count: 37 public sources. "37" is derived from `config.yml`: 12 collection connectors (arXiv, Hugging Face datasets/Spaces, GitHub Search, GitHub organizations, Hugging Face Papers, Kaggle, Zenodo, OpenReview, Semantic Scholar, GitHub Releases, OpenAlex, Brave Search) plus the 24 named first-party lab feeds in `first_party_feeds` plus the Hacker News attention source. 13 + 24 = 37.
2. **Acknowledgements.** Lists every source by name with a link, and keeps the existing LLM Stats sentence for the frontier-model score layer.
3. **More section style.** Converts path-heavy entries such as `- **Scoring rubric:** [\`src/benchmark_radar/rubric.py\`](...)` into the compact form `- [Scoring rubric](...)`. Drops the SEO/indexing guide entry from this public list.
4. **Foldable internal docs.** Adds a collapsed `<details>` block at the end of the README holding the two internal-only pointers: the SEO/indexing guide (which describes workflow, not public value) and the public logo gallery at `https://benchmark-radar.org/logos.html`.

## Trade-off

The 37-source figure is hard-coded. It will drift as `config.yml` changes. I added an HTML comment next to the existing badge comment at the top of `README.md` (and a mirrored comment in `README.zh-CN.md`) that names `config.yml` as the source that must be edited alongside the count. A badge-driven dynamic count would be a separate, larger change outside the scope of this issue.

## Verification

- CI sequence from `.github/workflows/ci.yml` run against a clean detached worktree of this branch. All six steps pass: `ruff check .`, `ruff format --check .`, `benchmark-radar normalize-external`, `benchmark-radar classify`, `benchmark-radar build-data-release`, `pytest -q` (1028 passed).
- Working tree contains only the two markdown files; no Python, data, or pipeline changes.
- `site/logos.html` exists in the repo, so `https://benchmark-radar.org/logos.html` resolves on the deployed site.