### PR TITLE
Wire reviewed llm-stats identity into catalog outputs

### DIFF
--- a/data/external/llm_stats_identity_overrides.yml
+++ b/data/external/llm_stats_identity_overrides.yml
@@ -4,12 +4,14 @@
 # carries cross-source equivalence and variant links and never per-benchmark
 # fields.
 #
-# Every row here cleared the two-anchor gate: a paper naming the benchmark plus
-# a repo that self-identifies with the same name, a repo linking its paper, or
-# a dataset card naming both. One matching page is not an anchor. The crawl this
-# was reviewed from returned 50 benchmarks; the 31 it could not anchor twice are
-# deliberately absent rather than present with guesses, and stay in the issue
-# thread until a second anchor is found for them.
+# Every resolved row here cleared the two-anchor gate: a paper naming the
+# benchmark plus a repo that self-identifies with the same name, a repo linking
+# its paper, or a dataset card naming both. One matching page is not an anchor.
+# Unresolved rows are retained only when they carry an explicit not_found or
+# needs_review status; they cannot produce an artifact. The first crawl reviewed
+# here returned 50 benchmarks, of which 19 cleared the gate and 31 stayed absent.
+# The later issue #303 tier records all 38 outcomes so gaps are named rather
+# than silently omitted.
 #
 # Reviewer corrections applied to the crawl, recorded so they are not silently
 # re-introduced by a later pass:
@@ -34,7 +36,11 @@ schema_version: 1
 
 benchmarks:
   "swe-bench-verified":
-    repo_url: https://github.com/princeton-nlp/SWE-bench/tree/main/swebench/harness
+    resolution_status: resolved
+    repo_kind: shared_parent
+    repo_url: https://github.com/princeton-nlp/SWE-bench
+    repo_full_name: princeton-nlp/SWE-bench
+    repo_subpath: swebench/harness
     dataset_url: https://huggingface.co/datasets/princeton-nlp/SWE-bench_Verified
     site_url: https://openai.com/index/introducing-swe-bench-verified/
     publisher: {name: "OpenAI", role: maintainer}
@@ -49,8 +55,12 @@ benchmarks:
       validated 500-task subset; the harness is shared with SWE-bench.
 
   "humanity's-last-exam":
+    resolution_status: resolved
+    repo_kind: benchmark_source
     paper_url: https://arxiv.org/abs/2501.14249
     repo_url: https://github.com/centerforaisafety/hle
+    repo_full_name: centerforaisafety/hle
+    repo_subpath: null
     dataset_url: https://huggingface.co/datasets/cais/hle
     site_url: https://lastexam.ai/
     publisher: {name: "Center for AI Safety", role: paper_org}
@@ -66,8 +76,12 @@ benchmarks:
       collaborators. Dataset access requires sharing contact information.
 
   "mmmu-pro":
+    resolution_status: resolved
+    repo_kind: shared_parent
     paper_url: https://arxiv.org/abs/2409.02813
-    repo_url: https://github.com/MMMU-Benchmark/MMMU/tree/main/mmmu-pro
+    repo_url: https://github.com/MMMU-Benchmark/MMMU
+    repo_full_name: MMMU-Benchmark/MMMU
+    repo_subpath: mmmu-pro
     dataset_url: https://huggingface.co/datasets/MMMU/MMMU_Pro
     released: 2024-09-04
     released_basis: paper_first_version
@@ -82,8 +96,12 @@ benchmarks:
       it is not summed with the standard test configuration.
 
   "browsecomp":
+    resolution_status: resolved
+    repo_kind: harness_only
     paper_url: https://arxiv.org/abs/2504.12516
-    repo_url: https://github.com/openai/simple-evals/blob/main/browsecomp_eval.py
+    repo_url: https://github.com/openai/simple-evals
+    repo_full_name: openai/simple-evals
+    repo_subpath: browsecomp_eval.py
     site_url: https://openai.com/index/browsecomp/
     publisher: {name: "OpenAI", role: maintainer}
     released: 2025-04-10
@@ -98,8 +116,12 @@ benchmarks:
       root.
 
   "terminal-bench":
+    resolution_status: resolved
+    repo_kind: benchmark_source
     paper_url: https://openreview.net/forum?id=a7Qa4CcHak
     repo_url: https://github.com/harbor-framework/terminal-bench-1
+    repo_full_name: harbor-framework/terminal-bench-1
+    repo_subpath: null
     site_url: https://www.tbench.ai/
     released: 2025-01-17
     released_basis: repo_created
@@ -114,7 +136,11 @@ benchmarks:
       while the release date remains repository creation.
 
   "terminal-bench-2":
+    resolution_status: resolved
+    repo_kind: benchmark_source
     repo_url: https://github.com/harbor-framework/terminal-bench-2
+    repo_full_name: harbor-framework/terminal-bench-2
+    repo_subpath: null
     site_url: https://www.tbench.ai/benchmarks/terminal-bench-2
     released: 2025-09-25
     released_basis: repo_created
@@ -127,8 +153,12 @@ benchmarks:
       embedded in the repository, not a separate dataset page.
 
   "terminal-bench-2.1":
+    resolution_status: resolved
+    repo_kind: benchmark_source
     paper_url: https://arxiv.org/abs/2601.11868
     repo_url: https://github.com/harbor-framework/terminal-bench-2-1
+    repo_full_name: harbor-framework/terminal-bench-2-1
+    repo_subpath: null
     dataset_url: https://hub.harborframework.com/datasets/terminal-bench/terminal-bench-2-1/latest
     site_url: https://www.tbench.ai/
     released: 2026-05-05
@@ -141,7 +171,11 @@ benchmarks:
       none is inferred.
 
   "swe-bench-pro":
+    resolution_status: resolved
+    repo_kind: benchmark_source
     repo_url: https://github.com/scaleapi/SWE-bench_Pro-os
+    repo_full_name: scaleapi/SWE-bench_Pro-os
+    repo_subpath: null
     dataset_url: https://huggingface.co/datasets/ScaleAI/SWE-bench_Pro
     publisher: {name: "Scale AI", role: maintainer}
     released: 2025-09-05
@@ -155,7 +189,11 @@ benchmarks:
       variant.
 
   "swe-bench-multilingual":
+    resolution_status: resolved
+    repo_kind: shared_parent
     repo_url: https://github.com/princeton-nlp/SWE-bench
+    repo_full_name: princeton-nlp/SWE-bench
+    repo_subpath: null
     dataset_url: https://huggingface.co/datasets/SWE-bench/SWE-bench_Multilingual
     site_url: https://www.swebench.com/multilingual.html
     code_license: MIT
@@ -169,7 +207,11 @@ benchmarks:
       original SWE-bench paper does not itself introduce this later variant.
 
   "mmmlu":
-    repo_url: https://github.com/openai/simple-evals/blob/main/multilingual_mmlu_benchmark_results.md
+    resolution_status: resolved
+    repo_kind: harness_only
+    repo_url: https://github.com/openai/simple-evals
+    repo_full_name: openai/simple-evals
+    repo_subpath: multilingual_mmlu_benchmark_results.md
     dataset_url: https://huggingface.co/datasets/openai/MMMLU
     publisher: {name: "OpenAI", role: maintainer}
     code_license: MIT
@@ -183,8 +225,12 @@ benchmarks:
       introduced MMMLU paper was verified.
 
   "mmlu-redux":
+    resolution_status: resolved
+    repo_kind: benchmark_source
     paper_url: https://arxiv.org/abs/2406.04127
     repo_url: https://github.com/aryopg/mmlu-redux
+    repo_full_name: aryopg/mmlu-redux
+    repo_subpath: null
     dataset_url: https://huggingface.co/datasets/edinburgh-dawg/mmlu-redux
     released: 2024-06-06
     released_basis: paper_first_version
@@ -200,8 +246,12 @@ benchmarks:
       substituted.
 
   "simpleqa":
+    resolution_status: resolved
+    repo_kind: harness_only
     paper_url: https://arxiv.org/abs/2411.04368
