### PR TITLE
fix(site): search all dates by default

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -839,6 +839,11 @@ const I18N = {
     "Citation file (.cff)": "引用文件 (.cff)",
     "View the citation file": "查看引用文件",
     CLI: "命令行",
+    "This search covers all dates.": "此处搜索全部日期的结果。",
+    "Still want today's results?": "仍要搜索今天的，请",
+    "Search today": "点击这里",
+    "More than 10 results.": "结果超过 10 条。",
+    "Use the CLI version to export all data.": "使用我们的命令行版本导出全部数据。",
     "Query it locally (CLI version)": "在本地查询（命令行版本）",
     "This website is the hosted view. The CLI version runs on your own computer: it installs the command-line tool, downloads the searchable data, and answers from those local files.":
       "本网站是在线版本。命令行版本在你自己的电脑上运行：它会安装命令行工具、下载可搜索的数据，并从这些本地文件中给出答案。",
@@ -1176,8 +1181,10 @@ function readUrl() {
   const requestedView = params.get("view");
   // Legacy Explorer permalinks resolve to the filterable Today list.
   state.view = ["trends", "map", "leaderboard"].includes(requestedView) ? requestedView : "today";
-  state.todayDate = params.get("date") || "";
   state.q = params.get("q") || "";
+  // A bare search permalink has archive-wide intent. An explicit date remains
+  // a deliberate narrow search, including the "today" link in the scope banner.
+  state.todayDate = params.get("date") || (state.q ? "all" : "");
   state.kind = params.get("kind") || "";
   state.category = params.get("category") || "";
   state.source = params.get("source") || "";
@@ -1227,7 +1234,13 @@ function writeUrl(mode = "replace") {
   if (state.view === "today") {
     if (state.todayDate === "all") {
       params.set("date", "all");
-    } else if (state.todayDate && state.todayDate !== state.data?.latest_date) {
+    } else if (
+      state.todayDate &&
+      (state.q || state.todayDate !== state.data?.latest_date)
+    ) {
+      // A latest-day search must keep its date in the URL. A bare ?q= link is
+      // intentionally archive-wide, so dropping this value would widen again
+      // on reload after the reader clicked "Search today" in the scope banner.
       params.set("date", state.todayDate);
     }
     if (state.q) params.set("q", state.q);
@@ -2186,6 +2199,63 @@ function renderTodayBenchmarks() {
   return !total && indexPending ? "pending" : total;
 }
 
+function todaySearchUrl() {
+  const params = new URLSearchParams();
+  params.set("date", state.data.latest_date);
+  if (state.q) params.set("q", state.q);
+  if (state.kind) params.set("kind", state.kind);
+  if (state.category) params.set("category", state.category);
+  if (state.source) params.set("source", state.source);
+  if (state.organization) params.set("organization", state.organization);
+  if (state.event) params.set("event", state.event);
+  return `${window.location.pathname}?${params.toString()}`;
+}
+
+function renderSearchScopeBanner(observationCount, benchmarkMatches) {
+  const banner = byId("search-scope-banner");
+  const query = state.q.trim();
+  if (!query || state.todayDate !== "all") {
+    banner.hidden = true;
+    banner.replaceChildren();
+    return;
+  }
+
+  const todayLink = element("a", {
+    text: t("Search today"),
+    attrs: { href: todaySearchUrl() },
+  });
+  todayLink.addEventListener("click", (event) => {
+    event.preventDefault();
+    state.todayDate = state.data.latest_date;
+    state.todayPage = 1;
+    renderToday();
+  });
+  const sentenceGap = getLang() === "zh" ? "" : " ";
+  const sentenceEnd = getLang() === "zh" ? "。" : ".";
+  const scopeMessage = element("p", { className: "search-scope-message" });
+  scopeMessage.append(
+    document.createTextNode(`${t("This search covers all dates.")}${sentenceGap}`),
+    document.createTextNode(`${t("Still want today's results?")}${sentenceGap}`),
+    todayLink,
+    document.createTextNode(sentenceEnd),
+  );
+
+  const knownBenchmarkMatches = Number.isFinite(benchmarkMatches) ? benchmarkMatches : 0;
+  const totalResults = observationCount + knownBenchmarkMatches;
+  const cliMessage = totalResults > 10
+    ? element("p", { className: "search-scope-export" }, [
+        document.createTextNode(`${t("More than 10 results.")}${sentenceGap}`),
+        element("a", {
+          text: t("Use the CLI version to export all data."),
+          attrs: { href: "https://benchmark-radar.org/#cli" },
+        }),
+      ])
+    : null;
+
+  replaceChildren(banner, [scopeMessage, cliMessage]);
+  banner.hidden = false;
+}
+
 function renderToday({ resultsOnly = false } = {}) {
   // Events are bound before the data file resolves (initialize), so a nav
   // click or filter keystroke in the load window must no-op, not throw.
@@ -2212,6 +2282,7 @@ function renderToday({ resultsOnly = false } = {}) {
   updateFiltersCount();
   const observations = filteredObservations();
   const benchmarkMatches = renderTodayBenchmarks();
+  renderSearchScopeBanner(observations.length, benchmarkMatches);
   const resultsKey = [
     state.todayDate,
     state.q,
@@ -8000,12 +8071,24 @@ function bindEvents() {
     // state.todayDate, which then writes the OLD date back onto the
     // control and clobbers the user's just-made selection.
     if (event.target === byId("today-date")) return;
+    const hadQuery = Boolean(state.q.trim());
     state.q = byId("search-filter").value;
     state.kind = byId("kind-filter").value;
     state.category = byId("category-filter").value;
     state.source = byId("source-filter").value;
     state.organization = byId("organization-filter").value;
     state.event = byId("event-filter").value;
+    // The homepage is a newest-scan browser, but a query is a retrieval action:
+    // its default scope is the full archive. Once a query exists, a reader can
+    // still narrow it with the date select or the banner's "today" link.
+    if (!hadQuery && state.q.trim() && state.todayDate !== "all") {
+      state.todayDate = "all";
+      state.todayPage = 1;
+      ensureFullData()
+        .then(() => renderToday())
+        .catch((error) => console.error(error));
+      return;
+    }
     scheduleTodayRender();
   });
   // Both filter panels are <form>s whose state lives in the URL query we

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -638,6 +638,36 @@ input {
   white-space: nowrap;
 }
 
+.search-scope-banner {
+  margin: 1rem 0;
+  padding: 0.9rem 1rem;
+  border: 1px solid color-mix(in srgb, var(--blue) 45%, var(--edge));
+  border-left: 5px solid var(--blue);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--blue) 9%, var(--panel));
+  box-shadow: var(--shadow);
+}
+
+.search-scope-banner p {
+  margin: 0;
+}
+
+.search-scope-message {
+  color: var(--ink);
+  font-weight: 700;
+}
+
+.search-scope-banner a {
+  font-weight: 700;
+}
+
+.search-scope-export {
+  margin-top: 0.35rem !important;
+  color: var(--muted);
+  font-family: var(--utility);
+  font-size: 0.76rem;
+}
+
 /* The day's narrative shares the right sidebar with the health and corpus
    cards, so it carries the same box treatment and the sidebar column
    constrains its width instead of an explicit cap (issue #248). */

--- a/site/index.html
+++ b/site/index.html
@@ -443,6 +443,10 @@
                 <span id="today-sort"></span>
               </div>
             </div>
+            <!-- Search is archive-wide by default even though browsing opens
+                 on the newest scan. This first result row makes that scope
+                 explicit and gives large result sets a practical export path. -->
+            <aside class="search-scope-banner" id="search-scope-banner" aria-live="polite" hidden></aside>
             <section class="today-benchmarks" id="today-benchmarks" hidden aria-labelledby="today-benchmarks-heading">
               <h3 class="today-benchmarks-heading" id="today-benchmarks-heading" data-i18n="Benchmarks with this name">Benchmarks with this name</h3>
               <p class="today-benchmarks-note" id="today-benchmarks-note"></p>

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -303,6 +303,42 @@ def test_scan_date_can_be_reset_to_all_dates():
     assert 'byId("source-health-panel").hidden = showingAllDates' in script
 
 
+def test_search_defaults_to_all_dates_and_explains_the_scope():
+    """Issue #481: searching must not silently inherit the newest scan."""
+    html = Path("site/index.html").read_text(encoding="utf-8")
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
+    styles = Path("site/assets/styles.css").read_text(encoding="utf-8")
+
+    # The scope explanation is the first row of the results area, before both
+    # registry matches and daily-discovery matches.
+    assert 'id="search-scope-banner"' in html
+    assert html.index('id="search-scope-banner"') < html.index('id="today-benchmarks"')
+    assert html.index('id="search-scope-banner"') < html.index('id="today-list"')
+    assert ".search-scope-banner" in styles
+
+    # A typed query and a bare ?q= permalink both start archive-wide. Once the
+    # reader explicitly narrows an existing query, continued typing preserves it.
+    assert 'params.get("date") || (state.q ? "all" : "")' in script
+    handler = script.split('byId("filters").addEventListener("input"', 1)[1].split("});", 1)[0]
+    assert "const hadQuery = Boolean(state.q.trim());" in handler
+    assert 'state.todayDate = "all";' in handler
+    assert "!hadQuery && state.q.trim()" in handler
+    assert "ensureFullData()" in handler
+
+    # The banner offers a real today link, and large result sets point to the
+    # public CLI setup route for a complete export.
+    banner = script.split("function renderSearchScopeBanner", 1)[1].split(
+        "function renderToday", 1
+    )[0]
+    assert 'state.todayDate !== "all"' in banner
+    assert "totalResults > 10" in banner
+    assert 'href: "https://benchmark-radar.org/#cli"' in banner
+    assert 'text: t("Search today")' in banner
+    assert "state.todayDate = state.data.latest_date;" in banner
+    assert "(state.q || state.todayDate !== state.data?.latest_date)" in script
+    assert '"This search covers all dates.": "此处搜索全部日期的结果。"' in script
+
+
 def test_dashboard_bounds_work_before_and_during_filtering():
     """Issue #222: hidden views and unbounded card lists must not block input."""
     script = Path("site/assets/app.js").read_text(encoding="utf-8")


### PR DESCRIPTION
## Result

Searching no longer silently inherits the newest scan. A new query searches the full archive by default and says so in a prominent first result row.

- offers a direct link to search the same query on today's scan
- points result sets over 10 entries to the CLI setup at https://benchmark-radar.org/#cli for full export
- keeps explicit dated searches stable across continued typing, refreshes, and shared URLs
- includes matching Chinese copy: “此处搜索全部日期的结果。仍要搜索今天的，请点击这里。”

## Verification

- browser-tested default search, banner placement, Today link, URL persistence, English, and Chinese
- clean detached checkout: `ruff check .`
- clean detached checkout: `ruff format --check .`
- clean detached checkout: `benchmark-radar normalize-external`
- clean detached checkout: `benchmark-radar classify`
- clean detached checkout: `benchmark-radar build-data-release`
- clean detached checkout: `pytest -q` — 1094 passed

Closes #481