### PR TITLE
Restore discovery for RSI-Exam releases

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -207,10 +207,10 @@ sources:
       - '"data contamination" in:name,description,readme'
       - '"agent benchmark" in:name,description,readme'
       - '"agentic benchmark" in:name,description,readme'
-      # Some executable research suites describe their capability target rather
-      # than using the adjacent phrase "agent benchmark". Keep that discovery
-      # surface explicit and route named suites through the watchlist.
-      - '"recursive self-improvement" in:name,description,readme'
+      # This named suite does not use the adjacent phrase "agent benchmark".
+      # Keep discovery suite-specific: the broader capability phrase also
+      # matches trading platforms, automation harnesses, and safety frameworks.
+      - '"RSI-Exam" in:name,description,readme'
 
   # Reviewed public organizations are an additional discovery surface for new
   # repositories whose names may not match generic GitHub search phrases. The

--- a/config.yml
+++ b/config.yml
@@ -115,6 +115,9 @@ watchlist:
   - name: Long-Horizon Bench
     aliases: ["long horizon bench", "long horizon benchmark", longhorizonbench]
     note: Evaluations targeting extended multi-step agent execution.
+  - name: RSI-Exam
+    aliases: [rsi-exam, "rsi exam"]
+    note: Executable long-horizon research benchmark for recursive self-improvement.
 
 sources:
   arxiv:
@@ -204,6 +207,10 @@ sources:
       - '"data contamination" in:name,description,readme'
       - '"agent benchmark" in:name,description,readme'
       - '"agentic benchmark" in:name,description,readme'
+      # Some executable research suites describe their capability target rather
+      # than using the adjacent phrase "agent benchmark". Keep that discovery
+      # surface explicit and route named suites through the watchlist.
+      - '"recursive self-improvement" in:name,description,readme'
 
   # Reviewed public organizations are an additional discovery surface for new
   # repositories whose names may not match generic GitHub search phrases. The

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -609,7 +609,7 @@ def test_github_config_discovers_and_routes_rsi_exam(monkeypatch):
     def fake_get_json(url, params=None, headers=None):
         query = params["q"].split(" pushed:", 1)[0]
         queries.append(query)
-        if query != '"recursive self-improvement" in:name,description,readme':
+        if query != '"RSI-Exam" in:name,description,readme':
             return {"items": []}
         return {
             "items": [
@@ -624,7 +624,16 @@ def test_github_config_discovers_and_routes_rsi_exam(monkeypatch):
                     ),
                     "stargazers_count": 75,
                     "forks_count": 3,
-                }
+                },
+                {
+                    "full_name": "example/AgentQuant",
+                    "html_url": "https://github.com/example/AgentQuant",
+                    "created_at": "2026-08-26T06:58:55Z",
+                    "pushed_at": "2026-08-29T05:24:25Z",
+                    "description": "A quantitative trading platform",
+                    "stargazers_count": 75,
+                    "forks_count": 3,
+                },
             ]
         }
 
@@ -639,8 +648,11 @@ def test_github_config_discovers_and_routes_rsi_exam(monkeypatch):
         suppressed_count=0,
     )
 
-    assert '"recursive self-improvement" in:name,description,readme' in queries
-    assert [item.source_id for item in items] == ["aiming-lab/RSI-Exam"]
+    assert '"RSI-Exam" in:name,description,readme' in queries
+    assert [item.source_id for item in items] == [
+        "aiming-lab/RSI-Exam",
+        "example/AgentQuant",
+    ]
     assert [item.source_id for item in published] == ["aiming-lab/RSI-Exam"]
     assert published[0].watchlist == "RSI-Exam"
 

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -7,7 +7,7 @@ import yaml
 
 from benchmark_radar.http import RequestError
 from benchmark_radar.models import RadarItem