-    repo_url: https://github.com/openai/simple-evals/blob/main/simpleqa_eval.py
+    repo_url: https://github.com/openai/simple-evals
+    repo_full_name: openai/simple-evals
+    repo_subpath: simpleqa_eval.py
     dataset_url: https://openaipublic.blob.core.windows.net/simple-evals/simple_qa_test_set.csv
     site_url: https://openai.com/index/introducing-simpleqa/
     publisher: {name: "OpenAI", role: maintainer}
@@ -217,8 +267,12 @@ benchmarks:
       observed.
 
   "toolathlon":
+    resolution_status: resolved
+    repo_kind: benchmark_source
     paper_url: https://arxiv.org/abs/2510.25726
     repo_url: https://github.com/hkust-nlp/Toolathlon
+    repo_full_name: hkust-nlp/Toolathlon
+    repo_subpath: null
     dataset_url: https://huggingface.co/datasets/hkust-nlp/Toolathlon-Trajectories
     site_url: https://toolathlon.xyz/
     released: 2025-10-29
@@ -233,8 +287,12 @@ benchmarks:
       applies to trajectories rather than task definitions.
 
   "tau2-airline":
+    resolution_status: resolved
+    repo_kind: shared_parent
     paper_url: https://arxiv.org/abs/2506.07982
     repo_url: https://github.com/sierra-research/tau2-bench
+    repo_full_name: sierra-research/tau2-bench
+    repo_subpath: null
     publisher: {name: "Sierra", role: paper_org}
     released: 2025-06-09
     released_basis: paper_first_version
@@ -247,8 +305,12 @@ benchmarks:
       the repository.
 
   "tau2-retail":
+    resolution_status: resolved
+    repo_kind: shared_parent
     paper_url: https://arxiv.org/abs/2506.07982
     repo_url: https://github.com/sierra-research/tau2-bench
+    repo_full_name: sierra-research/tau2-bench
+    repo_subpath: null
     publisher: {name: "Sierra", role: paper_org}
     released: 2025-06-09
     released_basis: paper_first_version
@@ -261,8 +323,12 @@ benchmarks:
       the repository.
 
   "tau2-telecom":
+    resolution_status: resolved
+    repo_kind: shared_parent
     paper_url: https://arxiv.org/abs/2506.07982
     repo_url: https://github.com/sierra-research/tau2-bench
+    repo_full_name: sierra-research/tau2-bench
+    repo_subpath: null
     publisher: {name: "Sierra", role: paper_org}
     released: 2025-06-09
     released_basis: paper_first_version
@@ -276,8 +342,12 @@ benchmarks:
       benchmark task count.
 
   "ifbench":
+    resolution_status: resolved
+    repo_kind: benchmark_source
     paper_url: https://arxiv.org/abs/2507.02833
     repo_url: https://github.com/allenai/IFBench
+    repo_full_name: allenai/IFBench
+    repo_subpath: null
     dataset_url: https://huggingface.co/datasets/allenai/IFBench_test
     publisher: {name: "Allen Institute for AI", role: paper_org}
     released: 2025-07-03
@@ -293,7 +363,11 @@ benchmarks:
       evaluation artifact.
 
   "math-500":
-    repo_url: https://github.com/openai/prm800k/tree/main/prm800k/math_splits
+    resolution_status: resolved
+    repo_kind: monorepo_subdir
+    repo_url: https://github.com/openai/prm800k
+    repo_full_name: openai/prm800k
+    repo_subpath: prm800k/math_splits
     dataset_url: https://github.com/openai/prm800k/blob/main/prm800k/math_splits/test.jsonl
     publisher: {name: "OpenAI", role: maintainer}
     code_license: MIT
@@ -306,8 +380,12 @@ benchmarks:
       separately verified introducing paper.
 
   "mgsm":
+    resolution_status: resolved
+    repo_kind: monorepo_subdir
     paper_url: https://arxiv.org/abs/2210.03057
-    repo_url: https://github.com/google-research/url-nlp/tree/main/mgsm
+    repo_url: https://github.com/google-research/url-nlp
+    repo_full_name: google-research/url-nlp
+    repo_subpath: mgsm
     dataset_url: https://huggingface.co/datasets/juletxara/mgsm
     released: 2022-10-06
     released_basis: paper_first_version
@@ -320,3 +398,418 @@ benchmarks:
       Paper, Google source repository, and independent evaluator/dataset records
       agree. Counts are not multiplied across the 11 translated language
       configurations.
