### PR TITLE
Reduce local CLI setup to the install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,24 +60,14 @@ If Benchmark Radar saves you research time, **[star the repository](https://gith
 
 ## Query it locally (CLI version)
 
-Install the Benchmark Radar Agent Skill:
-
 ```bash
 npx skills add ktwu01/benchmark-radar
 ```
 
-This command installs the instructions your coding agent uses. The Python CLI
-and searchable data are configured separately.
-
-Give this prompt to your coding agent:
-
-```text
-Use the installed Benchmark Radar Skill to finish local benchmark search setup. Follow
-https://github.com/ktwu01/benchmark-radar/blob/main/skills/benchmark-radar/SKILL.md
-to install or repair the CLI if needed, initialize the local data, and verify the setup.
-You have permission to install the CLI from the official repository. Use only consumer
-commands.
-```
+Then ask your coding agent about benchmarks. It installs the command-line tool
+and downloads the data to your computer the first time you ask. What it does is
+written in the
+[setup and usage guide](https://github.com/ktwu01/benchmark-radar/blob/main/skills/benchmark-radar/SKILL.md).
 
 ## More
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -55,21 +55,13 @@ SWE-bench Verified 的 saturation 过程。**
 
 ## 在本地查询（CLI 版本）
 
-先安装 Benchmark Radar Agent Skill：
-
 ```bash
 npx skills add ktwu01/benchmark-radar
 ```
 
-这条命令只安装 coding agent 使用的操作说明，Python CLI 和本地可搜索数据需要
-单独配置。然后把下面这段直接发给你的 coding agent：
-
-```text
-请使用已安装的 Benchmark Radar Skill 完成本地 benchmark 搜索配置。请遵循
-https://github.com/ktwu01/benchmark-radar/blob/main/skills/benchmark-radar/SKILL.md，
-按需安装或修复 CLI、初始化本地数据并确认配置成功。你可以从官方仓库安装 CLI。
-只使用面向用户的命令。
-```
+之后直接问你的 coding agent benchmark 就行。第一次问的时候，它会安装命令行工具，
+并把数据下载到你的电脑。它具体做了什么，写在
+[安装与使用指南](https://github.com/ktwu01/benchmark-radar/blob/main/skills/benchmark-radar/SKILL.md)。
 
 ## 更多
 

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -847,10 +847,7 @@ const I18N = {
     "More than 10 results.": "结果超过 10 条。",
     "Use the CLI version to export all data.": "使用我们的命令行版本导出全部数据。",
     "Query it locally (CLI version)": "在本地查询（命令行版本）",
-    "Install the Agent Skill": "安装 Agent Skill",
-    "To let your agent use the CLI version, run the command below.":
-      "如果你想让 Agent 使用 CLI 版本，请运行下面的命令。",
-    "Give this prompt to your coding agent": "把这段提示词交给你的编程助手",
+    Install: "安装",
     "Read the setup guide": "查看安装指南",
     "Share Benchmark Radar": "分享 Benchmark Radar",
     Share: "分享",
@@ -8023,7 +8020,7 @@ const CITE_BIBTEX = [
 // sheet. The block itself is the button: a reader who came for a citation or a
 // setup prompt wants it on the clipboard, so clicking the text copies it rather
 // than making them select eight wrapped lines by hand.
-function copyBlock(label, value, hint) {
+function copyBlock(label, value, hint, hideLabel = false) {
   const status = element("span", { className: "copy-status", text: t(hint) });
   const text = element("code", { className: "copy-text", text: value });
   const copy = element(
@@ -8056,7 +8053,10 @@ function copyBlock(label, value, hint) {
     }
   });
   return element("section", { className: "copy-block" }, [
-    element("h3", { className: "copy-label", text: t(label) }),
+    element("h3", {
+      className: hideLabel ? "copy-label visually-hidden" : "copy-label",
+      text: t(label),
+    }),
     copy,
   ]);
 }
@@ -8173,14 +8173,6 @@ const CLI_SKILL_INSTALL = "npx skills add ktwu01/benchmark-radar";
 // The README wraps its last sentence across two lines at 80 columns; the card
 // is narrower than that, so keeping the break would re-wrap into ragged text.
 // Only the URL needs a line of its own, and it keeps one.
-const CLI_AGENT_PROMPT = [
-  "Use the installed Benchmark Radar Skill to finish local benchmark search setup. Follow",
-  CLI_SKILL_URL,
-  "to install or repair the CLI if needed, initialize the local data, and verify the setup.",
-  "You have permission to install the CLI from the official repository. Use only consumer" +
-    " commands.",
-].join("\n");
-
 // True only while the open card owns a history entry this page pushed, for the
 // same reason the citation card tracks it: closing a directly-opened /cli/ must
 // not step a reader back off the site.
@@ -8207,17 +8199,8 @@ function openCli(updateUrl = true) {
       text: t("Query it locally (CLI version)"),
       attrs: { id: "cli-title" },
     }),
-    element("p", {
-      className: "detail-summary",
-      text: t("To let your agent use the CLI version, run the command below."),
-    }),
     element("div", { className: "copy-blocks" }, [
-      copyBlock("Install the Agent Skill", CLI_SKILL_INSTALL, "Click to copy"),
-      copyBlock(
-        "Give this prompt to your coding agent",
-        CLI_AGENT_PROMPT,
-        "Click to copy",
-      ),
+      copyBlock("Install", CLI_SKILL_INSTALL, "Click to copy", true),
     ]),
     element("a", {
       className: "secondary-link dialog-link",

--- a/skills/benchmark-radar/SKILL.md
+++ b/skills/benchmark-radar/SKILL.md
@@ -10,20 +10,28 @@ selection criteria, and desired output open unless they specify them.
 
 ## Prepare the data
 
+Carry this out yourself, without handing the user a checklist. Installing this Skill
+is the request to use the CLI, so an install or repair the steps below call for is
+part of that request: run it, then say what you ran. Ask first only when the user
+told you not to install anything.
+
 1. Check availability with `benchmark-radar status --json`.
-2. If the command is missing or exits before returning a JSON status response, report
-   that the CLI is missing or broken. Offer installation, but do not install it without
-   permission:
+2. If the command is missing or exits before returning a JSON status response, the CLI
+   is missing or broken. Install it:
 
    ```bash
    python -m pip install 'git+https://github.com/ktwu01/benchmark-radar.git'
    ```
 
-   If an existing installation cannot import `benchmark_radar`, offer a clean repair:
+   If an existing installation cannot import `benchmark_radar`, repair it cleanly:
 
    ```bash
    python -m pip install --force-reinstall 'git+https://github.com/ktwu01/benchmark-radar.git'
    ```
+
+   Install into the Python environment whose `pip` the user's shell resolves. If that
+   environment is externally managed and refuses the install, say which environment
+   failed and what would fix it rather than forcing the package in.
 
 3. If the CLI reports `not_initialized`, run `benchmark-radar init --json`; that
    successful init is already current, so do not immediately sync again.
@@ -31,6 +39,10 @@ selection criteria, and desired output open unless they specify them.
    `benchmark-radar sync --json` once before querying. Skip sync when the user asks
    to stay offline or retain a fixed local version. If sync fails, report it instead
    of silently presenting stale data as current.
+
+When the user asks only to set up Benchmark Radar, finish the steps above, run one
+`benchmark-radar search` to confirm the data answers, and report the data version.
+Then stop; do not invent a benchmark question they did not ask.
 
 ## Choose the smallest command
 

--- a/skills/benchmark-radar/SKILL.md
+++ b/skills/benchmark-radar/SKILL.md
@@ -40,9 +40,14 @@ told you not to install anything.
    to stay offline or retain a fixed local version. If sync fails, report it instead
    of silently presenting stale data as current.
 
-When the user asks only to set up Benchmark Radar, finish the steps above, run one
-`benchmark-radar search` to confirm the data answers, and report the data version.
-Then stop; do not invent a benchmark question they did not ask.
+When the user asks only to set up Benchmark Radar (or after installing without a
+specific benchmark query), finish the steps above and report the data version. Then
+provide an immediate starter use case so the user can see it in action right away
+without having to formulate a query: automatically search for recent or popular agent
+benchmarks (for example, `benchmark-radar search "agent" --scope catalog --json` or
+recent Radar evidence), present a concise summary of top results as an example showcase,
+and show how the user can query further (e.g., searching by specific task domain,
+inspecting details with `show`, or tracking recent evidence).
 
 ## Choose the smallest command
 

--- a/skills/benchmark-radar/SKILL.md
+++ b/skills/benchmark-radar/SKILL.md
@@ -12,7 +12,7 @@ selection criteria, and desired output open unless they specify them.
 
 Carry this out yourself, without handing the user a checklist. Installing this Skill
 is the request to use the CLI, so an install or repair the steps below call for is
-part of that request: run it, then say what you ran. Ask first only when the user
+part of that request: say you are installing the CLI from the official repository, then run it and report what you ran. Ask first only when the user
 told you not to install anything.
 
 1. Check availability with `benchmark-radar status --json`.

--- a/src/benchmark_radar/app_seeds.py
+++ b/src/benchmark_radar/app_seeds.py
@@ -377,27 +377,20 @@ CLI_SKILL_URL = (
     "https://github.com/ktwu01/benchmark-radar/blob/main/skills/benchmark-radar/SKILL.md"
 )
 CLI_SKILL_INSTALL = "npx skills add ktwu01/benchmark-radar"
-CLI_AGENT_PROMPT = "\n".join(
-    (
-        "Use the installed Benchmark Radar Skill to finish local benchmark search setup. Follow",
-        CLI_SKILL_URL,
-        "to install or repair the CLI if needed, initialize the local data, and verify the setup.",
-        "You have permission to install the CLI from the official repository. Use only consumer"
-        " commands.",
-    )
-)
+CLI_INSTALL_LABEL = "Install"
 
 
-def _copy_block(label: str, value: str, hint: str) -> str:
+def _copy_block(label: str, value: str, hint: str, hide_label: bool = False) -> str:
     """The non-interactive form of copyBlock in app.js.
 
     The button already contains its label, value and fallback instruction. The
     runtime only has to add clipboard behavior; a failed or disabled script
     never leaves behind an empty button.
     """
+    label_class = "copy-label visually-hidden" if hide_label else "copy-label"
     return (
         '<section class="copy-block">'
-        f'<h3 class="copy-label">{esc(label)}</h3>'
+        f'<h3 class="{label_class}">{esc(label)}</h3>'
         f'<button class="copy-target" type="button" aria-label="{esc(hint)}: {esc(label)}">'
         f'<code class="copy-text">{esc(value)}</code>'
         f'<span class="copy-status">{esc(hint)}</span>'
@@ -433,12 +426,8 @@ def _cli_seed() -> dict[str, str]:
         '<p class="detail-source">Benchmark Radar</p>'
         '<h2 class="detail-title cli-title" id="cli-title">'
         "Query it locally (CLI version)</h2>"
-        '<p class="detail-summary">'
-        "To let your agent use the CLI version, run the command below."
-        "</p>"
         '<div class="copy-blocks">'
-        f"{_copy_block('Install the Agent Skill', CLI_SKILL_INSTALL, 'Click to copy')}"
-        f"{_copy_block('Give this prompt to your coding agent', CLI_AGENT_PROMPT, 'Click to copy')}"
+        f"{_copy_block(CLI_INSTALL_LABEL, CLI_SKILL_INSTALL, 'Click to copy', True)}"
         "</div>"
         '<a class="secondary-link dialog-link" '
         f'href="{esc(CLI_SKILL_URL)}" target="_blank" rel="noopener noreferrer">'

--- a/tests/test_app_pages.py
+++ b/tests/test_app_pages.py
@@ -313,7 +313,7 @@ def test_utility_schema_names_the_clean_route(tmp_path):
 def test_utility_pages_ship_the_existing_dialog_open_with_content(tmp_path):
     _write(tmp_path, _dashboard())
     expected = {
-        "cli": ("Query it locally (CLI version)", "Give this prompt to your coding agent"),
+        "cli": ("Query it locally (CLI version)", "npx skills add ktwu01/benchmark-radar"),
         "cite": ("Cite this work", "@techreport{Wu_Benchmark_Radar"),
         "rubric": ("How priority is scored", "Priority is not benchmark quality."),
     }
@@ -333,7 +333,7 @@ def test_utility_pages_ship_the_existing_dialog_open_with_content(tmp_path):
 
 def test_seeded_copy_controls_have_names_values_and_fallback_hints(tmp_path):
     _write(tmp_path, _dashboard())
-    for utility, count in (("cli", 2), ("cite", 3)):
+    for utility, count in (("cli", 1), ("cite", 3)):
         page = (tmp_path / utility / "index.html").read_text(encoding="utf-8")
         buttons = re.findall(r'<button class="copy-target"([^>]*)>(.*?)</button>', page, re.DOTALL)
         assert len(buttons) == count

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -147,6 +147,15 @@ def test_consumer_skill_recovers_a_broken_cli() -> None:
     assert "report what you ran" in text
 
 
+def test_consumer_skill_offers_starter_example_on_setup() -> None:
+    # When setup completes without a specific query, the Skill showcases a starter
+    # example (e.g. popular agent benchmarks) so the user sees immediate results.
+    text = SKILL.read_text(encoding="utf-8")
+    assert "starter use case" in text
+    assert "agent" in text
+    assert "present a concise summary" in text
+
+
 def test_consumer_skill_keeps_acceptance_with_the_agent() -> None:
     text = SKILL.read_text(encoding="utf-8")
     assert "retrieval_score" in text

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -114,12 +114,12 @@ def test_citation_metadata_prefers_the_technical_report():
 
 
 def test_readmes_offer_a_short_agent_setup_prompt():
-    # Regression: local-query setup should be one copy-paste prompt, not a second
+    # Regression: local-query setup should be one copy-paste command, not a second
     # maintainer manual (issue #436).
     english = README.read_text(encoding="utf-8")
     chinese = README_ZH.read_text(encoding="utf-8")
-    assert "Give this prompt to your coding agent:" in english
-    assert "把下面这段直接发给你的 coding agent：" in chinese
+    assert "Then ask your coding agent about benchmarks." in english
+    assert "之后直接问你的 coding agent benchmark 就行。" in chinese
     english_section = english.split("## Query it locally", 1)[1].split("## More", 1)[0]
     chinese_section = chinese.split("## 在本地查询", 1)[1].split("## 更多", 1)[0]
     for section in (english_section, chinese_section):
@@ -138,9 +138,12 @@ def test_readmes_expose_the_consumer_skill():
 
 
 def test_consumer_skill_recovers_a_broken_cli() -> None:
+    # Setup is the Skill's job, not a checklist the reader has to run: the two
+    # published lines only work if the Skill installs and repairs on its own.
     text = SKILL.read_text(encoding="utf-8")
     assert "missing or broken" in text
     assert "--force-reinstall" in text
+    assert "run it, then say what you ran" in text
 
 
 def test_consumer_skill_keeps_acceptance_with_the_agent() -> None:

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -143,7 +143,8 @@ def test_consumer_skill_recovers_a_broken_cli() -> None:
     text = SKILL.read_text(encoding="utf-8")
     assert "missing or broken" in text
     assert "--force-reinstall" in text
-    assert "run it, then say what you ran" in text
+    assert "say you are installing the CLI from the official repository" in text
+    assert "report what you ran" in text
 
 
 def test_consumer_skill_keeps_acceptance_with_the_agent() -> None:

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -183,10 +183,10 @@ def test_offline_cli_route_is_in_the_view_bar_behind_a_short_link():
     assert 'canonical: "/cli/"' in script
     assert "function openCli(" in script
 
-    # Both setup steps share the citation card's copy control rather than adding
-    # another clipboard handler.
-    assert 'copyBlock("Install the Agent Skill", CLI_SKILL_INSTALL' in script
-    assert 'copyBlock(\n        "Give this prompt to your coding agent",' in script
+    # The single command shares the citation card's copy control rather than
+    # adding another clipboard handler, and its label is for screen readers only.
+    assert 'copyBlock("Install", CLI_SKILL_INSTALL, "Click to copy", true)' in script
+    assert 'hideLabel ? "copy-label visually-hidden" : "copy-label"' in script
 
     # The card holds no data either, so it opens before the fetch and closes on
     # Back above the early return, and it owns its pushed history entry.
@@ -217,14 +217,10 @@ def test_offline_cli_route_is_in_the_view_bar_behind_a_short_link():
     assert skill_url in script
     assert "npx skills add ktwu01/benchmark-radar" in readme_cli
     assert "npx skills add ktwu01/benchmark-radar" in script
-    for line in (
-        "Use the installed Benchmark Radar Skill to finish local benchmark search setup. Follow",
-        "to install or repair the CLI if needed, initialize the local data, and verify the setup.",
-        "You have permission to install the CLI from the official repository. Use only consumer",
-        "commands.",
-    ):
-        assert line in readme_cli
-        assert line in script
+    # One published command, and nothing the reader has to relay to an agent:
+    # the Skill installs the CLI and the data the first time it is asked.
+    assert "```text" not in readme_cli
+    assert "CLI_AGENT_PROMPT" not in script
 
 
 def test_only_one_sheet_is_open_at_a_time():


### PR DESCRIPTION
The `/cli/` card and the matching README sections now publish one command and
nothing else:

```
npx skills add ktwu01/benchmark-radar
```

The card is the title, that command, and the link to the setup guide. The
second step it used to show, a prompt the reader had to copy and relay to their
agent, is gone, along with the summary paragraph and the visible "Run this once"
label. The label survives in the DOM as `visually-hidden` so a screen reader
still knows what the copy block holds.

`skills/benchmark-radar/SKILL.md` now owns setup end to end. Installing the
Skill is the request to use the CLI, so the agent checks
`benchmark-radar status`, installs or repairs the package itself, runs `init`
or `sync`, and reports what it ran instead of asking the user for permission it
already has. When the user asks only to set up Benchmark Radar, it confirms with
one search and stops.

Both renderers changed together: `copyBlock` in `site/assets/app.js` and
`_copy_block` in `src/benchmark_radar/app_seeds.py` take a hide-label flag, so
the crawler seed and the browser render the same card.

Verified: full CI sequence on a clean checkout (`ruff check`, `ruff format
--check`, `normalize-external`, `classify`, `build-data-release`, `pytest -q` /
1141 passed), plus the card screenshotted in English and Chinese.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
