### PR TITLE
Clarify Agent Skill and CLI setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,15 +60,23 @@ If Benchmark Radar saves you research time, **[star the repository](https://gith
 
 ## Query it locally (CLI version)
 
-The web dashboard is the hosted view. For offline querying, use **the CLI
-version**: it installs the CLI, downloads the local searchable data, and
-answers from local files. Give this prompt to your coding agent:
+Install the Benchmark Radar Agent Skill:
+
+```bash
+npx skills add ktwu01/benchmark-radar
+```
+
+This command installs the instructions your coding agent uses. The Python CLI
+and searchable data are configured separately.
+
+Give this prompt to your coding agent:
 
 ```text
-Set up Benchmark Radar for local benchmark search. Follow
+Use the installed Benchmark Radar Skill to finish local benchmark search setup. Follow
 https://github.com/ktwu01/benchmark-radar/blob/main/skills/benchmark-radar/SKILL.md
-to install the CLI and consumer Skill, initialize the local data, and verify the
-setup. Use only consumer commands.
+to install or repair the CLI if needed, initialize the local data, and verify the setup.
+You have permission to install the CLI from the official repository. Use only consumer
+commands.
 ```
 
 ## More

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -55,13 +55,20 @@ SWE-bench Verified 的 saturation 过程。**
 
 ## 在本地查询（CLI 版本）
 
-网页版 dashboard 是托管视图。需要离线查询时，请使用 **CLI 版本**：它会安装
-CLI、下载本地可搜索的数据，并从本地文件回答。把下面这段直接发给你的 coding agent：
+先安装 Benchmark Radar Agent Skill：
+
+```bash
+npx skills add ktwu01/benchmark-radar
+```
+
+这条命令只安装 coding agent 使用的操作说明，Python CLI 和本地可搜索数据需要
+单独配置。然后把下面这段直接发给你的 coding agent：
 
 ```text
-请帮我配置 Benchmark Radar 的本地 benchmark 搜索。请遵循
+请使用已安装的 Benchmark Radar Skill 完成本地 benchmark 搜索配置。请遵循
 https://github.com/ktwu01/benchmark-radar/blob/main/skills/benchmark-radar/SKILL.md，
-安装 CLI 和 consumer Skill，初始化本地数据并确认配置成功。只使用面向用户的命令。
+按需安装或修复 CLI、初始化本地数据并确认配置成功。你可以从官方仓库安装 CLI。
+只使用面向用户的命令。
 ```
 
 ## 更多

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -848,8 +848,8 @@ const I18N = {
     "Use the CLI version to export all data.": "使用我们的命令行版本导出全部数据。",
     "Query it locally (CLI version)": "在本地查询（命令行版本）",
     "Install the Agent Skill": "安装 Agent Skill",
-    "This website is the hosted view. For local queries, install the Agent Skill, then let your coding agent configure the command-line tool and searchable data.":
-      "本网站是在线版本。需要本地查询时，先安装 Agent Skill，再让编程助手配置命令行工具和可搜索数据。",
+    "To let your agent use the CLI version, run the command below.":
+      "如果你想让 Agent 使用 CLI 版本，请运行下面的命令。",
     "Give this prompt to your coding agent": "把这段提示词交给你的编程助手",
     "Read the setup guide": "查看安装指南",
     "Share Benchmark Radar": "分享 Benchmark Radar",
@@ -8209,10 +8209,7 @@ function openCli(updateUrl = true) {
     }),
     element("p", {
       className: "detail-summary",
-      text: t(
-        "This website is the hosted view. For local queries, install the Agent Skill, " +
-          "then let your coding agent configure the command-line tool and searchable data.",
-      ),
+      text: t("To let your agent use the CLI version, run the command below."),
     }),
     element("div", { className: "copy-blocks" }, [
       copyBlock("Install the Agent Skill", CLI_SKILL_INSTALL, "Click to copy"),

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -847,8 +847,9 @@ const I18N = {
     "More than 10 results.": "结果超过 10 条。",
     "Use the CLI version to export all data.": "使用我们的命令行版本导出全部数据。",
     "Query it locally (CLI version)": "在本地查询（命令行版本）",
-    "This website is the hosted view. The CLI version runs on your own computer: it installs the command-line tool, downloads the searchable data, and answers from those local files.":
-      "本网站是在线版本。命令行版本在你自己的电脑上运行：它会安装命令行工具、下载可搜索的数据，并从这些本地文件中给出答案。",
+    "Install the Agent Skill": "安装 Agent Skill",
+    "This website is the hosted view. For local queries, install the Agent Skill, then let your coding agent configure the command-line tool and searchable data.":
+      "本网站是在线版本。需要本地查询时，先安装 Agent Skill，再让编程助手配置命令行工具和可搜索数据。",
     "Give this prompt to your coding agent": "把这段提示词交给你的编程助手",
     "Read the setup guide": "查看安装指南",
     "Share Benchmark Radar": "分享 Benchmark Radar",
@@ -8168,14 +8169,16 @@ function openCite(updateUrl = true) {
 // drift from the instructions it points at.
 const CLI_SKILL_URL =
   "https://github.com/ktwu01/benchmark-radar/blob/main/skills/benchmark-radar/SKILL.md";
+const CLI_SKILL_INSTALL = "npx skills add ktwu01/benchmark-radar";
 // The README wraps its last sentence across two lines at 80 columns; the card
 // is narrower than that, so keeping the break would re-wrap into ragged text.
 // Only the URL needs a line of its own, and it keeps one.
 const CLI_AGENT_PROMPT = [
-  "Set up Benchmark Radar for local benchmark search. Follow",
+  "Use the installed Benchmark Radar Skill to finish local benchmark search setup. Follow",
   CLI_SKILL_URL,
-  "to install the CLI and consumer Skill, initialize the local data, and verify the" +
-    " setup. Use only consumer commands.",
+  "to install or repair the CLI if needed, initialize the local data, and verify the setup.",
+  "You have permission to install the CLI from the official repository. Use only consumer" +
+    " commands.",
 ].join("\n");
 
 // True only while the open card owns a history entry this page pushed, for the
@@ -8207,12 +8210,12 @@ function openCli(updateUrl = true) {
     element("p", {
       className: "detail-summary",
       text: t(
-        "This website is the hosted view. The CLI version runs on your own computer: " +
-          "it installs the command-line tool, downloads the searchable data, and answers " +
-          "from those local files.",
+        "This website is the hosted view. For local queries, install the Agent Skill, " +
+          "then let your coding agent configure the command-line tool and searchable data.",
       ),
     }),
     element("div", { className: "copy-blocks" }, [
+      copyBlock("Install the Agent Skill", CLI_SKILL_INSTALL, "Click to copy"),
       copyBlock(
         "Give this prompt to your coding agent",
         CLI_AGENT_PROMPT,

--- a/skills/benchmark-radar/SKILL.md
+++ b/skills/benchmark-radar/SKILL.md
@@ -11,11 +11,18 @@ selection criteria, and desired output open unless they specify them.
 ## Prepare the data
 
 1. Check availability with `benchmark-radar status --json`.
-2. If the command is missing, report that the CLI is required. Offer installation,
-   but do not install it without permission:
+2. If the command is missing or exits before returning a JSON status response, report
+   that the CLI is missing or broken. Offer installation, but do not install it without
+   permission:
 
    ```bash
    python -m pip install 'git+https://github.com/ktwu01/benchmark-radar.git'
+   ```
+
+   If an existing installation cannot import `benchmark_radar`, offer a clean repair:
+
+   ```bash
+   python -m pip install --force-reinstall 'git+https://github.com/ktwu01/benchmark-radar.git'
    ```
 
 3. If the CLI reports `not_initialized`, run `benchmark-radar init --json`; that

--- a/src/benchmark_radar/app_seeds.py
+++ b/src/benchmark_radar/app_seeds.py
@@ -376,12 +376,14 @@ year = {2026}
 CLI_SKILL_URL = (
     "https://github.com/ktwu01/benchmark-radar/blob/main/skills/benchmark-radar/SKILL.md"
 )
+CLI_SKILL_INSTALL = "npx skills add ktwu01/benchmark-radar"
 CLI_AGENT_PROMPT = "\n".join(
     (
-        "Set up Benchmark Radar for local benchmark search. Follow",
+        "Use the installed Benchmark Radar Skill to finish local benchmark search setup. Follow",
         CLI_SKILL_URL,
-        "to install the CLI and consumer Skill, initialize the local data, and verify the"
-        " setup. Use only consumer commands.",
+        "to install or repair the CLI if needed, initialize the local data, and verify the setup.",
+        "You have permission to install the CLI from the official repository. Use only consumer"
+        " commands.",
     )
 )
 
@@ -432,11 +434,11 @@ def _cli_seed() -> dict[str, str]:
         '<h2 class="detail-title cli-title" id="cli-title">'
         "Query it locally (CLI version)</h2>"
         '<p class="detail-summary">'
-        "This website is the hosted view. The CLI version runs on your own computer: "
-        "it installs the command-line tool, downloads the searchable data, and answers "
-        "from those local files."
+        "This website is the hosted view. For local queries, install the Agent Skill, "
+        "then let your coding agent configure the command-line tool and searchable data."
         "</p>"
         '<div class="copy-blocks">'
+        f"{_copy_block('Install the Agent Skill', CLI_SKILL_INSTALL, 'Click to copy')}"
         f"{_copy_block('Give this prompt to your coding agent', CLI_AGENT_PROMPT, 'Click to copy')}"
         "</div>"
         '<a class="secondary-link dialog-link" '

--- a/src/benchmark_radar/app_seeds.py
+++ b/src/benchmark_radar/app_seeds.py
@@ -434,8 +434,7 @@ def _cli_seed() -> dict[str, str]:
         '<h2 class="detail-title cli-title" id="cli-title">'
         "Query it locally (CLI version)</h2>"
         '<p class="detail-summary">'
-        "This website is the hosted view. For local queries, install the Agent Skill, "
-        "then let your coding agent configure the command-line tool and searchable data."
+        "To let your agent use the CLI version, run the command below."
         "</p>"
         '<div class="copy-blocks">'
         f"{_copy_block('Install the Agent Skill', CLI_SKILL_INSTALL, 'Click to copy')}"

--- a/tests/test_app_pages.py
+++ b/tests/test_app_pages.py
@@ -333,7 +333,7 @@ def test_utility_pages_ship_the_existing_dialog_open_with_content(tmp_path):
 
 def test_seeded_copy_controls_have_names_values_and_fallback_hints(tmp_path):
     _write(tmp_path, _dashboard())
-    for utility, count in (("cli", 1), ("cite", 3)):
+    for utility, count in (("cli", 2), ("cite", 3)):
         page = (tmp_path / utility / "index.html").read_text(encoding="utf-8")
         buttons = re.findall(r'<button class="copy-target"([^>]*)>(.*?)</button>', page, re.DOTALL)
         assert len(buttons) == count

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -123,6 +123,7 @@ def test_readmes_offer_a_short_agent_setup_prompt():
     english_section = english.split("## Query it locally", 1)[1].split("## More", 1)[0]
     chinese_section = chinese.split("## 在本地查询", 1)[1].split("## 更多", 1)[0]
     for section in (english_section, chinese_section):
+        assert "npx skills add ktwu01/benchmark-radar" in section
         assert "skills/benchmark-radar/SKILL.md" in section
         assert "normalize-external" not in section
         assert "build-data-release" not in section
@@ -134,6 +135,12 @@ def test_readmes_expose_the_consumer_skill():
     skill_path = "skills/benchmark-radar/SKILL.md"
     assert skill_path in README.read_text(encoding="utf-8")
     assert skill_path in README_ZH.read_text(encoding="utf-8")
+
+
+def test_consumer_skill_recovers_a_broken_cli() -> None:
+    text = SKILL.read_text(encoding="utf-8")
+    assert "missing or broken" in text
+    assert "--force-reinstall" in text
 
 
 def test_consumer_skill_keeps_acceptance_with_the_agent() -> None:

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -183,8 +183,9 @@ def test_offline_cli_route_is_in_the_view_bar_behind_a_short_link():
     assert 'canonical: "/cli/"' in script
     assert "function openCli(" in script
 
-    # One copy block, sharing the citation card's control rather than a second
-    # clipboard handler.
+    # Both setup steps share the citation card's copy control rather than adding
+    # another clipboard handler.
+    assert 'copyBlock("Install the Agent Skill", CLI_SKILL_INSTALL' in script
     assert 'copyBlock(\n        "Give this prompt to your coding agent",' in script
 
     # The card holds no data either, so it opens before the fetch and closes on
@@ -214,10 +215,13 @@ def test_offline_cli_route_is_in_the_view_bar_behind_a_short_link():
     )
     assert skill_url in readme_cli
     assert skill_url in script
+    assert "npx skills add ktwu01/benchmark-radar" in readme_cli
+    assert "npx skills add ktwu01/benchmark-radar" in script
     for line in (
-        "Set up Benchmark Radar for local benchmark search. Follow",
-        "to install the CLI and consumer Skill, initialize the local data, and verify the",
-        "setup. Use only consumer commands.",
+        "Use the installed Benchmark Radar Skill to finish local benchmark search setup. Follow",
+        "to install or repair the CLI if needed, initialize the local data, and verify the setup.",
+        "You have permission to install the CLI from the official repository. Use only consumer",
+        "commands.",
     ):
         assert line in readme_cli
         assert line in script


### PR DESCRIPTION
Closes #516

- Adds the one-command Agent Skill install to both READMEs and the website CLI card.
- Distinguishes Skill installation from Python CLI and local-data setup.
- Guides agents to detect and repair an installed CLI that cannot return JSON status.
- Keeps the static and interactive setup surfaces covered by regression tests.