+
+  # Issue #303 Phase A. Unlike the earlier rows, this tier also retains
+  # not_found and needs_review results so all 38 inputs have a structured,
+  # build-validated outcome. Only resolved rows can produce repo artifacts.
+
+  "aime-2025":
+    resolution_status: resolved
+    repo_kind: shared_parent
+    repo_url: https://github.com/eth-sri/matharena
+    repo_full_name: eth-sri/matharena
+    repo_subpath: null
+    dataset_url: https://huggingface.co/datasets/MathArena/aime_2025
+    site_url: https://matharena.ai/competitions
+    note: >-
+      Shared parent: MathArena evaluates AIME 2025 from the same codebase used
+      for other competitions; its dataset card links this repository.
+
+  "livecodebench-v6":
+    resolution_status: resolved
+    repo_kind: benchmark_source
+    repo_url: https://github.com/LiveCodeBench/LiveCodeBench
+    repo_full_name: LiveCodeBench/LiveCodeBench
+    repo_subpath: null
+    paper_url: https://arxiv.org/abs/2403.07974
+    note: >-
+      The official repository documents release_v6, and the paper introduces
+      the same contamination-free code benchmark.
+
+  "aime-2024":
+    resolution_status: not_found
+    repo_kind: not_found
+    repo_url: null
+    repo_full_name: null
+    repo_subpath: null
+    candidate_matches:
+      - url: https://huggingface.co/datasets/Maxwell-Jia/AIME_2024
+        note: Third-party dataset copy, not a source repository.
+      - url: https://matharena.ai/competitions
+        note: MathArena lists later AIME competitions but not AIME 2024.
+    note: No canonical source repository was established for this competition instance.
+
+  "charxiv-r":
+    resolution_status: resolved
+    repo_kind: shared_parent
+    repo_url: https://github.com/princeton-nlp/CharXiv
+    repo_full_name: princeton-nlp/CharXiv
+    repo_subpath: null
+    site_url: https://princeton-nlp.github.io/CharXiv/
+    note: >-
+      Shared parent: CharXiv-R is the reasoning split of CharXiv, and the
+      repository and project page describe both splits.
+
+  "arc-c":
+    resolution_status: not_found
+    repo_kind: not_found
+    repo_url: null
+    repo_full_name: null
+    repo_subpath: null
+    candidate_matches:
+      - url: https://allenai.org/data/arc
+        note: Official dataset distribution page, not a GitHub repository.
+      - url: https://github.com/allenai/ARC-Solvers
+        note: Baseline solvers rather than the benchmark source.
+    note: ARC-Challenge has official data distribution but no verified source repository.
+
+  "ai2d":
+    resolution_status: not_found
+    repo_kind: not_found
+    repo_url: null
+    repo_full_name: null
+    repo_subpath: null
+    candidate_matches:
+      - url: https://allenai.org/data/diagrams
+        note: Official AI2D data portal, not a GitHub repository.
+      - url: https://arxiv.org/abs/1603.07396
+        note: The introducing paper points to the data portal and names no repository.
+    note: The official paper and data portal do not establish a source repository.
+
+  "hmmt-2025":
+    resolution_status: resolved
+    repo_kind: shared_parent
+    repo_url: https://github.com/eth-sri/matharena
+    repo_full_name: eth-sri/matharena
+    repo_subpath: null
+    dataset_url: https://huggingface.co/datasets/MathArena/hmmt_feb_2025
+    site_url: https://matharena.ai/competitions
+    note: >-
+      Shared parent: MathArena publishes the HMMT February 2025 problem set
+      from its common competition codebase.
+
+  "mcp-atlas":
+    resolution_status: resolved
+    repo_kind: benchmark_source
+    repo_url: https://github.com/scaleapi/mcp-atlas
+    repo_full_name: scaleapi/mcp-atlas
+    repo_subpath: null
+    paper_url: https://arxiv.org/html/2602.00933v3
+    note: The repository and paper identify the same 500-task MCP-Atlas benchmark.
+
+  "mmlu-prox":
+    resolution_status: resolved
+    repo_kind: benchmark_source
+    repo_url: https://github.com/weihao1115/MMLU-ProX
+    repo_full_name: weihao1115/MMLU-ProX
+    repo_subpath: null
+    paper_url: https://aclanthology.org/2025.emnlp-main.79/
+    note: The official repository and EMNLP paper identify the 29-language MMLU-ProX benchmark.
+
+  "include":
+    resolution_status: not_found
+    repo_kind: not_found
+    repo_url: null
+    repo_full_name: null
+    repo_subpath: null
+    candidate_matches:
+      - url: https://huggingface.co/datasets/CohereLabs/include-base-44
+        note: Official dataset card; it links the paper but no repository.
+      - url: https://arxiv.org/abs/2411.19799
+        note: Introducing paper with no source repository link.
+    note: The dataset card's only GitHub text is a commented-out user-profile placeholder.
+
+  "multichallenge":
+    resolution_status: resolved
+    repo_kind: benchmark_source
+    repo_url: https://github.com/ekwinox117/multi-challenge
+    repo_full_name: ekwinox117/multi-challenge
+    repo_subpath: null
+    paper_url: https://arxiv.org/abs/2501.17399
+    note: The paper releases MultiChallenge data and code at the matching repository.
+
+  "realworldqa":
+    resolution_status: not_found
+    repo_kind: not_found
+    repo_url: null
+    repo_full_name: null
+    repo_subpath: null
+    candidate_matches:
+      - url: https://huggingface.co/datasets/xai-org/RealworldQA
+        note: Official dataset card, not a repository.
+      - url: https://github.com/QwenLM/Qwen3-VL/tree/main/evaluation/RealWorldQA
+        note: Third-party model evaluation code, not the benchmark source.
+    note: Official xAI sources publish the dataset but no source repository.
+
+  "docvqa":
+    resolution_status: not_found
+    repo_kind: not_found
+    repo_url: null
+    repo_full_name: null
+    repo_subpath: null
+    candidate_matches:
+      - url: https://rrc.cvc.uab.es/?ch=17
+        note: Official challenge portal, not a GitHub repository.
+      - url: https://github.com/VLR-CVC/DocVQA2026
+        note: Evaluation code for a different 2026 competition variant.
+    note: The original DocVQA benchmark has an official portal but no verified source repository.
+
+  "arena-hard":
+    resolution_status: resolved
+    repo_kind: benchmark_source
+    repo_url: https://github.com/lmarena/arena-hard-auto
+    repo_full_name: lmarena/arena-hard-auto
+    repo_subpath: null
+    paper_url: https://arxiv.org/html/2406.11939v2
+    note: The repository ships Arena-Hard-Auto prompts and judging; the paper describes its curation.
+
+  "chartqa":
+    resolution_status: resolved
+    repo_kind: benchmark_source
+    repo_url: https://github.com/vis-nlp/ChartQA
+    repo_full_name: vis-nlp/ChartQA
+    repo_subpath: null
+    paper_url: https://aclanthology.org/2022.findings-acl.177.pdf
+    note: The introducing paper and official repository identify the same ChartQA benchmark.
+
+  "finance-agent-v2":
+    resolution_status: resolved
+    repo_kind: benchmark_source
+    repo_url: https://github.com/vals-ai/finance-agent-v2
+    repo_full_name: vals-ai/finance-agent-v2
+    repo_subpath: null
+    paper_url: https://arxiv.org/pdf/2508.00828
+    site_url: https://www.vals.ai/benchmarks/fabv2
+    note: The Vals repository, leaderboard, and benchmark paper identify Finance Agent v2.
+
+  "videommmu":
+    resolution_status: resolved
+    repo_kind: benchmark_source
+    repo_url: https://github.com/EvolvingLMMs-Lab/VideoMMMU
+    repo_full_name: EvolvingLMMs-Lab/VideoMMMU
+    repo_subpath: null
+    evidence:
+      - url: https://github.com/EvolvingLMMs-Lab/VideoMMMU
+        anchor_type: repo_readme
+        claim: The repository identifies itself as the VideoMMMU benchmark home.
+      - url: https://github.com/EvolvingLMMs-Lab/VideoMMMU/blob/main/README.md
+        anchor_type: repo_readme
+        claim: The README documents VideoMMMU data, metrics, and evaluation.
+    note: The repository publishes the VideoMMMU benchmark data and evaluation.
+
+  "deepswe-1.1":
+    resolution_status: resolved
+    repo_kind: benchmark_source
+    repo_url: https://github.com/datacurve-ai/deep-swe
+    repo_full_name: datacurve-ai/deep-swe
+    repo_subpath: null
+    paper_url: https://arxiv.org/abs/2607.07946
+    note: The paper and repository identify DeepSWE and document the v1.1 grading change.
+
+  "hmmt25":
+    resolution_status: needs_review
+    repo_kind: not_found
+    repo_url: null
+    repo_full_name: null
+    repo_subpath: null
+    candidate_matches:
+      - url: https://llm-stats.com/benchmarks/hmmt25
+        note: The source description spans November 2025 and February 2026 tournaments.
+      - url: https://huggingface.co/datasets/MathArena/hmmt_nov_2025
+        note: Plausible MathArena match, but the scored competition instance is ambiguous.
+    note: A real repository candidate exists, but the exact HMMT instance cannot be pinned down.
+
+  "lvbench":
+    resolution_status: resolved
+    repo_kind: benchmark_source
+    repo_url: https://github.com/zai-org/LVBench
+    repo_full_name: zai-org/LVBench
+    repo_subpath: null
+    dataset_url: https://huggingface.co/datasets/THUDM/LVBench
+    note: The renamed official repository and dataset card identify the same LVBench benchmark.
+
+  "screenspot-pro":
+    resolution_status: resolved
+    repo_kind: benchmark_source
+    repo_url: https://github.com/likaixin2000/ScreenSpot-Pro-GUI-Grounding
+    repo_full_name: likaixin2000/ScreenSpot-Pro-GUI-Grounding
+    repo_subpath: null
+    paper_url: https://huggingface.co/papers/2504.07981
+    note: The repository and paper publish ScreenSpot-Pro data and evaluation scripts.
+
+  "tau-bench-retail":
+    resolution_status: resolved
+    repo_kind: shared_parent
+    repo_url: https://github.com/sierra-research/tau-bench
+    repo_full_name: sierra-research/tau-bench
+    repo_subpath: null
+    paper_url: https://arxiv.org/pdf/2406.12045
+    note: "Shared parent: the tau-bench repository publishes both retail and airline domains."
+
+  "erqa":
+    resolution_status: resolved
+    repo_kind: benchmark_source
+    repo_url: https://github.com/embodiedreasoning/ERQA
+    repo_full_name: embodiedreasoning/ERQA
+    repo_subpath: null
+    site_url: https://deepmind.google/blog/gemini-robotics-er-1-6/
+    note: The repository publishes ERQA examples, and DeepMind's release identifies the benchmark.
+
+  "mathvista-mini":
+    resolution_status: resolved
+    repo_kind: shared_parent
+    repo_url: https://github.com/lupantech/MathVista
+    repo_full_name: lupantech/MathVista
+    repo_subpath: null
+    dataset_url: https://huggingface.co/datasets/AI4Math/MathVista
+    note: "Shared parent: MathVista-Mini is the testmini split published by MathVista."
+
+  "osworld-verified":
+    resolution_status: resolved
+    repo_kind: shared_parent
+    repo_url: https://github.com/xlang-ai/OSWorld
+    repo_full_name: xlang-ai/OSWorld
+    repo_subpath: null
+    site_url: https://xlang.ai/blog/osworld-verified
+    note: "Shared parent: the verified task revisions ship from the OSWorld repository."
+
+  "mrcr-v2-(8-needle)":
+    resolution_status: not_found
+    repo_kind: not_found
+    repo_url: null
+    repo_full_name: null
+    repo_subpath: null
+    candidate_matches:
+      - url: https://huggingface.co/datasets/openai/mrcr
+        note: Official dataset card for the needle variants; it links no repository.
+    note: The official artifact is a dataset card, with no verified source repository.
+
+  "multi-if":
+    resolution_status: resolved
+    repo_kind: benchmark_source
+    repo_url: https://github.com/facebookresearch/Multi-IF
+    repo_full_name: facebookresearch/Multi-IF
+    repo_subpath: null
+    paper_url: https://arxiv.org/abs/2410.15553
+    note: The paper states that Multi-IF is released at the matching repository.
+
+  "polymath":
+    resolution_status: not_found
+    repo_kind: not_found
+    repo_url: null
+    repo_full_name: null
+    repo_subpath: null
+    candidate_matches:
+      - url: https://arxiv.org/abs/2410.14702
+        note: The tracked multimodal PolyMATH paper names no GitHub repository.
+      - url: https://github.com/QwenLM/PolyMath
+        note: A different multilingual math benchmark with the same name.
+    note: No repository was verified for the multimodal PolyMATH tracked by llm-stats.
+
+  "t2-bench":
+    resolution_status: needs_review
+    repo_kind: not_found
+    repo_url: null
+    repo_full_name: null
+    repo_subpath: null
+    candidate_matches:
+      - url: https://llm-stats.com/benchmarks/t2-bench
+        note: The source page gives no paper, site, or repository.
+      - url: https://github.com/sierra-research/tau2-bench
+        note: Plausible ASCII-name match, but no source ties the label t2-bench to this repo.
+    note: The tau2-bench repository is plausible but cannot be resolved from source evidence.
+
+  "tau-bench-airline":
+    resolution_status: resolved
+    repo_kind: shared_parent
+    repo_url: https://github.com/sierra-research/tau-bench
+    repo_full_name: sierra-research/tau-bench
+    repo_subpath: null
+    paper_url: https://arxiv.org/pdf/2406.12045
+    note: "Shared parent: the tau-bench repository publishes both airline and retail domains."
+
+  "wmt24++":
+    resolution_status: not_found
+    repo_kind: not_found
+    repo_url: null
+    repo_full_name: null
+    repo_subpath: null
+    candidate_matches:
+      - url: https://huggingface.co/datasets/google/wmt24pp
+        note: Official dataset card, with no benchmark source repository.
+      - url: https://github.com/google-research/mt-metrics-eval
+        note: Metrics and system-output tooling, not the benchmark source.
+    note: Official WMT24++ sources publish data but no benchmark-specific repository.
+
+  "aider-polyglot":
+    resolution_status: resolved
+    repo_kind: benchmark_source
+    repo_url: https://github.com/Aider-AI/polyglot-benchmark
+    repo_full_name: Aider-AI/polyglot-benchmark
+    repo_subpath: null
+    site_url: https://aider.chat/2024/12/21/polyglot.html
+    note: The repository holds the problems described by aider's benchmark announcement.
+
+  "aime-2026":
+    resolution_status: resolved
+    repo_kind: shared_parent
+    repo_url: https://github.com/eth-sri/matharena
+    repo_full_name: eth-sri/matharena
+    repo_subpath: null
+    dataset_url: https://huggingface.co/datasets/MathArena/aime_2026
+    site_url: https://matharena.ai/?comp=aime--aime_2026
+    note: "Shared parent: MathArena publishes the AIME 2026 configuration and dataset."
+
+  "big-bench-hard":
+    resolution_status: resolved
+    repo_kind: benchmark_source
+    repo_url: https://github.com/suzgunmirac/BIG-Bench-Hard
+    repo_full_name: suzgunmirac/BIG-Bench-Hard
+    repo_subpath: null
+    evidence:
+      - url: https://github.com/suzgunmirac/BIG-Bench-Hard/blob/main/README.md
+        anchor_type: repo_readme
+        claim: The README defines BIG-Bench Hard and its 23 selected tasks.
+      - url: https://github.com/suzgunmirac/BIG-Bench-Hard/blob/main/bbh/boolean_expressions.json
+        anchor_type: repo_readme
+        claim: The repository publishes benchmark task data under bbh.
+    note: The repository defines BIG-Bench Hard and publishes its task data.
+
+  "scicode":
+    resolution_status: resolved
+    repo_kind: benchmark_source
+    repo_url: https://github.com/scicode-bench/SciCode
+    repo_full_name: scicode-bench/SciCode
+    repo_subpath: null
+    paper_url: https://arxiv.org/pdf/2407.13168
+    note: The repository and paper define the same scientist-curated SciCode benchmark.
+
+  "imo-answerbench":
+    resolution_status: resolved
+    repo_kind: monorepo_subdir
+    repo_url: https://github.com/google-deepmind/superhuman
+    repo_full_name: google-deepmind/superhuman
+    repo_subpath: imobench
+    paper_url: https://arxiv.org/html/2511.01846v1
+    dataset_url: https://huggingface.co/datasets/OpenEvals/IMO-AnswerBench
+    note: >-
+      Monorepo subdirectory: imobench contains IMO-AnswerBench inside the wider
+      superhuman repository and must not enter a benchmark-repo contributor crawl.
+
+  "mmbench-v1.1":
+    resolution_status: resolved
+    repo_kind: shared_parent
+    repo_url: https://github.com/open-compass/MMBench
+    repo_full_name: open-compass/MMBench
+    repo_subpath: null
+    paper_url: https://arxiv.org/abs/2307.06281
+    note: "Shared parent: MMBench v1.1 is the cleaned V11 release in the MMBench repository."
+
+  "osworld":
+    resolution_status: resolved
+    repo_kind: benchmark_source
+    repo_url: https://github.com/xlang-ai/OSWorld
+    repo_full_name: xlang-ai/OSWorld
+    repo_subpath: null
+    site_url: https://osworld-v1.xlang.ai/
+    note: The official repository and project site publish OSWorld tasks and evaluation.

