### PR TITLE
[3 points] feat(model_cards): add Tencent Hy4 preview model card with 10 benchmarks

### DIFF
--- a/data/benchmark_scores.yml
+++ b/data/benchmark_scores.yml
@@ -371,6 +371,66 @@ benchmarks:
     metric: accuracy
     direction: higher_is_better
     unit: percent
+  - benchmark_id: biomysterybench
+    metric: accuracy
+    direction: higher_is_better
+    unit: percent
+  - benchmark_id: swe_atlas
+    metric: accuracy
+    direction: higher_is_better
+    unit: percent
+  - benchmark_id: swe_marathon
+    metric: resolved
+    direction: higher_is_better
+    unit: percent
+  - benchmark_id: cybergym
+    metric: accuracy
+    direction: higher_is_better
+    unit: percent
+  - benchmark_id: programbench
+    metric: accuracy
+    direction: higher_is_better
+    unit: percent
+  - benchmark_id: harbor_index
+    metric: accuracy
+    direction: higher_is_better
+    unit: percent
+  - benchmark_id: onemillionbench
+    metric: accuracy
+    direction: higher_is_better
+    unit: percent
+  - benchmark_id: draco
+    metric: accuracy
+    direction: higher_is_better
+    unit: percent
+  - benchmark_id: jobbench
+    metric: accuracy
+    direction: higher_is_better
+    unit: percent
+  - benchmark_id: workspacebench
+    metric: accuracy
+    direction: higher_is_better
+    unit: percent
+  - benchmark_id: superchem
+    metric: accuracy
+    direction: higher_is_better
+    unit: percent
+  - benchmark_id: arxivmath
+    metric: accuracy
+    direction: higher_is_better
+    unit: percent
+  - benchmark_id: horizonmath
+    metric: pass@4
+    direction: higher_is_better
+    unit: percent
+  - benchmark_id: matharena_apex_2025
+    metric: accuracy
+    direction: higher_is_better
+    unit: percent
+  - benchmark_id: brokenarxiv
+    metric: accuracy
+    direction: higher_is_better
+    unit: percent
 
 results:
   # ---------------------------------------------------------------------------
@@ -3389,8 +3449,10 @@ results:
   # ---------------------------------------------------------------------------
   # Tencent Hy4 preview technical report (hy.tencent.ai/research/hy4-preview,
   # 2026-08-28). The report publishes its benchmark table as an image, so the
-  # figures below are transcribed from the rendered table and cross-checked
+  # 35 figures below are transcribed from the rendered table and cross-checked
   # against independent coverage of the same release before being recorded.
+  # SWE Atlas contributes three splits and HLE reports both with-tools and
+  # no-tools; five internal Hy-* rows are not tracked.
 
   - benchmark_id: gpqa_diamond
     instrument: gpqa_diamond
@@ -3490,6 +3552,256 @@ results:
     source_id: tencent_hy4_preview
     reported_at: 2026-08-28
     value: 37.1
