### PR TITLE
fix(seo): correct the benchmark page interactive link

### DIFF
--- a/src/benchmark_radar/site_pages.py
+++ b/src/benchmark_radar/site_pages.py
@@ -257,7 +257,7 @@ def _page_html(slug: str, shard: dict[str, Any]) -> str:
         scores_html = (
             '<p class="caveat">No reported scores are on record for this benchmark yet.</p>'
         )
-    interactive = f"{SITE_URL}/?lfrontier={slug}"
+    interactive = f"{SITE_URL}/?view=leaderboard&lfrontier={slug}"
     nav = _benchmark_nav(interactive)
     return f"""<!doctype html>
 <html lang="en">

--- a/tests/test_site_pages.py
+++ b/tests/test_site_pages.py
@@ -117,6 +117,17 @@ def test_page_has_unique_title_and_canonical(tmp_path):
     )
 
 
+def test_interactive_view_link_lands_on_the_leaderboard_with_the_slug(tmp_path):
+    output = _generated_pages(tmp_path, _shard("alpha-bench", "Alpha Bench"))
+    page = _page_text(output, "alpha-bench")
+    # The permalink needs the leaderboard view, not a bare lfrontier query that
+    # opens the default Today view and cannot resolve the slug.
+    assert 'href="https://benchmark-radar.org/?view=leaderboard&lfrontier=alpha-bench"' in page
+    assert "?lfrontier=alpha-bench" not in page.replace(
+        "?view=leaderboard&lfrontier=alpha-bench", ""
+    )
+
+
 def test_description_is_present_and_derived_from_the_shard(tmp_path):
     output = _generated_pages(
         tmp_path,


### PR DESCRIPTION
The per-benchmark pages' "Interactive view" link pointed at `?lfrontier=<slug>`, which the app resolves inside the default Today view where a slug cannot render. The leaderboard owns the lfrontier permalink state, so the link now carries `?view=leaderboard&lfrontier=<slug>` and lands on the benchmark's score workbench.

Regression test added. Full CI passes locally (ruff clean, 1050 tests).