### PR TITLE
feat(site): add a citation pop-out at /#cite

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -830,6 +830,14 @@ const I18N = {
     "If this saved you research time, cite the work, star the repo and help other eval builders find it.":
       "如果它帮你节省了研究时间，请引用这项工作、给仓库点 Star，让更多评测开发者找到它。",
     Cite: "引用",
+    "Cite this work": "引用这项工作",
+    "Pick the format your paper or repository needs, then click it to copy.":
+      "选择你的论文或仓库需要的格式，点击即可复制。",
+    "Click to copy": "点击复制",
+    "Click to copy link": "点击复制链接",
+    "Copy it with your keyboard": "请用键盘复制",
+    "Citation file (.cff)": "引用文件 (.cff)",
+    "View the citation file": "查看引用文件",
     "Share Benchmark Radar": "分享 Benchmark Radar",
     Share: "分享",
     Copied: "已复制",
@@ -1030,6 +1038,7 @@ const state = {
   entity: "",
   rubric: "",
   contact: false,
+  cite: false,
   trendReleasedOnly: false,
   // Leaderboard filters carry their own prefixed keys so a shared permalink can
   // hold a Today filter and a Leaderboard filter at once without either view
@@ -1178,6 +1187,7 @@ function readUrl() {
   const rawHash = window.location.hash.slice(1);
   const hashParams = new URLSearchParams(rawHash);
   state.contact = rawHash === "contact" || hashParams.has("contact");
+  state.cite = rawHash === "cite" || hashParams.has("cite");
   state.rubric = rawHash === "rubric"
     ? "current"
     : hashParams.get("rubric") || "";
@@ -1237,6 +1247,7 @@ function writeUrl(mode = "replace") {
   // #rubric=2 reads as "jump to this section" rather than another filter.
   let hash = "";
   if (state.contact) hash = "contact";
+  else if (state.cite) hash = "cite";
   else if (state.rubric === "current") hash = "rubric";
   else if (state.rubric) hash = `rubric=${encodeURIComponent(state.rubric)}`;
   const url = `${window.location.pathname}${query ? `?${query}` : ""}${hash ? `#${hash}` : ""}`;
@@ -1262,6 +1273,15 @@ async function onPopState() {
   // read here would leave it rendering whatever the reader navigated away
   // from while the address bar showed the restored entry.
   readUrl();
+  // The citation card draws no data, so it opens before the payload lands and
+  // has to close before it too. Below the early return it would survive Back
+  // on a slow or failing build: the hash would go, the dialog would stay.
+  const citeDialog = byId("cite-dialog");
+  if (state.cite) {
+    if (!citeDialog?.open) openCite(false);
+  } else if (citeDialog?.open) {
+    citeDialog.close();
+  }
   if (!state.data) return;
   await ensureDataForState();
   // A leaderboard permalink on a build with no curated registry has nothing to
@@ -3159,6 +3179,7 @@ function openRubric(item = null, versionOverride = null) {
   const current = Number(state.data?.rubric?.scoring_version) || version;
   const isLegacy = version !== current;
   state.contact = false;
+  state.cite = false;
   state.rubric = isLegacy ? String(version) : "current";
   syncNavState();
   writeUrl();
@@ -7570,6 +7591,7 @@ function brandIcon(name) {
 function openContact(updateUrl = true) {
   const dialog = byId("contact-dialog");
   state.rubric = "";
+  state.cite = false;
   state.contact = true;
   if (updateUrl) writeUrl("push");
   replaceChildren(byId("contact-content"), [
@@ -7630,6 +7652,104 @@ function openContact(updateUrl = true) {
         },
       }),
     ]),
+  ]);
+  if (!dialog.open) dialog.showModal();
+}
+
+// The published technical report. These strings are the citation itself, so
+// they are held verbatim rather than assembled from parts: a citation the page
+// rebuilds on the fly is a citation that can drift from CITATION.cff.
+const CITE_DOI_URL = "https://doi.org/10.5281/zenodo.22167102";
+const CITE_CFF_URL = "https://github.com/ktwu01/benchmark-radar/blob/main/CITATION.cff";
+const CITE_APA =
+  "Wu, K. (2026). Benchmark Radar v0.9.0: Technical Report (Version 0.9.0). " + CITE_DOI_URL;
+const CITE_BIBTEX = [
+  "@techreport{Wu_Benchmark_Radar_v0_9_0_2026,",
+  "author = {Wu, Koutian},",
+  "doi = {10.5281/zenodo.22167102},",
+  "month = aug,",
+  "title = {{Benchmark Radar v0.9.0: Technical Report}},",
+  "url = {https://zenodo.org/records/22167102},",
+  "year = {2026}",
+  "}",
+].join("\n");
+
+// One block per citation format. The block itself is the button: a reader who
+// came for a citation wants it on the clipboard, so clicking the text copies
+// it rather than making them select eight wrapped lines by hand.
+function citeBlock(label, value, hint) {
+  const status = element("span", { className: "cite-status", text: t(hint) });
+  const text = element("code", { className: "cite-text", text: value });
+  const copy = element(
+    "button",
+    {
+      className: "cite-copy",
+      attrs: { type: "button", "aria-label": `${t(hint)}: ${t(label)}` },
+    },
+    [text, status],
+  );
+  copy.addEventListener("click", async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+      copy.classList.add("is-copied");
+      status.textContent = t("Copied");
+      setTimeout(() => {
+        copy.classList.remove("is-copied");
+        status.textContent = t(hint);
+      }, 1600);
+    } catch (error) {
+      // Clipboard access is refused outright in some browsers and embedded
+      // webviews. Selecting the citation leaves the reader one keystroke from
+      // copying it by hand, rather than a click that visibly did nothing.
+      const range = document.createRange();
+      range.selectNodeContents(text);
+      const selection = window.getSelection();
+      selection.removeAllRanges();
+      selection.addRange(range);
+      status.textContent = t("Copy it with your keyboard");
+    }
+  });
+  return element("section", { className: "cite-block" }, [
+    element("h3", { className: "cite-label", text: t(label) }),
+    copy,
+  ]);
+}
+
+// True only while the open card owns a history entry this page pushed. A
+// reader who landed on /#cite directly does not have one, so closing must not
+// step back: the entry behind them belongs to whatever site sent them here.
+let citeOwnsHistoryEntry = false;
+
+// Reachable at /#cite, so the card has a short link that can be pasted into a
+// paper, a README or a message instead of a reader hunting the footer for it.
+function openCite(updateUrl = true) {
+  const dialog = byId("cite-dialog");
+  state.rubric = "";
+  state.contact = false;
+  state.cite = true;
+  citeOwnsHistoryEntry = updateUrl;
+  if (updateUrl) writeUrl("push");
+  replaceChildren(byId("cite-content"), [
+    element("p", { className: "detail-source", text: "Benchmark Radar" }),
+    element("h2", {
+      className: "detail-title cite-title",
+      text: t("Cite this work"),
+      attrs: { id: "cite-title" },
+    }),
+    element("p", {
+      className: "detail-summary",
+      text: t("Pick the format your paper or repository needs, then click it to copy."),
+    }),
+    element("div", { className: "cite-blocks" }, [
+      citeBlock("APA", CITE_APA, "Click to copy"),
+      citeBlock("BibTeX", CITE_BIBTEX, "Click to copy"),
+      citeBlock("Citation file (.cff)", CITE_CFF_URL, "Click to copy link"),
+    ]),
+    element("a", {
+      className: "secondary-link cite-view",
+      text: t("View the citation file"),
+      attrs: { href: CITE_CFF_URL, target: "_blank", rel: "noopener noreferrer" },
+    }),
   ]);
   if (!dialog.open) dialog.showModal();
 }
@@ -7845,6 +7965,32 @@ function bindEvents() {
   });
   byId("contact-dialog").addEventListener("close", () => {
     state.contact = false;
+    writeUrl();
+  });
+  // The footer entry is an anchor to the same short link, so it still reads as
+  // a link to a crawler and to a reader copying it out of the context menu;
+  // the handler keeps the click itself on the page.
+  byId("cite-open").addEventListener("click", (event) => {
+    event.preventDefault();
+    openCite();
+  });
+  byId("cite-close").addEventListener("click", () => byId("cite-dialog").close());
+  byId("cite-dialog").addEventListener("click", (event) => {
+    if (event.target === byId("cite-dialog")) byId("cite-dialog").close();
+  });
+  byId("cite-dialog").addEventListener("close", () => {
+    state.cite = false;
+    const owned = citeOwnsHistoryEntry;
+    citeOwnsHistoryEntry = false;
+    // Replacing an entry this page pushed would leave two identical entries
+    // stacked, so the reader's next Back would look broken: same URL, same
+    // page, nothing visibly happening. Stepping back consumes it instead.
+    // When Back is what closed the card the hash is already gone, and this
+    // falls through to the ordinary rewrite.
+    if (owned && window.location.hash === "#cite") {
+      window.history.back();
+      return;
+    }
     writeUrl();
   });
   byId("share-radar").addEventListener("click", async (event) => {
@@ -8081,6 +8227,10 @@ async function initialize() {
   bindEvents();
   // Independent of the data file, so badges still render on an error state.
   renderRepoBadges();
+  // The citation is fixed text, not a reading of the corpus. Someone arriving
+  // from a paper's reference link should still get it on a build whose data
+  // file is broken, so it opens before the fetch rather than after it.
+  if (state.cite) openCite(false);
   try {
     // The default payload carries the latest day, aggregate counts, and the
     // leaderboard. Trends, Explore, All dates, and historical permalinks lazily

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -3821,6 +3821,76 @@ dialog::backdrop {
   word-break: break-all;
 }
 
+/* The citation sheet at /#cite. Three formats stacked in one column: a reader
+   wants exactly one of them and should be able to tell which is which before
+   reading a character of the citation itself. */
+.cite-blocks {
+  display: grid;
+  gap: 1.5rem;
+  margin: 1.5rem 0;
+}
+
+.cite-label {
+  margin: 0 0 0.5rem;
+  color: var(--muted);
+  font-family: var(--utility);
+  font-size: 0.7rem;
+  letter-spacing: 0.05em;
+}
+
+/* The whole citation is the copy control, so the hit area matches the thing
+   the reader is looking at. Left-aligned and full width because it holds a
+   block of text, not a label. */
+.cite-copy {
+  display: block;
+  width: 100%;
+  padding: 0.9rem 1rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--canvas);
+  color: var(--ink);
+  text-align: left;
+  cursor: pointer;
+}
+
+.cite-copy:hover,
+.cite-copy:focus-visible {
+  border-color: var(--blue);
+}
+
+.cite-copy.is-copied {
+  border-color: var(--sea);
+}
+
+/* BibTeX is written line by line and stays that way; APA and the .cff URL are
+   single runs with no break opportunity, so they need `anywhere` to keep the
+   dialog from growing wider than the viewport. */
+.cite-text {
+  display: block;
+  font-family: var(--utility);
+  font-size: 0.78rem;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.cite-status {
+  display: block;
+  margin-top: 0.6rem;
+  color: var(--blue);
+  font-family: var(--utility);
+  font-size: 0.62rem;
+  letter-spacing: 0.05em;
+}
+
+.cite-copy.is-copied .cite-status {
+  color: var(--sea);
+}
+
+.cite-view {
+  display: inline-block;
+}
+
 .supporting-signals {
   margin: 1.8rem 0;
   padding-top: 1.2rem;

--- a/site/index.html
+++ b/site/index.html
@@ -837,6 +837,16 @@
       <div id="rubric-content"></div>
     </dialog>
 
+    <dialog id="cite-dialog" aria-labelledby="cite-title">
+      <button
+        class="dialog-close"
+        id="cite-close"
+        type="button"
+        aria-label="Close citation formats"
+      >×</button>
+      <div id="cite-content"></div>
+    </dialog>
+
     <dialog id="contact-dialog" aria-labelledby="contact-title">
       <button
         class="dialog-close"
@@ -854,11 +864,15 @@
           If this saved you research time, cite the work, star the repo and help other eval builders find it.
         </p>
         <span class="adoption-actions">
+          <!-- A real anchor, so the citation card has a short link a reader can
+               copy out of the address bar and paste into a paper's repo notes.
+               app.js opens it as the same pop-out the Rubric uses. -->
           <a
             class="primary-link"
-            href="https://github.com/ktwu01/benchmark-radar/blob/main/CITATION.cff"
-            target="_blank"
-            rel="noopener noreferrer"
+            id="cite-open"
+            href="https://benchmark-radar.org/#cite"
+            aria-haspopup="dialog"
+            aria-controls="cite-dialog"
             data-i18n="Cite"
           >Cite</a>
           <a

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -114,6 +114,50 @@ def test_priority_score_is_reachably_explained():
     assert "How is this scored?" in script
 
 
+def test_citation_formats_are_one_click_away_behind_a_short_link():
+    html = Path("site/index.html").read_text(encoding="utf-8")
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+    styles = Path("site/assets/styles.css").read_text(encoding="utf-8")
+    cff = Path("CITATION.cff").read_text(encoding="utf-8")
+
+    # Same pop-out treatment as the rubric, reachable at a link short enough to
+    # paste into a paper or a message.
+    assert 'id="cite-dialog"' in html
+    assert 'id="cite-content"' in html
+    assert 'href="https://benchmark-radar.org/#cite"' in html
+    assert 'aria-controls="cite-dialog"' in html
+    assert 'state.cite = rawHash === "cite" || hashParams.has("cite");' in script
+    assert 'else if (state.cite) hash = "cite";' in script
+    assert "function openCite(" in script
+
+    # Three formats, each copied by clicking the citation itself.
+    assert 'citeBlock("APA", CITE_APA, "Click to copy")' in script
+    assert 'citeBlock("BibTeX", CITE_BIBTEX, "Click to copy")' in script
+    assert 'citeBlock("Citation file (.cff)", CITE_CFF_URL, "Click to copy link")' in script
+    assert "navigator.clipboard.writeText(value)" in script
+    assert ".cite-copy {" in styles
+
+    # The card draws no data, so a build whose payload never arrives must still
+    # open it and must still close it on Back: both sides of that sit above the
+    # early return in onPopState.
+    pop_state = script.split("async function onPopState() {", 1)[1]
+    cite_sync = pop_state.index('const citeDialog = byId("cite-dialog");')
+    assert cite_sync < pop_state.index("if (!state.data) return;")
+
+    # Opening from the footer pushes an entry. Closing steps back through it
+    # rather than replacing it, or Back would land on an identical URL and
+    # look broken -- but only when this page pushed the entry, so closing a
+    # directly-opened /#cite never sends the reader off the site.
+    assert "citeOwnsHistoryEntry = updateUrl;" in script
+    assert 'if (owned && window.location.hash === "#cite") {' in script
+
+    # The rendered citations must agree with the file they claim to mirror, or
+    # the site would hand out a citation the repository does not make.
+    for fragment in ("10.5281/zenodo.22167102", "Benchmark Radar v0.9.0: Technical Report"):
+        assert fragment in cff
+        assert fragment in script
+
+
 def test_every_navigation_item_uses_the_same_active_state():
     html = Path("site/index.html").read_text(encoding="utf-8")
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
@@ -579,11 +623,15 @@ def test_records_expand_inline_without_an_exclusive_accordion_or_record_modal():
     assert "detail-dialog" not in script
     # A shared details[name] would force one row closed when another opens.
     assert "attrs: { name:" not in script
-    # The two dialogs on the page are non-record chrome: the scoring rubric and
-    # the contact sheet (the export dialog went with the export button,
-    # issue #311). Record detail must stay inline, so any third showModal()
-    # is a regression to a record modal.
-    assert script.count(".showModal()") == 2
+    # The dialogs on the page are non-record chrome: the scoring rubric, the
+    # contact sheet (the export dialog went with the export button, issue
+    # #311), and the citation card. Record detail must stay inline, so a
+    # showModal() the list below does not name is a regression to a record
+    # modal.
+    assert script.count(".showModal()") == 3
+    assert 'byId("rubric-dialog")' in script
+    assert 'byId("contact-dialog")' in script
+    assert 'byId("cite-dialog")' in script
 
 
 def test_hugging_face_expansion_links_to_the_full_card():


### PR DESCRIPTION
## What this adds

A citation card at **https://benchmark-radar.org/#cite**, so anyone writing a paper, a README, or a reference list can get the citation for Benchmark Radar in the format they need without leaving the page.

It is the same pop-out treatment as `#rubric`: click **Cite** in the footer, the card opens over the page, the address bar shows a short link that can be pasted into a message or a paper's repo notes. Someone who opens that link directly lands on the card.

## What is in the card

Three formats, each copied by clicking the citation itself:

1. **APA** — `Wu, K. (2026). Benchmark Radar v0.9.0: Technical Report (Version 0.9.0). https://doi.org/10.5281/zenodo.22167102`
2. **BibTeX** — the full `@techreport` entry
3. **Citation file (.cff)** — copies the link to `CITATION.cff`, with a separate link to open it

The status line under each block says "Click to copy" and flips to "Copied" for a moment after the click. Where the browser refuses clipboard access, the citation is selected instead and the status reads "Copy it with your keyboard", so a blocked click never looks like a click that did nothing. English and Chinese both covered.

## Notes

- The card holds fixed text, not a reading of the corpus, so it opens before the data fetch. A reader arriving from a paper's reference link still gets the citation on a build whose data file is broken, and Back still closes it there.
- Opening from the footer pushes a history entry and closing steps back through it, so Back never lands on an identical URL. Closing a directly-opened `/#cite` does not step back, because that entry belongs to whatever site sent the reader here.
- `tests/test_site.py` covers the short link, the three blocks, the copy handler, the pre-fetch ordering, and the history handling. The existing record-modal guard now names all three dialogs, so an unnamed `showModal()` is still caught as a regression.
- The citation strings match `CITATION.cff`; a test asserts the DOI and title appear in both.

## Verification

Full CI sequence on a clean detached checkout: `ruff check` / `ruff format --check` / `normalize-external` / `classify` / `build-data-release` / `pytest -q` — 1091 passed.

Checked in a real browser at desktop and mobile widths, in English and Chinese: the copy path, the permission-denied fallback, the footer-click round trip, direct landing on `/#cite`, and Back on a build with no data.