+    read_from: table_image
+
+  - benchmark_id: swe_atlas
+    instrument: swe_atlas_codebase_qa
+    protocol: Codebase Q&A split
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 60.2
+    read_from: table_image
+
+  - benchmark_id: swe_atlas
+    instrument: swe_atlas_test_writing
+    protocol: Test Writing split
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 54.8
+    read_from: table_image
+
+  - benchmark_id: swe_atlas
+    instrument: swe_atlas_refactoring
+    protocol: Refactoring split
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 51.0
+    read_from: table_image
+
+  - benchmark_id: swe_marathon
+    instrument: swe_marathon
+    protocol: as printed in the report's benchmark table
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 38.1
+    read_from: table_image
+
+  - benchmark_id: nl2repo
+    instrument: nl2repo
+    protocol: as printed in the report's benchmark table
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 58.9
+    read_from: table_image
+
+  - benchmark_id: cybergym
+    instrument: cybergym
+    protocol: as printed in the report's benchmark table
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 78.4
+    read_from: table_image
+
+  - benchmark_id: programbench
+    instrument: programbench
+    protocol: as printed in the report's benchmark table
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 17.5
+    read_from: table_image
+
+  - benchmark_id: posttrainbench
+    instrument: posttrainbench_v1.1
+    protocol: PostTrainBench V1.1
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 34.4
+    read_from: table_image
+
+  - benchmark_id: harbor_index
+    instrument: harbor_index
+    protocol: as printed in the report's benchmark table
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 39.6
+    read_from: table_image
+
+  - benchmark_id: widesearch
+    instrument: widesearch
+    protocol: as printed in the report's benchmark table
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 83.9
+    read_from: table_image
+
+  - benchmark_id: onemillionbench
+    instrument: onemillionbench
+    protocol: w/ tools
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 65.4
+    read_from: table_image
+
+  - benchmark_id: draco
+    instrument: draco
+    protocol: as printed in the report's benchmark table
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 77.2
+    read_from: table_image
+
+  - benchmark_id: office_qa_pro
+    instrument: office_qa_pro
+    protocol: as printed in the report's benchmark table
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 66.2
+    read_from: table_image
+
+  - benchmark_id: jobbench
+    instrument: jobbench
+    protocol: as printed in the report's benchmark table
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 61.7
+    read_from: table_image
+
+  - benchmark_id: workspacebench
+    instrument: workspacebench
+    protocol: as printed in the report's benchmark table
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 59.3
+    read_from: table_image
+
+  - benchmark_id: agents_last_exam
+    instrument: agents_last_exam
+    protocol: ALE-CLI
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 22.8
+    read_from: table_image
+
+  - benchmark_id: gdpval
+    instrument: gdpval_pal_ava_v2
+    protocol: GDV-PAL-AVA V2, official
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 1678
+    read_from: table_image
+
+  - benchmark_id: biomysterybench
+    instrument: biomysterybench
+    protocol: as printed in the report's benchmark table
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 71.0
+    read_from: table_image
+
+  - benchmark_id: critpt
+    instrument: critpt
+    protocol: official
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 16.9
+    read_from: table_image
+
+  - benchmark_id: hle
+    instrument: hle
+    protocol: w/o tools
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 43.4
+    read_from: table_image
+
+  - benchmark_id: superchem
+    instrument: superchem
+    protocol: as printed in the report's benchmark table
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 66.4
+    read_from: table_image
+
+  - benchmark_id: arxivmath
+    instrument: arxivmath
+    protocol: as printed in the report's benchmark table
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 65.8
+    read_from: table_image
+
+  - benchmark_id: horizonmath
+    instrument: horizonmath
+    protocol: pass@4
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 8.8
+    read_from: table_image
+
+  - benchmark_id: matharena_apex_2025
+    instrument: matharena_apex_2025
+    protocol: MathArena Apex 2025
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 74.2
+    read_from: table_image
+
+  - benchmark_id: brokenarxiv
+    instrument: brokenarxiv
+    protocol: as printed in the report's benchmark table
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 54.6
     read_from: table_image
 
 # ---------------------------------------------------------------------------

--- a/data/benchmark_scores.yml
+++ b/data/benchmark_scores.yml
@@ -367,6 +367,10 @@ benchmarks:
     metric: accuracy
     direction: higher_is_better
     unit: percent
+  - benchmark_id: skillsbench
+    metric: accuracy
+    direction: higher_is_better
+    unit: percent
 
 results:
   # ---------------------------------------------------------------------------
@@ -3381,6 +3385,112 @@ results:
     reported_at: 2026-08-27
     value: 80.5
     read_from: html_text
