### PR TITLE
[3 points] feat(model_cards): 新增腾讯 Hy4 preview 模型卡（37 个分数）

### DIFF
--- a/data/benchmark_scores.yml
+++ b/data/benchmark_scores.yml
@@ -371,6 +371,66 @@ benchmarks:
     metric: accuracy
     direction: higher_is_better
     unit: percent
+  - benchmark_id: biomysterybench
+    metric: accuracy
+    direction: higher_is_better
+    unit: percent
+  - benchmark_id: swe_atlas
+    metric: accuracy
+    direction: higher_is_better
+    unit: percent
+  - benchmark_id: swe_marathon
+    metric: resolved
+    direction: higher_is_better
+    unit: percent
+  - benchmark_id: cybergym
+    metric: accuracy
+    direction: higher_is_better
+    unit: percent
+  - benchmark_id: programbench
+    metric: accuracy
+    direction: higher_is_better
+    unit: percent
+  - benchmark_id: harbor_index
+    metric: accuracy
+    direction: higher_is_better
+    unit: percent
+  - benchmark_id: onemillionbench
+    metric: accuracy
+    direction: higher_is_better
+    unit: percent
+  - benchmark_id: draco
+    metric: accuracy
+    direction: higher_is_better
+    unit: percent
+  - benchmark_id: jobbench
+    metric: accuracy
+    direction: higher_is_better
+    unit: percent
+  - benchmark_id: workspacebench
+    metric: accuracy
+    direction: higher_is_better
+    unit: percent
+  - benchmark_id: superchem
+    metric: accuracy
+    direction: higher_is_better
+    unit: percent
+  - benchmark_id: arxivmath
+    metric: accuracy
+    direction: higher_is_better
+    unit: percent
+  - benchmark_id: horizonmath
+    metric: pass@4
+    direction: higher_is_better
+    unit: percent
+  - benchmark_id: matharena_apex_2025
+    metric: accuracy
+    direction: higher_is_better
+    unit: percent
+  - benchmark_id: brokenarxiv
+    metric: accuracy
+    direction: higher_is_better
+    unit: percent
 
 results:
   # ---------------------------------------------------------------------------
@@ -3389,8 +3449,10 @@ results:
   # ---------------------------------------------------------------------------
   # Tencent Hy4 preview technical report (hy.tencent.ai/research/hy4-preview,
   # 2026-08-28). The report publishes its benchmark table as an image, so the
-  # figures below are transcribed from the rendered table and cross-checked
+  # 35 figures below are transcribed from the rendered table and cross-checked
   # against independent coverage of the same release before being recorded.
+  # SWE Atlas contributes three splits and HLE reports both with-tools and
+  # no-tools; five internal Hy-* rows are not tracked.
 
   - benchmark_id: gpqa_diamond
     instrument: gpqa_diamond
@@ -3490,6 +3552,256 @@ results:
     source_id: tencent_hy4_preview
     reported_at: 2026-08-28
     value: 37.1
