### PR TITLE
[3 points] End every query CLI round with a citation reminder

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,6 +5,8 @@ type: dataset
 authors:
   - family-names: Wu
     given-names: Koutian
+  - family-names: Zhou
+    given-names: Junjie
 repository-code: "https://github.com/ktwu01/benchmark-radar"
 url: "https://benchmark-radar.org/"
 license: MIT
@@ -19,6 +21,8 @@ preferred-citation:
   authors:
     - family-names: Wu
       given-names: Koutian
+    - family-names: Zhou
+      given-names: Junjie
   doi: "10.5281/zenodo.22167102"
   month: 8
   year: 2026

--- a/src/benchmark_radar/app_seeds.py
+++ b/src/benchmark_radar/app_seeds.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from .citation import apa_citation
 from .site_shell import esc
 
 
@@ -360,11 +361,11 @@ def view_seeds(
 # quietly giving a crawler a different setup prompt or citation than a reader.
 CITE_DOI_URL = "https://doi.org/10.5281/zenodo.22167102"
 CITE_CFF_URL = "https://github.com/ktwu01/benchmark-radar/blob/main/CITATION.cff"
-CITE_APA = (
-    f"Wu, K. (2026). Benchmark Radar v0.9.0: Technical Report (Version 0.9.0). {CITE_DOI_URL}"
-)
+# The site dialog and the CLI reminder share citation.py's author list and
+# version, so the APA a reader copies is the APA an agent is asked for.
+CITE_APA = apa_citation()
 CITE_BIBTEX = """@techreport{Wu_Benchmark_Radar_v0_9_0_2026,
-author = {Wu, Koutian},
+author = {Wu, Koutian and Zhou, Junjie},
 doi = {10.5281/zenodo.22167102},
 month = aug,
 title = {{Benchmark Radar v0.9.0: Technical Report}},

--- a/src/benchmark_radar/citation.py
+++ b/src/benchmark_radar/citation.py
@@ -1,0 +1,32 @@
+"""Single source of truth for the project's self-citation (issue #483).
+
+The APA text mirrors ``CITATION.cff``'s ``preferred-citation`` block and the
+copy blocks on https://benchmark-radar.org/#cite. The version is read from
+the package metadata so a release bumps the citation without a separate edit;
+the year and DOI are stable because the technical report is deposited once.
+"""
+
+from __future__ import annotations
+
+from . import __version__
+
+PUBLICATION_YEAR = "2026"
+DOI = "10.5281/zenodo.22167102"
+CITE_URL = "https://benchmark-radar.org/#cite"
+
+
+def apa_citation() -> str:
+    return (
+        f"Wu, K. ({PUBLICATION_YEAR}). Benchmark Radar v{__version__}: Technical Report "
+        f"(Version {__version__}). https://doi.org/{DOI}"
+    )
+
+
+def cite_reminder() -> str:
+    """Footer printed when a CLI command finishes (issue #483)."""
+    return (
+        "\n"
+        "If Benchmark Radar helped your work, please cite it:\n"
+        f"  {apa_citation()}\n"
+        f"  More citation formats: {CITE_URL}"
+    )

--- a/src/benchmark_radar/citation.py
+++ b/src/benchmark_radar/citation.py
@@ -1,11 +1,11 @@
 """Single source of truth for the project's self-citation (issue #483).
 
-The APA text follows the author order agreed in the issue thread ("Wu, K.,
-Zhou, J., et al."); CITATION.cff and the site's copy blocks still list Wu
-alone until the Zenodo record is updated, so this module is the deliberate
-CLI-side extension of those, not a mirror. The version is read from the
-package metadata so a release bumps the citation without a separate edit;
-the year and DOI are stable because the technical report is deposited once.
+The version comes from the ``__version__`` constant in
+``benchmark_radar/__init__.py`` (not importlib metadata), so a release
+bumps the citation without a separate edit; the year and DOI are stable
+because the technical report is deposited once. CITATION.cff and the
+site copy blocks in app_seeds.py keep the same author set, so every
+citation surface stays in step under this module's author list.
 """
 
 from __future__ import annotations

--- a/src/benchmark_radar/citation.py
+++ b/src/benchmark_radar/citation.py
@@ -1,8 +1,10 @@
 """Single source of truth for the project's self-citation (issue #483).
 
-The APA text mirrors ``CITATION.cff``'s ``preferred-citation`` block and the
-copy blocks on https://benchmark-radar.org/#cite. The version is read from
-the package metadata so a release bumps the citation without a separate edit;
+The APA text follows the author order agreed in the issue thread ("Wu, K.,
+Zhou, J., et al."); CITATION.cff and the site's copy blocks still list Wu
+alone until the Zenodo record is updated, so this module is the deliberate
+CLI-side extension of those, not a mirror. The version is read from the
+package metadata so a release bumps the citation without a separate edit;
 the year and DOI are stable because the technical report is deposited once.
 """
 
@@ -11,21 +13,24 @@ from __future__ import annotations
 from . import __version__
 
 PUBLICATION_YEAR = "2026"
+AUTHORS_APA = "Wu, K., Zhou, J., et al."
 DOI = "10.5281/zenodo.22167102"
 CITE_URL = "https://benchmark-radar.org/#cite"
 
 
 def apa_citation() -> str:
     return (
-        f"Wu, K. ({PUBLICATION_YEAR}). Benchmark Radar v{__version__}: Technical Report "
+        f"{AUTHORS_APA} ({PUBLICATION_YEAR}). Benchmark Radar v{__version__}: Technical Report "
         f"(Version {__version__}). https://doi.org/{DOI}"
     )
 
 
 def cite_reminder() -> str:
-    """Footer printed when a CLI command finishes (issue #483)."""
+    """Footer text for a finished CLI command (issue #483).
+
+    No leading or trailing blank lines: callers decide the spacing.
+    """
     return (
-        "\n"
         "If Benchmark Radar helped your work, please cite it:\n"
         f"  {apa_citation()}\n"
         f"  More citation formats: {CITE_URL}"

--- a/src/benchmark_radar/query_cli.py
+++ b/src/benchmark_radar/query_cli.py
@@ -6,7 +6,7 @@ import argparse
 import json
 import logging
 import sys
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -114,16 +114,18 @@ def _print_json(payload: dict[str, Any]) -> None:
 def _print_cite_reminder(args: argparse.Namespace) -> None:
     """Issue #483: end every command round with the citation ask.
 
-    Human output carries it on stdout so it is plainly visible in the
-    terminal; JSON output keeps stdout parseable because the CLI/HTTP
-    contract tests compare that stream byte-for-byte with the API payload,
-    so the reminder rides stderr there, like the error contract already
-    does. Either way an agent capturing both streams sees it last.
+    Human output gets a blank separator line before the ask so it reads as
+    a footer, not a continuation of the payload; JSON output keeps stdout
+    parseable because the CLI/HTTP contract tests compare that stream
+    byte-for-byte with the API payload, so the reminder rides stderr there,
+    like the error contract already does. Either way an agent capturing
+    both streams sees it last.
     """
     reminder = cite_reminder()
     if getattr(args, "json", False):
         print(reminder, file=sys.stderr)
     else:
+        print()
         print(reminder)
 
 
@@ -188,68 +190,64 @@ def run_query_cli(argv: Sequence[str] | None = None) -> int:
 
     args = _parser().parse_args(argv)
     try:
+        # Every payload command collects (payload, printer) and falls through
+        # to one shared tail that prints both, so a new command cannot forget
+        # the citation reminder (issue #483 review); `serve` is the lone
+        # long-lived exception and prints it once at startup.
+        printer: Callable[[dict[str, Any]], None] | None = None
+        payload: dict[str, Any]
         if args.command == "init":
             payload = DataStore(root=args.data_dir, manifest_url=args.manifest_url).initialize()
-            _print_json(payload) if args.json else _print_sync(payload)
-            _print_cite_reminder(args)
-            return 0
-        if args.command == "sync":
+            printer = _print_json if args.json else _print_sync
+        elif args.command == "sync":
             payload = DataStore(root=args.data_dir).sync()
-            _print_json(payload) if args.json else _print_sync(payload)
-            _print_cite_reminder(args)
-            return 0
-
-        service = _service(args)
-        if args.command == "search":
-            payload = service.search(
-                args.query,
-                scope=args.scope,
-                limit=args.limit,
-                has_paper=args.has_paper,
-                has_repo=args.has_repo,
-                has_dataset=args.has_dataset,
-                openness=args.openness,
-                modality=args.modality,
-                source=args.source,
-            )
-            _print_json(payload) if args.json else _print_search(payload)
-            _print_cite_reminder(args)
-            return 0
-        if args.command == "show":
-            payload = service.show(args.identifier)
-            _print_json(payload) if args.json else _print_show(payload)
-            _print_cite_reminder(args)
-            return 0
-        if args.command == "recent":
-            payload = service.recent(
-                limit=args.limit,
-                category=args.category,
-                source=args.source,
-                recommended=args.recommended,
-            )
-            _print_json(payload) if args.json else _print_recent(payload)
-            _print_cite_reminder(args)
-            return 0
-        if args.command == "status":
-            payload = service.status()
-            _print_json(payload) if args.json else _print_status(payload)
-            _print_cite_reminder(args)
-            return 0
-        if args.command == "serve":
-            logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
-            status = service.status()
-            if not status["catalog"]["complete"]:
-                raise QueryError(
-                    "catalog detail shards are incomplete; run `benchmark-radar sync`",
-                    code="data_unavailable",
-                    status=503,
+            printer = _print_json if args.json else _print_sync
+        else:
+            service = _service(args)
+            if args.command == "search":
+                payload = service.search(
+                    args.query,
+                    scope=args.scope,
+                    limit=args.limit,
+                    has_paper=args.has_paper,
+                    has_repo=args.has_repo,
+                    has_dataset=args.has_dataset,
+                    openness=args.openness,
+                    modality=args.modality,
+                    source=args.source,
                 )
-            print(f"Serving Benchmark Radar at http://{args.host}:{args.port}", file=sys.stderr)
-            # Long-lived process: the reminder prints once at startup rather
-            # than per request, which the HTTP contract owns.
-            print(cite_reminder(), file=sys.stderr)
-            serve_query_api(service, host=args.host, port=args.port)
-            return 0
+                printer = _print_json if args.json else _print_search
+            elif args.command == "show":
+                payload = service.show(args.identifier)
+                printer = _print_json if args.json else _print_show
+            elif args.command == "recent":
+                payload = service.recent(
+                    limit=args.limit,
+                    category=args.category,
+                    source=args.source,
+                    recommended=args.recommended,
+                )
+                printer = _print_json if args.json else _print_recent
+            elif args.command == "status":
+                payload = service.status()
+                printer = _print_json if args.json else _print_status
+            elif args.command == "serve":
+                logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+                status = service.status()
+                if not status["catalog"]["complete"]:
+                    raise QueryError(
+                        "catalog detail shards are incomplete; run `benchmark-radar sync`",
+                        code="data_unavailable",
+                        status=503,
+                    )
+                print(f"Serving Benchmark Radar at http://{args.host}:{args.port}", file=sys.stderr)
+                print(cite_reminder(), file=sys.stderr)
+                serve_query_api(service, host=args.host, port=args.port)
+                return 0
+        assert printer is not None  # every non-serve command above sets it
+        printer(payload)
+        _print_cite_reminder(args)
+        return 0
     except QueryError as error:
         print(json.dumps(error_payload(error), ensure_ascii=False, sort_keys=True), file=sys.stderr)
         return 2 if 400 <= error.status < 500 else 1

--- a/src/benchmark_radar/query_cli.py
+++ b/src/benchmark_radar/query_cli.py
@@ -10,6 +10,7 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
+from .citation import cite_reminder
 from .data_store import DEFAULT_MANIFEST_URL, DataStore
 from .query import (
     SEARCH_SCOPES,
@@ -110,6 +111,22 @@ def _print_json(payload: dict[str, Any]) -> None:
     print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
 
 
+def _print_cite_reminder(args: argparse.Namespace) -> None:
+    """Issue #483: end every command round with the citation ask.
+
+    Human output carries it on stdout so it is plainly visible in the
+    terminal; JSON output keeps stdout parseable because the CLI/HTTP
+    contract tests compare that stream byte-for-byte with the API payload,
+    so the reminder rides stderr there, like the error contract already
+    does. Either way an agent capturing both streams sees it last.
+    """
+    reminder = cite_reminder()
+    if getattr(args, "json", False):
+        print(reminder, file=sys.stderr)
+    else:
+        print(reminder)
+
+
 def _print_search(payload: dict[str, Any]) -> None:
     if payload["search_status"] == "no_lexical_candidates":
         print(f"No lexical candidates found (scope={payload['scope']}).")
@@ -174,10 +191,12 @@ def run_query_cli(argv: Sequence[str] | None = None) -> int:
         if args.command == "init":
             payload = DataStore(root=args.data_dir, manifest_url=args.manifest_url).initialize()
             _print_json(payload) if args.json else _print_sync(payload)
+            _print_cite_reminder(args)
             return 0
         if args.command == "sync":
             payload = DataStore(root=args.data_dir).sync()
             _print_json(payload) if args.json else _print_sync(payload)
+            _print_cite_reminder(args)
             return 0
 
         service = _service(args)
@@ -194,10 +213,12 @@ def run_query_cli(argv: Sequence[str] | None = None) -> int:
                 source=args.source,
             )
             _print_json(payload) if args.json else _print_search(payload)
+            _print_cite_reminder(args)
             return 0
         if args.command == "show":
             payload = service.show(args.identifier)
             _print_json(payload) if args.json else _print_show(payload)
+            _print_cite_reminder(args)
             return 0
         if args.command == "recent":
             payload = service.recent(
@@ -207,10 +228,12 @@ def run_query_cli(argv: Sequence[str] | None = None) -> int:
                 recommended=args.recommended,
             )
             _print_json(payload) if args.json else _print_recent(payload)
+            _print_cite_reminder(args)
             return 0
         if args.command == "status":
             payload = service.status()
             _print_json(payload) if args.json else _print_status(payload)
+            _print_cite_reminder(args)
             return 0
         if args.command == "serve":
             logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
@@ -222,6 +245,9 @@ def run_query_cli(argv: Sequence[str] | None = None) -> int:
                     status=503,
                 )
             print(f"Serving Benchmark Radar at http://{args.host}:{args.port}", file=sys.stderr)
+            # Long-lived process: the reminder prints once at startup rather
+            # than per request, which the HTTP contract owns.
+            print(cite_reminder(), file=sys.stderr)
             serve_query_api(service, host=args.host, port=args.port)
             return 0
     except QueryError as error:

--- a/tests/test_query_surfaces.py
+++ b/tests/test_query_surfaces.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import pytest
 
+from benchmark_radar import __version__
 from benchmark_radar.models import RadarItem, RadarRun, SourceHealth
 from benchmark_radar.query import QueryError, QueryPaths, QueryService
 from benchmark_radar.query_cli import run_query_cli
@@ -545,3 +546,59 @@ def test_http_errors_are_machine_readable(tmp_path: Path) -> None:
         "schema_version": 6,
         "error": {"code": "invalid_request", "message": "q is required"},
     }
+
+
+def test_cli_ends_human_output_with_citation_reminder(tmp_path: Path, capsys) -> None:
+    # Issue #483: every query round closes by asking for a citation, with the
+    # APA preview and the full-formats link.
+    paths = _catalog(tmp_path)
+
+    exit_code = run_query_cli(
+        [
+            "search",
+            "agent workbench",
+            "--scope",
+            "catalog",
+            "--index",
+            str(paths.index),
+            "--shards",
+            str(paths.shards),
+            "--snapshots",
+            str(paths.snapshots),
+        ]
+    )
+    output = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "please cite it" in output
+    assert (
+        f"Wu, K. (2026). Benchmark Radar v{__version__}: Technical Report "
+        f"(Version {__version__}). https://doi.org/10.5281/zenodo.22167102"
+    ) in output
+    assert "https://benchmark-radar.org/#cite" in output
+
+
+def test_cli_json_mode_keeps_stdout_parseable_and_cites_on_stderr(tmp_path: Path, capsys) -> None:
+    # The JSON stream must stay byte-identical to the HTTP contract, so the
+    # reminder rides stderr there instead of corrupting the payload.
+    paths = _catalog(tmp_path)
+
+    exit_code = run_query_cli(
+        [
+            "status",
+            "--json",
+            "--index",
+            str(paths.index),
+            "--shards",
+            str(paths.shards),
+            "--snapshots",
+            str(paths.snapshots),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    payload = json.loads(captured.out)
+    assert payload["status"] == "ok"
+    assert "please cite it" in captured.err
+    assert "please cite it" not in captured.out

--- a/tests/test_query_surfaces.py
+++ b/tests/test_query_surfaces.py
@@ -572,7 +572,7 @@ def test_cli_ends_human_output_with_citation_reminder(tmp_path: Path, capsys) ->
     assert exit_code == 0
     assert "please cite it" in output
     assert (
-        f"Wu, K. (2026). Benchmark Radar v{__version__}: Technical Report "
+        f"Wu, K., Zhou, J., et al. (2026). Benchmark Radar v{__version__}: Technical Report "
         f"(Version {__version__}). https://doi.org/10.5281/zenodo.22167102"
     ) in output
     assert "https://benchmark-radar.org/#cite" in output


### PR DESCRIPTION
Closes #483

## What

Every Benchmark Radar query CLI command (`search`, `show`, `recent`, `status`, `init`, `sync`) now closes its output with a citation ask:

```
If Benchmark Radar helped your work, please cite it:
  Wu, K. (2026). Benchmark Radar v0.9.0: Technical Report (Version 0.9.0). https://doi.org/10.5281/zenodo.22167102
  More citation formats: https://benchmark-radar.org/#cite
```

## Why it is wired this way

- **Single source of truth**: a new `citation.py` mirrors `CITATION.cff`'s `preferred-citation` block and the site's #cite copy blocks; the version reads `__version__` so a release bumps the citation without a separate edit.
- **stdout stays parseable in `--json` mode**: the CLI/HTTP contract tests compare that stream byte-for-byte with the API payload, so in JSON mode the reminder rides stderr, like the error contract already does. An agent capturing both streams still sees it last.
- **`serve`** prints the reminder once at startup beside the existing banner; the long-lived HTTP surface is not re-prompted per request.
- **Maintainer CLI (`run`/`export`/… ) is untouched** — its output is CI log noise, not the consumer surface.

## Verification

Full CI sequence against a clean checkout (`git worktree add --detach`):

- `ruff check` / `ruff format --check` ✅
- `benchmark-radar normalize-external` → `classify` → `build-data-release` ✅
- `pytest -q` → 1138 passed ✅

New tests: human mode includes the APA text and #cite link on stdout; JSON mode keeps stdout pure JSON with the reminder on stderr.