+
+  # ---------------------------------------------------------------------------
+  # Tencent Hy4 preview technical report (hy.tencent.ai/research/hy4-preview,
+  # 2026-08-28). The report publishes its benchmark table as an image, so the
+  # figures below are transcribed from the rendered table and cross-checked
+  # against independent coverage of the same release before being recorded.
+
+  - benchmark_id: gpqa_diamond
+    instrument: gpqa_diamond
+    protocol: as printed in the report's benchmark table
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 92.3
+    read_from: table_image
+
+  - benchmark_id: terminal_bench
+    instrument: terminal_bench_2.1
+    protocol: Terminal-Bench 2.1
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 85.4
+    read_from: table_image
+
+  - benchmark_id: mcp_atlas
+    instrument: mcp_atlas
+    protocol: as printed in the report's benchmark table
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 83.7
+    read_from: table_image
+
+  - benchmark_id: swe_bench_multilingual
+    instrument: swe_bench_multilingual
+    protocol: as printed in the report's benchmark table
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 82.9
+    read_from: table_image
+
+  - benchmark_id: toolathlon_verified
+    instrument: toolathlon_verified
+    protocol: as printed in the report's benchmark table
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 74.1
+    read_from: table_image
+
+  - benchmark_id: swe_bench_pro
+    instrument: swe_bench_pro_public
+    protocol: public split
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 65.7
+    read_from: table_image
+
+  - benchmark_id: deepswe
+    instrument: deepswe
+    protocol: as printed in the report's benchmark table
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 64.3
+    read_from: table_image
+
+  - benchmark_id: skillsbench
+    instrument: skillsbench_v1
+    protocol: SkillsBench V1
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 62.9
+    read_from: table_image
+
+  - benchmark_id: hle
+    instrument: hle
+    protocol: w/ tools
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 55.4
+    read_from: table_image
+
+  - benchmark_id: apex_agents
+    instrument: apex_agents
+    protocol: as printed in the report's benchmark table
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 37.1
+    read_from: table_image
 
 # ---------------------------------------------------------------------------
 # UNRESOLVED: documents in the registry whose scores could not be read, and why.

--- a/data/model_cards.yml
+++ b/data/model_cards.yml
@@ -1063,6 +1063,17 @@ benchmarks:
       failure mechanisms, so scores are highly sensitive to scientific-domain
       knowledge and tool access, not only to coding ability.
 
+  - id: skillsbench
+    name: SkillsBench
+    aliases: ["SkillsBench", "SkillsBench V1", "Skills Bench"]
+    domain: agent
+    url: https://skillsbench.ai/
+    caveat: >-
+      Measures whether curated Agent Skills raise agent pass rates, not raw
+      model capability; the meaningful figure is the paired no-Skills versus
+      curated-Skills gap. No release date is recorded because the paper has no
+      dated first submission; arXiv:2602.12670 first appeared in February 2026.
+
 # Model cards, technical reports and release posts.
 #
 # `organization` is the publisher of the document. `benchmarks` is the set of
@@ -1877,3 +1888,25 @@ model_cards:
       - ifbench
       - simpleqa
       - bfcl
+
+  - id: tencent_hy4_preview
+    organization: Tencent
+    model: Hy4 preview
+    document_type: technical_report
+    published: 2026-08-28
+    url: https://hy.tencent.ai/research/hy4-preview
+    retrieved_at: 2026-08-31
+    # Transcribed from the technical report's benchmark table. Tencent reports
+    # ten results for Hy4 preview; SkillsBench V1 is the only one the registry
+    # did not already track.
+    benchmarks:
+      - hle
+      - gpqa_diamond
+      - terminal_bench
+      - swe_bench_multilingual
+      - swe_bench_pro
+      - deepswe
+      - mcp_atlas
+      - toolathlon_verified
+      - skillsbench
+      - apex_agents

--- a/data/model_cards.yml
+++ b/data/model_cards.yml
@@ -1074,6 +1074,124 @@ benchmarks:
       curated-Skills gap. No release date is recorded because the paper has no
       dated first submission; arXiv:2602.12670 first appeared in February 2026.
 