-from benchmark_radar.pipeline import score_item
+from benchmark_radar.pipeline import _score_and_select, score_item
 from benchmark_radar.sources import (
     GITHUB_RELEASE_PARSER_VERSION,
     ConnectorPayloadError,
@@ -598,6 +598,51 @@ def test_github_preserves_creation_and_update_times(monkeypatch):
     assert items[0].published_at == datetime(2026, 6, 1, tzinfo=UTC)
     assert items[0].updated_at == datetime(2026, 7, 27, 12, tzinfo=UTC)
     assert items[0].event_kind == "updated"
+
+
+def test_github_config_discovers_and_routes_rsi_exam(monkeypatch):
+    """Issue #408: the named benchmark matched no configured GitHub query."""
+    config = yaml.safe_load(Path("config.yml").read_text(encoding="utf-8"))
+    github_config = {**config["sources"]["github"], "request_delay_seconds": 0}
+    queries = []
+
+    def fake_get_json(url, params=None, headers=None):
+        query = params["q"].split(" pushed:", 1)[0]
+        queries.append(query)
+        if query != '"recursive self-improvement" in:name,description,readme':
+            return {"items": []}
+        return {
+            "items": [
+                {
+                    "full_name": "aiming-lab/RSI-Exam",
+                    "html_url": "https://github.com/aiming-lab/RSI-Exam",
+                    "created_at": "2026-08-26T06:58:55Z",
+                    "pushed_at": "2026-08-29T05:24:25Z",
+                    "description": (
+                        "RSI-Exam: Measuring Recursive Self-Improvement on Long-Horizon, "
+                        "Executable Research Tasks"
+                    ),
+                    "stargazers_count": 75,
+                    "forks_count": 3,
+                }
+            ]
+        }
+
+    monkeypatch.setattr("benchmark_radar.sources.get_json", fake_get_json)
+
+    items = fetch_github(github_config, datetime(2026, 8, 27, tzinfo=UTC), 300)
+    published, _selection = _score_and_select(
+        items,
+        config,
+        now=datetime(2026, 8, 29, 12, tzinfo=UTC),
+        fetched_count=len(items),
+        suppressed_count=0,
+    )
+
+    assert '"recursive self-improvement" in:name,description,readme' in queries
+    assert [item.source_id for item in items] == ["aiming-lab/RSI-Exam"]
+    assert [item.source_id for item in published] == ["aiming-lab/RSI-Exam"]
+    assert published[0].watchlist == "RSI-Exam"
 
 
 def _github_organization_row(index, *, created="2026-07-27T12:00:00Z"):


### PR DESCRIPTION
## Introduction

RSI-Exam was public, active, and explicitly presented as a benchmark for executable recursive self-improvement, but the GitHub connector never searched for the suite's exact name. Existing queries covered adjacent phrases such as `agent benchmark`. GitHub Search could match the README, yet the fetched record exposed only a sparse repository description with no taxonomy category. The suite therefore failed two gates: it was not discovered, and a direct fetch would not have been eligible for publication.

This change closes both gaps without broadening the general taxonomy. GitHub discovery now includes the suite-specific query `"RSI-Exam" in:name,description,readme`, while a named RSI-Exam watchlist entry routes the suite only when its title or source identity matches. Other repositories returned by the query still have to satisfy the normal taxonomy or their own watchlist match.

The exact-name query avoids the unrelated trading, automation, and safety repositories admitted by the earlier `recursive self-improvement` proposal. A live GitHub Search API request over RSI-Exam's original 2026-08-26 through 2026-08-29 activity window returned only `aiming-lab/RSI-Exam`. The [repository](https://github.com/aiming-lab/RSI-Exam) and [project page](https://rsi-exam.ai/) describe an executable long-horizon benchmark with hidden-set re-execution across 88 tasks and six domains.

## Evidence

- Added a regression that loads the real repository configuration, invokes the real GitHub fetcher, and exercises the real score/select path.
- Before the configuration change, no configured query returned RSI-Exam.
- The fixture publishes RSI-Exam with `watchlist == "RSI-Exam"` even though its sparse GitHub description correctly produces no taxonomy category.
- A negative fixture proves an unrelated AgentQuant trading repository can be fetched but is not published.
- The maintainer's selectivity finding is resolved, and the completed review of the current head found no major issues.

## Technical summary

- `config.yml`: add the exact-name GitHub query and named watchlist routing.
- `tests/test_sources.py`: cover configuration query → GitHub fetch → scoring/selection → publication, including the unrelated-record rejection.

## Verification

Current head `d93a85c`, clean synthetic merge into `main` at `713e1e7`:

- `ruff check .`
- `ruff format --check .`
- `benchmark-radar normalize-external`
- `benchmark-radar classify`
- `benchmark-radar build-data-release`
- `pytest -q` — 1,197 passed

Closes #408