--- a/src/benchmark_radar/cli.py
+++ b/src/benchmark_radar/cli.py
@@ -323,8 +323,6 @@ def main() -> None:
             for snapshot in crawled["snapshots"]
             if snapshot["id"] in SOURCES
         ]
-        for result in normalized:
-            write_catalog(result)
 
         opencompass = normalize_opencompass()
         (DEFAULT_OUTPUT_DIR / "opencompass_source_records.jsonl").write_text(
@@ -341,6 +339,37 @@ def main() -> None:
         all_series = [item for result in normalized for item in result["score_series"]]
         all_observations = [item for result in normalized for item in result["score_observations"]]
         series_by_key = {row["key"]: row for row in all_series}
+        raw_records = [
+            item for result in normalized for item in result["source_records"]
+        ] + opencompass["source_records"]
+
+        from .external_overrides import (
+            apply_llm_stats_identity_overrides,
+            load_llm_stats_identity_overrides,
+            overridden_validation,
+        )
+
+        # llm-stats itself carries no benchmark provenance. Its raw records
+        # above remain the input to candidate generation; separately reviewed
+        # facts are applied before source records, the index, and shards are
+        # written so the product actually receives them.
+        overrides = load_llm_stats_identity_overrides(raw_records)
+        enriched_normalized = []
+        for result in normalized:
+            if result["validation"]["source"] != "llm_stats":
+                enriched_normalized.append(result)
+                continue
+            enriched = dict(result)
+            enriched["source_records"] = apply_llm_stats_identity_overrides(
+                result["source_records"], overrides
+            )
+            enriched["validation"] = overridden_validation(
+                result["validation"], enriched["source_records"], overrides
+            )
+            enriched_normalized.append(enriched)
+        normalized = enriched_normalized
+        for result in normalized:
+            write_catalog(result)
         all_records = [
             item for result in normalized for item in result["source_records"]
         ] + opencompass["source_records"]
@@ -359,7 +388,7 @@ def main() -> None:
         # hand, and the candidates only feed that review. Candidates are built
         # from the raw records, before inheritance, so a borrowed anchor never
         # manufactures a machine candidate.
-        candidates = build_identity_candidates(all_records)
+        candidates = build_identity_candidates(raw_records)
         write_identity_candidates(candidates, DEFAULT_CANDIDATES_PATH)
 
         # Resolve the reviewed join, then let a record in an `equivalent` group
@@ -403,6 +432,8 @@ def main() -> None:
             f"identity candidates: {candidates['equivalent_candidate_count']} anchor-backed, "
             f"{candidates['name_only_count']} name-only -> {DEFAULT_CANDIDATES_PATH}\n"
             f"identity inherited: {inherited_count} records show a reviewed donor's identity\n"
+            f"llm-stats identity overrides: {overrides.validation['override_count']} reviewed "
+            f"records, {overrides.validation['resolution_status_counts']['resolved']} resolved\n"
             f"catalog written to {DEFAULT_OUTPUT_DIR}"
         )
         return

