### PR TITLE
docs(readme): thank Xiaopai Liu, move Acknowledgements last, flag CLI version

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,11 @@ how scores on each one climb until there is almost no headroom left.**
 
 If Benchmark Radar saves you research time, **[star the repository](https://github.com/ktwu01/benchmark-radar)**. It helps other eval builders find it.
 
-## Query it locally
+## Query it locally (CLI version)
 
-Give this prompt to your coding agent:
+The web dashboard is the hosted view. For offline querying, use **the CLI
+version**: give this prompt to your coding agent and it will install the CLI,
+download the same corpus, and answer from local data.
 
 ```text
 Set up Benchmark Radar for local benchmark search. Follow
@@ -94,34 +96,6 @@ Wu. Third-party source material remains under its original terms.
 Scan the QR code to join the WeChat group for daily benchmark updates and eval discussions:
 
 <img src="assets/wechat-group-qr.jpg" alt="WeChat group QR code" width="280" />
-
-## Acknowledgements
-
-The daily evidence feed is built on public data from [arXiv](https://arxiv.org),
-[GitHub Search](https://github.com/search), [GitHub organizations](https://github.com),
-[GitHub Releases](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases),
-[Hugging Face datasets and Spaces](https://huggingface.co), [Hugging Face Papers](https://huggingface.co/papers),
-[OpenAlex](https://openalex.org), [OpenReview](https://openreview.net),
-[Kaggle datasets](https://www.kaggle.com/datasets), [Zenodo](https://zenodo.org),
-[Semantic Scholar](https://www.semanticscholar.org), [Brave Search](https://search.brave.com),
-and [Hacker News](https://news.ycombinator.com), plus first-party lab feeds from
-[OpenAI](https://openai.com/news), [Google AI](https://blog.google/technology/ai/),
-[Google DeepMind](https://deepmind.google/blog/), [Google Research](https://research.google/blog/),
-[Meta Research](https://research.facebook.com), [Microsoft Research](https://www.microsoft.com/en-us/research/),
-[AWS Machine Learning](https://aws.amazon.com/blogs/machine-learning/),
-[Apple Machine Learning Research](https://machinelearning.apple.com),
-[NVIDIA AI Blog](https://blogs.nvidia.com), [NVIDIA Developer](https://developer.nvidia.com/blog/),
-[Hugging Face Blog](https://huggingface.co/blog), [Ai2](https://allenai.org),
-[Mistral AI](https://mistral.ai/news), [Together AI](https://www.together.ai/blog),
-[Sakana AI](https://sakana.ai), [Qwen](https://qwenlm.github.io/blog/),
-[Ollama](https://ollama.com/blog), [Stability AI](https://stability.ai),
-[Nomic AI](https://www.nomic.ai), [Replicate](https://replicate.com/blog),
-[IBM Research](https://research.ibm.com), [Databricks](https://www.databricks.com),
-[LangChain](https://www.langchain.com/blog), and [Meituan Engineering](https://tech.meituan.com).
-
-The frontier-model score layer, including the SWE-bench Verified timeline above,
-is built on benchmark data collected by [LLM Stats](https://llm-stats.com).
-Thank you for keeping that data open.
 
 ## Contributors
 
@@ -159,6 +133,38 @@ See [`CITATION.cff`](CITATION.cff) for machine-readable citation metadata.
     <img alt="Benchmark Radar star history chart" src="https://raw.githubusercontent.com/ktwu01/benchmark-radar/star-history/assets/star-history.svg" />
   </picture>
 </a>
+
+## Acknowledgements
+
+The daily evidence feed is built on public data from [arXiv](https://arxiv.org),
+[GitHub Search](https://github.com/search), [GitHub organizations](https://github.com),
+[GitHub Releases](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases),
+[Hugging Face datasets and Spaces](https://huggingface.co), [Hugging Face Papers](https://huggingface.co/papers),
+[OpenAlex](https://openalex.org), [OpenReview](https://openreview.net),
+[Kaggle datasets](https://www.kaggle.com/datasets), [Zenodo](https://zenodo.org),
+[Semantic Scholar](https://www.semanticscholar.org), [Brave Search](https://search.brave.com),
+and [Hacker News](https://news.ycombinator.com), plus first-party lab feeds from
+[OpenAI](https://openai.com/news), [Google AI](https://blog.google/technology/ai/),
+[Google DeepMind](https://deepmind.google/blog/), [Google Research](https://research.google/blog/),
+[Meta Research](https://research.facebook.com), [Microsoft Research](https://www.microsoft.com/en-us/research/),
+[AWS Machine Learning](https://aws.amazon.com/blogs/machine-learning/),
+[Apple Machine Learning Research](https://machinelearning.apple.com),
+[NVIDIA AI Blog](https://blogs.nvidia.com), [NVIDIA Developer](https://developer.nvidia.com/blog/),
+[Hugging Face Blog](https://huggingface.co/blog), [Ai2](https://allenai.org),
+[Mistral AI](https://mistral.ai/news), [Together AI](https://www.together.ai/blog),
+[Sakana AI](https://sakana.ai), [Qwen](https://qwenlm.github.io/blog/),
+[Ollama](https://ollama.com/blog), [Stability AI](https://stability.ai),
+[Nomic AI](https://www.nomic.ai), [Replicate](https://replicate.com/blog),
+[IBM Research](https://research.ibm.com), [Databricks](https://www.databricks.com),
+[LangChain](https://www.langchain.com/blog), and [Meituan Engineering](https://tech.meituan.com).
+
+The frontier-model score layer, including the SWE-bench Verified timeline above,
+is built on benchmark data collected by [LLM Stats](https://llm-stats.com).
+Thank you for keeping that data open.
+
+A special thank you to [Xiaopai Liu](https://github.com/liuxiaopai-ai)
+([@bourneliu66](https://x.com/bourneliu66)) for the shout-out on X, and to his
+daily builder brief, [BuilderPulse](https://github.com/BuilderPulse/BuilderPulse).
 
 <details>
 <summary>Internal documentation</summary>

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ If Benchmark Radar saves you research time, **[star the repository](https://gith
 ## Query it locally (CLI version)
 
 The web dashboard is the hosted view. For offline querying, use **the CLI
-version**: give this prompt to your coding agent and it will install the CLI,
-download the same corpus, and answer from local data.
+version**: it installs the CLI, downloads the local searchable data, and
+answers from local files. Give this prompt to your coding agent:
 
 ```text
 Set up Benchmark Radar for local benchmark search. Follow

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -52,9 +52,10 @@ SWE-bench Verified 的 saturation 过程。**
 
 如果 Benchmark Radar 帮你节省了研究时间，请 **[给仓库点个 Star](https://github.com/ktwu01/benchmark-radar)**，让更多做评测的人发现它。
 
-## 在本地查询
+## 在本地查询（CLI 版本）
 
-把下面这段直接发给你的 coding agent：
+网页版 dashboard 是托管视图。需要离线查询时，请使用 **CLI 版本**：它会安装
+CLI、下载本地可搜索的数据，并从本地文件回答。把下面这段直接发给你的 coding agent：
 
 ```text
 请帮我配置 Benchmark Radar 的本地 benchmark 搜索。请遵循
@@ -80,12 +81,6 @@ https://github.com/ktwu01/benchmark-radar/blob/main/skills/benchmark-radar/SKILL
 扫码加入微信群，获取每日 benchmark 更新、交流评测相关话题：
 
 <img src="assets/wechat-group-qr.jpg" alt="微信群二维码" width="280" />
-
-## 感谢
-
-每日信息流基于以下公开来源：[arXiv](https://arxiv.org)、[GitHub Search](https://github.com/search)、[GitHub organizations](https://github.com)、[GitHub Releases](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases)、[Hugging Face datasets and Spaces](https://huggingface.co)、[Hugging Face Papers](https://huggingface.co/papers)、[OpenAlex](https://openalex.org)、[OpenReview](https://openreview.net)、[Kaggle datasets](https://www.kaggle.com/datasets)、[Zenodo](https://zenodo.org)、[Semantic Scholar](https://www.semanticscholar.org)、[Brave Search](https://search.brave.com)、[Hacker News](https://news.ycombinator.com)，以及各家 first-party lab feed：[OpenAI](https://openai.com/news)、[Google AI](https://blog.google/technology/ai/)、[Google DeepMind](https://deepmind.google/blog/)、[Google Research](https://research.google/blog/)、[Meta Research](https://research.facebook.com)、[Microsoft Research](https://www.microsoft.com/en-us/research/)、[AWS Machine Learning](https://aws.amazon.com/blogs/machine-learning/)、[Apple Machine Learning Research](https://machinelearning.apple.com)、[NVIDIA AI Blog](https://blogs.nvidia.com)、[NVIDIA Developer](https://developer.nvidia.com/blog/)、[Hugging Face Blog](https://huggingface.co/blog)、[Ai2](https://allenai.org)、[Mistral AI](https://mistral.ai/news)、[Together AI](https://www.together.ai/blog)、[Sakana AI](https://sakana.ai)、[Qwen](https://qwenlm.github.io/blog/)、[Ollama](https://ollama.com/blog)、[Stability AI](https://stability.ai)、[Nomic AI](https://www.nomic.ai)、[Replicate](https://replicate.com/blog)、[IBM Research](https://research.ibm.com)、[Databricks](https://www.databricks.com)、[LangChain](https://www.langchain.com/blog)、[Meituan Engineering](https://tech.meituan.com)。
-
-前沿模型分数层（包括上方的 SWE-bench Verified 时间线）基于 [LLM Stats](https://llm-stats.com) 采集的 benchmark 数据构建，感谢他们把这些数据公开出来。
 
 ## 贡献者
 
@@ -122,6 +117,14 @@ https://github.com/ktwu01/benchmark-radar/blob/main/skills/benchmark-radar/SKILL
     <img alt="Benchmark Radar Star 历史图" src="https://raw.githubusercontent.com/ktwu01/benchmark-radar/star-history/assets/star-history.svg" />
   </picture>
 </a>
+
+## 感谢
+
+每日信息流基于以下公开来源：[arXiv](https://arxiv.org)、[GitHub Search](https://github.com/search)、[GitHub organizations](https://github.com)、[GitHub Releases](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases)、[Hugging Face datasets and Spaces](https://huggingface.co)、[Hugging Face Papers](https://huggingface.co/papers)、[OpenAlex](https://openalex.org)、[OpenReview](https://openreview.net)、[Kaggle datasets](https://www.kaggle.com/datasets)、[Zenodo](https://zenodo.org)、[Semantic Scholar](https://www.semanticscholar.org)、[Brave Search](https://search.brave.com)、[Hacker News](https://news.ycombinator.com)，以及各家 first-party lab feed：[OpenAI](https://openai.com/news)、[Google AI](https://blog.google/technology/ai/)、[Google DeepMind](https://deepmind.google/blog/)、[Google Research](https://research.google/blog/)、[Meta Research](https://research.facebook.com)、[Microsoft Research](https://www.microsoft.com/en-us/research/)、[AWS Machine Learning](https://aws.amazon.com/blogs/machine-learning/)、[Apple Machine Learning Research](https://machinelearning.apple.com)、[NVIDIA AI Blog](https://blogs.nvidia.com)、[NVIDIA Developer](https://developer.nvidia.com/blog/)、[Hugging Face Blog](https://huggingface.co/blog)、[Ai2](https://allenai.org)、[Mistral AI](https://mistral.ai/news)、[Together AI](https://www.together.ai/blog)、[Sakana AI](https://sakana.ai)、[Qwen](https://qwenlm.github.io/blog/)、[Ollama](https://ollama.com/blog)、[Stability AI](https://stability.ai)、[Nomic AI](https://www.nomic.ai)、[Replicate](https://replicate.com/blog)、[IBM Research](https://research.ibm.com)、[Databricks](https://www.databricks.com)、[LangChain](https://www.langchain.com/blog)、[Meituan Engineering](https://tech.meituan.com)。
+
+前沿模型分数层（包括上方的 SWE-bench Verified 时间线）基于 [LLM Stats](https://llm-stats.com) 采集的 benchmark 数据构建，感谢他们把这些数据公开出来。
+
+特别感谢 [Xiaopai Liu](https://github.com/liuxiaopai-ai)（[@bourneliu66](https://x.com/bourneliu66)）在 X 上为 Benchmark Radar 宣传，也感谢他的每日 builder 简报 [BuilderPulse](https://github.com/BuilderPulse/BuilderPulse)。
 
 <details>
 <summary>内部文档</summary>

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -38,7 +38,7 @@ same slug used in that benchmark's page URL.
 ## Command line
 
 - [Source repository](https://github.com/ktwu01/benchmark-radar): MIT licensed, includes the collection pipeline, the scoring rubric, and the committed daily snapshots the site is built from.
-- [Install the CLI](https://github.com/ktwu01/benchmark-radar#query-it-locally): `python -m pip install 'git+https://github.com/ktwu01/benchmark-radar.git'`, then `benchmark-radar init` downloads the dataset and `benchmark-radar search` queries it offline.
+- [Install the CLI](https://github.com/ktwu01/benchmark-radar#query-it-locally-cli-version): `python -m pip install 'git+https://github.com/ktwu01/benchmark-radar.git'`, then `benchmark-radar init` downloads the dataset and `benchmark-radar search` queries it offline.
 - [CLI data release](https://github.com/ktwu01/benchmark-radar/releases/tag/cli-data): one checksummed archive of the same data, refreshed on every deploy.
 
 ## Optional


### PR DESCRIPTION
Fixes #440

## Summary

Three README changes on `README.md`:

1. **Thank Xiaopai Liu.** Added a thank-you to [Xiaopai Liu](https://github.com/liuxiaopai-ai) (@bourneliu66) and his [BuilderPulse](https://github.com/BuilderPulse/BuilderPulse) project in the Acknowledgements section for the shout-out on X.
2. **Acknowledgements last.** Moved the Acknowledgements section to be the last section, directly under Star History.
3. **CLI version emphasis.** Retitled "Query it locally" to "Query it locally (CLI version)" and clarified that the CLI downloads the local searchable data for offline querying.

## Test plan

- `pytest tests/test_readme.py::test_readmes_offer_a_short_agent_setup_prompt` and the other README regression tests pass (the tested sentence `Give this prompt to your coding agent:` and heading prefix are preserved).
- Codex review against `main`: no actionable regressions.