### PR TITLE
[3 points] Fix Today rendering empty after closing a utility sheet or pressing Back

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -1413,6 +1413,17 @@ async function onPopState() {
     window.location.assign(window.location.href);
     return;
   }
+  // readUrl() restores a bare Today URL as an empty date, which only
+  // initialize() and refreshData() then default to the latest scan. A history
+  // restore skipped that step, so closing a utility sheet or pressing Back
+  // filtered every observation against snapshot_date === "" and Today rendered
+  // its empty state (issue #503). Normalize the restored date the same way.
+  if (
+    state.todayDate !== "all"
+    && !state.data.facets.dates.includes(state.todayDate)
+  ) {
+    state.todayDate = state.data.latest_date;
+  }
   // A leaderboard permalink on a build with no curated registry has nothing to
   // show, same fallback initialize() applies. Without it, Back into such an
   // entry opens an empty section behind a hidden nav button.


### PR DESCRIPTION
## Problem / 问题

Closes #503

Switching to the Rubric tab and closing it left the Today list showing "No
observations match these filters" with 0 results. Reproduced reliably in a
clean local build (generated data + headless browser).

## Root cause

Opening a utility sheet (Rubric / CLI / Cite) pushes a history entry
(`/rubric/`, …). Closing it calls `window.history.back()`, which runs
`onPopState()` → `readUrl()`. For a bare Today URL, `readUrl()` sets
`state.todayDate = ""`.

Only `initialize()` and `refreshData()` then default that empty date to
`state.data.latest_date`. `onPopState()` skipped that step, so the restored
Today view filtered observations against `item.snapshot_date === ""` in
`filteredObservations()`, matched nothing, and rendered the empty state.

The same failure occurs without any dialog: pushing to `/leaderboard/` and
pressing browser Back empties Today too.

## Fix

In `onPopState()`, after `ensureDataForState()`, normalize the restored date
the same way `refreshData()` does: if it is neither `"all"` nor a known
facet date, fall back to `latest_date`. Date permalinks (`?date=...`) and
archive-wide search permalinks (`?q=...`, date `"all"`) are untouched.

## Verification

Reproduced before, verified after, in a local static build against generated
`site/data` with a headless browser:

| Scenario | Before | After |
| --- | --- | --- |
| Open Rubric → close (×) | 0 rows, empty state | 20 rows ✅ |
| Open Rubric → close (Esc) | 0 rows | 20 rows ✅ |
| Open CLI → close | 0 rows | 20 rows ✅ |
| Open Cite → close | 0 rows | 20 rows ✅ |
| Leaderboard → browser Back | 0 rows | 20 rows ✅ |
| `/?date=2026-08-30` → Rubric open/close | date reset, 0 rows | date kept, 20 rows ✅ |

Clean-checkout CI sequence passes (`git worktree` on this branch):

```
ruff check .
ruff format --check .
benchmark-radar normalize-external
benchmark-radar classify
benchmark-radar build-data-release
pytest -q   # 1138 passed
```