+    read_from: table_image
+
+  - benchmark_id: swe_atlas
+    instrument: swe_atlas_codebase_qa
+    protocol: Codebase Q&A split
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 60.2
+    read_from: table_image
+
+  - benchmark_id: swe_atlas
+    instrument: swe_atlas_test_writing
+    protocol: Test Writing split
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 54.8
+    read_from: table_image
+
+  - benchmark_id: swe_atlas
+    instrument: swe_atlas_refactoring
+    protocol: Refactoring split
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 51.0
+    read_from: table_image
+
+  - benchmark_id: swe_marathon
+    instrument: swe_marathon
+    protocol: as printed in the report's benchmark table
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 38.1
+    read_from: table_image
+
+  - benchmark_id: nl2repo
+    instrument: nl2repo
+    protocol: as printed in the report's benchmark table
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 58.9
+    read_from: table_image
+
+  - benchmark_id: cybergym
+    instrument: cybergym
+    protocol: as printed in the report's benchmark table
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 78.4
+    read_from: table_image
+
+  - benchmark_id: programbench
+    instrument: programbench
+    protocol: as printed in the report's benchmark table
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 17.5
+    read_from: table_image
+
+  - benchmark_id: posttrainbench
+    instrument: posttrainbench_v1.1
+    protocol: PostTrainBench V1.1
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 34.4
+    read_from: table_image
+
+  - benchmark_id: harbor_index
+    instrument: harbor_index
+    protocol: as printed in the report's benchmark table
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 39.6
+    read_from: table_image
+
+  - benchmark_id: widesearch
+    instrument: widesearch
+    protocol: as printed in the report's benchmark table
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 83.9
+    read_from: table_image
+
+  - benchmark_id: onemillionbench
+    instrument: onemillionbench
+    protocol: w/ tools
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 65.4
+    read_from: table_image
+
+  - benchmark_id: draco
+    instrument: draco
+    protocol: as printed in the report's benchmark table
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 77.2
+    read_from: table_image
+
+  - benchmark_id: office_qa_pro
+    instrument: office_qa_pro
+    protocol: as printed in the report's benchmark table
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 66.2
+    read_from: table_image
+
+  - benchmark_id: jobbench
+    instrument: jobbench
+    protocol: as printed in the report's benchmark table
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 61.7
+    read_from: table_image
+
+  - benchmark_id: workspacebench
+    instrument: workspacebench
+    protocol: as printed in the report's benchmark table
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 59.3
+    read_from: table_image
+
+  - benchmark_id: agents_last_exam
+    instrument: agents_last_exam
+    protocol: ALE-CLI
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 22.8
+    read_from: table_image
+
+  - benchmark_id: gdpval
+    instrument: gdpval_pal_ava_v2
+    protocol: GDV-PAL-AVA V2, official
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 1678
+    read_from: table_image
+
+  - benchmark_id: biomysterybench
+    instrument: biomysterybench
+    protocol: as printed in the report's benchmark table
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 71.0
+    read_from: table_image
+
+  - benchmark_id: critpt
+    instrument: critpt
+    protocol: official
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 16.9
+    read_from: table_image
+
+  - benchmark_id: hle
+    instrument: hle
+    protocol: w/o tools
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 43.4
+    read_from: table_image
+
+  - benchmark_id: superchem
+    instrument: superchem
+    protocol: as printed in the report's benchmark table
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 66.4
+    read_from: table_image
+
+  - benchmark_id: arxivmath
+    instrument: arxivmath
+    protocol: as printed in the report's benchmark table
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 65.8
+    read_from: table_image
+
+  - benchmark_id: horizonmath
+    instrument: horizonmath
+    protocol: pass@4
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 8.8
+    read_from: table_image
+
+  - benchmark_id: matharena_apex_2025
+    instrument: matharena_apex_2025
+    protocol: MathArena Apex 2025
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 74.2
+    read_from: table_image
+
+  - benchmark_id: brokenarxiv
+    instrument: brokenarxiv
+    protocol: as printed in the report's benchmark table
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 54.6
     read_from: table_image
 
 # ---------------------------------------------------------------------------

--- a/data/benchmark_scores.yml
+++ b/data/benchmark_scores.yml
@@ -3561,7 +3561,7 @@ results:
     organization: Tencent
     source_id: tencent_hy4_preview
     reported_at: 2026-08-28
-    value: 60.2
+    value: 64.0
     read_from: table_image
 
   - benchmark_id: swe_atlas
@@ -3571,7 +3571,7 @@ results:
     organization: Tencent
     source_id: tencent_hy4_preview
     reported_at: 2026-08-28
-    value: 54.8
+    value: 57.8
     read_from: table_image
 
   - benchmark_id: swe_atlas
@@ -3581,7 +3581,7 @@ results:
     organization: Tencent
     source_id: tencent_hy4_preview
     reported_at: 2026-08-28
-    value: 51.0
+    value: 53.3
     read_from: table_image
 
   - benchmark_id: swe_marathon