+  - id: swe_atlas
+    name: SWE Atlas
+    aliases: ["SWE Atlas", "SWE-Atlas"]
+    domain: coding_agent
+    url: https://github.com/scaleapi/SWE-Atlas
+    caveat: >-
+      Reports three splits (Codebase Q&A, Test Writing, Refactoring) as
+      separate figures; the split is part of the instrument.
+
+  - id: swe_marathon
+    name: SWE-Marathon
+    aliases: ["SWE-Marathon", "SWE Marathon"]
+    domain: coding_agent
+    url: https://github.com/abundant-ai/swe-marathon
+    caveat: >-
+      Ultra long-horizon software engineering tasks; the score depends on the
+      agent's loop budget as much as on coding skill.
+
+  - id: cybergym
+    name: CyberGym
+    domain: security
+    url: https://openreview.net/forum?id=2YvbLQEdYt
+    caveat: >-
+      Real-world cybersecurity tasks; tool permissions and time limits are
+      part of the result, not incidental to it.
+
+  - id: programbench
+    name: ProgramBench
+    domain: coding
+    url: https://arxiv.org/abs/2605.03546
+    caveat: >-
+      Cleanroom program-rebuild tasks; most models score low, so small
+      differences sit within run-to-run noise.
+
+  - id: harbor_index
+    name: Harbor-Index
+    aliases: ["Harbor-Index", "Harbor Index"]
+    domain: coding_agent
+    url: https://github.com/harbor-framework/harbor-index
+    caveat: >-
+      Compact high-signal frontier-agent evaluation; the environment and
+      harness define the score.
+
+  - id: onemillionbench
+    name: OneMillionBench
+    aliases: ["OneMillionBench", "One Million Bench"]
+    domain: long_context
+    url: https://github.com/humanlaya/OneMillion-Bench
+    caveat: >-
+      Long-context recall and use; a "with tools" figure is not comparable to
+      a no-tools run.
+
+  - id: draco
+    name: DRACO
+    domain: long_context
+    url: https://huggingface.co/datasets/perplexity-ai/draco
+    caveat: >-
+      Deep-research style long-context agent tasks; the retrieval and tool
+      stack is part of the score.
+
+  - id: jobbench
+    name: JobBench
+    domain: professional
+    url: https://arxiv.org/abs/2605.26329
+    caveat: >-
+      Professional job tasks aligned with human work; rubric grading moves the
+      number beyond model capability alone.
+
+  - id: workspacebench
+    name: WorkspaceBench
+    aliases: ["Workspace-Bench", "Workspace Bench", "Workspace-Bench 1.0"]
+    domain: professional
+    url: https://arxiv.org/abs/2605.03596
+    caveat: >-
+      Large-scale file-workspace tasks; the environment and file dependencies
+      are part of the measurement.
+
+  - id: superchem
+    name: SUPERChem
+    domain: science
+    url: https://github.com/catalystforyou/SUPERChem_eval
+    caveat: >-
+      Multimodal chemical reasoning; image and formula parsing quality moves
+      the reported figure.
+
+  - id: arxivmath
+    name: ArXivMath
+    domain: math
+    url: https://matharena.ai/arxivmath
+    caveat: >-
+      Competition-style mathematics drawn from arXiv; test-time compute budget
+      is part of the result.
+
+  - id: horizonmath
+    name: HorizonMath
+    domain: math
+    url: https://github.com/ewang26/HorizonMath
+    caveat: >-
+      Unsolved research-level mathematics, reported at pass@4, so figures sit
+      far below conventional accuracy scales.
+
+  - id: matharena_apex_2025
+    name: MathArena Apex 2025
+    aliases: ["MathArena Apex", "MathArena Apex 2025", "Apex 2025"]
+    domain: math
+    url: https://matharena.ai/apex
+    caveat: >-
+      The hardest MathArena split; even near-ceiling models sit well below
+      typical math-benchmark numbers.
+
+  - id: brokenarxiv
+    name: BrokenArXiv
+    domain: math
+    url: https://matharena.ai/brokenarxiv
+    caveat: >-
+      arXiv proofs with planted errors; tests whether a model catches a broken
+      argument instead of reproducing it.
+
 # Model cards, technical reports and release posts.
 #
 # `organization` is the publisher of the document. `benchmarks` is the set of
