### PR TITLE
feat(site): add a CLI setup sheet at /#cli

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -838,6 +838,12 @@ const I18N = {
     "Copy it with your keyboard": "请用键盘复制",
     "Citation file (.cff)": "引用文件 (.cff)",
     "View the citation file": "查看引用文件",
+    CLI: "命令行",
+    "Query it locally (CLI version)": "在本地查询（命令行版本）",
+    "This website is the hosted view. The CLI version runs on your own computer: it installs the command-line tool, downloads the searchable data, and answers from those local files.":
+      "本网站是在线版本。命令行版本在你自己的电脑上运行：它会安装命令行工具、下载可搜索的数据，并从这些本地文件中给出答案。",
+    "Give this prompt to your coding agent": "把这段提示词交给你的编程助手",
+    "Read the setup guide": "查看安装指南",
     "Share Benchmark Radar": "分享 Benchmark Radar",
     Share: "分享",
     Copied: "已复制",
@@ -1039,6 +1045,7 @@ const state = {
   rubric: "",
   contact: false,
   cite: false,
+  cli: false,
   trendReleasedOnly: false,
   // Leaderboard filters carry their own prefixed keys so a shared permalink can
   // hold a Today filter and a Leaderboard filter at once without either view
@@ -1188,6 +1195,7 @@ function readUrl() {
   const hashParams = new URLSearchParams(rawHash);
   state.contact = rawHash === "contact" || hashParams.has("contact");
   state.cite = rawHash === "cite" || hashParams.has("cite");
+  state.cli = rawHash === "cli" || hashParams.has("cli");
   state.rubric = rawHash === "rubric"
     ? "current"
     : hashParams.get("rubric") || "";
@@ -1248,6 +1256,7 @@ function writeUrl(mode = "replace") {
   let hash = "";
   if (state.contact) hash = "contact";
   else if (state.cite) hash = "cite";
+  else if (state.cli) hash = "cli";
   else if (state.rubric === "current") hash = "rubric";
   else if (state.rubric) hash = `rubric=${encodeURIComponent(state.rubric)}`;
   const url = `${window.location.pathname}${query ? `?${query}` : ""}${hash ? `#${hash}` : ""}`;
@@ -1281,6 +1290,12 @@ async function onPopState() {
     if (!citeDialog?.open) openCite(false);
   } else if (citeDialog?.open) {
     citeDialog.close();
+  }
+  const cliDialog = byId("cli-dialog");
+  if (state.cli) {
+    if (!cliDialog?.open) openCli(false);
+  } else if (cliDialog?.open) {
+    cliDialog.close();
   }
   if (!state.data) return;
   await ensureDataForState();
@@ -1369,7 +1384,7 @@ function applyViewSeo(view) {
 function syncNavState() {
   const rubricActive = Boolean(state.rubric);
   document.querySelectorAll("[data-view]").forEach((item) => {
-    const active = !rubricActive && item.dataset.view === state.view;
+    const active = !rubricActive && !state.cli && item.dataset.view === state.view;
     item.classList.toggle("nav-active", active);
     if (active) {
       item.setAttribute("aria-current", "page");
@@ -1380,6 +1395,9 @@ function syncNavState() {
   const rubricNav = byId("rubric-nav");
   rubricNav.classList.toggle("nav-active", rubricActive);
   rubricNav.setAttribute("aria-expanded", String(rubricActive));
+  const cliNav = byId("cli-nav");
+  cliNav.classList.toggle("nav-active", state.cli);
+  cliNav.setAttribute("aria-expanded", String(state.cli));
 }
 
 // `update` false is for restoring a view that is already in the URL (boot and
@@ -3178,8 +3196,10 @@ function openRubric(item = null, versionOverride = null) {
   const version = Number(data.scoring_version) || 1;
   const current = Number(state.data?.rubric?.scoring_version) || version;
   const isLegacy = version !== current;
+  closeOtherSheets("rubric-dialog");
   state.contact = false;
   state.cite = false;
+  state.cli = false;
   state.rubric = isLegacy ? String(version) : "current";
   syncNavState();
   writeUrl();
@@ -7590,8 +7610,10 @@ function brandIcon(name) {
 // dataset and the repository.
 function openContact(updateUrl = true) {
   const dialog = byId("contact-dialog");
+  closeOtherSheets("contact-dialog");
   state.rubric = "";
   state.cite = false;
+  state.cli = false;
   state.contact = true;
   if (updateUrl) writeUrl("push");
   replaceChildren(byId("contact-content"), [
@@ -7674,16 +7696,17 @@ const CITE_BIBTEX = [
   "}",
 ].join("\n");
 
-// One block per citation format. The block itself is the button: a reader who
-// came for a citation wants it on the clipboard, so clicking the text copies
-// it rather than making them select eight wrapped lines by hand.
-function citeBlock(label, value, hint) {
-  const status = element("span", { className: "cite-status", text: t(hint) });
-  const text = element("code", { className: "cite-text", text: value });
+// One labelled block of copyable text, shared by the citation sheet and the CLI
+// sheet. The block itself is the button: a reader who came for a citation or a
+// setup prompt wants it on the clipboard, so clicking the text copies it rather
+// than making them select eight wrapped lines by hand.
+function copyBlock(label, value, hint) {
+  const status = element("span", { className: "copy-status", text: t(hint) });
+  const text = element("code", { className: "copy-text", text: value });
   const copy = element(
     "button",
     {
-      className: "cite-copy",
+      className: "copy-target",
       attrs: { type: "button", "aria-label": `${t(hint)}: ${t(label)}` },
     },
     [text, status],
@@ -7699,7 +7722,7 @@ function citeBlock(label, value, hint) {
       }, 1600);
     } catch (error) {
       // Clipboard access is refused outright in some browsers and embedded
-      // webviews. Selecting the citation leaves the reader one keystroke from
+      // webviews. Selecting the text leaves the reader one keystroke from
       // copying it by hand, rather than a click that visibly did nothing.
       const range = document.createRange();
       range.selectNodeContents(text);
@@ -7709,8 +7732,8 @@ function citeBlock(label, value, hint) {
       status.textContent = t("Copy it with your keyboard");
     }
   });
-  return element("section", { className: "cite-block" }, [
-    element("h3", { className: "cite-label", text: t(label) }),
+  return element("section", { className: "copy-block" }, [
+    element("h3", { className: "copy-label", text: t(label) }),
     copy,
   ]);
 }
@@ -7720,12 +7743,29 @@ function citeBlock(label, value, hint) {
 // step back: the entry behind them belongs to whatever site sent them here.
 let citeOwnsHistoryEntry = false;
 
+// One sheet at a time. showModal() stacks a dialog on top of an open one rather
+// than replacing it, so opening the rubric over the CLI card would leave the CLI
+// card waiting underneath to reappear when the rubric closed. Ownership is
+// dropped first: the sheet being replaced must not step history back, because
+// the entry it pushed is the one the reader came through.
+function closeOtherSheets(keep) {
+  citeOwnsHistoryEntry = false;
+  cliOwnsHistoryEntry = false;
+  for (const id of ["rubric-dialog", "contact-dialog", "cite-dialog", "cli-dialog"]) {
+    if (id === keep) continue;
+    const other = byId(id);
+    if (other?.open) other.close();
+  }
+}
+
 // Reachable at /#cite, so the card has a short link that can be pasted into a
 // paper, a README or a message instead of a reader hunting the footer for it.
 function openCite(updateUrl = true) {
   const dialog = byId("cite-dialog");
+  closeOtherSheets("cite-dialog");
   state.rubric = "";
   state.contact = false;
+  state.cli = false;
   state.cite = true;
   citeOwnsHistoryEntry = updateUrl;
   if (updateUrl) writeUrl("push");
@@ -7740,15 +7780,79 @@ function openCite(updateUrl = true) {
       className: "detail-summary",
       text: t("Pick the format your paper or repository needs, then click it to copy."),
     }),
-    element("div", { className: "cite-blocks" }, [
-      citeBlock("APA", CITE_APA, "Click to copy"),
-      citeBlock("BibTeX", CITE_BIBTEX, "Click to copy"),
-      citeBlock("Citation file (.cff)", CITE_CFF_URL, "Click to copy link"),
+    element("div", { className: "copy-blocks" }, [
+      copyBlock("APA", CITE_APA, "Click to copy"),
+      copyBlock("BibTeX", CITE_BIBTEX, "Click to copy"),
+      copyBlock("Citation file (.cff)", CITE_CFF_URL, "Click to copy link"),
     ]),
     element("a", {
-      className: "secondary-link cite-view",
+      className: "secondary-link dialog-link",
       text: t("View the citation file"),
       attrs: { href: CITE_CFF_URL, target: "_blank", rel: "noopener noreferrer" },
+    }),
+  ]);
+  if (!dialog.open) dialog.showModal();
+}
+
+// The setup route published in the README under "Query it locally (CLI
+// version)". The prompt is held verbatim: it names the Skill file a coding
+// agent has to read, and a prompt this page paraphrases is a prompt that can
+// drift from the instructions it points at.
+const CLI_SKILL_URL =
+  "https://github.com/ktwu01/benchmark-radar/blob/main/skills/benchmark-radar/SKILL.md";
+// The README wraps its last sentence across two lines at 80 columns; the card
+// is narrower than that, so keeping the break would re-wrap into ragged text.
+// Only the URL needs a line of its own, and it keeps one.
+const CLI_AGENT_PROMPT = [
+  "Set up Benchmark Radar for local benchmark search. Follow",
+  CLI_SKILL_URL,
+  "to install the CLI and consumer Skill, initialize the local data, and verify the" +
+    " setup. Use only consumer commands.",
+].join("\n");
+
+// True only while the open card owns a history entry this page pushed, for the
+// same reason the citation card tracks it: closing a directly-opened /#cli must
+// not step a reader back off the site.
+let cliOwnsHistoryEntry = false;
+
+// Reachable at /#cli from the view bar, so the offline route is one click from
+// every view rather than a section of the README a reader has to scroll to.
+function openCli(updateUrl = true) {
+  const dialog = byId("cli-dialog");
+  closeOtherSheets("cli-dialog");
+  state.rubric = "";
+  state.contact = false;
+  state.cite = false;
+  state.cli = true;
+  cliOwnsHistoryEntry = updateUrl;
+  syncNavState();
+  if (updateUrl) writeUrl("push");
+  replaceChildren(byId("cli-content"), [
+    element("p", { className: "detail-source", text: "Benchmark Radar" }),
+    element("h2", {
+      className: "detail-title cli-title",
+      text: t("Query it locally (CLI version)"),
+      attrs: { id: "cli-title" },
+    }),
+    element("p", {
+      className: "detail-summary",
+      text: t(
+        "This website is the hosted view. The CLI version runs on your own computer: " +
+          "it installs the command-line tool, downloads the searchable data, and answers " +
+          "from those local files.",
+      ),
+    }),
+    element("div", { className: "copy-blocks" }, [
+      copyBlock(
+        "Give this prompt to your coding agent",
+        CLI_AGENT_PROMPT,
+        "Click to copy",
+      ),
+    ]),
+    element("a", {
+      className: "secondary-link dialog-link",
+      text: t("Read the setup guide"),
+      attrs: { href: CLI_SKILL_URL, target: "_blank", rel: "noopener noreferrer" },
     }),
   ]);
   if (!dialog.open) dialog.showModal();
@@ -7993,6 +8097,28 @@ function bindEvents() {
     }
     writeUrl();
   });
+  // The view bar entry is an anchor to the same short link, so /#cli reads as a
+  // link to a crawler and can be copied out of the context menu; the handler
+  // keeps the click itself on the page.
+  byId("cli-nav").addEventListener("click", (event) => {
+    event.preventDefault();
+    openCli();
+  });
+  byId("cli-close").addEventListener("click", () => byId("cli-dialog").close());
+  byId("cli-dialog").addEventListener("click", (event) => {
+    if (event.target === byId("cli-dialog")) byId("cli-dialog").close();
+  });
+  byId("cli-dialog").addEventListener("close", () => {
+    state.cli = false;
+    syncNavState();
+    const owned = cliOwnsHistoryEntry;
+    cliOwnsHistoryEntry = false;
+    if (owned && window.location.hash === "#cli") {
+      window.history.back();
+      return;
+    }
+    writeUrl();
+  });
   byId("share-radar").addEventListener("click", async (event) => {
     const button = event.currentTarget;
     const shareData = {
@@ -8227,10 +8353,12 @@ async function initialize() {
   bindEvents();
   // Independent of the data file, so badges still render on an error state.
   renderRepoBadges();
-  // The citation is fixed text, not a reading of the corpus. Someone arriving
-  // from a paper's reference link should still get it on a build whose data
-  // file is broken, so it opens before the fetch rather than after it.
+  // The citation and the CLI setup route are fixed text, not readings of the
+  // corpus. Someone arriving from a paper's reference link or looking for the
+  // offline route should still get them on a build whose data file is broken,
+  // so they open before the fetch rather than after it.
   if (state.cite) openCite(false);
+  if (state.cli) openCli(false);
   try {
     // The default payload carries the latest day, aggregate counts, and the
     // leaderboard. Trends, Explore, All dates, and historical permalinks lazily

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -446,17 +446,22 @@ button.repo-badge svg {
   color: white;
 }
 
-/* Rubric is a dialog trigger rather than a page link, so its inactive blue is
-   kept separate from the shared active treatment above. */
-#rubric-nav:not(.nav-active) {
+/* Rubric and CLI are dialog triggers rather than page links, so their inactive
+   blue is kept separate from the shared active treatment above. A reader should
+   be able to tell before clicking that these two open a sheet over the page
+   instead of changing the view under it. */
+#rubric-nav:not(.nav-active),
+#cli-nav:not(.nav-active) {
   color: var(--blue-deep);
 }
 
-#rubric-nav::after {
+#rubric-nav::after,
+#cli-nav::after {
   content: " ⓘ";
 }
 
-#rubric-nav:not(.nav-active):hover {
+#rubric-nav:not(.nav-active):hover,
+#cli-nav:not(.nav-active):hover {
   background: var(--panel);
 }
 
@@ -3821,16 +3826,16 @@ dialog::backdrop {
   word-break: break-all;
 }
 
-/* The citation sheet at /#cite. Three formats stacked in one column: a reader
-   wants exactly one of them and should be able to tell which is which before
-   reading a character of the citation itself. */
-.cite-blocks {
+/* Shared by the citation sheet at /#cite and the CLI sheet at /#cli: blocks of
+   text a reader came to copy, stacked in one column so each one's label is
+   readable before a character of the block itself is. */
+.copy-blocks {
   display: grid;
   gap: 1.5rem;
   margin: 1.5rem 0;
 }
 
-.cite-label {
+.copy-label {
   margin: 0 0 0.5rem;
   color: var(--muted);
   font-family: var(--utility);
@@ -3838,10 +3843,10 @@ dialog::backdrop {
   letter-spacing: 0.05em;
 }
 
-/* The whole citation is the copy control, so the hit area matches the thing
-   the reader is looking at. Left-aligned and full width because it holds a
-   block of text, not a label. */
-.cite-copy {
+/* The whole block is the copy control, so the hit area matches the thing the
+   reader is looking at. Left-aligned and full width because it holds a block of
+   text, not a label. */
+.copy-target {
   display: block;
   width: 100%;
   padding: 0.9rem 1rem;
@@ -3853,19 +3858,19 @@ dialog::backdrop {
   cursor: pointer;
 }
 
-.cite-copy:hover,
-.cite-copy:focus-visible {
+.copy-target:hover,
+.copy-target:focus-visible {
   border-color: var(--blue);
 }
 
-.cite-copy.is-copied {
+.copy-target.is-copied {
   border-color: var(--sea);
 }
 
-/* BibTeX is written line by line and stays that way; APA and the .cff URL are
-   single runs with no break opportunity, so they need `anywhere` to keep the
-   dialog from growing wider than the viewport. */
-.cite-text {
+/* BibTeX and the agent prompt are written line by line and stay that way; APA
+   and the bare URLs are single runs with no break opportunity, so they need
+   `anywhere` to keep the dialog from growing wider than the viewport. */
+.copy-text {
   display: block;
   font-family: var(--utility);
   font-size: 0.78rem;
@@ -3874,7 +3879,7 @@ dialog::backdrop {
   overflow-wrap: anywhere;
 }
 
-.cite-status {
+.copy-status {
   display: block;
   margin-top: 0.6rem;
   color: var(--blue);
@@ -3883,11 +3888,11 @@ dialog::backdrop {
   letter-spacing: 0.05em;
 }
 
-.cite-copy.is-copied .cite-status {
+.copy-target.is-copied .copy-status {
   color: var(--sea);
 }
 
-.cite-view {
+.dialog-link {
   display: inline-block;
 }
 

--- a/site/index.html
+++ b/site/index.html
@@ -341,6 +341,19 @@
       >
         Rubric
       </button>
+      <!-- Sits beside Rubric because neither is a view: both open a sheet over
+         whatever the reader is already looking at. A real anchor, so /#cli is a
+         short link a reader can paste and a crawler can follow. -->
+      <a
+        href="https://benchmark-radar.org/#cli"
+        id="cli-nav"
+        aria-haspopup="dialog"
+        aria-controls="cli-dialog"
+        aria-expanded="false"
+        data-i18n="CLI"
+      >
+        CLI
+      </a>
     </nav>
 
     <main id="main-content" tabindex="-1">
@@ -845,6 +858,16 @@
         aria-label="Close citation formats"
       >×</button>
       <div id="cite-content"></div>
+    </dialog>
+
+    <dialog id="cli-dialog" aria-labelledby="cli-title">
+      <button
+        class="dialog-close"
+        id="cli-close"
+        type="button"
+        aria-label="Close CLI setup"
+      >×</button>
+      <div id="cli-content"></div>
     </dialog>
 
     <dialog id="contact-dialog" aria-labelledby="contact-title">

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -131,11 +131,11 @@ def test_citation_formats_are_one_click_away_behind_a_short_link():
     assert "function openCite(" in script
 
     # Three formats, each copied by clicking the citation itself.
-    assert 'citeBlock("APA", CITE_APA, "Click to copy")' in script
-    assert 'citeBlock("BibTeX", CITE_BIBTEX, "Click to copy")' in script
-    assert 'citeBlock("Citation file (.cff)", CITE_CFF_URL, "Click to copy link")' in script
+    assert 'copyBlock("APA", CITE_APA, "Click to copy")' in script
+    assert 'copyBlock("BibTeX", CITE_BIBTEX, "Click to copy")' in script
+    assert 'copyBlock("Citation file (.cff)", CITE_CFF_URL, "Click to copy link")' in script
     assert "navigator.clipboard.writeText(value)" in script
-    assert ".cite-copy {" in styles
+    assert ".copy-target {" in styles
 
     # The card draws no data, so a build whose payload never arrives must still
     # open it and must still close it on Back: both sides of that sit above the
@@ -156,6 +156,81 @@ def test_citation_formats_are_one_click_away_behind_a_short_link():
     for fragment in ("10.5281/zenodo.22167102", "Benchmark Radar v0.9.0: Technical Report"):
         assert fragment in cff
         assert fragment in script
+
+
+def test_offline_cli_route_is_in_the_view_bar_behind_a_short_link():
+    html = Path("site/index.html").read_text(encoding="utf-8")
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+    readme = Path("README.md").read_text(encoding="utf-8")
+
+    # Same pop-out treatment as the rubric, reached from the view bar rather
+    # than from a section of the README a reader has to scroll to.
+    nav = html.split('<nav class="view-nav"', 1)[1].split("</nav>", 1)[0]
+    assert 'id="cli-nav"' in nav
+    assert 'href="https://benchmark-radar.org/#cli"' in nav
+    assert 'aria-controls="cli-dialog"' in nav
+    assert 'id="cli-dialog"' in html
+    assert 'id="cli-content"' in html
+    assert 'state.cli = rawHash === "cli" || hashParams.has("cli");' in script
+    assert 'else if (state.cli) hash = "cli";' in script
+    assert "function openCli(" in script
+
+    # One copy block, sharing the citation card's control rather than a second
+    # clipboard handler.
+    assert 'copyBlock(\n        "Give this prompt to your coding agent",' in script
+
+    # The card holds no data either, so it opens before the fetch and closes on
+    # Back above the early return, and it owns its pushed history entry.
+    assert "if (state.cli) openCli(false);" in script
+    pop_state = script.split("async function onPopState() {", 1)[1]
+    assert pop_state.index('const cliDialog = byId("cli-dialog");') < pop_state.index(
+        "if (!state.data) return;"
+    )
+    assert "cliOwnsHistoryEntry = updateUrl;" in script
+    assert 'if (owned && window.location.hash === "#cli") {' in script
+
+    # A view entry and the CLI entry must not both read as current, and the CLI
+    # entry carries the rubric's dialog-trigger treatment: both open a sheet
+    # over the page rather than changing the view under it.
+    assert 'cliNav.classList.toggle("nav-active", state.cli);' in script
+    assert "!rubricActive && !state.cli && item.dataset.view === state.view" in script
+    styles = Path("site/assets/styles.css").read_text(encoding="utf-8")
+    assert "#cli-nav:not(.nav-active) {" in styles
+    assert "#cli-nav::after {" in styles
+
+    # The card is the README's setup route, not a second one written for the
+    # site: the prompt it hands out has to be the prompt the README publishes.
+    readme_cli = readme.split("## Query it locally (CLI version)", 1)[1].split("## More", 1)[0]
+    skill_url = (
+        "https://github.com/ktwu01/benchmark-radar/blob/main/skills/benchmark-radar/SKILL.md"
+    )
+    assert skill_url in readme_cli
+    assert skill_url in script
+    for line in (
+        "Set up Benchmark Radar for local benchmark search. Follow",
+        "to install the CLI and consumer Skill, initialize the local data, and verify the",
+        "setup. Use only consumer commands.",
+    ):
+        assert line in readme_cli
+        assert line in script
+
+
+def test_only_one_sheet_is_open_at_a_time():
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+
+    # showModal() stacks a dialog on top of an open one instead of replacing it,
+    # so every opener has to close the others first or the previous sheet waits
+    # underneath and reappears when the new one is dismissed.
+    assert "function closeOtherSheets(" in script
+    for keep in ("rubric-dialog", "contact-dialog", "cite-dialog", "cli-dialog"):
+        assert f'closeOtherSheets("{keep}");' in script
+    guard = script.split("function closeOtherSheets(", 1)[1].split("\n}", 1)[0]
+    for dialog in ("rubric-dialog", "contact-dialog", "cite-dialog", "cli-dialog"):
+        assert dialog in guard
+    # Dropped before closing, so the sheet being replaced does not step history
+    # back through the entry the reader arrived on.
+    assert guard.index("citeOwnsHistoryEntry = false;") < guard.index("other.close();")
+    assert guard.index("cliOwnsHistoryEntry = false;") < guard.index("other.close();")
 
 
 def test_every_navigation_item_uses_the_same_active_state():
@@ -625,13 +700,14 @@ def test_records_expand_inline_without_an_exclusive_accordion_or_record_modal():
     assert "attrs: { name:" not in script
     # The dialogs on the page are non-record chrome: the scoring rubric, the
     # contact sheet (the export dialog went with the export button, issue
-    # #311), and the citation card. Record detail must stay inline, so a
-    # showModal() the list below does not name is a regression to a record
-    # modal.
-    assert script.count(".showModal()") == 3
+    # #311), the citation card, and the CLI setup card. Record detail must stay
+    # inline, so a showModal() the list below does not name is a regression to a
+    # record modal.
+    assert script.count(".showModal()") == 4
     assert 'byId("rubric-dialog")' in script
     assert 'byId("contact-dialog")' in script
     assert 'byId("cite-dialog")' in script
+    assert 'byId("cli-dialog")' in script
 
 
 def test_hugging_face_expansion_links_to_the_full_card():


### PR DESCRIPTION
## What a reader sees

A **CLI** entry in the dashboard view bar, beside Rubric and carrying the same ⓘ dialog-trigger treatment. Clicking it opens a sheet over whatever view the reader is on, with one click-to-copy block: the setup prompt to hand a coding agent.

Before this, the offline route existed only in the README, so a reader on the dashboard had to leave the site to find it.

## Behavior

- `/#cli` is a short link that can be pasted into a message or followed by a crawler. The nav entry is a real anchor to the canonical URL, matching the treatment the other non-default view links already use.
- The sheet holds no data, so it opens before the corpus fetch and still works on a build whose payload never arrives.
- Opening it from the view bar pushes one history entry, so Back closes the sheet. Arriving directly at `/#cli` pushes nothing, so Back does not step the reader off the site.
- The prompt is held verbatim from the README's "Query it locally (CLI version)" section. A test asserts the two stay identical, because a paraphrase here can drift from the Skill file it points at.

## Shared internals

The citation card's copy control is generalized from `citeBlock`/`.cite-*` to `copyBlock`/`.copy-*`, so both sheets use one clipboard handler and one set of styles rather than a second copy.

`closeOtherSheets` closes any other open sheet before `showModal()`. Without it a second sheet stacks on top of the first, and the one underneath reappears when the top is dismissed. It drops history ownership first so the sheet being replaced does not step back through the entry the reader arrived on.

## Verification

`ruff check`, `ruff format --check` and `pytest -q` (1093 passed) are green locally. Reviewed in a real browser: the sheet renders, the nav active state moves off the view entry, and the push/Back cycle returns to a hash-less URL with the view intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