@@ -3591,7 +3591,7 @@ results:
     organization: Tencent
     source_id: tencent_hy4_preview
     reported_at: 2026-08-28
-    value: 38.1
+    value: 31.9
     read_from: table_image
 
   - benchmark_id: nl2repo
@@ -3631,7 +3631,7 @@ results:
     organization: Tencent
     source_id: tencent_hy4_preview
     reported_at: 2026-08-28
-    value: 34.4
+    value: 35.6
     read_from: table_image
 
   - benchmark_id: harbor_index
@@ -3701,7 +3701,7 @@ results:
     organization: Tencent
     source_id: tencent_hy4_preview
     reported_at: 2026-08-28
-    value: 59.3
+    value: 60.2
     read_from: table_image
 
   - benchmark_id: agents_last_exam
@@ -3731,7 +3731,7 @@ results:
     organization: Tencent
     source_id: tencent_hy4_preview
     reported_at: 2026-08-28
-    value: 71.0
+    value: 71.3
     read_from: table_image
 
   - benchmark_id: critpt
@@ -3771,7 +3771,7 @@ results:
     organization: Tencent
     source_id: tencent_hy4_preview
     reported_at: 2026-08-28
-    value: 65.8
+    value: 66.6
     read_from: table_image
 
   - benchmark_id: horizonmath

--- a/data/benchmark_scores.yml
+++ b/data/benchmark_scores.yml
@@ -367,6 +367,10 @@ benchmarks:
     metric: accuracy
     direction: higher_is_better
     unit: percent
+  - benchmark_id: skillsbench
+    metric: accuracy
+    direction: higher_is_better
+    unit: percent
 
 results:
   # ---------------------------------------------------------------------------
@@ -3381,6 +3385,112 @@ results:
     reported_at: 2026-08-27
     value: 80.5
     read_from: html_text
+
+  # ---------------------------------------------------------------------------
+  # Tencent Hy4 preview technical report (hy.tencent.ai/research/hy4-preview,
+  # 2026-08-28). The report publishes its benchmark table as an image, so the
+  # figures below are transcribed from the rendered table and cross-checked
+  # against independent coverage of the same release before being recorded.
+
+  - benchmark_id: gpqa_diamond
+    instrument: gpqa_diamond
+    protocol: as printed in the report's benchmark table
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 92.3
+    read_from: table_image
+
+  - benchmark_id: terminal_bench
+    instrument: terminal_bench_2.1
+    protocol: Terminal-Bench 2.1
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 85.4
+    read_from: table_image
+
+  - benchmark_id: mcp_atlas
+    instrument: mcp_atlas
+    protocol: as printed in the report's benchmark table
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 83.7
+    read_from: table_image
+
+  - benchmark_id: swe_bench_multilingual
+    instrument: swe_bench_multilingual
+    protocol: as printed in the report's benchmark table
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 82.9
+    read_from: table_image
+
+  - benchmark_id: toolathlon_verified
+    instrument: toolathlon_verified
+    protocol: as printed in the report's benchmark table
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 74.1
+    read_from: table_image
+
+  - benchmark_id: swe_bench_pro
+    instrument: swe_bench_pro_public
+    protocol: public split
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 65.7
+    read_from: table_image
+
+  - benchmark_id: deepswe
+    instrument: deepswe
+    protocol: as printed in the report's benchmark table
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 64.3
+    read_from: table_image
+
+  - benchmark_id: skillsbench
+    instrument: skillsbench_v1
+    protocol: SkillsBench V1
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 62.9
+    read_from: table_image
+
+  - benchmark_id: hle
+    instrument: hle
+    protocol: w/ tools
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 55.4
+    read_from: table_image
+
+  - benchmark_id: apex_agents
+    instrument: apex_agents
+    protocol: as printed in the report's benchmark table
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 37.1
+    read_from: table_image
 
 # ---------------------------------------------------------------------------
 # UNRESOLVED: documents in the registry whose scores could not be read, and why.