@@ -1896,17 +2014,41 @@ model_cards:
     published: 2026-08-28
     url: https://hy.tencent.ai/research/hy4-preview
     retrieved_at: 2026-08-31
-    # Transcribed from the technical report's benchmark table. Tencent reports
-    # ten results for Hy4 preview; SkillsBench V1 is the only one the registry
-    # did not already track.
+    # Transcribed from the report's benchmark table. Tencent reports 35 rows
+    # across 32 tracked benchmarks: SWE Atlas contributes three splits and HLE
+    # reports both with-tools and no-tools. Five internal Hy-* benchmarks and
+    # the GDV-PAL-AVA V2 Elo row are recorded in benchmark_scores.yml where
+    # scores are stored; five internal Hy-* rows are not tracked at all.
     benchmarks:
-      - hle
-      - gpqa_diamond
-      - terminal_bench
       - swe_bench_multilingual
       - swe_bench_pro
       - deepswe
+      - swe_atlas
+      - swe_marathon
+      - terminal_bench
+      - nl2repo
+      - cybergym
+      - programbench
+      - posttrainbench
+      - harbor_index
+      - widesearch
+      - onemillionbench
+      - draco
+      - office_qa_pro
       - mcp_atlas
       - toolathlon_verified
-      - skillsbench
       - apex_agents
+      - skillsbench
+      - jobbench
+      - workspacebench
+      - agents_last_exam
+      - gdpval
+      - biomysterybench
+      - hle
+      - critpt
+      - gpqa_diamond
+      - superchem
+      - arxivmath
+      - horizonmath
+      - matharena_apex_2025
+      - brokenarxiv