--- a/src/benchmark_radar/external_catalog.py
+++ b/src/benchmark_radar/external_catalog.py
@@ -511,6 +511,7 @@ def build_benchmark_index(
         artifacts = record.get("artifacts") or []
         series = series_by_key.get(record["key"]) or {}
         publisher = record.get("publisher")
+        repository = record.get("repository") or {}
         index.append(
             {
                 "slug": record["slug"],
@@ -538,6 +539,8 @@ def build_benchmark_index(
                 "score_count": series.get("observation_count", 0),
                 "has_paper": any(item["kind"] == "paper" for item in artifacts),
                 "has_repo": any(item["kind"] == "repo" for item in artifacts),
+                "repo_kind": repository.get("kind"),
+                "repo_resolution_status": repository.get("resolution_status"),
                 "has_dataset": any(item["kind"] == "dataset" for item in artifacts),
                 "has_size": bool(record.get("sizes")),
             }

--- a/src/benchmark_radar/external_overrides.py
+++ b/src/benchmark_radar/external_overrides.py
@@ -1,0 +1,525 @@
+"""Reviewed identity enrichment for llm-stats source records.
+
+The llm-stats API does not publish benchmark provenance. Its raw normalized
+records therefore remain empty, while this module applies separately reviewed
+facts from ``llm_stats_identity_overrides.yml`` before generated source
+records, the search index, and detail shards are written.
+
+Repository identity is structural here. A consumer can distinguish a
+benchmark's own repository from a shared parent, monorepo subdirectory, or
+evaluation harness without parsing prose. Unresolved research is retained too,
+but it cannot manufacture an artifact or make ``has_repo`` true.
+"""
+
+from __future__ import annotations
+
+import re
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+import yaml
+
+from .external_catalog import CATALOG_SCHEMA_VERSION, ExternalCatalogError
+
+DEFAULT_LLM_STATS_IDENTITY_OVERRIDES_PATH = Path("data/external/llm_stats_identity_overrides.yml")
+
+_RESOLUTION_STATUSES = {"resolved", "needs_review", "not_found"}
+_RESOLVED_REPO_KINDS = {
+    "benchmark_source",
+    "shared_parent",
+    "monorepo_subdir",
+    "harness_only",
+}
+_REPO_KINDS = _RESOLVED_REPO_KINDS | {"not_found"}
+_ANCHOR_TYPES = {"paper", "repo_readme", "dataset_card", "leaderboard", "project_site"}
+_OWN_ANCHOR_TYPES = {"paper", "repo_readme", "dataset_card"}
+_OPEN_DATA_LICENSES = {
+    "MIT",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC0-1.0",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "CC-BY-SA-4.0",
+    "ODC-BY-1.0",
+}
+_URL_FIELDS = {
+    "paper_url": "paper",
+    "repo_url": "repo_readme",
+    "dataset_url": "dataset_card",
+    "site_url": "project_site",
+}
+_ROW_FIELDS = {
+    "resolution_status",
+    "repo_kind",
+    "repo_url",
+    "repo_full_name",
+    "repo_subpath",
+    "paper_url",
+    "dataset_url",
+    "site_url",
+    "publisher",
+    "released",
+    "released_basis",
+    "code_license",
+    "data_license",
+    "data_located",
+    "sizes",
+    "evidence",
+    "candidate_matches",
+    "note",
+}
+_FULL_NAME = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+_ARXIV_ID = re.compile(r"/(?:abs|pdf|html)/([0-9]{4}\.[0-9]{4,5})(?:v[0-9]+)?(?:\.pdf)?$")
+
+
+class IdentityOverrideError(ExternalCatalogError):
+    """Raised when a reviewed override is malformed or cannot be applied."""
+
+
+class _UniqueKeyLoader(yaml.SafeLoader):
+    """Safe YAML loader that rejects duplicate mappings instead of overwriting."""
+
+
+def _construct_mapping(
+    loader: _UniqueKeyLoader, node: yaml.MappingNode, deep: bool = False
+) -> dict[Any, Any]:
+    mapping: dict[Any, Any] = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if key in mapping:
+            raise IdentityOverrideError(
+                f"duplicate YAML key {key!r} at line {key_node.start_mark.line + 1}"
+            )
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+_UniqueKeyLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    _construct_mapping,
+)
+
+
+@dataclass(frozen=True)
+class LlmStatsIdentityOverrides:
+    """Validated override rows plus counts reported by the generator."""
+
+    by_benchmark_id: dict[str, dict[str, Any]]
+    validation: dict[str, Any]
+    source_path: Path
+
+
+def _error(path: Path, benchmark_id: str | None, message: str) -> IdentityOverrideError:
+    location = str(path)
+    if benchmark_id is not None:
+        location += f": benchmark {benchmark_id!r}"
+    return IdentityOverrideError(f"{location}: {message}")
+
+
+def _require_url(path: Path, benchmark_id: str, field: str, value: Any) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise _error(path, benchmark_id, f"{field} must be a non-empty URL or null")
+    text = value.strip()
+    parsed = urlsplit(text)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise _error(path, benchmark_id, f"{field} is not an http(s) URL: {text!r}")
+    return text
+
+
+def _normalize_evidence(
+    path: Path,
+    benchmark_id: str,
+    row: dict[str, Any],
+) -> list[dict[str, Any]]:
+    raw = row.get("evidence")
+    evidence: list[dict[str, Any]] = []
+    if raw is not None:
+        if not isinstance(raw, list):
+            raise _error(path, benchmark_id, "evidence must be a list")
+        for index, item in enumerate(raw):
+            if not isinstance(item, dict):
+                raise _error(path, benchmark_id, f"evidence[{index}] must be an object")
+            url = _require_url(path, benchmark_id, f"evidence[{index}].url", item.get("url"))
+            if url is None:
+                raise _error(path, benchmark_id, f"evidence[{index}].url is required")
+            anchor_type = item.get("anchor_type")
+            claim = item.get("claim")
+            if anchor_type not in _ANCHOR_TYPES:
+                raise _error(
+                    path,
+                    benchmark_id,
+                    f"evidence[{index}].anchor_type must be one of {sorted(_ANCHOR_TYPES)}",
+                )
+            if not isinstance(claim, str) or not claim.strip():
+                raise _error(path, benchmark_id, f"evidence[{index}].claim is required")
+            evidence.append({"url": url, "anchor_type": anchor_type, "claim": claim.strip()})
+
+    # Existing reviewed rows predate the explicit evidence list. Their named
+    # artifact URLs still form a mechanical two-URL gate, while the row note
+    # records the identity judgement. New research can use the richer list.
+    if not evidence:
+        note = str(row.get("note") or "").strip()
+        for field, anchor_type in _URL_FIELDS.items():
+            url = _require_url(path, benchmark_id, field, row.get(field))
+            if url:
+                evidence.append(
+                    {
+                        "url": url,
+                        "anchor_type": anchor_type,
+                        "claim": note,
+                    }
+                )
+    return evidence
+
+
+def _normalize_candidates(
+    path: Path,
+    benchmark_id: str,
+    raw: Any,
+) -> list[dict[str, str]]:
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        raise _error(path, benchmark_id, "candidate_matches must be a list")
+    candidates: list[dict[str, str]] = []
+    for index, item in enumerate(raw):
+        if not isinstance(item, dict):
+            raise _error(path, benchmark_id, f"candidate_matches[{index}] must be an object")
+        url = _require_url(path, benchmark_id, f"candidate_matches[{index}].url", item.get("url"))
+        if url is None:
+            raise _error(path, benchmark_id, f"candidate_matches[{index}].url is required")
+        note = item.get("note")
+        if not isinstance(note, str) or not note.strip():
+            raise _error(path, benchmark_id, f"candidate_matches[{index}].note is required")
+        candidates.append({"url": url, "note": note.strip()})
+    return candidates
+
+
+def _validate_repository(
+    path: Path,
+    benchmark_id: str,
+    row: dict[str, Any],
+    status: str,
+) -> dict[str, Any]:
+    kind = row.get("repo_kind")
+    if kind not in _REPO_KINDS:
+        raise _error(path, benchmark_id, f"repo_kind must be one of {sorted(_REPO_KINDS)}")
+
+    url = _require_url(path, benchmark_id, "repo_url", row.get("repo_url"))
+    full_name = row.get("repo_full_name")
+    subpath = row.get("repo_subpath")
+    if subpath is not None and (not isinstance(subpath, str) or not subpath.strip()):
+        raise _error(path, benchmark_id, "repo_subpath must be a non-empty string or null")
+    subpath = subpath.strip().strip("/") if isinstance(subpath, str) else None
+
+    if status == "resolved":
+        if kind not in _RESOLVED_REPO_KINDS:
+            raise _error(path, benchmark_id, "a resolved row needs a resolved repo_kind")
+        if not isinstance(full_name, str) or not _FULL_NAME.fullmatch(full_name):
+            raise _error(path, benchmark_id, "repo_full_name must be canonical owner/repo")
+        expected_url = f"https://github.com/{full_name}"
+        if url is None or url.rstrip("/").lower() != expected_url.lower():
+            raise _error(
+                path,
+                benchmark_id,
+                f"repo_url must be the repository root {expected_url!r}; put paths in repo_subpath",
+            )
+        if kind == "monorepo_subdir" and not subpath:
+            raise _error(path, benchmark_id, "monorepo_subdir requires repo_subpath")
+    else:
+        if kind != "not_found":
+            raise _error(path, benchmark_id, f"{status} rows must use repo_kind: not_found")
+        if any(value is not None for value in (url, full_name, subpath)):
+            raise _error(path, benchmark_id, f"{status} rows cannot publish repository fields")
+
+    return {
+        "url": url,
+        "full_name": full_name,
+        "kind": kind,
+        "subpath": subpath,
+        "resolution_status": status,
+    }
+
+
+def _validate_row(path: Path, benchmark_id: str, raw: Any) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise _error(path, benchmark_id, "override must be an object")
+    unknown = sorted(set(raw) - _ROW_FIELDS)
+    if unknown:
+        raise _error(path, benchmark_id, f"unknown fields: {', '.join(unknown)}")
+
+    row = dict(raw)
+    status = row.get("resolution_status")
+    if status not in _RESOLUTION_STATUSES:
+        raise _error(
+            path,
+            benchmark_id,
+            f"resolution_status must be one of {sorted(_RESOLUTION_STATUSES)}",
+        )
+    note = row.get("note")
+    if not isinstance(note, str) or not note.strip():
+        raise _error(path, benchmark_id, "note is required")
+
+    for field in _URL_FIELDS:
+        row[field] = _require_url(path, benchmark_id, field, row.get(field))
+    row["repository"] = _validate_repository(path, benchmark_id, row, status)
+    row["evidence"] = _normalize_evidence(path, benchmark_id, row)
+    row["candidate_matches"] = _normalize_candidates(
+        path, benchmark_id, row.get("candidate_matches")
+    )
+    row["note"] = note.strip()
+
+    if status == "resolved":
+        distinct_urls = {item["url"] for item in row["evidence"]}
+        if len(distinct_urls) < 2:
+            raise _error(path, benchmark_id, "resolved rows need evidence from two different URLs")
+        if not any(item["anchor_type"] in _OWN_ANCHOR_TYPES for item in row["evidence"]):
+            raise _error(
+                path,
+                benchmark_id,
+                "resolved rows need a paper, repo_readme, or dataset_card anchor",
+            )
+    elif not row["candidate_matches"]:
+        raise _error(path, benchmark_id, f"{status} rows need at least one candidate_match")
+
+    publisher = row.get("publisher")
+    if publisher is not None:
+        if not isinstance(publisher, dict) or not str(publisher.get("name") or "").strip():
+            raise _error(path, benchmark_id, "publisher needs a name")
+        if publisher.get("role") not in {"hub_publisher", "paper_org", "maintainer"}:
+            raise _error(path, benchmark_id, "publisher has an unsupported role")
+
+    released = row.get("released")
+    if released is not None:
+        text = released.isoformat() if isinstance(released, date) else str(released)
+        try:
+            parsed = date.fromisoformat(text)
+        except ValueError as exc:
+            raise _error(path, benchmark_id, f"released is not an ISO date: {text!r}") from exc
+        if parsed.isoformat() != text:
+            raise _error(path, benchmark_id, f"released is not canonical YYYY-MM-DD: {text!r}")
+        row["released"] = text
+        if not str(row.get("released_basis") or "").strip():
+            raise _error(path, benchmark_id, "released needs released_basis")
+
+    sizes = row.get("sizes") or []
+    if not isinstance(sizes, list) or any(not isinstance(item, dict) for item in sizes):
+        raise _error(path, benchmark_id, "sizes must be a list of objects")
+    for index, item in enumerate(sizes):
+        missing = [field for field in ("value", "unit", "split", "measures") if field not in item]
+        if missing:
+            raise _error(path, benchmark_id, f"sizes[{index}] is missing {', '.join(missing)}")
+
+    if row.get("data_located") not in {None, "found", "gated", "not_found"}:
+        raise _error(path, benchmark_id, "data_located must be found, gated, not_found, or null")
+    return row
+
+
+def load_llm_stats_identity_overrides(
+    records: list[dict[str, Any]],
+    path: Path = DEFAULT_LLM_STATS_IDENTITY_OVERRIDES_PATH,
+) -> LlmStatsIdentityOverrides:
+    """Load and validate every reviewed row against current llm-stats ids."""
+    if not path.exists():
+        raise IdentityOverrideError(f"{path}: reviewed llm-stats identity overrides not found")
+    try:
+        data = yaml.load(path.read_text(encoding="utf-8"), Loader=_UniqueKeyLoader) or {}
+    except yaml.YAMLError as exc:
+        raise IdentityOverrideError(f"{path}: invalid YAML: {exc}") from exc
+    if not isinstance(data, dict):
+        raise IdentityOverrideError(f"{path}: document must be an object")
+    if set(data) != {"schema_version", "benchmarks"}:
+        raise IdentityOverrideError(
+            f"{path}: top-level fields must be schema_version and benchmarks"
+        )
+    if data.get("schema_version") != CATALOG_SCHEMA_VERSION:
+        raise IdentityOverrideError(
+            f"{path}: schema_version {data.get('schema_version')!r} != {CATALOG_SCHEMA_VERSION}"
+        )
+    raw_rows = data.get("benchmarks")
+    if not isinstance(raw_rows, dict):
+        raise IdentityOverrideError(f"{path}: benchmarks must be an object")
+
+    record_ids = {
+        record["source_benchmark_id"] for record in records if record.get("source") == "llm_stats"
+    }
+    rows: dict[str, dict[str, Any]] = {}
+    for benchmark_id, raw in raw_rows.items():
+        if not isinstance(benchmark_id, str) or not benchmark_id:
+            raise IdentityOverrideError(f"{path}: benchmark ids must be non-empty strings")
+        if benchmark_id not in record_ids:
+            raise _error(path, benchmark_id, "does not match a current llm-stats source record")
+        rows[benchmark_id] = _validate_row(path, benchmark_id, raw)
+
+    status_counts = {
+        status: sum(1 for row in rows.values() if row["resolution_status"] == status)
+        for status in sorted(_RESOLUTION_STATUSES)
+    }
+    kind_counts = {
+        kind: sum(1 for row in rows.values() if row["repo_kind"] == kind)
+        for kind in sorted(_REPO_KINDS)
+    }
+    return LlmStatsIdentityOverrides(
+        by_benchmark_id=rows,
+        validation={
+            "override_count": len(rows),
+            "resolution_status_counts": status_counts,
+            "repo_kind_counts": kind_counts,
+        },
+        source_path=path,
+    )
+
+
+def _artifact_id(kind: str, url: str, repository: dict[str, Any]) -> str:
+    if kind == "repo":
+        return f"gh:{repository['full_name']}"
+    if kind == "paper":
+        match = _ARXIV_ID.search(urlsplit(url).path)
+        if match:
+            return f"arxiv:{match.group(1)}"
+    if kind == "dataset":
+        parsed = urlsplit(url)
+        parts = [part for part in parsed.path.split("/") if part]
+        if parsed.netloc.lower() == "huggingface.co" and len(parts) >= 3 and parts[0] == "datasets":
+            return f"hf:{parts[1]}/{parts[2]}"
+    return f"url:{url}"
+
+
+def _openness(row: dict[str, Any]) -> dict[str, Any]:
+    data_located = row.get("data_located")
+    data_license = row.get("data_license")
+    if data_located == "gated":
+        status, basis = "restricted", "reviewed_data_gated"
+    elif data_located == "found" and not data_license:
+        status, basis = "restricted", "reviewed_data_found_without_license"
+    elif data_located == "found" and data_license not in _OPEN_DATA_LICENSES:
+        status, basis = "restricted", "reviewed_data_license_restricts_reuse"
+    elif data_located == "found" and data_license:
+        status, basis = "open", "reviewed_code_and_licensed_data_public"
+    else:
+        status, basis = "unknown", "reviewed_data_availability_not_established"
+    return {
+        "status": status,
+        "basis": basis,
+        "code_license": row.get("code_license"),
+        "code_license_note": None,
+        "data_license": data_license,
+        "data_license_note": None,
+        "data_located": data_located,
+        "access_gate": "reviewed_gate" if data_located == "gated" else None,
+        "link_status": None,
+        "evidence": [
+            item["url"]
+            for item in row["evidence"]
+            if item["anchor_type"] in {"repo_readme", "dataset_card"}
+        ],
+    }
+
+
+def _apply_row(record: dict[str, Any], row: dict[str, Any], source_path: Path) -> dict[str, Any]:
+    merged = dict(record)
+    repository = deepcopy(row["repository"])
+    merged["repository"] = repository
+
+    artifacts = list(record.get("artifacts") or [])
+    for field, kind in (("paper_url", "paper"), ("repo_url", "repo"), ("dataset_url", "dataset")):
+        url = row.get(field)
+        if not url:
+            continue
+        artifact = {
+            "kind": kind,
+            "id": _artifact_id(kind, url, repository),
+            "url": url,
+            "locator": f"{source_path}#benchmarks.{record['source_benchmark_id']}.{field}",
+        }
+        if artifact not in artifacts:
+            artifacts.append(artifact)
+    merged["artifacts"] = artifacts
+
+    if row.get("publisher"):
+        merged["publisher"] = {
+            **row["publisher"],
+            "locator": f"{source_path}#benchmarks.{record['source_benchmark_id']}.publisher",
+        }
+    if row.get("released"):
+        merged["released"] = row["released"]
+        merged["released_basis"] = row.get("released_basis")
+    if row.get("sizes"):
+        merged["sizes"] = [
+            {**item, "origin": "reviewed_llm_stats_identity_override"}
+            for item in deepcopy(row["sizes"])
+        ]
+    merged["openness"] = _openness(row)
+    merged["identity_override"] = {
+        "source": "reviewed_llm_stats_identity_override",
+        "source_path": str(source_path),
+        "resolution_status": row["resolution_status"],
+        "repository": repository,
+        "evidence": deepcopy(row["evidence"]),
+        "candidate_matches": deepcopy(row["candidate_matches"]),
+        "note": row["note"],
+    }
+    return merged
+
+
+def apply_llm_stats_identity_overrides(
+    records: list[dict[str, Any]],
+    overrides: LlmStatsIdentityOverrides,
+) -> list[dict[str, Any]]:
+    """Apply reviewed identity without changing keys, scores, or other sources."""
+    resolved: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for record in records:
+        benchmark_id = record.get("source_benchmark_id")
+        row = (
+            overrides.by_benchmark_id.get(benchmark_id)
+            if record.get("source") == "llm_stats"
+            else None
+        )
+        if row is None:
+            resolved.append(record)
+            continue
+        if benchmark_id in seen:
+            raise IdentityOverrideError(
+                f"duplicate llm-stats source record for benchmark {benchmark_id!r}"
+            )
+        seen.add(benchmark_id)
+        resolved.append(_apply_row(record, row, overrides.source_path))
+
+    missing = sorted(set(overrides.by_benchmark_id) - seen)
+    if missing:
+        raise IdentityOverrideError(
+            "reviewed llm-stats overrides were not applied: " + ", ".join(missing)
+        )
+    return resolved
+
+
+def overridden_validation(
+    validation: dict[str, Any],
+    records: list[dict[str, Any]],
+    overrides: LlmStatsIdentityOverrides,
+) -> dict[str, Any]:
+    """Update the written source-record validation after reviewed enrichment."""
+    enriched = dict(validation)
+    enriched["identity_overrides"] = overrides.validation
+    enriched["empty_provenance_fraction"] = (
+        sum(
+            1
+            for record in records
+            if record.get("publisher") is None
+            and not record.get("artifacts")
+            and not record.get("sizes")
+        )
+        / len(records)
+        if records
+        else 1.0
+    )
+    return enriched

--- a/tests/test_external_overrides.py
+++ b/tests/test_external_overrides.py
@@ -1,0 +1,215 @@
+"""Reviewed llm-stats identity must reach every generated catalog surface."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from benchmark_radar.external_catalog import (
+    build_benchmark_index,
+    normalize_snapshot,
+    write_catalog,
+)
+from benchmark_radar.external_overrides import (
+    DEFAULT_LLM_STATS_IDENTITY_OVERRIDES_PATH,
+    IdentityOverrideError,
+    apply_llm_stats_identity_overrides,
+    load_llm_stats_identity_overrides,
+    overridden_validation,
+)
+from benchmark_radar.leaderboard_snapshots import DEFAULT_SNAPSHOTS_PATH, load_snapshots
+
+LLM_STATS_SNAPSHOT_ID = "llm_stats_2026-08-17"
+
+
+@pytest.fixture(scope="module")
+def normalized() -> dict:
+    snapshots = load_snapshots(DEFAULT_SNAPSHOTS_PATH)
+    snapshot = next(item for item in snapshots["snapshots"] if item["id"] == LLM_STATS_SNAPSHOT_ID)
+    return normalize_snapshot(snapshot)
+
+
+@pytest.fixture(scope="module")
+def overrides(normalized: dict):
+    return load_llm_stats_identity_overrides(
+        normalized["source_records"], DEFAULT_LLM_STATS_IDENTITY_OVERRIDES_PATH
+    )
+
+
+@pytest.fixture(scope="module")
+def enriched(normalized: dict, overrides) -> list[dict]:
+    return apply_llm_stats_identity_overrides(normalized["source_records"], overrides)
+
+
+def test_checked_in_overrides_cover_every_phase_a_outcome(overrides) -> None:
+    assert overrides.validation == {
+        "override_count": 57,
+        "resolution_status_counts": {
+            "needs_review": 2,
+            "not_found": 9,
+            "resolved": 46,
+        },
+        "repo_kind_counts": {
+            "benchmark_source": 25,
+            "harness_only": 3,
+            "monorepo_subdir": 3,
+            "not_found": 11,
+            "shared_parent": 15,
+        },
+    }
+
+
+def test_all_resolved_overrides_become_searchable_repository_artifacts(
+    enriched: list[dict],
+) -> None:
+    index = build_benchmark_index(enriched)
+    resolved = [row for row in index if row["repo_resolution_status"] == "resolved"]
+
+    assert len(resolved) == 46
+    assert all(row["has_repo"] for row in resolved)
+    assert {row["repo_kind"] for row in resolved} == {
+        "benchmark_source",
+        "harness_only",
+        "monorepo_subdir",
+        "shared_parent",
+    }
+
+
+def test_repository_classification_is_structural_and_crawl_safe(enriched: list[dict]) -> None:
+    by_id = {row["source_benchmark_id"]: row for row in enriched}
+
+    assert by_id["mcp-atlas"]["repository"]["kind"] == "benchmark_source"
+    assert by_id["aime-2025"]["repository"]["kind"] == "shared_parent"
+    assert by_id["browsecomp"]["repository"]["kind"] == "harness_only"
+    assert by_id["imo-answerbench"]["repository"] == {
+        "url": "https://github.com/google-deepmind/superhuman",
+        "full_name": "google-deepmind/superhuman",
+        "kind": "monorepo_subdir",
+        "subpath": "imobench",
+        "resolution_status": "resolved",
+    }
+
+    crawlable = {
+        benchmark_id
+        for benchmark_id, row in by_id.items()
+        if (row.get("repository") or {}).get("kind") == "benchmark_source"
+    }
+    assert "mcp-atlas" in crawlable
+    assert "aime-2025" not in crawlable
+    assert "browsecomp" not in crawlable
+    assert "imo-answerbench" not in crawlable
+
+
+def test_unresolved_rows_remain_visible_without_manufacturing_artifacts(
+    enriched: list[dict],
+) -> None:
+    by_id = {row["source_benchmark_id"]: row for row in enriched}
+    for benchmark_id in ("aime-2024", "include", "hmmt25", "t2-bench"):
+        row = by_id[benchmark_id]
+        assert row["repository"]["kind"] == "not_found"
+        assert row["repository"]["url"] is None
+        assert row["artifacts"] == []
+        assert row["identity_override"]["candidate_matches"]
+
+
+def test_enriched_source_records_are_the_records_written_to_disk(
+    normalized: dict, overrides, enriched: list[dict], tmp_path: Path
+) -> None:
+    result = dict(normalized)
+    result["source_records"] = enriched
+    result["validation"] = overridden_validation(normalized["validation"], enriched, overrides)
+    paths = write_catalog(result, tmp_path)
+    rows = [
+        json.loads(line)
+        for line in paths["source_records"].read_text(encoding="utf-8").splitlines()
+    ]
+    by_id = {row["source_benchmark_id"]: row for row in rows}
+
+    assert by_id["mcp-atlas"]["repository"]["full_name"] == "scaleapi/mcp-atlas"
+    assert any(artifact["kind"] == "repo" for artifact in by_id["mcp-atlas"]["artifacts"])
+    validation = json.loads(paths["validation"].read_text(encoding="utf-8"))
+    assert validation["identity_overrides"]["override_count"] == 57
+    assert validation["empty_provenance_fraction"] < 1.0
+
+
+def _write_override(tmp_path: Path, row: dict, benchmark_id: str = "mcp-atlas") -> Path:
+    path = tmp_path / "overrides.yml"
+    path.write_text(
+        yaml.safe_dump(
+            {"schema_version": 1, "benchmarks": {benchmark_id: row}},
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _valid_row() -> dict:
+    return {
+        "resolution_status": "resolved",
+        "repo_kind": "benchmark_source",
+        "repo_url": "https://github.com/scaleapi/mcp-atlas",
+        "repo_full_name": "scaleapi/mcp-atlas",
+        "repo_subpath": None,
+        "paper_url": "https://arxiv.org/abs/2602.00933",
+        "note": "The paper and repository identify the same benchmark.",
+    }
+
+
+def test_loader_rejects_repository_subpaths_hidden_in_repo_url(
+    normalized: dict, tmp_path: Path
+) -> None:
+    row = _valid_row()
+    row["repo_url"] += "/tree/main/tasks"
+    path = _write_override(tmp_path, row)
+    with pytest.raises(IdentityOverrideError, match="repository root"):
+        load_llm_stats_identity_overrides(normalized["source_records"], path)
+
+
+def test_loader_rejects_resolved_rows_without_two_url_evidence(
+    normalized: dict, tmp_path: Path
+) -> None:
+    row = _valid_row()
+    row.pop("paper_url")
+    path = _write_override(tmp_path, row)
+    with pytest.raises(IdentityOverrideError, match="two different URLs"):
+        load_llm_stats_identity_overrides(normalized["source_records"], path)
+
+
+def test_loader_rejects_monorepo_without_a_structured_subpath(
+    normalized: dict, tmp_path: Path
+) -> None:
+    row = _valid_row()
+    row["repo_kind"] = "monorepo_subdir"
+    path = _write_override(tmp_path, row)
+    with pytest.raises(IdentityOverrideError, match="requires repo_subpath"):
+        load_llm_stats_identity_overrides(normalized["source_records"], path)
+
+
+def test_loader_rejects_unresolved_rows_that_publish_a_repository(
+    normalized: dict, tmp_path: Path
+) -> None:
+    row = _valid_row()
+    row.update(
+        {
+            "resolution_status": "needs_review",
+            "repo_kind": "not_found",
+            "candidate_matches": [
+                {"url": "https://github.com/scaleapi/mcp-atlas", "note": "Candidate only."}
+            ],
+        }
+    )
+    path = _write_override(tmp_path, row)
+    with pytest.raises(IdentityOverrideError, match="cannot publish repository fields"):
+        load_llm_stats_identity_overrides(normalized["source_records"], path)
+
+
+def test_loader_rejects_an_override_for_an_unknown_source_id(
+    normalized: dict, tmp_path: Path
+) -> None:
+    path = _write_override(tmp_path, _valid_row(), benchmark_id="does-not-exist")
+    with pytest.raises(IdentityOverrideError, match="current llm-stats source record"):
+        load_llm_stats_identity_overrides(normalized["source_records"], path)


### PR DESCRIPTION
## Result

Reviewed llm-stats repository identity now reaches the product instead of stopping in an unused YAML file. Rebuilt outputs expose 46 resolved repositories; the 11 unresolved rows stay visible without manufacturing repository links.

## What changes

- Load and strictly validate `llm_stats_identity_overrides.yml` during `normalize-external`.
- Write reviewed identity into source records, the search index, detail shards, and the offline CLI release.
- Preserve structured `repo_kind`, `repo_full_name`, `repo_subpath`, and resolution status so shared parents, harnesses, and monorepos are not mistaken for benchmark-owned repositories.
- Record all 38 takeover outcomes: 27 resolved, 9 not found, and 2 needing review, alongside the 19 existing resolved overrides.
- Keep repository roots separate from subpaths, including `google-deepmind/superhuman` plus `imobench` for IMO-AnswerBench.
- Add regression coverage for two-anchor validation, unresolved rows, repository-root validation, generated records, index flags, and crawl-safe repo classification.

## Verification

Run from a fresh detached worktree based on current `origin/main`, in CI order:

- `ruff check .`
- `ruff format --check .`
- `benchmark-radar normalize-external`
- `benchmark-radar classify`
- `benchmark-radar build-data-release`
- `pytest -q` — 1,068 passed