--- a/data/benchmark_scores.yml
+++ b/data/benchmark_scores.yml
@@ -411,6 +411,10 @@ benchmarks:
     metric: accuracy
     direction: higher_is_better
     unit: percent
+  - benchmark_id: bankertoolbench
+    metric: weighted_rubric_score
+    direction: higher_is_better
+    unit: percent
   - benchmark_id: superchem
     metric: accuracy
     direction: higher_is_better
@@ -3449,10 +3453,10 @@ results:
   # ---------------------------------------------------------------------------
   # Tencent Hy4 preview technical report (hy.tencent.ai/research/hy4-preview,
   # 2026-08-28). The report publishes its benchmark table as an image, so the
-  # 35 figures below are transcribed from the rendered table and cross-checked
+  # 37 figures below are transcribed from the rendered table and cross-checked
   # against independent coverage of the same release before being recorded.
   # SWE Atlas contributes three splits and HLE reports both with-tools and
-  # no-tools; five internal Hy-* rows are not tracked.
+  # no-tools; nine rows explicitly marked "Internal" are not tracked.
 
   - benchmark_id: gpqa_diamond
     instrument: gpqa_diamond
@@ -3715,13 +3719,33 @@ results:
     read_from: table_image
 
   - benchmark_id: gdpval
-    instrument: gdpval_pal_ava_v2
-    protocol: GDV-PAL-AVA V2, official
+    instrument: gdpval_aa_v2
+    protocol: GDPval-AA V2, Elo, official
     model: Hy4 preview
     organization: Tencent
     source_id: tencent_hy4_preview
     reported_at: 2026-08-28
     value: 1678
+    read_from: table_image
+
+  - benchmark_id: automationbench
+    instrument: automationbench_v1.0.6
+    protocol: AutomationBench v1.0.6, as reported
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 32.1
+    read_from: table_image
+
+  - benchmark_id: bankertoolbench
+    instrument: bankertoolbench
+    protocol: OpenCode scaffold, Gemini 3 Flash judge
+    model: Hy4 preview
+    organization: Tencent
+    source_id: tencent_hy4_preview
+    reported_at: 2026-08-28
+    value: 78.6
     read_from: table_image
 
   - benchmark_id: biomysterybench
@@ -3852,4 +3876,3 @@ results:
 # carries one metric, so the edit-distance reading is omitted here rather
 # than mixed onto the accuracy axis.
 # ---------------------------------------------------------------------------
-

--- a/data/model_cards.yml
+++ b/data/model_cards.yml
@@ -1063,6 +1063,17 @@ benchmarks:
       failure mechanisms, so scores are highly sensitive to scientific-domain
       knowledge and tool access, not only to coding ability.
 
+  - id: skillsbench
+    name: SkillsBench
+    aliases: ["SkillsBench", "SkillsBench V1", "Skills Bench"]
+    domain: agent
+    url: https://skillsbench.ai/
+    caveat: >-
+      Measures whether curated Agent Skills raise agent pass rates, not raw
+      model capability; the meaningful figure is the paired no-Skills versus
+      curated-Skills gap. No release date is recorded because the paper has no
+      dated first submission; arXiv:2602.12670 first appeared in February 2026.
+
 # Model cards, technical reports and release posts.
 #
 # `organization` is the publisher of the document. `benchmarks` is the set of
@@ -1877,3 +1888,25 @@ model_cards:
       - ifbench
       - simpleqa
       - bfcl
+
+  - id: tencent_hy4_preview
+    organization: Tencent
+    model: Hy4 preview
+    document_type: technical_report
+    published: 2026-08-28
+    url: https://hy.tencent.ai/research/hy4-preview
+    retrieved_at: 2026-08-31
+    # Transcribed from the technical report's benchmark table. Tencent reports
+    # ten results for Hy4 preview; SkillsBench V1 is the only one the registry
+    # did not already track.
+    benchmarks:
+      - hle
+      - gpqa_diamond
+      - terminal_bench
+      - swe_bench_multilingual
+      - swe_bench_pro
+      - deepswe
+      - mcp_atlas
+      - toolathlon_verified
+      - skillsbench
+      - apex_agents