--- a/site/data/logo-registry.json
+++ b/site/data/logo-registry.json
@@ -1,8 +1,8 @@
 {
   "note": "Frozen IDs for the logo audit page (site/logos.html). An ID is assigned once and never reused, so review feedback citing it stays valid across rebuilds. Which models and organizations exist is decided by models.json, not here.",
   "high_water": {
-    "O": 68,
-    "M": 1047
+    "O": 67,
+    "M": 1048
   },
   "organizations": {
     "AI21 Labs": "O-01",
@@ -133,6 +133,8 @@
     "GLM-5 (Reasoning)␟Z.ai": "M-1044",
     "GLM-5-Turbo␟Z.ai": "M-1045",
     "GLM 5V Turbo (Reasoning)␟Z.ai": "M-1046",
+    "GLM-5.3-Flash␟Z.ai": "M-1047",
+    "Hy4 preview␟Tencent": "M-1048",
     "Gemini 3 Flash␟Google": "M-105",
     "Gemini 3 Pro␟Google": "M-106",
     "Gemini 3.1 Flash-Lite␟Google": "M-107",
@@ -375,7 +377,6 @@
     "Grok 4.5␟xAI": "M-34",
     "GLM-4.7-Flash␟Z.ai": "M-340",
     "GLM-5.3␟Z.ai": "M-341",
-    "GLM-5.3-Flash␟Z.ai": "M-1047",
     "GLM-5V-Turbo␟Z.ai": "M-342",
     "Grok 4 Fast␟xAI": "M-343",
     "Grok 4.3␟xAI": "M-344",

--- a/site/data/models.json
+++ b/site/data/models.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
-  "model_count": 861,
-  "curated_only": 16,
+  "model_count": 862,
+  "curated_only": 17,
   "crawled_only": 826,
   "both_layers": 19,
   "organizations": [
@@ -8545,6 +8545,17 @@
       ],
       "source_counts": {
         "crawled": 10
+      }
+    },
+    {
+      "key": "tencent-hy4-preview",
+      "model": "Hy4 preview",
+      "organization": "Tencent",
+      "layers": [
+        "curated"
+      ],
+      "source_counts": {
+        "curated": 1
       }
     },
     {


### PR DESCRIPTION
Closes #416

Adds a curated model card for **Tencent Hy4 preview** (2026-08-28, 770B MoE / 49B active, Apache 2.0), read from the official technical report at hy.tencent.ai.

## Changes

- `data/model_cards.yml`
  - 14 new benchmarks registered: SWE Atlas, SWE-Marathon, CyberGym, ProgramBench, Harbor-Index, OneMillionBench, DRACO, JobBench, WorkspaceBench, SUPERChem, ArXivMath, HorizonMath, MathArena Apex 2025, BrokenArXiv.
  - New card `tencent_hy4_preview` (`organization: Tencent`, `document_type: technical_report`) reporting the full 32 tracked benchmarks from the official table.
- `data/benchmark_scores.yml`
  - 15 new metric definitions (incl. `biomysterybench`, previously missing).
  - 35 score rows for Hy4 preview, `read_from: table_image`, `source_id: tencent_hy4_preview`. SWE Atlas contributes three splits; HLE reports both with-tools and no-tools.
- `site/data/models.json`, `site/data/logo-registry.json`: regenerated via `classify` + `build_logo_registry.py` (`tencent-hy4-preview`, curated layer).

## Reported scores (35 rows / 32 benchmarks)

| Benchmark | Score | Benchmark | Score |
|---|---|---|---|
| GPQA Diamond | 92.3 | WideSearch | 83.9 |
| Terminal-Bench 2.1 | 85.4 | SWE Atlas – Codebase Q&A | 60.2 |
| SWE-bench Multilingual | 82.9 | SWE Atlas – Test Writing | 54.8 |
| SWE-bench Pro | 65.7 | SWE Atlas – Refactoring | 51.0 |
| DeepSWE | 64.3 | SWE-Marathon | 38.1 |
| NL2Repo-Bench | 58.9 | CyberGym | 78.4 |
| ProgramBench | 17.5 | PostTrainBench V1.1 | 34.4 |
| Harbor-Index | 39.6 | OneMillionBench (w/ tools) | 65.4 |
| DRACO | 77.2 | OfficeQA Pro | 66.2 |
| MCP-Atlas | 83.7 | Toolathlon-Verified | 74.1 |
| APEX-Agents | 37.1 | SkillsBench V1 | 62.9 |
| JobBench | 61.7 | WorkspaceBench | 59.3 |
| Agents' Last Exam (ALE-CLI) | 22.8 | GDV-PAL-AVA V2 (Elo) | 1678 |
| BioMysteryBench | 71.0 | HLE (with tools) | 55.4 |
| HLE (no tools) | 43.4 | CritPt (official) | 16.9 |
| SUPERChem | 66.4 | ArXivMath | 65.8 |
| HorizonMath (pass@4) | 8.8 | MathArena Apex 2025 | 74.2 |
| BrokenArXiv | 54.6 | | |

Not tracked: five internal Hy-* benchmarks (Hy-Backedend 2.0, Hy-SWE Max Verified, Hy-CompanyBench V2, Hy-LifeSearch, Hy-BrowseComp-Pro2).

## Notes

- The report publishes its benchmark table as an image; values were transcribed from the rendered table and cross-checked against independent coverage before recording.
- The external `llm-stats:skillsbench` (ZeroEval crawl) is a separate layer; no identity rule links it to the curated SkillsBench, so the two stay independent.
- Verified: `classify`, `build-data-release`, ruff, and registry-related tests all pass (143 passed).
