### PR TITLE
Make singular daily briefing sources directly clickable

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -1722,18 +1722,19 @@ function briefingParts(line) {
   // Lift the trailing "Evidence: E001, E002." clause out of the prose in both
   // the split and the fallback shapes, so the IDs never stay in the running
   // sentences a scan of the findings has to wade through.
-  const sources = (text.match(/\bE\d{3}\b/g) || []).length;
+  const evidenceIds = [...new Set(text.match(/\bE\d{3}\b/g) || [])];
+  const sources = evidenceIds.length;
   text = text.replace(/\s*\.?\s*Evidence:\s*((?:E\d{3}\s*,\s*)*E\d{3})\.?\s*/i, "").trim();
   const whyIndex = text.search(/\bWhy it matters:\s*/i);
-  if (whyIndex === -1) return { head: text, body: "", confidence, sources };
+  if (whyIndex === -1) return { head: text, body: "", confidence, sources, evidenceIds };
   const head = text.slice(0, whyIndex).trim();
   const body = text
     .slice(whyIndex + "Why it matters:".length)
     .trim();
-  return { head, body, confidence, sources };
+  return { head, body, confidence, sources, evidenceIds };
 }
 
-function briefingMeta(parts) {
+function briefingMeta(parts, citations) {
   const chips = [];
   if (parts.confidence) {
     chips.push(element("span", {
@@ -1742,10 +1743,26 @@ function briefingMeta(parts) {
     }));
   }
   if (parts.sources > 0) {
-    chips.push(element("span", {
-      className: "briefing-chip briefing-chip-sources",
-      text: `${parts.sources} ${parts.sources === 1 ? t("source") : t("sources")}`,
-    }));
+    const sourceText = `${parts.sources} ${parts.sources === 1 ? t("source") : t("sources")}`;
+    const citation = parts.sources === 1
+      ? citations.find((entry) => entry.id === parts.evidenceIds[0])
+      : null;
+    chips.push(citation
+      ? element("a", {
+          className: "briefing-chip briefing-chip-sources",
+          text: sourceText,
+          attrs: {
+            href: citation.href,
+            target: "_blank",
+            rel: "noopener noreferrer",
+            title: `Open evidence: ${citation.title}`,
+            "aria-label": `${sourceText}: ${citation.title}`,
+          },
+        })
+      : element("span", {
+          className: "briefing-chip briefing-chip-sources",
+          text: sourceText,
+        }));
   }
   if (!chips.length) return null;
   return element("p", { className: "briefing-insight-meta" }, chips);
@@ -1760,7 +1777,11 @@ function briefingInsight(line, citations) {
   const body = parts.body
     ? element("p", { className: "briefing-insight-body" }, briefingContent(parts.body, citations))
     : null;
-  return element("article", { className: "briefing-insight" }, [head, body, briefingMeta(parts)]);
+  return element("article", { className: "briefing-insight" }, [
+    head,
+    body,
+    briefingMeta(parts, citations),
+  ]);
 }
 
 function briefingProvenance(briefing) {

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -1723,15 +1723,14 @@ function briefingParts(line) {
   // the split and the fallback shapes, so the IDs never stay in the running
   // sentences a scan of the findings has to wade through.
   const evidenceIds = [...new Set(text.match(/\bE\d{3}\b/g) || [])];
-  const sources = evidenceIds.length;
   text = text.replace(/\s*\.?\s*Evidence:\s*((?:E\d{3}\s*,\s*)*E\d{3})\.?\s*/i, "").trim();
   const whyIndex = text.search(/\bWhy it matters:\s*/i);
-  if (whyIndex === -1) return { head: text, body: "", confidence, sources, evidenceIds };
+  if (whyIndex === -1) return { head: text, body: "", confidence, evidenceIds };
   const head = text.slice(0, whyIndex).trim();
   const body = text
     .slice(whyIndex + "Why it matters:".length)
     .trim();
-  return { head, body, confidence, sources, evidenceIds };
+  return { head, body, confidence, evidenceIds };
 }
 
 function briefingMeta(parts, citations) {
@@ -1742,11 +1741,15 @@ function briefingMeta(parts, citations) {
       text: `${parts.confidence} ${t("confidence")}`,
     }));
   }
-  if (parts.sources > 0) {
-    const sourceText = `${parts.sources} ${parts.sources === 1 ? t("source") : t("sources")}`;
-    const citation = parts.sources === 1
-      ? citations.find((entry) => entry.id === parts.evidenceIds[0])
-      : null;
+  const citedSources = parts.evidenceIds.flatMap((id) => {
+    const citation = citations.find((entry) => entry.id === id);
+    return citation ? [citation] : [];
+  });
+  if (citedSources.length > 0) {
+    const sourceText = `${citedSources.length} ${
+      citedSources.length === 1 ? t("source") : t("sources")
+    }`;
+    const citation = citedSources.length === 1 ? citedSources[0] : null;
     chips.push(citation
       ? element("a", {
           className: "briefing-chip briefing-chip-sources",
@@ -1833,7 +1836,9 @@ function briefingDetails(briefing, citations) {
   if (!provenance && !caveat && !evidence) return null;
 
   const label = citations.length
-    ? `${t("Evidence & briefing details")} · ${citations.length.toLocaleString()} ${t("sources")}`
+    ? `${t("Evidence & briefing details")} · ${citations.length.toLocaleString()} ${
+        citations.length === 1 ? t("source") : t("sources")
+      }`
     : t("Briefing details");
   return element("details", { className: "daily-briefing-details" }, [
     element("summary", { text: label }),

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -748,6 +748,16 @@ input {
   font-weight: 600;
 }
 
+a.briefing-chip-sources {
+  text-decoration: none;
+}
+
+a.briefing-chip-sources:hover,
+a.briefing-chip-sources:focus-visible {
+  background: var(--ink);
+  color: white;
+}
+
 .briefing-evidence-link {
   color: var(--blue-deep);
   font-weight: 500;

--- a/tests/fixtures/daily_briefing_one_source.json
+++ b/tests/fixtures/daily_briefing_one_source.json
@@ -1,0 +1,19 @@
+{
+  "date": "2026-08-31",
+  "briefing": {
+    "bullets": [
+      "A benchmark release added executable graders. Why it matters: Readers can inspect the supporting dataset directly. Evidence: E001. Medium confidence."
+    ],
+    "caveat": "One source supports this bounded briefing item.",
+    "citations": [
+      {
+        "id": "E001",
+        "source": "GitHub",
+        "title": "example/benchmark-release",
+        "url": "https://github.com/example/benchmark-release"
+      }
+    ],
+    "date": "2026-08-31",
+    "generator": "deterministic-fallback"
+  }
+}

--- a/tests/fixtures/daily_briefing_one_source.json
+++ b/tests/fixtures/daily_briefing_one_source.json
@@ -2,7 +2,7 @@
   "date": "2026-08-31",
   "briefing": {
     "bullets": [
-      "A benchmark release added executable graders. Why it matters: Readers can inspect the supporting dataset directly. Evidence: E001. Medium confidence."
+      "A benchmark release added executable graders. Why it matters: Readers can inspect the supporting dataset directly. Evidence: E001, E404. Medium confidence."
     ],
     "caveat": "One source supports this bounded briefing item.",
     "citations": [

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1391,6 +1391,11 @@ def test_rendered_briefing_splits_each_bullet_into_head_body_and_meta():
     assert "Evidence:" not in subtext(body)
     assert "High confidence" in subtext(meta)
     assert "3 sources" in subtext(meta)
+    multi_source_chip = next(
+        node for node in meta["children"] if "briefing-chip-sources" in node["className"].split()
+    )
+    assert multi_source_chip["tag"] == "span"
+    assert multi_source_chip["href"] == ""
 
     # An older bullet without the "Why it matters" structure degrades to a head
     # with no body, yet its evidence and confidence still move to the metadata.
@@ -1401,6 +1406,21 @@ def test_rendered_briefing_splits_each_bullet_into_head_body_and_meta():
     assert "Evidence:" not in subtext(fbhead)
     assert "Medium confidence" in subtext(fbmeta)
     assert "2 sources" in subtext(fbmeta)
+
+
+def test_rendered_single_source_chip_links_to_its_evidence():
+    """Issue #467: the singular source count is the evidence affordance."""
+    nodes = list(_flatten(_rendered_briefing("tests/fixtures/daily_briefing_one_source.json")))
+    source_chip = next(
+        node for node in nodes if "briefing-chip-sources" in node["className"].split()
+    )
+    confidence_chip = next(node for node in nodes if "briefing-chip-medium" in node["className"])
+
+    assert source_chip["tag"] == "a"
+    assert source_chip["text"] == "1 source"
+    assert source_chip["href"] == "https://github.com/example/benchmark-release"
+    assert confidence_chip["tag"] == "span"
+    assert confidence_chip["href"] == ""
 
 
 def test_rendered_briefing_shows_chinese_when_the_snapshot_has_it():

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1305,10 +1305,7 @@ def test_daily_briefing_collapses_verbose_evidence_details_by_default():
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
 
     assert 'element("details", { className: "daily-briefing-details" }' in script
-    assert (
-        '{t("Evidence & briefing details")} · ${citations.length.toLocaleString()} '
-        '${t("sources")}' in script
-    )
+    assert 'citations.length === 1 ? t("source") : t("sources")' in script
     assert "briefingDetails(briefing, citations)" in script
     assert 'attrs: { open: "" }' not in script
 
@@ -1415,12 +1412,14 @@ def test_rendered_single_source_chip_links_to_its_evidence():
         node for node in nodes if "briefing-chip-sources" in node["className"].split()
     )
     confidence_chip = next(node for node in nodes if "briefing-chip-medium" in node["className"])
+    details_summary = next(node for node in nodes if node["tag"] == "summary")
 
     assert source_chip["tag"] == "a"
     assert source_chip["text"] == "1 source"
     assert source_chip["href"] == "https://github.com/example/benchmark-release"
     assert confidence_chip["tag"] == "span"
     assert confidence_chip["href"] == ""
+    assert details_summary["text"] == "Evidence & briefing details · 1 source"
 
 
 def test_rendered_briefing_shows_chinese_when_the_snapshot_has_it():


### PR DESCRIPTION
## Introduction

The daily briefing already exposed a compact source count, but the common one-source case made readers open the expanded evidence section before they could inspect the underlying source. The useful object was visible but not actionable.

This change turns the singular source chip into a direct evidence link when—and only when—the briefing's evidence identifier resolves to one validated citation. Multiple-source chips remain counts rather than ambiguous links. Counts are derived from the intersection of cited evidence IDs and rendered citations, so stale identifiers cannot inflate the display or suppress a valid singular link.

The result is a shorter path from a briefing claim to its evidence without changing the compact multi-source behavior. The details summary now also uses the correct singular/plural source label.

## Evidence

- Added a DOM-harness regression fixture containing one resolvable citation plus one stale evidence ID.
- Confirmed the initial test failed because the source chip rendered as a `span`.
- Confirmed the final DOM renders `1 source` as an anchor to the validated citation while the confidence chip remains non-interactive.
- Confirmed existing multi-source fixtures still render source counts as non-links.
- Browser-checked the daily briefing at the desktop and verified the linked pill's visual, hover, and focus treatment.
- Independent code review returned a clean verdict after checking count validation, singular/multiple behavior, grammar, accessibility, and safe external-link attributes.

## Technical summary

- `site/assets/app.js`: resolve source metadata against validated citations; link the singular case; correct source-label grammar.
- `site/assets/styles.css`: preserve pill styling for anchor chips and add hover/focus-visible feedback.
- `tests/fixtures/daily_briefing_one_source.json`: add the bounded one-valid/one-stale evidence case.
- `tests/test_site.py`: execute the renderer in a DOM harness and assert link semantics, destination, confidence-chip behavior, and singular details text.

## Verification

Clean detached worktree at `2925019`:

- `ruff check .`
- `ruff format --check .`
- `benchmark-radar normalize-external`
- `benchmark-radar classify`
- `benchmark-radar build-data-release`
- `pytest -q` — 1095 passed

Closes #467