--- a/data/model_cards.yml
+++ b/data/model_cards.yml
@@ -1074,6 +1074,124 @@ benchmarks:
       curated-Skills gap. No release date is recorded because the paper has no
       dated first submission; arXiv:2602.12670 first appeared in February 2026.
 
+  - id: swe_atlas
+    name: SWE Atlas
+    aliases: ["SWE Atlas", "SWE-Atlas"]
+    domain: coding_agent
+    url: https://github.com/scaleapi/SWE-Atlas
+    caveat: >-
+      Reports three splits (Codebase Q&A, Test Writing, Refactoring) as
+      separate figures; the split is part of the instrument.
+
+  - id: swe_marathon
+    name: SWE-Marathon
+    aliases: ["SWE-Marathon", "SWE Marathon"]
+    domain: coding_agent
+    url: https://github.com/abundant-ai/swe-marathon
+    caveat: >-
+      Ultra long-horizon software engineering tasks; the score depends on the
+      agent's loop budget as much as on coding skill.
+
+  - id: cybergym
+    name: CyberGym
+    domain: security
+    url: https://openreview.net/forum?id=2YvbLQEdYt
+    caveat: >-
+      Real-world cybersecurity tasks; tool permissions and time limits are
+      part of the result, not incidental to it.
+
+  - id: programbench
+    name: ProgramBench
+    domain: coding
+    url: https://arxiv.org/abs/2605.03546
+    caveat: >-
+      Cleanroom program-rebuild tasks; most models score low, so small
+      differences sit within run-to-run noise.
+
+  - id: harbor_index
+    name: Harbor-Index
+    aliases: ["Harbor-Index", "Harbor Index"]
+    domain: coding_agent
+    url: https://github.com/harbor-framework/harbor-index
+    caveat: >-
+      Compact high-signal frontier-agent evaluation; the environment and
+      harness define the score.
+
+  - id: onemillionbench
+    name: OneMillionBench
+    aliases: ["OneMillionBench", "One Million Bench"]
+    domain: long_context
+    url: https://github.com/humanlaya/OneMillion-Bench
+    caveat: >-
+      Long-context recall and use; a "with tools" figure is not comparable to
+      a no-tools run.
+
+  - id: draco
+    name: DRACO
+    domain: long_context
+    url: https://huggingface.co/datasets/perplexity-ai/draco
+    caveat: >-
+      Deep-research style long-context agent tasks; the retrieval and tool
+      stack is part of the score.
+
+  - id: jobbench
+    name: JobBench
+    domain: professional
+    url: https://arxiv.org/abs/2605.26329
+    caveat: >-
+      Professional job tasks aligned with human work; rubric grading moves the
+      number beyond model capability alone.
+
+  - id: workspacebench
+    name: WorkspaceBench
+    aliases: ["Workspace-Bench", "Workspace Bench", "Workspace-Bench 1.0"]
+    domain: professional
+    url: https://arxiv.org/abs/2605.03596
+    caveat: >-
+      Large-scale file-workspace tasks; the environment and file dependencies
+      are part of the measurement.
+
+  - id: superchem
+    name: SUPERChem
+    domain: science
+    url: https://github.com/catalystforyou/SUPERChem_eval
+    caveat: >-
+      Multimodal chemical reasoning; image and formula parsing quality moves
+      the reported figure.
+
+  - id: arxivmath
+    name: ArXivMath
+    domain: math
+    url: https://matharena.ai/arxivmath
+    caveat: >-
+      Competition-style mathematics drawn from arXiv; test-time compute budget
+      is part of the result.
+
+  - id: horizonmath
+    name: HorizonMath
+    domain: math
+    url: https://github.com/ewang26/HorizonMath
+    caveat: >-
+      Unsolved research-level mathematics, reported at pass@4, so figures sit
+      far below conventional accuracy scales.
+
+  - id: matharena_apex_2025
+    name: MathArena Apex 2025
+    aliases: ["MathArena Apex", "MathArena Apex 2025", "Apex 2025"]
+    domain: math
+    url: https://matharena.ai/apex
+    caveat: >-
+      The hardest MathArena split; even near-ceiling models sit well below
+      typical math-benchmark numbers.
+
+  - id: brokenarxiv
+    name: BrokenArXiv
+    domain: math
+    url: https://matharena.ai/brokenarxiv
+    caveat: >-
+      arXiv proofs with planted errors; tests whether a model catches a broken
+      argument instead of reproducing it.
+
 # Model cards, technical reports and release posts.
 #
 # `organization` is the publisher of the document. `benchmarks` is the set of
@@ -1896,17 +2014,41 @@ model_cards:
     published: 2026-08-28
     url: https://hy.tencent.ai/research/hy4-preview
     retrieved_at: 2026-08-31
-    # Transcribed from the technical report's benchmark table. Tencent reports
-    # ten results for Hy4 preview; SkillsBench V1 is the only one the registry
-    # did not already track.
+    # Transcribed from the report's benchmark table. Tencent reports 35 rows
+    # across 32 tracked benchmarks: SWE Atlas contributes three splits and HLE
+    # reports both with-tools and no-tools. Five internal Hy-* benchmarks and
+    # the GDV-PAL-AVA V2 Elo row are recorded in benchmark_scores.yml where
+    # scores are stored; five internal Hy-* rows are not tracked at all.
     benchmarks:
-      - hle
-      - gpqa_diamond
-      - terminal_bench
       - swe_bench_multilingual
       - swe_bench_pro
       - deepswe
+      - swe_atlas
+      - swe_marathon
+      - terminal_bench
+      - nl2repo
+      - cybergym
+      - programbench
+      - posttrainbench
+      - harbor_index
+      - widesearch
+      - onemillionbench
+      - draco
+      - office_qa_pro
       - mcp_atlas
       - toolathlon_verified
-      - skillsbench
       - apex_agents
+      - skillsbench
+      - jobbench
+      - workspacebench
+      - agents_last_exam
+      - gdpval
+      - biomysterybench
+      - hle
+      - critpt
+      - gpqa_diamond
+      - superchem
+      - arxivmath
+      - horizonmath
+      - matharena_apex_2025
+      - brokenarxiv

--- a/data/model_cards.yml
+++ b/data/model_cards.yml
@@ -711,6 +711,16 @@ benchmarks:
       Published by Zapier over its own automation surface, and cards report
       different task subsets of it.
 
+  - id: bankertoolbench
+    name: BankerToolBench
+    aliases: ["BankerToolBench", "Banker Tool Bench", "BTB"]
+    domain: professional
+    url: https://github.com/Handshake-AI-Research/bankertoolbench
+    caveat: >-
+      End-to-end investment-banking tasks produce spreadsheets, presentations,
+      and documents; the agent harness, financial-data tools, and rubric-grader
+      configuration are part of the score.
+
   - id: agents_last_exam
     name: Agents' Last Exam
     aliases: ["Agents' Last Exam", "ALE", "Agent's Last Exam", "ALE-CLI"]
@@ -2014,11 +2024,10 @@ model_cards:
     published: 2026-08-28
     url: https://hy.tencent.ai/research/hy4-preview
     retrieved_at: 2026-08-31
-    # Transcribed from the report's benchmark table. Tencent reports 35 rows
-    # across 32 tracked benchmarks: SWE Atlas contributes three splits and HLE
-    # reports both with-tools and no-tools. Five internal Hy-* benchmarks and
-    # the GDV-PAL-AVA V2 Elo row are recorded in benchmark_scores.yml where
-    # scores are stored; five internal Hy-* rows are not tracked at all.
+    # Transcribed from the report's benchmark table. Tencent reports 37 rows
+    # across 34 tracked benchmarks: SWE Atlas contributes three splits and HLE
+    # reports both with-tools and no-tools. Nine rows explicitly marked
+    # "Internal" in the report are not tracked.
     benchmarks:
       - swe_bench_multilingual
       - swe_bench_pro
@@ -2043,6 +2052,8 @@ model_cards:
       - workspacebench
       - agents_last_exam
       - gdpval
+      - automationbench
+      - bankertoolbench
       - biomysterybench
       - hle
       - critpt

--- a/scripts/build_logo_registry.py
+++ b/scripts/build_logo_registry.py
@@ -61,8 +61,14 @@ def main() -> None:
     # The highest number ever issued, kept even for entries about to be
     # dropped, so a retired ID is never handed to a different model later.
     retired = {
-        "O": max((int(v.split("-")[1]) for v in org_ids.values()), default=0),
-        "M": max((int(v.split("-")[1]) for v in model_ids.values()), default=0),
+        "O": max(
+            int(high_water.get("O", 0)),
+            max((int(v.split("-")[1]) for v in org_ids.values()), default=0),
+        ),
+        "M": max(
+            int(high_water.get("M", 0)),
+            max((int(v.split("-")[1]) for v in model_ids.values()), default=0),
+        ),
     }
 
     assign(org_ids, organizations, "O")

--- a/site/data/logo-registry.json
+++ b/site/data/logo-registry.json
@@ -1,8 +1,8 @@
 {
   "note": "Frozen IDs for the logo audit page (site/logos.html). An ID is assigned once and never reused, so review feedback citing it stays valid across rebuilds. Which models and organizations exist is decided by models.json, not here.",
   "high_water": {
-    "O": 68,
-    "M": 1047
+    "O": 67,
+    "M": 1048
   },
   "organizations": {
     "AI21 Labs": "O-01",
@@ -133,6 +133,8 @@
     "GLM-5 (Reasoning)␟Z.ai": "M-1044",
     "GLM-5-Turbo␟Z.ai": "M-1045",
     "GLM 5V Turbo (Reasoning)␟Z.ai": "M-1046",
+    "GLM-5.3-Flash␟Z.ai": "M-1047",
+    "Hy4 preview␟Tencent": "M-1048",
     "Gemini 3 Flash␟Google": "M-105",
     "Gemini 3 Pro␟Google": "M-106",
     "Gemini 3.1 Flash-Lite␟Google": "M-107",
@@ -375,7 +377,6 @@
     "Grok 4.5␟xAI": "M-34",
     "GLM-4.7-Flash␟Z.ai": "M-340",
     "GLM-5.3␟Z.ai": "M-341",
-    "GLM-5.3-Flash␟Z.ai": "M-1047",
     "GLM-5V-Turbo␟Z.ai": "M-342",
     "Grok 4 Fast␟xAI": "M-343",
     "Grok 4.3␟xAI": "M-344",

--- a/site/data/logo-registry.json
+++ b/site/data/logo-registry.json
@@ -1,7 +1,7 @@
 {
   "note": "Frozen IDs for the logo audit page (site/logos.html). An ID is assigned once and never reused, so review feedback citing it stays valid across rebuilds. Which models and organizations exist is decided by models.json, not here.",
   "high_water": {
-    "O": 67,
+    "O": 68,
     "M": 1048
   },
   "organizations": {

--- a/site/data/models.json
+++ b/site/data/models.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
-  "model_count": 861,
-  "curated_only": 16,
+  "model_count": 862,
+  "curated_only": 17,
   "crawled_only": 826,
   "both_layers": 19,
   "organizations": [
@@ -8545,6 +8545,17 @@
       ],
       "source_counts": {
         "crawled": 10
+      }
+    },
+    {
+      "key": "tencent-hy4-preview",
+      "model": "Hy4 preview",
+      "organization": "Tencent",
+      "layers": [
+        "curated"
+      ],
+      "source_counts": {
+        "curated": 1
       }
     },
     {

--- a/tests/test_models_registry.py
+++ b/tests/test_models_registry.py
@@ -10,6 +10,7 @@ dropped 321 models: Gemini had a record and MiMo did not.
 from __future__ import annotations
 
 import json
+import runpy
 from pathlib import Path
 
 import pytest
@@ -161,6 +162,42 @@ def test_a_retired_id_is_never_handed_to_a_different_model():
         assert high_water[prefix] >= max(issued), prefix
     # M's high-water mark exceeds its live count, which is what retirement looks like.
     assert high_water["M"] >= len(logos["models"])
+
+
+def test_the_logo_generator_preserves_a_retired_high_water_mark(tmp_path, monkeypatch):
+    """A retired maximum survives even when no live entry still carries it."""
+    script = Path("scripts/build_logo_registry.py").resolve()
+    data_dir = tmp_path / "site" / "data"
+    data_dir.mkdir(parents=True)
+    (data_dir / "models.json").write_text(
+        json.dumps(
+            {
+                "models": [
+                    {
+                        "model": "Model One",
+                        "organization": "Org One",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    (data_dir / "logo-registry.json").write_text(
+        json.dumps(
+            {
+                "high_water": {"O": 68, "M": 1048},
+                "organizations": {"Org One": "O-01"},
+                "models": {"Model One␟Org One": "M-01"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    runpy.run_path(str(script), run_name="__main__")
+
+    generated = json.loads((data_dir / "logo-registry.json").read_text(encoding="utf-8"))
+    assert generated["high_water"] == {"O": 68, "M": 1048}
 
 
 def test_a_missing_shard_directory_refuses_to_write_a_curated_only_registry(tmp_path):


### PR DESCRIPTION
Closes #416

为 Hy4 preview 新增完整的公开 benchmark 模型卡：收录 37 个分数，对应 34 个 benchmark ID。SWE Atlas 包含 3 个 split，HLE 分为有工具和无工具两种协议。报告中 9 个明确标注为 Internal 的 benchmark 不进入公开跟踪层。

评测分数已逐一与报告核实。本次同时统一 GDPval-AA V2 的 instrument ID，并修复 logo registry 退休 ID 的 high-water mark 保留逻辑。

| 基准 | 分数 |
|---|---:|
| GPQA Diamond | 92.3 |
| Terminal-Bench 2.1 | 85.4 |
| SWE-bench Multilingual | 82.9 |
| SWE-bench Pro | 65.7 |
| DeepSWE | 64.3 |
| NL2Repo-Bench | 58.9 |
| ProgramBench | 17.5 |
| Harbor-Index | 39.6 |
| DRACO | 77.2 |
| MCP-Atlas | 83.7 |
| APEX-Agents | 37.1 |
| JobBench | 61.7 |
| Agents' Last Exam (ALE-CLI) | 22.8 |
| BioMysteryBench | 71.3 |
| HLE (no tools) | 43.4 |
| SUPERChem | 66.4 |
| HorizonMath (pass@4) | 8.8 |
| BrokenArXiv | 54.6 |
| WideSearch | 83.9 |
| SWE Atlas – Codebase Q&A | 64.0 |
| SWE Atlas – Test Writing | 57.8 |
| SWE Atlas – Refactoring | 53.3 |
| SWE-Marathon | 31.9 |
| CyberGym | 78.4 |
| PostTrainBench V1.1 | 35.6 |
| OneMillionBench (with tools) | 65.4 |
| OfficeQA Pro | 66.2 |
| Toolathlon-Verified | 74.1 |
| SkillsBench V1 | 62.9 |
| WorkspaceBench | 60.2 |
| GDPval-AA V2 (Elo, official) | 1678 |
| AutomationBench v1.0.6 | 32.1 |
| BankerToolBench | 78.6 |
| HLE (with tools) | 55.4 |
| CritPt (official) | 16.9 |
| ArXivMath | 66.6 |
| MathArena Apex 2025 | 74.2 |
