### PR TITLE
Add a daily brief blog at /blog/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,11 @@ graphify-out/
 # reason as the benchmark pages: the generator and inputs are reviewed, not a
 # stale HTML copy.
 /site/leaderboard/
+# One page per collection day, written by the same `classify` run from the
+# committed snapshots. The whole tree is replaced on every build, so a
+# committed copy would be a stale brief reviewed as if it were the day's
+# report, and a day removed from the history would keep its page.
+/site/blog/
 /site/trends/
 /site/explore/
 /site/cli/

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -383,6 +383,7 @@ const I18N = {
     Leaderboard: "排行榜",
     Trends: "趋势",
     Explore: "探索",
+    Blog: "博客",
     Rubric: "评分标准",
     "Daily briefing": "每日简报",
     "Questions for today": "今日问答",

--- a/site/assets/blog.css
+++ b/site/assets/blog.css
@@ -138,9 +138,22 @@
   color: var(--muted);
 }
 
-.blog-page .blog-list,
-.blog-page .blog-evidence {
+.blog-page .blog-list {
   padding-left: 1.25rem;
+}
+
+/* The source list is keyed by stored citation ID, not by position, so it
+   carries no marker of its own. The ID sits in its own column so a title that
+   wraps stays aligned under itself rather than under the reference. */
+.blog-page .blog-evidence {
+  padding-left: 0;
+  list-style: none;
+}
+
+.blog-page .blog-evidence li {
+  display: grid;
+  grid-template-columns: 3.2rem 1fr;
+  align-items: baseline;
 }
 
 .blog-page .blog-list li + li,

--- a/site/assets/blog.css
+++ b/site/assets/blog.css
@@ -1,0 +1,286 @@
+/* Blog pages use the dashboard's stylesheet as their visual source of truth
+   and only compose its existing tokens into a reading layout. Nothing here
+   applies to the dashboard: every rule is scoped to .blog-page, which only the
+   generated blog documents carry. */
+.blog-page .masthead-end {
+  display: flex;
+}
+
+.blog-page .blog-view {
+  padding: clamp(2.25rem, 4vw, 3.75rem) 0 6rem;
+}
+
+.blog-page .blog-hero {
+  display: grid;
+  gap: 1rem;
+  max-width: 980px;
+  margin-bottom: 2rem;
+}
+
+.blog-page .blog-hero h1 {
+  max-width: 920px;
+}
+
+.blog-page .blog-lede {
+  max-width: 760px;
+  margin: 0;
+  color: var(--muted);
+  font-size: clamp(1rem, 2vw, 1.25rem);
+}
+
+.blog-page .blog-actions,
+.blog-page .blog-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  align-items: center;
+}
+
+.blog-page .blog-stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+  margin: 0 0 2.5rem;
+}
+
+.blog-page .blog-stat,
+.blog-page .blog-panel,
+.blog-page .blog-card {
+  border: 1px solid var(--edge);
+  border-radius: var(--radius);
+  background: var(--panel);
+  box-shadow: var(--shadow);
+}
+
+.blog-page .blog-stat {
+  padding: 1.1rem;
+}
+
+.blog-page .blog-stat strong {
+  display: block;
+  font-family: var(--display);
+  font-size: clamp(1.35rem, 3vw, 2rem);
+  line-height: 1.1;
+}
+
+.blog-page .blog-stat span,
+.blog-page .blog-meta,
+.blog-page .blog-kicker {
+  color: var(--muted);
+  font-family: var(--utility);
+  font-size: 0.7rem;
+  letter-spacing: 0.05em;
+}
+
+.blog-page .blog-panel {
+  margin: 1.5rem 0;
+  padding: clamp(1rem, 2.5vw, 1.6rem);
+}
+
+.blog-page .blog-panel > :last-child,
+.blog-page .blog-card > :last-child {
+  margin-bottom: 0;
+}
+
+.blog-page .blog-section {
+  margin: 2.5rem 0;
+}
+
+.blog-page .blog-section-heading {
+  margin-bottom: 1rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--edge);
+}
+
+.blog-page .blog-section-heading h2,
+.blog-page .blog-section-heading p {
+  margin-bottom: 0;
+}
+
+.blog-page .blog-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.blog-page .blog-card {
+  padding: 1.1rem;
+}
+
+.blog-page .blog-card h2,
+.blog-page .blog-card h3 {
+  margin-bottom: 0.45rem;
+}
+
+.blog-page .blog-card p {
+  color: var(--muted);
+}
+
+.blog-page .blog-table {
+  min-width: 640px;
+}
+
+.blog-page .blog-table th,
+.blog-page .blog-table td {
+  padding: 0.75rem;
+}
+
+.blog-page .blog-table .num {
+  text-align: right;
+  white-space: nowrap;
+}
+
+.blog-page .blog-caveat {
+  max-width: 840px;
+  padding: 0.9rem 1rem;
+  border-left: 3px solid var(--orange);
+  background: var(--panel);
+  color: var(--muted);
+}
+
+.blog-page .blog-list,
+.blog-page .blog-evidence {
+  padding-left: 1.25rem;
+}
+
+.blog-page .blog-list li + li,
+.blog-page .blog-evidence li + li {
+  margin-top: 0.6rem;
+}
+
+.blog-page .blog-evidence a,
+.blog-page .blog-prose a,
+.blog-page .blog-facts dd {
+  overflow-wrap: anywhere;
+}
+
+.blog-page .blog-index {
+  display: grid;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.blog-page .blog-index .blog-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.5rem 1.5rem;
+  align-items: start;
+}
+
+.blog-page .blog-index .blog-card p {
+  grid-column: 1 / -1;
+  margin: 0;
+}
+
+.blog-page .blog-chip {
+  display: inline-flex;
+  width: fit-content;
+  padding: 0.18rem 0.5rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--muted);
+  font-family: var(--utility);
+  font-size: 0.65rem;
+  letter-spacing: 0.05em;
+}
+
+.blog-page .blog-prose {
+  max-width: 820px;
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.blog-page .blog-prose h2,
+.blog-page .blog-prose h3 {
+  margin-top: 2rem;
+}
+
+.blog-page .blog-prose pre,
+.blog-page .blog-prose code {
+  font-family: var(--utility);
+}
+
+.blog-page .blog-prose pre {
+  max-width: 100%;
+  overflow-x: auto;
+  padding: 1rem;
+  border: 1px solid var(--edge);
+  background: var(--ink);
+  color: var(--panel);
+}
+
+.blog-page .blog-prose blockquote {
+  margin-left: 0;
+  padding-left: 1rem;
+  border-left: 3px solid var(--sea);
+  color: var(--muted);
+}
+
+.blog-page .blog-prose table {
+  min-width: 0;
+}
+
+.blog-page .blog-directory {
+  columns: 3;
+  gap: 0.5rem 2rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.blog-page .blog-directory li {
+  break-inside: avoid;
+  margin: 0 0 0.35rem;
+}
+
+.blog-page .blog-facts {
+  display: grid;
+  grid-template-columns: max-content minmax(0, 1fr);
+  gap: 0.5rem 1.25rem;
+}
+
+.blog-page .blog-facts dt {
+  color: var(--muted);
+  font-family: var(--utility);
+  font-size: 0.72rem;
+}
+
+.blog-page .blog-facts dd {
+  margin: 0;
+}
+
+.blog-page .blog-footer {
+  gap: 0.65rem;
+  padding: 1.5rem 0 2.5rem;
+  border-top: 1px solid var(--edge);
+  color: var(--muted);
+}
+
+.blog-page [data-lang-content][hidden] {
+  display: none !important;
+}
+
+@media (max-width: 760px) {
+  .blog-page .blog-stats,
+  .blog-page .blog-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .blog-page .blog-index .blog-card {
+    grid-template-columns: 1fr;
+  }
+
+  .blog-page .blog-index .blog-card p {
+    grid-column: 1;
+  }
+
+  .blog-page .blog-facts {
+    grid-template-columns: 1fr;
+  }
+
+  .blog-page .blog-directory {
+    columns: 1;
+  }
+}

--- a/site/assets/blog.css
+++ b/site/assets/blog.css
@@ -2,10 +2,6 @@
    and only compose its existing tokens into a reading layout. Nothing here
    applies to the dashboard: every rule is scoped to .blog-page, which only the
    generated blog documents carry. */
-.blog-page .masthead-end {
-  display: flex;
-}
-
 .blog-page .blog-view {
   padding: clamp(2.25rem, 4vw, 3.75rem) 0 6rem;
 }
@@ -262,13 +258,6 @@
 
 .blog-page .blog-facts dd {
   margin: 0;
-}
-
-.blog-page .blog-footer {
-  gap: 0.65rem;
-  padding: 1.5rem 0 2.5rem;
-  border-top: 1px solid var(--edge);
-  color: var(--muted);
 }
 
 .blog-page [data-lang-content][hidden] {

--- a/site/assets/blog.css
+++ b/site/assets/blog.css
@@ -284,3 +284,13 @@
     columns: 1;
   }
 }
+
+/* The prose cites evidence and figures by stored ID, so the ID has to be
+   readable next to the thing it names. Monospaced and muted keeps it legible
+   as a reference marker without competing with the title it precedes. */
+.blog-page .blog-cite-id {
+  font-family: var(--utility);
+  font-size: 0.78rem;
+  color: var(--muted);
+  letter-spacing: 0.04em;
+}

--- a/site/assets/blog.js
+++ b/site/assets/blog.js
@@ -1,10 +1,16 @@
-// Language switch for the generated blog pages.
+// Client behavior for the generated blog pages.
 //
-// Each brief ships both language versions in the document when the snapshot
-// stored a reviewed Chinese translation, so switching is a visibility change
-// and never a fetch. Pages without a stored translation ship no toggle at all:
-// a control that switches to identical text is broken, and translating here
-// would publish text nobody reviewed.
+// The chrome around the reading pane is extracted from site/index.html at
+// build time, so this script lights up exactly the bits the dashboard's
+// app.js would have handled — with the same visible contracts: the language
+// toggle flips title, glyph, and aria-pressed; the repository badges fill
+// their counts from the same GitHub endpoints; the footer share control uses
+// navigator.share with a clipboard fallback.
+//
+// The body's language blocks stay a pure visibility change and never a fetch.
+// Pages without a stored translation ship no toggle at all: a control that
+// switches to identical text is broken, and translating here would publish
+// text nobody reviewed.
 //
 // The stored preference is shared with the dashboard under the same key, so a
 // reader who chose 中文 there keeps it here. Only an explicit click writes to
@@ -35,12 +41,8 @@ function showLanguage(language, { remember = false } = {}) {
   const toggle = document.getElementById("lang-toggle");
   if (toggle) {
     const next = resolved === "zh" ? "en" : "zh";
-    toggle.dataset.nextLanguage = next;
     toggle.setAttribute("aria-pressed", String(resolved === "zh"));
-    toggle.setAttribute(
-      "aria-label",
-      next === "zh" ? "Switch to Chinese (中文)" : "Switch to English",
-    );
+    toggle.title = next === "zh" ? "Switch to Chinese (中文)" : "Switch to English";
     document.getElementById("lang-toggle-label").textContent = next === "zh" ? "中" : "EN";
   }
   if (!remember || resolved !== language) return;
@@ -51,13 +53,84 @@ function showLanguage(language, { remember = false } = {}) {
   }
 }
 
-const toggle = document.getElementById("lang-toggle");
-if (toggle) {
-  toggle.addEventListener("click", () =>
-    showLanguage(toggle.dataset.nextLanguage || "zh", { remember: true }),
-  );
+const langToggle = document.getElementById("lang-toggle");
+if (langToggle) {
+  langToggle.addEventListener("click", () => {
+    const current = document.documentElement.lang === "zh-CN" ? "zh" : "en";
+    showLanguage(current === "zh" ? "en" : "zh", { remember: true });
+  });
 }
 showLanguage(savedLanguage());
+
+// Repository badge counts. Mirrors app.js's renderRepoBadges: same endpoints,
+// same rule that counts are decoration, so a rate-limited API must never
+// surface as an error state — the badges link out and stay usable blank.
+const REPO_SLUG = "ktwu01/benchmark-radar";
+
+const BADGE_ACTIONS = {
+  "badge-stars": (count) => `Star this repository on GitHub. ${count} stars`,
+  "badge-forks": (count) => `Fork this repository on GitHub. ${count} forks`,
+  "badge-issues": (count) => `Open a new issue on GitHub. ${count} issues open`,
+};
+
+function setBadgeCount(id, value) {
+  const badge = document.getElementById(id);
+  const node = badge?.querySelector("[data-count]");
+  if (!node) return;
+  const count = Number(value || 0).toLocaleString();
+  node.textContent = count;
+  badge.setAttribute("aria-label", BADGE_ACTIONS[id](count));
+}
+
+async function renderRepoBadges() {
+  try {
+    const response = await fetch(`https://api.github.com/repos/${REPO_SLUG}`, {
+      headers: { Accept: "application/vnd.github+json" },
+    });
+    if (!response.ok) return;
+    const repo = await response.json();
+    setBadgeCount("badge-stars", repo.stargazers_count);
+    setBadgeCount("badge-forks", repo.forks_count);
+    // open_issues_count includes pull requests, so the issues badge asks the
+    // search API for issues only, and stays blank if that fails rather than
+    // showing the inflated number.
+    const issues = await fetch(
+      `https://api.github.com/search/issues?q=${encodeURIComponent(
+        `repo:${REPO_SLUG} is:issue is:open`,
+      )}&per_page=1`,
+      { headers: { Accept: "application/vnd.github+json" } },
+    );
+    if (issues.ok) {
+      setBadgeCount("badge-issues", (await issues.json()).total_count);
+    }
+  } catch (error) {
+    console.debug("Repository badge counts unavailable", error);
+  }
+}
+renderRepoBadges();
+
+// The footer's share control, same behavior as the dashboard's.
+const shareButton = document.getElementById("share-radar");
+if (shareButton) {
+  shareButton.addEventListener("click", async (event) => {
+    const button = event.currentTarget;
+    const shareData = {
+      title: document.title,
+      text: "Share Benchmark Radar",
+      url: window.location.href,
+    };
+    try {
+      if (navigator.share) await navigator.share(shareData);
+      else await navigator.clipboard.writeText(shareData.url);
+      button.textContent = "Copied";
+      setTimeout(() => {
+        button.textContent = "Share";
+      }, 1600);
+    } catch (error) {
+      if (error?.name !== "AbortError") console.error(error);
+    }
+  });
+}
 
 // The section nav scrolls horizontally on narrow screens, and Blog is its last
 // item, so on a phone the reader lands on a brief with the active tab parked

--- a/site/assets/blog.js
+++ b/site/assets/blog.js
@@ -5,7 +5,9 @@
 // app.js would have handled — with the same visible contracts: the language
 // toggle flips title, glyph, and aria-pressed; the repository badges fill
 // their counts from the same GitHub endpoints; the footer share control uses
-// navigator.share with a clipboard fallback.
+// navigator.share with a clipboard fallback; and the chrome itself translates
+// from the same reviewed I18N table app.js uses, baked into the page at build
+// time as #chrome-i18n.
 //
 // The body's language blocks stay a pure visibility change and never a fetch.
 // Pages without a stored translation ship no toggle at all: a control that
@@ -31,6 +33,62 @@ function savedLanguage() {
   return "en";
 }
 
+let chromeI18N = null;
+try {
+  const baked = document.getElementById("chrome-i18n");
+  if (baked) chromeI18N = JSON.parse(baked.textContent);
+} catch (_) {
+  // A malformed table must not break the page; the chrome stays English.
+}
+function t(key, params) {
+  let value = (document.documentElement.lang === "zh-CN" ? chromeI18N?.[key] : null) ?? key;
+  if (params) {
+    for (const [name, replacement] of Object.entries(params)) {
+      value = value.replaceAll(`{${name}}`, String(replacement));
+    }
+  }
+  return value;
+}
+
+// The same three passes app.js applies, including the repo-badge tooltip
+// contract: a data-i18n-title on a badge becomes the CSS-rendered
+// data-tooltip instead of the browser's delayed native title.
+function applyChromeI18n() {
+  if (!chromeI18N) return;
+  const zh = document.documentElement.lang === "zh-CN";
+  document.querySelectorAll("[data-i18n]").forEach((node) => {
+    if (node.dataset.i18nEn === undefined) {
+      node.dataset.i18nEn = node.textContent;
+    }
+    node.textContent = zh ? (chromeI18N[node.dataset.i18n] ?? node.dataset.i18nEn) : node.dataset.i18nEn;
+  });
+  document.querySelectorAll("[data-i18n-title]").forEach((node) => {
+    if (node.dataset.i18nTitleEn === undefined) {
+      node.dataset.i18nTitleEn = node.getAttribute("title") || "";
+    }
+    const resolved = zh ? (chromeI18N[node.dataset.i18nTitle] ?? node.dataset.i18nTitleEn) : node.dataset.i18nTitleEn;
+    if (node.classList.contains("repo-badge")) {
+      if (zh) {
+        node.setAttribute("data-tooltip", resolved);
+        node.removeAttribute("title");
+        if (!node.hasAttribute("aria-label")) node.setAttribute("aria-label", resolved);
+      } else {
+        node.removeAttribute("data-tooltip");
+        node.setAttribute("title", resolved);
+      }
+    } else {
+      node.setAttribute("title", resolved);
+    }
+  });
+  document.querySelectorAll("[data-i18n-aria]").forEach((node) => {
+    if (node.dataset.i18nAriaEn === undefined) {
+      node.dataset.i18nAriaEn = node.getAttribute("aria-label") || "";
+    }
+    const resolved = zh ? (chromeI18N[node.dataset.i18nAria] ?? node.dataset.i18nAriaEn) : node.dataset.i18nAriaEn;
+    node.setAttribute("aria-label", resolved);
+  });
+}
+
 function showLanguage(language, { remember = false } = {}) {
   const available = document.querySelector(`[data-lang-content="${language}"]`);
   const resolved = available ? language : "en";
@@ -38,11 +96,15 @@ function showLanguage(language, { remember = false } = {}) {
     node.hidden = node.dataset.langContent !== resolved;
   });
   document.documentElement.lang = resolved === "zh" ? "zh-CN" : "en";
+  applyChromeI18n();
   const toggle = document.getElementById("lang-toggle");
   if (toggle) {
     const next = resolved === "zh" ? "en" : "zh";
+    const titleKey = next === "zh" ? "Switch to Chinese (中文)" : "Switch to English";
     toggle.setAttribute("aria-pressed", String(resolved === "zh"));
-    toggle.title = next === "zh" ? "Switch to Chinese (中文)" : "Switch to English";
+    toggle.setAttribute("aria-label", t(titleKey));
+    toggle.setAttribute("data-tooltip", t(titleKey));
+    toggle.removeAttribute("title");
     document.getElementById("lang-toggle-label").textContent = next === "zh" ? "中" : "EN";
   }
   if (!remember || resolved !== language) return;
@@ -68,9 +130,9 @@ showLanguage(savedLanguage());
 const REPO_SLUG = "ktwu01/benchmark-radar";
 
 const BADGE_ACTIONS = {
-  "badge-stars": (count) => `Star this repository on GitHub. ${count} stars`,
-  "badge-forks": (count) => `Fork this repository on GitHub. ${count} forks`,
-  "badge-issues": (count) => `Open a new issue on GitHub. ${count} issues open`,
+  "badge-stars": "Star this repository on GitHub. {count} stars",
+  "badge-forks": "Fork this repository on GitHub. {count} forks",
+  "badge-issues": "Open a new issue on GitHub. {count} issues open",
 };
 
 function setBadgeCount(id, value) {
@@ -79,7 +141,7 @@ function setBadgeCount(id, value) {
   if (!node) return;
   const count = Number(value || 0).toLocaleString();
   node.textContent = count;
-  badge.setAttribute("aria-label", BADGE_ACTIONS[id](count));
+  badge.setAttribute("aria-label", t(BADGE_ACTIONS[id], { count }));
 }
 
 async function renderRepoBadges() {

--- a/site/assets/blog.js
+++ b/site/assets/blog.js
@@ -58,3 +58,13 @@ if (toggle) {
   );
 }
 showLanguage(savedLanguage());
+
+// The section nav scrolls horizontally on narrow screens, and Blog is its last
+// item, so on a phone the reader lands on a brief with the active tab parked
+// off the right edge. Nudging it into view keeps the "you are here" state
+// visible; the dashboard needs no equivalent because its default view is the
+// leftmost item.
+const activeNav = document.querySelector('.view-nav [aria-current="page"]');
+if (activeNav?.scrollIntoView) {
+  activeNav.scrollIntoView({ block: "nearest", inline: "nearest" });
+}

--- a/site/assets/blog.js
+++ b/site/assets/blog.js
@@ -1,0 +1,60 @@
+// Language switch for the generated blog pages.
+//
+// Each brief ships both language versions in the document when the snapshot
+// stored a reviewed Chinese translation, so switching is a visibility change
+// and never a fetch. Pages without a stored translation ship no toggle at all:
+// a control that switches to identical text is broken, and translating here
+// would publish text nobody reviewed.
+//
+// The stored preference is shared with the dashboard under the same key, so a
+// reader who chose 中文 there keeps it here. Only an explicit click writes to
+// it. Falling back to English on an untranslated brief must not quietly reset
+// the preference the reader set somewhere else.
+const LANG_STORAGE_KEY = "benchmark-radar:lang";
+const LANGS = ["en", "zh"];
+
+function savedLanguage() {
+  const param = new URLSearchParams(window.location.search).get("lang");
+  if (LANGS.includes(param)) return param;
+  try {
+    const saved = localStorage.getItem(LANG_STORAGE_KEY);
+    if (LANGS.includes(saved)) return saved;
+  } catch (_) {
+    // Storage can be unavailable in private browsing and text-only readers.
+  }
+  return "en";
+}
+
+function showLanguage(language, { remember = false } = {}) {
+  const available = document.querySelector(`[data-lang-content="${language}"]`);
+  const resolved = available ? language : "en";
+  document.querySelectorAll("[data-lang-content]").forEach((node) => {
+    node.hidden = node.dataset.langContent !== resolved;
+  });
+  document.documentElement.lang = resolved === "zh" ? "zh-CN" : "en";
+  const toggle = document.getElementById("lang-toggle");
+  if (toggle) {
+    const next = resolved === "zh" ? "en" : "zh";
+    toggle.dataset.nextLanguage = next;
+    toggle.setAttribute("aria-pressed", String(resolved === "zh"));
+    toggle.setAttribute(
+      "aria-label",
+      next === "zh" ? "Switch to Chinese (中文)" : "Switch to English",
+    );
+    document.getElementById("lang-toggle-label").textContent = next === "zh" ? "中" : "EN";
+  }
+  if (!remember || resolved !== language) return;
+  try {
+    localStorage.setItem(LANG_STORAGE_KEY, resolved);
+  } catch (_) {
+    // The page still switches even when preference storage is unavailable.
+  }
+}
+
+const toggle = document.getElementById("lang-toggle");
+if (toggle) {
+  toggle.addEventListener("click", () =>
+    showLanguage(toggle.dataset.nextLanguage || "zh", { remember: true }),
+  );
+}
+showLanguage(savedLanguage());

--- a/site/index.html
+++ b/site/index.html
@@ -349,6 +349,10 @@
       </a>
       <a href="/trends/" data-view="trends" aria-controls="trends-view" data-i18n="Trends">Trends</a>
       <a href="/explore/" data-view="map" aria-controls="map-view" data-i18n="Explore">Explore</a>
+      <!-- The blog is a set of documents, not a dashboard view, so this link
+           carries no data-view: app.js only intercepts clicks on elements that
+           have one, and a brief has to arrive as a full page load. -->
+      <a href="/blog/" data-i18n="Blog">Blog</a>
       <!-- These remain the same pop-up panels readers already use, but their
            hrefs give each one a server-rendered, indexable entry point. -->
       <a

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -12,7 +12,7 @@ showing a zero.
 
 The interactive dashboard has four views. Each heavy view also arrives with a
 server-delivered first screen in the same visual language. The benchmark
-directory is a set of plain pages that need no JavaScript to read.
+directory and the daily brief are plain pages that need no JavaScript to read.
 
 ## Start here
 
@@ -24,6 +24,7 @@ directory is a set of plain pages that need no JavaScript to read.
 - [Command-line access](https://benchmark-radar.org/cli/): how to install and use the offline benchmark search CLI.
 - [Citation information](https://benchmark-radar.org/cite/): the preferred project citation and machine-readable citation metadata.
 - [Scoring rubric](https://benchmark-radar.org/rubric/): how evidence is collected and scored.
+- [Daily brief](https://benchmark-radar.org/blog/): one page per collection day covering what appeared, how strong the evidence was, and what the record does not support. The [archive](https://benchmark-radar.org/blog/archive/) lists every day.
 
 ## Data
 
@@ -33,6 +34,7 @@ directory is a set of plain pages that need no JavaScript to read.
 - [leaderboard.json](https://benchmark-radar.org/data/leaderboard.json): the model card adoption ranking as standalone data. Also published as [leaderboard.csv](https://benchmark-radar.org/data/leaderboard.csv) and [leaderboard.md](https://benchmark-radar.org/data/leaderboard.md).
 - [records-badge.json](https://benchmark-radar.org/data/records-badge.json): the current number of collected records.
 - [RSS feed](https://benchmark-radar.org/feed.xml): one entry per collection day.
+- [Daily brief RSS feed](https://benchmark-radar.org/blog/feed.xml): one entry per published brief.
 - [sitemap.xml](https://benchmark-radar.org/sitemap.xml): every indexable page on the site.
 
 Per-benchmark data is served one file per benchmark under

--- a/src/benchmark_radar/blog.py
+++ b/src/benchmark_radar/blog.py
@@ -89,7 +89,7 @@ def _post_page(post: BlogPost) -> str:
         "author": {"@type": "Organization", "name": "Benchmark Radar"},
         "publisher": {"@id": f"{SITE_URL}/#organization"},
         "isPartOf": {"@id": SITE_URL + BLOG_PATH},
-        "citation": [url for _, url in post.sources],
+        "citation": [url for _, _, url in post.sources],
         "keywords": list(post.tags),
     }
     return render_page(

--- a/src/benchmark_radar/blog.py
+++ b/src/benchmark_radar/blog.py
@@ -24,6 +24,7 @@ collect that day.
 
 from __future__ import annotations
 
+import re
 import shutil
 from datetime import UTC, date, datetime, time
 from email.utils import format_datetime
@@ -46,6 +47,18 @@ from .site_shell import breadcrumb_schema, esc, webpage_schema
 
 LATEST_POST_LIMIT = 30
 
+# The dashboard's toggle and repo badges translate these at runtime; the
+# chrome's own data-i18n keys cover everything else.
+_TOGGLE_I18N_KEYS = ("Switch to Chinese (中文)", "Switch to English")
+_BADGE_I18N_KEYS = (
+    "Star this repository on GitHub. {count} stars",
+    "Fork this repository on GitHub. {count} forks",
+    "Open a new issue on GitHub. {count} issues open",
+)
+# The footer's build date prefix is baked in per page, after the keys were
+# collected from the raw extracted chrome, so it is listed here.
+_FOOTER_I18N_KEYS = ("Updated",)
+
 _INDEX_TITLE = "AI benchmark daily brief | Benchmark Radar"
 _INDEX_HEADING = "What changed in AI evaluation, and why it matters"
 _INDEX_DESCRIPTION = (
@@ -60,7 +73,7 @@ _ARCHIVE_DESCRIPTION = (
 )
 
 
-def _post_page(post: BlogPost, chrome: SiteChrome) -> str:
+def _post_page(post: BlogPost, chrome: SiteChrome, chrome_i18n: dict[str, str]) -> str:
     tags = "".join(f'<span class="blog-chip">{esc(tag)}</span>' for tag in post.tags)
 
     def language_body(language: str, content: str, *, hidden: bool) -> str:
@@ -106,6 +119,7 @@ def _post_page(post: BlogPost, chrome: SiteChrome) -> str:
         canonical=post.canonical,
         body=body,
         chrome=chrome,
+        chrome_i18n=chrome_i18n,
         updated=post.updated,
         schemas=(
             posting,
@@ -130,7 +144,9 @@ def _post_card(post: BlogPost) -> str:
 </article></li>"""
 
 
-def _index_page(posts: list[BlogPost], *, archive: bool, chrome: SiteChrome) -> str:
+def _index_page(
+    posts: list[BlogPost], *, archive: bool, chrome: SiteChrome, chrome_i18n: dict[str, str]
+) -> str:
     canonical = SITE_URL + (BLOG_ARCHIVE_PATH if archive else BLOG_PATH)
     shown = posts if archive else posts[:LATEST_POST_LIMIT]
     cards = "".join(_post_card(post) for post in shown) or (
@@ -171,6 +187,7 @@ def _index_page(posts: list[BlogPost], *, archive: bool, chrome: SiteChrome) -> 
         canonical=canonical,
         body=body,
         chrome=chrome,
+        chrome_i18n=chrome_i18n,
         updated=posts[0].updated if posts else "—",
         schemas=(
             webpage_schema(title=title, description=description, canonical=canonical),
@@ -234,15 +251,71 @@ def build_posts(snapshots: list[dict[str, Any]]) -> list[BlogPost]:
     return posts
 
 
+def _parse_zh_table(app_js: str) -> dict[str, str]:
+    """The reviewed English→Chinese strings from app.js's ``I18N.zh`` table."""
+    start = app_js.find("const I18N = {")
+    if start == -1:
+        raise ValueError(
+            "app.js no longer defines `const I18N`; the blog chrome cannot bake its translations"
+        )
+    open_brace = app_js.find("{", start)
+    depth = 0
+    end = -1
+    for index in range(open_brace, len(app_js)):
+        if app_js[index] == "{":
+            depth += 1
+        elif app_js[index] == "}":
+            depth -= 1
+            if depth == 0:
+                end = index
+                break
+    if end == -1:
+        raise ValueError(
+            "app.js's I18N table is unbalanced; the blog chrome cannot bake its translations"
+        )
+    table: dict[str, str] = {}
+    # Object keys are quoted or bare JS identifiers (both appear in the table).
+    pair = re.compile(r'(?:"((?:[^"\\]|\\.)*)"|([A-Za-z_$][\w$]*))\s*:\s*"((?:[^"\\]|\\.)*)"')
+    for quoted, bare, value in pair.findall(app_js[open_brace:end]):
+        table[quoted or bare] = value
+    return table
+
+
+def _chrome_i18n_script(chrome: SiteChrome, app_js: str) -> dict[str, str]:
+    """Bake the reviewed zh subset the chrome needs from app.js's I18N table.
+
+    The dashboard translates its chrome in place from the same table; the blog
+    has no app.js, so the needed entries ship with the page and blog.js applies
+    them with the same contract. Keys come from the chrome itself, so a new
+    badge or nav label is covered without touching this function.
+    """
+    chrome_html = chrome.header + chrome.navigation + chrome.footer
+    keys = set(re.findall(r'data-i18n(?:-title|-aria)?="([^"]+)"', chrome_html))
+    keys.update(_TOGGLE_I18N_KEYS)
+    keys.update(_BADGE_I18N_KEYS)
+    keys.update(_FOOTER_I18N_KEYS)
+    table = _parse_zh_table(app_js)
+    # Keys the table does not carry (short nav labels like Blog and Trends)
+    # stay English on the dashboard too — t() falls back to the key itself —
+    # so the blog mirrors that instead of inventing translations.
+    return {key: table[key] for key in sorted(keys) if key in table}
+
+
 def write_blog(
-    snapshots: list[dict[str, Any]], site_dir: Path, *, dashboard_html: str | None = None
+    snapshots: list[dict[str, Any]],
+    site_dir: Path,
+    *,
+    dashboard_html: str | None = None,
+    app_js: str | None = None,
 ) -> dict[str, Any]:
     """Write the whole blog tree atomically and report what it published.
 
     The chrome around every page is extracted from the dashboard source,
     ``site/index.html``, so the site has one masthead, nav, and footer rather
-    than two drifting copies. Tests pass ``dashboard_html`` explicitly; the
-    default reads the committed dashboard beside the output directory.
+    than two drifting copies. The zh strings the chrome needs are baked from
+    app.js's I18N table for the same reason. Tests pass both sources
+    explicitly; the defaults read the committed files beside the output
+    directory.
     """
     if dashboard_html is None:
         dashboard_source = site_dir / "index.html"
@@ -252,7 +325,16 @@ def write_blog(
                 f"source, which is missing at {dashboard_source}"
             )
         dashboard_html = dashboard_source.read_text(encoding="utf-8")
+    if app_js is None:
+        app_js_source = site_dir / "assets" / "app.js"
+        if not app_js_source.is_file():
+            raise FileNotFoundError(
+                "the blog chrome translations are baked from the committed "
+                f"app.js, which is missing at {app_js_source}"
+            )
+        app_js = app_js_source.read_text(encoding="utf-8")
     chrome = extract_site_chrome(dashboard_html)
+    chrome_i18n = _chrome_i18n_script(chrome, app_js)
     posts = build_posts(snapshots)
     output_dir = site_dir / "blog"
     staging = site_dir / "blog.staging"
@@ -260,17 +342,21 @@ def write_blog(
         shutil.rmtree(staging)
     staging.mkdir(parents=True)
     (staging / "index.html").write_text(
-        _index_page(posts, archive=False, chrome=chrome), encoding="utf-8"
+        _index_page(posts, archive=False, chrome=chrome, chrome_i18n=chrome_i18n),
+        encoding="utf-8",
     )
     archive_dir = staging / "archive"
     archive_dir.mkdir()
     (archive_dir / "index.html").write_text(
-        _index_page(posts, archive=True, chrome=chrome), encoding="utf-8"
+        _index_page(posts, archive=True, chrome=chrome, chrome_i18n=chrome_i18n),
+        encoding="utf-8",
     )
     for post in posts:
         page_dir = staging / post.slug
         page_dir.mkdir()
-        (page_dir / "index.html").write_text(_post_page(post, chrome), encoding="utf-8")
+        (page_dir / "index.html").write_text(
+            _post_page(post, chrome, chrome_i18n), encoding="utf-8"
+        )
     tree = blog_feed_tree(posts)
     ET.indent(tree, space="  ")
     tree.write(staging / "feed.xml", encoding="utf-8", xml_declaration=True)

--- a/src/benchmark_radar/blog.py
+++ b/src/benchmark_radar/blog.py
@@ -1,0 +1,260 @@
+"""Publish one page per collection day under /blog/.
+
+The site already had two ways to look at the daily corpus: the dashboard's
+Today view, which shows one day at a time behind JavaScript, and feed.xml,
+which lists a one-line count summary per day. Neither is a page. The briefing
+text, the six question answers, the cited statistics and the counter-views that
+the pipeline writes into every snapshot were stored and never displayed
+anywhere a reader or a crawler could reach them, so the most readable thing the
+project produces was also its least visible.
+
+This module gives each committed snapshot a URL. Every page is derived from the
+snapshot and only from the snapshot, so the output directory is generated,
+gitignored, and replaced wholesale on each build rather than patched. A day
+that leaves the history loses its page in the same run, which is why the whole
+tree is staged and swapped instead of written in place: a half-written blog
+that still serves last build's pages under this build's sitemap is worse than
+no blog.
+
+Calendar days with no snapshot get no page. Inventing an empty post for a day
+the collector did not run would put a URL in the sitemap that reports nothing,
+and the gap in the archive is itself accurate: it says the radar did not
+collect that day.
+"""
+
+from __future__ import annotations
+
+import shutil
+from datetime import UTC, date, datetime, time
+from email.utils import format_datetime
+from pathlib import Path
+from typing import Any
+from xml.etree import ElementTree as ET
+
+from .blog_content import build_post
+from .blog_shell import BLOG_ARCHIVE_PATH, BLOG_FEED_PATH, BLOG_PATH, BlogPost, render_page
+from .feed import ATOM_NAMESPACE, SITE_URL
+from .site_shell import breadcrumb_schema, esc, webpage_schema
+
+LATEST_POST_LIMIT = 30
+
+_INDEX_TITLE = "AI benchmark daily brief | Benchmark Radar"
+_INDEX_HEADING = "What changed in AI evaluation, and why it matters"
+_INDEX_DESCRIPTION = (
+    "One page per collection day: what new benchmarks and evaluations appeared, "
+    "how strong the evidence was, and which claims the record does not support."
+)
+_ARCHIVE_TITLE = "Daily brief archive | Benchmark Radar"
+_ARCHIVE_HEADING = "Every collection day on record"
+_ARCHIVE_DESCRIPTION = (
+    "The complete archive of Benchmark Radar daily briefs, one page for every "
+    "day the radar collected evidence."
+)
+
+
+def _post_page(post: BlogPost) -> str:
+    tags = "".join(f'<span class="blog-chip">{esc(tag)}</span>' for tag in post.tags)
+
+    def language_body(language: str, content: str, *, hidden: bool) -> str:
+        title = post.title_zh if language == "zh" and post.title_zh else post.title
+        description = (
+            post.description_zh if language == "zh" and post.description_zh else post.description
+        )
+        hidden_attr = " hidden" if hidden else ""
+        return f"""<div data-lang-content="{language}"{hidden_attr}>
+<header class="blog-hero">
+  <p class="eyebrow">{esc(post.kind)}</p>
+  <h1>{esc(title)}</h1>
+  <p class="blog-lede">{esc(description)}</p>
+  <p class="blog-meta"><time datetime="{esc(post.published)}">{esc(post.published)}</time></p>
+  <div class="blog-tags">{tags}</div>
+</header>
+<div class="blog-prose">{content}</div>
+</div>"""
+
+    body = language_body("en", post.body_en, hidden=False)
+    if post.body_zh is not None:
+        body += language_body("zh", post.body_zh, hidden=True)
+    posting = {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "@id": post.canonical,
+        "headline": post.title,
+        "description": post.description,
+        "url": post.canonical,
+        "mainEntityOfPage": post.canonical,
+        "datePublished": post.published,
+        "dateModified": post.updated,
+        "inLanguage": ["en", "zh-Hans"] if post.translated else "en",
+        "author": {"@type": "Organization", "name": "Benchmark Radar"},
+        "publisher": {"@id": f"{SITE_URL}/#organization"},
+        "isPartOf": {"@id": SITE_URL + BLOG_PATH},
+        "citation": [url for _, url in post.sources],
+        "keywords": list(post.tags),
+    }
+    return render_page(
+        title=f"{post.title} | Benchmark Radar",
+        description=post.description,
+        canonical=post.canonical,
+        body=body,
+        schemas=(
+            posting,
+            breadcrumb_schema(
+                ("Benchmark Radar", f"{SITE_URL}/"),
+                ("Blog", SITE_URL + BLOG_PATH),
+                (post.title, post.canonical),
+                canonical=post.canonical,
+            ),
+        ),
+        og_type="article",
+        translated=post.translated,
+    )
+
+
+def _post_card(post: BlogPost) -> str:
+    return f"""<li><article class="blog-card">
+  <div><span class="blog-chip">{esc(post.kind)}</span>
+  <h2><a href="{esc(post.canonical)}">{esc(post.title)}</a></h2></div>
+  <time class="blog-meta" datetime="{esc(post.published)}">{esc(post.published)}</time>
+  <p>{esc(post.description)}</p>
+</article></li>"""
+
+
+def _index_page(posts: list[BlogPost], *, archive: bool) -> str:
+    canonical = SITE_URL + (BLOG_ARCHIVE_PATH if archive else BLOG_PATH)
+    shown = posts if archive else posts[:LATEST_POST_LIMIT]
+    cards = "".join(_post_card(post) for post in shown) or (
+        '<li class="blog-panel">No collection days are on record yet.</li>'
+    )
+    if archive:
+        title, heading, description = _ARCHIVE_TITLE, _ARCHIVE_HEADING, _ARCHIVE_DESCRIPTION
+        action = f'<a class="secondary-link" href="{SITE_URL}{BLOG_PATH}">Latest briefs</a>'
+        crumb = "Blog archive"
+    else:
+        title, heading, description = _INDEX_TITLE, _INDEX_HEADING, _INDEX_DESCRIPTION
+        action = f'<a class="secondary-link" href="{SITE_URL}{BLOG_ARCHIVE_PATH}">Full archive</a>'
+        crumb = "Blog"
+    count = (
+        f"{len(shown)} of {len(posts)} collection days"
+        if not archive and len(shown) < len(posts)
+        else f"{len(posts)} collection days"
+    )
+    body = f"""<header class="blog-hero">
+  <p class="eyebrow">Daily brief</p><h1>{esc(heading)}</h1>
+  <p class="blog-lede">{esc(description)}</p>
+  <p class="blog-meta">{esc(count)}</p>
+  <div class="blog-actions">{action}
+    <a class="secondary-link" href="{BLOG_FEED_PATH}">RSS</a></div>
+</header>
+<ol class="blog-index">{cards}</ol>"""
+    item_list = {
+        "@context": "https://schema.org",
+        "@type": "ItemList",
+        "itemListElement": [
+            {"@type": "ListItem", "position": index, "url": post.canonical}
+            for index, post in enumerate(shown, start=1)
+        ],
+    }
+    return render_page(
+        title=title,
+        description=description,
+        canonical=canonical,
+        body=body,
+        schemas=(
+            webpage_schema(title=title, description=description, canonical=canonical),
+            item_list,
+            breadcrumb_schema(
+                ("Benchmark Radar", f"{SITE_URL}/"),
+                (crumb, canonical),
+                canonical=canonical,
+            ),
+        ),
+    )
+
+
+def blog_feed_tree(posts: list[BlogPost]) -> ET.ElementTree:
+    """A feed of the blog itself, separate from the site feed.
+
+    ``/feed.xml`` publishes one count summary per collection day and points at
+    the dashboard. This one points at the written pages and carries their
+    descriptions, so a subscriber to either gets what that feed promised
+    instead of two feeds racing to describe the same days differently.
+    """
+    root = ET.Element("rss", {"version": "2.0"})
+    channel = ET.SubElement(root, "channel")
+    ET.SubElement(channel, "title").text = "Benchmark Radar daily brief"
+    ET.SubElement(channel, "link").text = SITE_URL + BLOG_PATH
+    ET.SubElement(channel, "description").text = _INDEX_DESCRIPTION
+    ET.SubElement(channel, "language").text = "en"
+    ET.SubElement(
+        channel,
+        f"{{{ATOM_NAMESPACE}}}link",
+        {
+            "href": SITE_URL + BLOG_FEED_PATH,
+            "rel": "self",
+            "type": "application/rss+xml",
+        },
+    )
+    if posts:
+        newest = max(date.fromisoformat(post.updated) for post in posts)
+        ET.SubElement(channel, "lastBuildDate").text = format_datetime(
+            datetime.combine(newest, time.min, tzinfo=UTC), usegmt=True
+        )
+    for post in posts:
+        published = datetime.combine(date.fromisoformat(post.published), time.min, tzinfo=UTC)
+        item = ET.SubElement(channel, "item")
+        ET.SubElement(item, "title").text = post.title
+        ET.SubElement(item, "link").text = post.canonical
+        ET.SubElement(item, "guid", {"isPermaLink": "true"}).text = post.canonical
+        ET.SubElement(item, "pubDate").text = format_datetime(published, usegmt=True)
+        ET.SubElement(item, "description").text = post.description
+    return ET.ElementTree(root)
+
+
+def build_posts(snapshots: list[dict[str, Any]]) -> list[BlogPost]:
+    """One post per snapshot, newest first, with duplicate days rejected."""
+    posts = [build_post(snapshot) for snapshot in snapshots]
+    slugs = [post.slug for post in posts]
+    duplicates = sorted({slug for slug in slugs if slugs.count(slug) > 1})
+    if duplicates:
+        raise ValueError(f"duplicate snapshot dates cannot share a blog URL: {duplicates}")
+    posts.sort(key=lambda post: post.slug, reverse=True)
+    return posts
+
+
+def write_blog(snapshots: list[dict[str, Any]], site_dir: Path) -> dict[str, Any]:
+    """Write the whole blog tree atomically and report what it published."""
+    posts = build_posts(snapshots)
+    output_dir = site_dir / "blog"
+    staging = site_dir / "blog.staging"
+    if staging.exists():
+        shutil.rmtree(staging)
+    staging.mkdir(parents=True)
+    (staging / "index.html").write_text(_index_page(posts, archive=False), encoding="utf-8")
+    archive_dir = staging / "archive"
+    archive_dir.mkdir()
+    (archive_dir / "index.html").write_text(_index_page(posts, archive=True), encoding="utf-8")
+    for post in posts:
+        page_dir = staging / post.slug
+        page_dir.mkdir()
+        (page_dir / "index.html").write_text(_post_page(post), encoding="utf-8")
+    tree = blog_feed_tree(posts)
+    ET.indent(tree, space="  ")
+    tree.write(staging / "feed.xml", encoding="utf-8", xml_declaration=True)
+
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
+    staging.rename(output_dir)
+
+    lastmod = max((post.updated for post in posts), default=None)
+    sitemap_entries: list[tuple[str, str | None]] = [
+        (BLOG_PATH, lastmod),
+        (BLOG_ARCHIVE_PATH, lastmod),
+    ]
+    sitemap_entries.extend((post.path, post.updated) for post in posts)
+    return {
+        "post_count": len(posts),
+        "page_count": len(posts) + 2,
+        "sitemap_entries": sitemap_entries,
+        "output_dir": output_dir,
+    }

--- a/src/benchmark_radar/blog.py
+++ b/src/benchmark_radar/blog.py
@@ -32,7 +32,15 @@ from typing import Any
 from xml.etree import ElementTree as ET
 
 from .blog_content import build_post
-from .blog_shell import BLOG_ARCHIVE_PATH, BLOG_FEED_PATH, BLOG_PATH, BlogPost, render_page
+from .blog_shell import (
+    BLOG_ARCHIVE_PATH,
+    BLOG_FEED_PATH,
+    BLOG_PATH,
+    BlogPost,
+    SiteChrome,
+    extract_site_chrome,
+    render_page,
+)
 from .feed import ATOM_NAMESPACE, SITE_URL
 from .site_shell import breadcrumb_schema, esc, webpage_schema
 
@@ -52,7 +60,7 @@ _ARCHIVE_DESCRIPTION = (
 )
 
 
-def _post_page(post: BlogPost) -> str:
+def _post_page(post: BlogPost, chrome: SiteChrome) -> str:
     tags = "".join(f'<span class="blog-chip">{esc(tag)}</span>' for tag in post.tags)
 
     def language_body(language: str, content: str, *, hidden: bool) -> str:
@@ -97,6 +105,8 @@ def _post_page(post: BlogPost) -> str:
         description=post.description,
         canonical=post.canonical,
         body=body,
+        chrome=chrome,
+        updated=post.updated,
         schemas=(
             posting,
             breadcrumb_schema(
@@ -120,7 +130,7 @@ def _post_card(post: BlogPost) -> str:
 </article></li>"""
 
 
-def _index_page(posts: list[BlogPost], *, archive: bool) -> str:
+def _index_page(posts: list[BlogPost], *, archive: bool, chrome: SiteChrome) -> str:
     canonical = SITE_URL + (BLOG_ARCHIVE_PATH if archive else BLOG_PATH)
     shown = posts if archive else posts[:LATEST_POST_LIMIT]
     cards = "".join(_post_card(post) for post in shown) or (
@@ -160,6 +170,8 @@ def _index_page(posts: list[BlogPost], *, archive: bool) -> str:
         description=description,
         canonical=canonical,
         body=body,
+        chrome=chrome,
+        updated=posts[0].updated if posts else "—",
         schemas=(
             webpage_schema(title=title, description=description, canonical=canonical),
             item_list,
@@ -222,22 +234,43 @@ def build_posts(snapshots: list[dict[str, Any]]) -> list[BlogPost]:
     return posts
 
 
-def write_blog(snapshots: list[dict[str, Any]], site_dir: Path) -> dict[str, Any]:
-    """Write the whole blog tree atomically and report what it published."""
+def write_blog(
+    snapshots: list[dict[str, Any]], site_dir: Path, *, dashboard_html: str | None = None
+) -> dict[str, Any]:
+    """Write the whole blog tree atomically and report what it published.
+
+    The chrome around every page is extracted from the dashboard source,
+    ``site/index.html``, so the site has one masthead, nav, and footer rather
+    than two drifting copies. Tests pass ``dashboard_html`` explicitly; the
+    default reads the committed dashboard beside the output directory.
+    """
+    if dashboard_html is None:
+        dashboard_source = site_dir / "index.html"
+        if not dashboard_source.is_file():
+            raise FileNotFoundError(
+                "the blog chrome is extracted from the committed dashboard "
+                f"source, which is missing at {dashboard_source}"
+            )
+        dashboard_html = dashboard_source.read_text(encoding="utf-8")
+    chrome = extract_site_chrome(dashboard_html)
     posts = build_posts(snapshots)
     output_dir = site_dir / "blog"
     staging = site_dir / "blog.staging"
     if staging.exists():
         shutil.rmtree(staging)
     staging.mkdir(parents=True)
-    (staging / "index.html").write_text(_index_page(posts, archive=False), encoding="utf-8")
+    (staging / "index.html").write_text(
+        _index_page(posts, archive=False, chrome=chrome), encoding="utf-8"
+    )
     archive_dir = staging / "archive"
     archive_dir.mkdir()
-    (archive_dir / "index.html").write_text(_index_page(posts, archive=True), encoding="utf-8")
+    (archive_dir / "index.html").write_text(
+        _index_page(posts, archive=True, chrome=chrome), encoding="utf-8"
+    )
     for post in posts:
         page_dir = staging / post.slug
         page_dir.mkdir()
-        (page_dir / "index.html").write_text(_post_page(post), encoding="utf-8")
+        (page_dir / "index.html").write_text(_post_page(post, chrome), encoding="utf-8")
     tree = blog_feed_tree(posts)
     ET.indent(tree, space="  ")
     tree.write(staging / "feed.xml", encoding="utf-8", xml_declaration=True)

--- a/src/benchmark_radar/blog.py
+++ b/src/benchmark_radar/blog.py
@@ -131,7 +131,6 @@ def _post_page(post: BlogPost, chrome: SiteChrome, chrome_i18n: dict[str, str]) 
             ),
         ),
         og_type="article",
-        translated=post.translated,
     )
 
 

--- a/src/benchmark_radar/blog_content.py
+++ b/src/benchmark_radar/blog_content.py
@@ -390,7 +390,9 @@ def _sources_section(sources: tuple[tuple[str, str, str], ...], language: str) -
         f'<li>{_cite_id(identifier)}<a href="{esc(url)}">{esc(title)}</a></li>'
         for identifier, title, url in sources
     )
-    return _section(_LABELS[language]["sources"], f'<ol class="blog-evidence">{links}</ol>')
+    # Unnumbered on purpose: the stored ID is how the prose refers to a source,
+    # and a list counter beside it reads as a second, contradictory number.
+    return _section(_LABELS[language]["sources"], f'<ul class="blog-evidence">{links}</ul>')
 
 
 def _cite_id(identifier: str) -> str:

--- a/src/benchmark_radar/blog_content.py
+++ b/src/benchmark_radar/blog_content.py
@@ -67,6 +67,38 @@ _LABELS = {
     },
 }
 
+# The question and group headings are the fixed prompts in questions.py, stored
+# in English in every snapshot because that is the text the model was asked.
+# The dashboard translates them client-side against the same English keys, so a
+# Chinese brief has to do the same or it publishes English headings inside a
+# document declared zh-CN. Keys the table does not carry fall back to English,
+# which is what the dashboard does with the same string.
+# tests/test_blog.py checks every value here against the dashboard's table, so
+# the two surfaces cannot drift into translating the same prompt differently.
+_QUESTION_ZH = {
+    "What arrived": "今日新增",
+    "What is still moving": "仍在变动",
+    "What it means": "这意味着什么",
+    "What benchmarks, datasets, or evaluation methods did the radar first see today?": (
+        "雷达今天首次看到了哪些benchmark、数据集或评估方法？"
+    ),
+    "Which of today's arrivals document how they score an answer?": (
+        "今天的哪些新增条目记录了它们如何给答案评分？"
+    ),
+    "Which artifacts the radar already tracked moved measurably, and over what span?": (
+        "雷达已跟踪的哪些条目出现了可测变动，跨度如何？"
+    ),
+    "Which of that movement is corroborated by more than one data source?": (
+        "其中哪些变动得到了不止一个数据源的印证？"
+    ),
+    "What does today's evidence fail to show, and what would change the reading?": (
+        "今天的证据未能说明什么，什么会改变这一解读？"
+    ),
+    "What should someone building or evaluating AI systems do differently today?": (
+        "构建或评估 AI 系统的人今天应该做哪些不同的选择？"
+    ),
+}
+
 
 def _safe_url(value: Any) -> str | None:
     """Accept only an absolute http(s) URL, so a stored value cannot inject a scheme."""
@@ -135,8 +167,15 @@ def _description_zh(snapshot: dict[str, Any]) -> str | None:
     return _clip(str(bullets[0]), trailing="，。；：")
 
 
-def _citations(snapshot: dict[str, Any], *, allow_fallback: bool) -> tuple[tuple[str, str], ...]:
-    """The documents this day's text actually cited.
+def _citations(
+    snapshot: dict[str, Any], *, allow_fallback: bool
+) -> tuple[tuple[str, str, str], ...]:
+    """The documents this day's text actually cited, each with its stored ID.
+
+    The briefing prose cites evidence by ID ("Evidence: E011"), and the IDs are
+    not contiguous, so the list position is not the ID. Carrying the stored
+    identifier through is what lets a reader resolve a cited ID to its link;
+    without it a page can say E011 and show that document as item 3.
 
     A ``no_material_insight`` briefing cites nothing by design, but its question
     answers still cite the records they read, so those days are not left with an
@@ -145,9 +184,10 @@ def _citations(snapshot: dict[str, Any], *, allow_fallback: bool) -> tuple[tuple
     ``allow_fallback`` backfills the day's own evidence when a stored briefing
     cited nothing at all, so its claims still lead somewhere. It is off for a
     day with no briefing, because that page already lists its evidence records
-    and would otherwise print the same links twice under two headings.
+    and would otherwise print the same links twice under two headings. Those
+    backfilled records were not cited by ID, so they carry no identifier.
     """
-    citations: list[tuple[str, str]] = []
+    citations: list[tuple[str, str, str]] = []
     seen: set[str] = set()
 
     def collect(entries: Any) -> None:
@@ -159,7 +199,7 @@ def _citations(snapshot: dict[str, Any], *, allow_fallback: bool) -> tuple[tuple
                 continue
             seen.add(url)
             title = str(citation.get("title") or citation.get("source") or url).strip()
-            citations.append((title, url))
+            citations.append((str(citation.get("id") or "").strip(), title, url))
 
     collect(_briefing_of(snapshot).get("citations"))
     for _, answer in _answers(snapshot):
@@ -171,7 +211,7 @@ def _citations(snapshot: dict[str, Any], *, allow_fallback: bool) -> tuple[tuple
         if url is None or url in seen:
             continue
         seen.add(url)
-        citations.append((str(item.get("title") or item.get("source") or url), url))
+        citations.append(("", str(item.get("title") or item.get("source") or url), url))
         if len(citations) == _CITATION_FALLBACK_LIMIT:
             break
     return tuple(citations)
@@ -222,12 +262,27 @@ def _briefing_section(snapshot: dict[str, Any], language: str) -> str:
 
 
 def _stat_line(stat: dict[str, Any]) -> str:
+    """One cited figure, shown with the S### ID the answer text refers to.
+
+    The answers cite figures by registry ID rather than by name, so a line that
+    prints only the label leaves the reader unable to match "S020" in the prose
+    to the number underneath it.
+    """
     value = stat.get("value")
     rendered = f"{value:,}" if isinstance(value, (int, float)) else str(value or "—")
     unit = str(stat.get("unit") or "").strip()
     suffix = f" {unit}" if unit and unit != "count" else ""
-    label = stat.get("label") or stat.get("id") or "Statistic"
-    return f"{esc(label)}: <strong>{esc(rendered)}{esc(suffix)}</strong>"
+    identifier = str(stat.get("id") or "").strip()
+    label = str(stat.get("label") or identifier or "Statistic")
+    prefix = _cite_id(identifier) if identifier and label != identifier else ""
+    return f"{prefix}{esc(label)}: <strong>{esc(rendered)}{esc(suffix)}</strong>"
+
+
+def _prompt(text: str, language: str) -> str:
+    """A fixed question or group heading in the reading language."""
+    if language != "zh":
+        return text
+    return _QUESTION_ZH.get(text, text)
 
 
 def _answer_html(answer: dict[str, Any], language: str) -> str:
@@ -238,7 +293,7 @@ def _answer_html(answer: dict[str, Any], language: str) -> str:
         value = answer.get(translated_key) if zh else None
         return str(value or answer.get(base) or "").strip()
 
-    question = pick("question", "question_zh") or labels["questions"]
+    question = _prompt(pick("question", "question_zh"), language) or labels["questions"]
     signal = pick("signal", "signal_zh")
     plain = pick("plain_english", "plain_chinese")
     takeaway = pick("takeaway", "takeaway_zh")
@@ -271,7 +326,9 @@ def _questions_section(snapshot: dict[str, Any], language: str) -> str:
     grouped: dict[str, list[str]] = {}
     for title, answer in _answers(snapshot):
         grouped.setdefault(title, []).append(_answer_html(answer, language))
-    return "".join(_section(title, "".join(items)) for title, items in grouped.items())
+    return "".join(
+        _section(_prompt(title, language), "".join(items)) for title, items in grouped.items()
+    )
 
 
 def _provenance_section(snapshot: dict[str, Any], language: str) -> str:
@@ -326,11 +383,19 @@ def _provenance_section(snapshot: dict[str, Any], language: str) -> str:
     )
 
 
-def _sources_section(sources: tuple[tuple[str, str], ...], language: str) -> str:
+def _sources_section(sources: tuple[tuple[str, str, str], ...], language: str) -> str:
     if not sources:
         return ""
-    links = "".join(f'<li><a href="{esc(url)}">{esc(title)}</a></li>' for title, url in sources)
+    links = "".join(
+        f'<li>{_cite_id(identifier)}<a href="{esc(url)}">{esc(title)}</a></li>'
+        for identifier, title, url in sources
+    )
     return _section(_LABELS[language]["sources"], f'<ol class="blog-evidence">{links}</ol>')
+
+
+def _cite_id(identifier: str) -> str:
+    """The stored citation ID, shown so prose that says E011 can be followed."""
+    return f'<span class="blog-cite-id">{esc(identifier)}</span> ' if identifier else ""
 
 
 def _kind(snapshot: dict[str, Any]) -> str:

--- a/src/benchmark_radar/blog_content.py
+++ b/src/benchmark_radar/blog_content.py
@@ -1,0 +1,381 @@
+"""Turn one committed daily snapshot into one rendered brief.
+
+Nothing in here calls a model or reaches the network. The briefing text, the
+question answers, the Chinese translation and the citations were all written
+when the snapshot was produced and stored in it; this module only decides how
+to lay them out. That is what makes a rebuild deterministic and what makes the
+`classify` step safe to run in CI.
+
+Three kinds of day exist in the committed history, and each gets a page that
+says which kind it is:
+
+* a snapshot with a full stored briefing, which is the normal case;
+* a snapshot whose briefing reported ``no_material_insight``, which is a
+  finding and is published unchanged, because "nothing moved enough to call it
+  a change" is the honest report for that day and hiding it would leave a hole
+  in the record;
+* an early snapshot from before briefings were stored, which gets a labelled
+  deterministic summary of the evidence it does hold and never pretends to be
+  a synthesized briefing.
+
+A field the snapshot does not carry is omitted, never filled in. The old build
+printed "briefing model: deterministic snapshot summary" and "0 of 0" evidence
+records for a day that had simply stored bullets without generator metadata,
+which invents provenance for text nobody can trace.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import urlparse
+
+from .blog_shell import BlogPost
+from .site_shell import esc
+
+_DESCRIPTION_LIMIT = 155
+_EVIDENCE_FALLBACK_LIMIT = 10
+_CITATION_FALLBACK_LIMIT = 20
+
+KIND_BRIEF = "Daily brief"
+KIND_NO_CHANGE = "No material change"
+KIND_EVIDENCE = "Evidence summary"
+
+_LABELS = {
+    "en": {
+        "briefing": "Daily briefing",
+        "evidence": "What the radar collected that day",
+        "sources": "Evidence sources",
+        "provenance": "Where this came from, and what it does not cover",
+        "takeaway": "Takeaway",
+        "counter": "Another reading",
+        "insufficient": "Not enough evidence",
+        "questions": "Questions",
+        "confidence": "confidence",
+        "empty": "No evidence observations were recorded for this day.",
+    },
+    "zh": {
+        "briefing": "每日简报",
+        "evidence": "当天雷达收集到的内容",
+        "sources": "证据来源",
+        "provenance": "内容来源与局限",
+        "takeaway": "结论",
+        "counter": "另一种解读",
+        "insufficient": "证据不足",
+        "questions": "问题",
+        "confidence": "置信度",
+        "empty": "当天没有记录到任何证据观察。",
+    },
+}
+
+
+def _safe_url(value: Any) -> str | None:
+    """Accept only an absolute http(s) URL, so a stored value cannot inject a scheme."""
+    url = str(value or "").strip()
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return None
+    return url
+
+
+def _briefing_of(snapshot: dict[str, Any]) -> dict[str, Any]:
+    briefing = snapshot.get("briefing")
+    return briefing if isinstance(briefing, dict) else {}
+
+
+def _answers(snapshot: dict[str, Any]) -> list[tuple[str, dict[str, Any]]]:
+    """Every stored answer, paired with the title of the group it belongs to."""
+    groups = (snapshot.get("questions") or {}).get("groups") or []
+    return [
+        (str(group.get("title") or _LABELS["en"]["questions"]), answer)
+        for group in groups
+        for answer in group.get("answers") or []
+        if isinstance(answer, dict)
+    ]
+
+
+def _attention(snapshot: dict[str, Any]) -> list[Any]:
+    raw = snapshot.get("attention")
+    if isinstance(raw, dict):
+        return list(raw.get("observations") or [])
+    return list(raw or [])
+
+
+def has_translation(snapshot: dict[str, Any]) -> bool:
+    """True when the snapshot stored reviewed Chinese text for this day."""
+    if _briefing_of(snapshot).get("bullets_zh"):
+        return True
+    return any(
+        answer.get("signal_zh") or answer.get("plain_chinese") for _, answer in _answers(snapshot)
+    )
+
+
+def _clip(text: str, *, trailing: str = ".,;:") -> str:
+    text = " ".join(str(text).split())
+    if len(text) <= _DESCRIPTION_LIMIT:
+        return text
+    return text[:_DESCRIPTION_LIMIT].rsplit(" ", 1)[0].rstrip(trailing) + "…"
+
+
+def _description(snapshot: dict[str, Any]) -> str:
+    bullets = _briefing_of(snapshot).get("bullets") or []
+    if bullets:
+        return _clip(str(bullets[0]).split(" Why it matters:", 1)[0])
+    evidence = snapshot.get("evidence_items") or []
+    sources = {str(item.get("source") or "") for item in evidence if item.get("source")}
+    return (
+        f"Benchmark Radar collected {len(evidence)} evidence observations from "
+        f"{len(sources)} sources on {snapshot.get('date')}."
+    )
+
+
+def _description_zh(snapshot: dict[str, Any]) -> str | None:
+    bullets = _briefing_of(snapshot).get("bullets_zh") or []
+    if not bullets:
+        return None
+    return _clip(str(bullets[0]), trailing="，。；：")
+
+
+def _citations(snapshot: dict[str, Any], *, allow_fallback: bool) -> tuple[tuple[str, str], ...]:
+    """The documents this day's text actually cited.
+
+    A ``no_material_insight`` briefing cites nothing by design, but its question
+    answers still cite the records they read, so those days are not left with an
+    empty source list.
+
+    ``allow_fallback`` backfills the day's own evidence when a stored briefing
+    cited nothing at all, so its claims still lead somewhere. It is off for a
+    day with no briefing, because that page already lists its evidence records
+    and would otherwise print the same links twice under two headings.
+    """
+    citations: list[tuple[str, str]] = []
+    seen: set[str] = set()
+
+    def collect(entries: Any) -> None:
+        for citation in entries or []:
+            if not isinstance(citation, dict):
+                continue
+            url = _safe_url(citation.get("url"))
+            if url is None or url in seen:
+                continue
+            seen.add(url)
+            title = str(citation.get("title") or citation.get("source") or url).strip()
+            citations.append((title, url))
+
+    collect(_briefing_of(snapshot).get("citations"))
+    for _, answer in _answers(snapshot):
+        collect(answer.get("cited_evidence"))
+    if citations or not allow_fallback:
+        return tuple(citations)
+    for item in snapshot.get("evidence_items") or []:
+        url = _safe_url(item.get("url"))
+        if url is None or url in seen:
+            continue
+        seen.add(url)
+        citations.append((str(item.get("title") or item.get("source") or url), url))
+        if len(citations) == _CITATION_FALLBACK_LIMIT:
+            break
+    return tuple(citations)
+
+
+def _stats(snapshot: dict[str, Any]) -> str:
+    evidence = snapshot.get("evidence_items") or []
+    sources = {str(item.get("source") or "") for item in evidence if item.get("source")}
+    sources.discard("")
+    cells = (
+        (len(evidence), "evidence observations"),
+        (len(sources), "sources represented"),
+        (len(_attention(snapshot)), "public-attention signals"),
+    )
+    return "".join(
+        f'<div class="blog-stat"><strong>{value:,}</strong><span>{label}</span></div>'
+        for value, label in cells
+    )
+
+
+def _section(heading: str, body: str) -> str:
+    return (
+        '<section class="blog-section">'
+        f'<div class="blog-section-heading"><h2>{esc(heading)}</h2></div>'
+        f"{body}</section>"
+    )
+
+
+def _briefing_section(snapshot: dict[str, Any], language: str) -> str:
+    """The stored briefing bullets, or a labelled evidence list for a legacy day."""
+    labels = _LABELS[language]
+    briefing = _briefing_of(snapshot)
+    bullets = briefing.get("bullets_zh" if language == "zh" else "bullets") or briefing.get(
+        "bullets"
+    )
+    if bullets:
+        items = "".join(f'<li class="blog-card">{esc(bullet)}</li>' for bullet in bullets)
+        return _section(labels["briefing"], f'<ol class="blog-index">{items}</ol>')
+    rendered: list[str] = []
+    for item in (snapshot.get("evidence_items") or [])[:_EVIDENCE_FALLBACK_LIMIT]:
+        title = esc(item.get("title") or "Untitled")
+        url = _safe_url(item.get("url"))
+        heading = f'<a href="{esc(url)}">{title}</a>' if url else title
+        source = esc(item.get("source") or "Unknown source")
+        rendered.append(f'<li class="blog-card">{heading}<p>{source}</p></li>')
+    items = "".join(rendered) or f'<li class="blog-card">{esc(labels["empty"])}</li>'
+    return _section(labels["evidence"], f'<ol class="blog-index">{items}</ol>')
+
+
+def _stat_line(stat: dict[str, Any]) -> str:
+    value = stat.get("value")
+    rendered = f"{value:,}" if isinstance(value, (int, float)) else str(value or "—")
+    unit = str(stat.get("unit") or "").strip()
+    suffix = f" {unit}" if unit and unit != "count" else ""
+    label = stat.get("label") or stat.get("id") or "Statistic"
+    return f"{esc(label)}: <strong>{esc(rendered)}{esc(suffix)}</strong>"
+
+
+def _answer_html(answer: dict[str, Any], language: str) -> str:
+    labels = _LABELS[language]
+    zh = language == "zh"
+
+    def pick(base: str, translated_key: str) -> str:
+        value = answer.get(translated_key) if zh else None
+        return str(value or answer.get(base) or "").strip()
+
+    question = pick("question", "question_zh") or labels["questions"]
+    signal = pick("signal", "signal_zh")
+    plain = pick("plain_english", "plain_chinese")
+    takeaway = pick("takeaway", "takeaway_zh")
+    counter = pick("counter_view", "counter_view_zh")
+    confidence = str(answer.get("confidence") or "unrated")
+    stats = "".join(f"<li>{_stat_line(stat)}</li>" for stat in answer.get("cited_stats") or [])
+    stats_html = f'<ul class="blog-list">{stats}</ul>' if stats else ""
+    status_html = (
+        f'<span class="blog-chip">{esc(labels["insufficient"])}</span>'
+        if not answer.get("sufficient_evidence", True)
+        else ""
+    )
+    body = "".join(f"<p>{esc(text)}</p>" for text in (signal, plain) if text)
+    if takeaway:
+        body += f"<p><strong>{esc(labels['takeaway'])}:</strong> {esc(takeaway)}</p>"
+    if counter:
+        body += (
+            f'<p class="blog-caveat"><strong>{esc(labels["counter"])}:</strong> {esc(counter)}</p>'
+        )
+    return (
+        '<article class="blog-panel">'
+        f"<h3>{esc(question)}</h3>"
+        f'<div class="blog-tags"><span class="blog-chip">'
+        f"{esc(confidence)} {esc(labels['confidence'])}</span>{status_html}</div>"
+        f"{body}{stats_html}</article>"
+    )
+
+
+def _questions_section(snapshot: dict[str, Any], language: str) -> str:
+    grouped: dict[str, list[str]] = {}
+    for title, answer in _answers(snapshot):
+        grouped.setdefault(title, []).append(_answer_html(answer, language))
+    return "".join(_section(title, "".join(items)) for title, items in grouped.items())
+
+
+def _provenance_section(snapshot: dict[str, Any], language: str) -> str:
+    """State exactly what produced this page, using only fields the snapshot has."""
+    labels = _LABELS[language]
+    zh = language == "zh"
+    briefing = _briefing_of(snapshot)
+    corpus = len(snapshot.get("evidence_items") or [])
+    lines: list[str] = []
+    if not briefing:
+        lines.append(
+            f"这一天的快照没有存储简报，本页是对其 {corpus:,} 条证据记录的确定性汇总，"
+            "而非综合分析。"
+            if zh
+            else "No briefing was stored for this day, so this page is a deterministic "
+            f"summary of the {corpus:,} evidence records the snapshot holds, not a "
+            "synthesized briefing."
+        )
+    else:
+        lines.append(
+            f"内容来自已验证的每日快照，共 {corpus:,} 条证据记录。"
+            if zh
+            else f"Built from the validated daily snapshot and its {corpus:,} evidence records."
+        )
+        model = str(briefing.get("model") or "").strip()
+        coverage = (briefing.get("input") or {}).get("coverage") or {}
+        injected = coverage.get("evidence_injected")
+        total = coverage.get("corpus_evidence_records")
+        if model:
+            lines.append(f"简报模型：{model}。" if zh else f"Briefing model: {model}.")
+        if isinstance(injected, int) and isinstance(total, int):
+            lines.append(
+                f"实际读取了 {total:,} 条记录中的 {injected:,} 条。"
+                if zh
+                else f"It read {injected:,} of {total:,} records."
+            )
+        if not model and injected is None:
+            lines.append(
+                "该快照保存了简报文本，但没有保存生成它的模型或覆盖范围信息。"
+                if zh
+                else "The snapshot stored the briefing text without recording the model "
+                "that produced it or how much of the corpus it read."
+            )
+    caveat = str(
+        briefing.get("caveat_zh" if zh else "caveat") or briefing.get("caveat") or ""
+    ).strip()
+    caveat_html = f'<p class="blog-caveat">{esc(caveat)}</p>' if caveat else ""
+    body = "".join(f"<p>{esc(line)}</p>" for line in lines)
+    return (
+        '<section class="blog-section blog-panel">'
+        f"<h2>{esc(labels['provenance'])}</h2>{body}{caveat_html}</section>"
+    )
+
+
+def _sources_section(sources: tuple[tuple[str, str], ...], language: str) -> str:
+    if not sources:
+        return ""
+    links = "".join(f'<li><a href="{esc(url)}">{esc(title)}</a></li>' for title, url in sources)
+    return _section(_LABELS[language]["sources"], f'<ol class="blog-evidence">{links}</ol>')
+
+
+def _kind(snapshot: dict[str, Any]) -> str:
+    briefing = _briefing_of(snapshot)
+    if not briefing:
+        return KIND_EVIDENCE
+    if str(briefing.get("status") or "") == "no_material_insight":
+        return KIND_NO_CHANGE
+    return KIND_BRIEF
+
+
+def build_post(snapshot: dict[str, Any]) -> BlogPost:
+    """Render one snapshot into a publishable brief."""
+    day = str(snapshot["date"])
+    kind = _kind(snapshot)
+    sources = _citations(snapshot, allow_fallback=kind != KIND_EVIDENCE)
+
+    def body(language: str) -> str:
+        return (
+            f'<div class="blog-stats">{_stats(snapshot)}</div>'
+            + _briefing_section(snapshot, language)
+            + _questions_section(snapshot, language)
+            + _sources_section(sources, language)
+            + _provenance_section(snapshot, language)
+        )
+
+    translated = has_translation(snapshot)
+    if kind == KIND_EVIDENCE:
+        title = f"Benchmark evidence summary: {day}"
+        title_zh = f"Benchmark 证据汇总：{day}"
+    else:
+        title = f"Daily AI benchmark brief: {day}"
+        title_zh = f"AI Benchmark 每日简报：{day}"
+    generated = str(snapshot.get("generated_at") or day)
+    return BlogPost(
+        slug=day,
+        title=title,
+        description=_description(snapshot),
+        published=day,
+        updated=generated[:10] if len(generated) >= 10 else day,
+        kind=kind,
+        tags=("daily brief", "AI benchmarks", "evaluation"),
+        sources=sources,
+        body_en=body("en"),
+        body_zh=body("zh") if translated else None,
+        title_zh=title_zh if translated else None,
+        description_zh=_description_zh(snapshot),
+    )

--- a/src/benchmark_radar/blog_shell.py
+++ b/src/benchmark_radar/blog_shell.py
@@ -65,7 +65,10 @@ class BlogPost:
 
 
 def _brand() -> str:
-    return f"""<a class="brand" href="{SITE_URL}/" aria-label="Benchmark Radar home">
+    # Root-relative, like the dashboard's own menubar. A canonical absolute URL
+    # belongs in the SEO tags, not in a nav anchor: absolute links here eject a
+    # local preview (or any non-canonical mirror) to the production domain.
+    return """<a class="brand" href="/" aria-label="Benchmark Radar home">
   <span class="brand-mark" aria-hidden="true"><span></span></span>
   <strong>Benchmark Radar</strong>
 </a>"""
@@ -123,10 +126,13 @@ def header(*, translated: bool) -> str:
 
 
 def navigation(active: str) -> str:
+    # Root-relative for the same reason as the brand link above: these stay on
+    # whatever host serves the page. Sitemap locs, canonical, and og:url keep
+    # the absolute SITE_URL because those are semantically absolute by spec.
     rendered = []
     for key, path, label in _NAV_LINKS:
         current = ' class="nav-active" aria-current="page"' if key == active else ""
-        rendered.append(f'<a href="{SITE_URL}{path}"{current}>{label}</a>')
+        rendered.append(f'<a href="{path}"{current}>{label}</a>')
     return '<nav class="view-nav" aria-label="Site sections">' + "".join(rendered) + "</nav>"
 
 

--- a/src/benchmark_radar/blog_shell.py
+++ b/src/benchmark_radar/blog_shell.py
@@ -45,7 +45,7 @@ class BlogPost:
     updated: str
     kind: str
     tags: tuple[str, ...]
-    sources: tuple[tuple[str, str], ...]
+    sources: tuple[tuple[str, str, str], ...]
     body_en: str
     body_zh: str | None
     title_zh: str | None

--- a/src/benchmark_radar/blog_shell.py
+++ b/src/benchmark_radar/blog_shell.py
@@ -1,0 +1,185 @@
+"""Page chrome and the post record for the daily brief blog.
+
+Blog pages are not the dashboard. The dashboard is one JavaScript application
+whose views are published at their own paths by ``app_pages.py``; a brief is a
+document that has to be readable with no script at all, because the whole point
+of writing one per collection day is that a search engine and a reader arriving
+cold can both see what changed that day. So these pages carry their own
+skeleton and link the dashboard stylesheet for its design tokens rather than
+reusing ``site/index.html``.
+
+Nothing here writes files. It owns the record a brief is built into and the
+markup that wraps it, so ``blog_content.py`` can turn snapshots into posts and
+``blog.py`` can decide which pages exist without either of them restating the
+masthead.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any
+
+from .feed import SITE_URL
+from .site_shell import esc, json_ld
+
+BLOG_PATH = "/blog/"
+BLOG_ARCHIVE_PATH = "/blog/archive/"
+BLOG_FEED_PATH = "/blog/feed.xml"
+
+
+@dataclass(frozen=True)
+class BlogPost:
+    """One published brief, with its body already rendered.
+
+    ``body_zh`` is None when the snapshot carries no stored translation. That
+    absence is what suppresses the language toggle: a toggle that switches to a
+    page identical to the one already shown is a broken control, and machine
+    translating here would publish text nobody reviewed.
+    """
+
+    slug: str
+    title: str
+    description: str
+    published: str
+    updated: str
+    kind: str
+    tags: tuple[str, ...]
+    sources: tuple[tuple[str, str], ...]
+    body_en: str
+    body_zh: str | None
+    title_zh: str | None
+    description_zh: str | None
+
+    @property
+    def path(self) -> str:
+        return f"{BLOG_PATH}{self.slug}/"
+
+    @property
+    def canonical(self) -> str:
+        return SITE_URL + self.path
+
+    @property
+    def translated(self) -> bool:
+        return self.body_zh is not None
+
+
+def _brand() -> str:
+    return f"""<a class="brand" href="{SITE_URL}/" aria-label="Benchmark Radar home">
+  <span class="brand-mark" aria-hidden="true"><span></span></span>
+  <strong>Benchmark Radar</strong>
+</a>"""
+
+
+_RSS_ICON = """<svg viewBox="0 0 24 24" aria-hidden="true">
+  <circle cx="5" cy="19" r="2"></circle>
+  <path d="M4 11a9 9 0 0 1 9 9"></path>
+  <path d="M4 4a16 16 0 0 1 16 16"></path>
+</svg>"""
+
+_GITHUB_ICON = """<svg class="brand-icon github-icon" viewBox="0 0 24 24" aria-hidden="true">
+  <path d="M12 2.5a9.5 9.5 0 0 0-3 18.52c.48.09.65-.21.65-.46v-1.67
+    c-2.67.58-3.23-1.13-3.23-1.13-.44-1.12-1.07-1.42-1.07-1.42-.87-.6.07-.59.07-.59
+    .96.07 1.47.99 1.47.99.86 1.47 2.25 1.05 2.8.8.09-.62.34-1.05.61-1.29
+    -2.13-.24-4.37-1.07-4.37-4.75 0-1.05.38-1.91.99-2.58-.1-.24-.43-1.22.09-2.54
+    0 0 .81-.26 2.63.98A9.16 9.16 0 0 1 12 7.96c.82 0 1.65.11 2.42.33
+    1.82-1.24 2.63-.98 2.63-.98.52 1.32.19 2.3.09 2.54.61.67.99 1.53.99 2.58
+    0 3.69-2.25 4.5-4.39 4.74.35.3.65.88.65 1.78v2.63c0 .25.17.55.66.46
+    A9.5 9.5 0 0 0 12 2.5Z"></path>
+</svg>"""
+
+# Every dashboard route plus the blog, so a reader who landed on a brief from
+# search can reach the rest of the site. The dashboard's own menubar is a
+# separate list in site/index.html and stays the source of truth for it.
+_NAV_LINKS: tuple[tuple[str, str, str], ...] = (
+    ("today", "/", "Today"),
+    ("leaderboard", "/leaderboard/", "Leaderboard"),
+    ("trends", "/trends/", "Trends"),
+    ("explore", "/explore/", "Explore"),
+    ("blog", BLOG_PATH, "Blog"),
+)
+
+
+def header(*, translated: bool) -> str:
+    toggle = (
+        '<button type="button" class="repo-badge" id="lang-toggle" aria-pressed="false" '
+        'aria-label="Switch to Chinese (中文)" data-next-language="zh">'
+        '<span class="repo-badge-glyph" id="lang-toggle-label">中</span></button>'
+        if translated
+        else ""
+    )
+    return f"""<header class="masthead">
+{_brand()}
+<div class="masthead-end" aria-label="Site utilities">
+  <a class="repo-badge feed-badge" href="{BLOG_FEED_PATH}"
+     aria-label="Subscribe to the daily brief via RSS">{_RSS_ICON}
+    <span class="repo-badge-label">RSS</span></a>
+  {toggle}
+  <a class="repo-badge" href="https://github.com/ktwu01/benchmark-radar"
+     aria-label="Open Benchmark Radar on GitHub">{_GITHUB_ICON}
+    <span class="repo-badge-label">GitHub</span></a>
+</div>
+</header>"""
+
+
+def navigation(active: str) -> str:
+    rendered = []
+    for key, path, label in _NAV_LINKS:
+        current = ' class="nav-active" aria-current="page"' if key == active else ""
+        rendered.append(f'<a href="{SITE_URL}{path}"{current}>{label}</a>')
+    return '<nav class="view-nav" aria-label="Site sections">' + "".join(rendered) + "</nav>"
+
+
+def render_page(
+    *,
+    title: str,
+    description: str,
+    canonical: str,
+    body: str,
+    schemas: Iterable[dict[str, Any]] = (),
+    og_type: str = "website",
+    translated: bool = False,
+) -> str:
+    """Wrap one rendered body in the blog skeleton."""
+    schema_blocks = "".join(
+        f'<script type="application/ld+json">{json_ld(payload)}</script>' for payload in schemas
+    )
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="description" content="{esc(description)}">
+<meta name="robots" content="index,follow,max-image-preview:large">
+<title>{esc(title)}</title>
+<link rel="canonical" href="{esc(canonical)}">
+<meta property="og:type" content="{esc(og_type)}">
+<meta property="og:site_name" content="Benchmark Radar">
+<meta property="og:title" content="{esc(title)}">
+<meta property="og:description" content="{esc(description)}">
+<meta property="og:url" content="{esc(canonical)}">
+<meta property="og:image" content="{SITE_URL}/assets/og-card.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="{esc(title)}">
+<meta name="twitter:description" content="{esc(description)}">
+<meta name="twitter:image" content="{SITE_URL}/assets/og-card.png">
+<link rel="icon" href="/icon.svg" type="image/svg+xml">
+<link rel="alternate" type="application/rss+xml" title="Benchmark Radar daily brief"
+      href="{BLOG_FEED_PATH}">
+<link rel="stylesheet" href="/assets/styles.css">
+<link rel="stylesheet" href="/assets/blog.css">
+{schema_blocks}
+<script src="/assets/blog.js" defer></script>
+</head>
+<body class="blog-page">
+<a class="skip-link" href="#main-content">Skip to content</a>
+{header(translated=translated)}
+{navigation("blog")}
+<main id="main-content" tabindex="-1"><div class="blog-view">{body}</div></main>
+<footer class="blog-footer">
+  <strong>Benchmark Radar</strong>
+  <span>Evidence first. Every claim should lead back to its source.</span>
+</footer>
+</body>
+</html>
+"""

--- a/src/benchmark_radar/blog_shell.py
+++ b/src/benchmark_radar/blog_shell.py
@@ -1,21 +1,42 @@
-"""Page chrome and the post record for the daily brief blog.
+"""The shared site chrome, extracted for the daily brief blog.
 
-Blog pages are not the dashboard. The dashboard is one JavaScript application
-whose views are published at their own paths by ``app_pages.py``; a brief is a
-document that has to be readable with no script at all, because the whole point
-of writing one per collection day is that a search engine and a reader arriving
-cold can both see what changed that day. So these pages carry their own
-skeleton and link the dashboard stylesheet for its design tokens rather than
-reusing ``site/index.html``.
+``site/index.html`` is the single hand-maintained source of the site's
+masthead, section navigation, and footer. Every dashboard route is that same
+document served at its own path by ``app_pages.py``; the blog joins it here by
+extracting those three regions at build time, so a menubar item, badge, or
+footer line can no longer exist on the dashboard but not on a brief.
+
+A blog page is still a static document outside the single-page app, so the
+extracted chrome carries a small, explicit set of transforms, each of which
+exists because the SPA machinery it referenced is absent:
+
+* the Today control is a view-switching button in the SPA and becomes the
+  plain link to ``/`` it already is for crawlers;
+* view-only attributes (``data-view``, ``aria-controls``, ``aria-expanded``)
+  are dropped from the section nav, and the blog's own link is marked
+  active. Element ids stay: styles.css keys the dialog-trigger treatment of
+  Rubric and CLI (the inactive blue and the "ⓘ" marker) off #rubric-nav and
+  #cli-nav, so a brief's tabs must carry the same ids to look the same;
+* the Contact button opens a sheet that only exists inside the SPA, so it
+  becomes a link to ``/#contact`` — the dashboard deep link that opens the
+  same sheet on load;
+* the masthead RSS badge keeps the site-wide feed but with a root-relative
+  href, so a locally served preview (or any non-canonical mirror) stays on
+  the serving host; canonical and ``og:`` URLs keep the absolute SITE_URL;
+* the language toggle ships only on pages that store a reviewed Chinese
+  translation; ``blog.js`` owns its state on these pages with the same
+  visible contract ``app.js`` uses (title, glyph, aria-pressed);
+* the footer's build date is baked from the day the page describes.
 
 Nothing here writes files. It owns the record a brief is built into and the
-markup that wraps it, so ``blog_content.py`` can turn snapshots into posts and
-``blog.py`` can decide which pages exist without either of them restating the
-masthead.
+chrome that wraps it, so ``blog_content.py`` can turn snapshots into posts
+and ``blog.py`` can decide which pages exist without either of them
+restating the masthead.
 """
 
 from __future__ import annotations
 
+import re
 from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Any
@@ -26,6 +47,10 @@ from .site_shell import esc, json_ld
 BLOG_PATH = "/blog/"
 BLOG_ARCHIVE_PATH = "/blog/archive/"
 BLOG_FEED_PATH = "/blog/feed.xml"
+
+# The SPA's Today control maps to the dashboard root; every other section is
+# already a real anchor whose href is the server-rendered page.
+_TODAY_HREFS = {"today": "/"}
 
 
 @dataclass(frozen=True)
@@ -64,76 +89,123 @@ class BlogPost:
         return self.body_zh is not None
 
 
-def _brand() -> str:
-    # Root-relative, like the dashboard's own menubar. A canonical absolute URL
-    # belongs in the SEO tags, not in a nav anchor: absolute links here eject a
-    # local preview (or any non-canonical mirror) to the production domain.
-    return """<a class="brand" href="/" aria-label="Benchmark Radar home">
-  <span class="brand-mark" aria-hidden="true"><span></span></span>
-  <strong>Benchmark Radar</strong>
-</a>"""
+@dataclass(frozen=True)
+class SiteChrome:
+    """The masthead, section nav, and footer extracted from ``index.html``."""
+
+    header: str
+    navigation: str
+    footer: str
 
 
-_RSS_ICON = """<svg viewBox="0 0 24 24" aria-hidden="true">
-  <circle cx="5" cy="19" r="2"></circle>
-  <path d="M4 11a9 9 0 0 1 9 9"></path>
-  <path d="M4 4a16 16 0 0 1 16 16"></path>
-</svg>"""
-
-_GITHUB_ICON = """<svg class="brand-icon github-icon" viewBox="0 0 24 24" aria-hidden="true">
-  <path d="M12 2.5a9.5 9.5 0 0 0-3 18.52c.48.09.65-.21.65-.46v-1.67
-    c-2.67.58-3.23-1.13-3.23-1.13-.44-1.12-1.07-1.42-1.07-1.42-.87-.6.07-.59.07-.59
-    .96.07 1.47.99 1.47.99.86 1.47 2.25 1.05 2.8.8.09-.62.34-1.05.61-1.29
-    -2.13-.24-4.37-1.07-4.37-4.75 0-1.05.38-1.91.99-2.58-.1-.24-.43-1.22.09-2.54
-    0 0 .81-.26 2.63.98A9.16 9.16 0 0 1 12 7.96c.82 0 1.65.11 2.42.33
-    1.82-1.24 2.63-.98 2.63-.98.52 1.32.19 2.3.09 2.54.61.67.99 1.53.99 2.58
-    0 3.69-2.25 4.5-4.39 4.74.35.3.65.88.65 1.78v2.63c0 .25.17.55.66.46
-    A9.5 9.5 0 0 0 12 2.5Z"></path>
-</svg>"""
-
-# Every dashboard route plus the blog, so a reader who landed on a brief from
-# search can reach the rest of the site. The dashboard's own menubar is a
-# separate list in site/index.html and stays the source of truth for it.
-_NAV_LINKS: tuple[tuple[str, str, str], ...] = (
-    ("today", "/", "Today"),
-    ("leaderboard", "/leaderboard/", "Leaderboard"),
-    ("trends", "/trends/", "Trends"),
-    ("explore", "/explore/", "Explore"),
-    ("blog", BLOG_PATH, "Blog"),
-)
+def _region(dashboard_html: str, pattern: str, what: str) -> str:
+    found = re.search(pattern, dashboard_html, re.S)
+    if not found:
+        raise ValueError(
+            f"cannot extract the {what} from site/index.html: "
+            "the dashboard source changed shape; update the blog chrome extractor"
+        )
+    return found.group(0)
 
 
-def header(*, translated: bool) -> str:
-    toggle = (
-        '<button type="button" class="repo-badge" id="lang-toggle" aria-pressed="false" '
-        'aria-label="Switch to Chinese (中文)" data-next-language="zh">'
-        '<span class="repo-badge-glyph" id="lang-toggle-label">中</span></button>'
-        if translated
-        else ""
+def _strip_comments(fragment: str) -> str:
+    without = re.sub(r"<!--.*?-->", "", fragment, flags=re.S)
+    return re.sub(r"\n[ \t]*\n", "\n", without)
+
+
+def _drop_spa_attributes(fragment: str) -> str:
+    # Ids stay on purpose: styles.css styles #rubric-nav and #cli-nav by id,
+    # so stripping them would silently turn those tabs into plain links.
+    return re.sub(r'\s(?:data-view|aria-controls|aria-expanded)="[^"]*"', "", fragment)
+
+
+def _today_link(button: str) -> str:
+    view = re.search(r'data-view="([^"]*)"', button)
+    label = re.sub(r"<[^>]+>", "", button).strip()
+    if not view or view.group(1) not in _TODAY_HREFS or not label:
+        raise ValueError(
+            "the dashboard nav contains a button this extractor cannot turn "
+            f"into a link: {button[:120]!r}"
+        )
+    href = _TODAY_HREFS[view.group(1)]
+    return f'<a href="{href}" data-i18n="{esc(label)}">{esc(label)}</a>'
+
+
+def _adapt_navigation(nav: str) -> str:
+    nav = _strip_comments(nav)
+    nav = re.sub(r"<button\b[^>]*>.*?</button>", lambda m: _today_link(m.group(0)), nav, flags=re.S)
+    nav = _drop_spa_attributes(nav)
+    # The blog's own entry is the current page everywhere the blog renders.
+    marked = re.sub(
+        r'<a href="' + BLOG_PATH + '"',
+        f'<a class="nav-active" aria-current="page" href="{BLOG_PATH}"',
+        nav,
     )
-    return f"""<header class="masthead">
-{_brand()}
-<div class="masthead-end" aria-label="Site utilities">
-  <a class="repo-badge feed-badge" href="{BLOG_FEED_PATH}"
-     aria-label="Subscribe to the daily brief via RSS">{_RSS_ICON}
-    <span class="repo-badge-label">RSS</span></a>
-  {toggle}
-  <a class="repo-badge" href="https://github.com/ktwu01/benchmark-radar"
-     aria-label="Open Benchmark Radar on GitHub">{_GITHUB_ICON}
-    <span class="repo-badge-label">GitHub</span></a>
-</div>
-</header>"""
+    if marked == nav:
+        raise ValueError(
+            "the dashboard nav no longer links to the blog at "
+            f"{BLOG_PATH!r}; the blog pages cannot mark their section active"
+        )
+    return marked
 
 
-def navigation(active: str) -> str:
-    # Root-relative for the same reason as the brand link above: these stay on
-    # whatever host serves the page. Sitemap locs, canonical, and og:url keep
-    # the absolute SITE_URL because those are semantically absolute by spec.
-    rendered = []
-    for key, path, label in _NAV_LINKS:
-        current = ' class="nav-active" aria-current="page"' if key == active else ""
-        rendered.append(f'<a href="{path}"{current}>{label}</a>')
-    return '<nav class="view-nav" aria-label="Site sections">' + "".join(rendered) + "</nav>"
+def _adapt_header(header: str) -> str:
+    header = _strip_comments(header)
+    # Same host-relative rule as the section nav: the badge keeps the site
+    # feed, but a local preview or mirror must not eject to the canonical
+    # domain on click.
+    header = header.replace(f'href="{SITE_URL}/feed.xml"', 'href="/feed.xml"', 1)
+    contact = re.search(r'<button\b([^>]*\bid="badge-contact"[^>]*)>(.*?)</button>', header, re.S)
+    if not contact:
+        raise ValueError(
+            "the dashboard masthead no longer carries the contact button; "
+            "the blog chrome cannot link to /#contact"
+        )
+    attrs, inner = contact.group(1), contact.group(2)
+    title = re.search(r'title="([^"]*)"', attrs)
+    header = header.replace(
+        contact.group(0),
+        '<a class="repo-badge" href="/#contact"'
+        + (f' title="{esc(title.group(1))}"' if title else "")
+        + f">{inner}</a>",
+        1,
+    )
+    return header
+
+
+def _with_toggle(header: str, *, translated: bool) -> str:
+    if translated:
+        return header
+    return re.sub(
+        r'<button\b[^>]*\bid="lang-toggle"[^>]*>.*?</button>',
+        "",
+        header,
+        flags=re.S,
+    )
+
+
+def _page_footer(footer: str, updated: str) -> str:
+    stamped, count = re.subn(
+        r'(<p id="build-meta">Updated )—(</p>)', rf"\g<1>{esc(updated)}\g<2>", footer
+    )
+    if count != 1:
+        raise ValueError(
+            "the dashboard footer no longer has the 'Updated —' placeholder; "
+            "the blog pages cannot bake their build date"
+        )
+    return stamped
+
+
+def extract_site_chrome(dashboard_html: str) -> SiteChrome:
+    """Pull the shared masthead, nav, and footer out of ``site/index.html``."""
+    header = _region(dashboard_html, r'<header class="masthead">.*?</header>', "masthead")
+    navigation = _region(dashboard_html, r'<nav class="view-nav".*?</nav>', "section nav")
+    footer = _region(dashboard_html, r"<footer>.*?</footer>", "footer")
+    return SiteChrome(
+        header=_adapt_header(header),
+        navigation=_adapt_navigation(navigation),
+        footer=_strip_comments(footer),
+    )
 
 
 def render_page(
@@ -142,11 +214,13 @@ def render_page(
     description: str,
     canonical: str,
     body: str,
+    chrome: SiteChrome,
+    updated: str,
     schemas: Iterable[dict[str, Any]] = (),
     og_type: str = "website",
     translated: bool = False,
 ) -> str:
-    """Wrap one rendered body in the blog skeleton."""
+    """Wrap one rendered body in the extracted site chrome."""
     schema_blocks = "".join(
         f'<script type="application/ld+json">{json_ld(payload)}</script>' for payload in schemas
     )
@@ -179,13 +253,10 @@ def render_page(
 </head>
 <body class="blog-page">
 <a class="skip-link" href="#main-content">Skip to content</a>
-{header(translated=translated)}
-{navigation("blog")}
+{_with_toggle(chrome.header, translated=translated)}
+{chrome.navigation}
 <main id="main-content" tabindex="-1"><div class="blog-view">{body}</div></main>
-<footer class="blog-footer">
-  <strong>Benchmark Radar</strong>
-  <span>Evidence first. Every claim should lead back to its source.</span>
-</footer>
+{_page_footer(chrome.footer, updated)}
 </body>
 </html>
 """

--- a/src/benchmark_radar/blog_shell.py
+++ b/src/benchmark_radar/blog_shell.py
@@ -24,8 +24,11 @@ exists because the SPA machinery it referenced is absent:
   href, so a locally served preview (or any non-canonical mirror) stays on
   the serving host; canonical and ``og:`` URLs keep the absolute SITE_URL;
 * the language toggle ships only on pages that store a reviewed Chinese
-  translation; ``blog.js`` owns its state on these pages with the same
-  visible contract ``app.js`` uses (title, glyph, aria-pressed);
+  translation; ``blog.js`` drives it with the same visible contract
+  ``app.js`` uses (title, glyph, aria-pressed), and applies the same
+  reviewed translations to the chrome: the app.js ``I18N`` table is parsed
+  at build time and the subset the chrome needs is baked into the page,
+  so a Chinese reader sees 联系作者 and the ⓘ tooltips on a brief too;
 * the footer's build date is baked from the day the page describes.
 
 Nothing here writes files. It owns the record a brief is built into and the
@@ -36,6 +39,7 @@ restating the masthead.
 
 from __future__ import annotations
 
+import json
 import re
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -163,10 +167,12 @@ def _adapt_header(header: str) -> str:
         )
     attrs, inner = contact.group(1), contact.group(2)
     title = re.search(r'title="([^"]*)"', attrs)
+    i18n_title = re.search(r'data-i18n-title="([^"]*)"', attrs)
     header = header.replace(
         contact.group(0),
-        '<a class="repo-badge" href="/#contact"'
+        '<a class="repo-badge" href="/#contact" aria-haspopup="dialog"'
         + (f' title="{esc(title.group(1))}"' if title else "")
+        + (f' data-i18n-title="{esc(i18n_title.group(1))}"' if i18n_title else "")
         + f">{inner}</a>",
         1,
     )
@@ -186,7 +192,9 @@ def _with_toggle(header: str, *, translated: bool) -> str:
 
 def _page_footer(footer: str, updated: str) -> str:
     stamped, count = re.subn(
-        r'(<p id="build-meta">Updated )—(</p>)', rf"\g<1>{esc(updated)}\g<2>", footer
+        r'(<p id="build-meta">)Updated —(</p>)',
+        rf'\g<1><span data-i18n="Updated">Updated</span> {esc(updated)}\g<2>',
+        footer,
     )
     if count != 1:
         raise ValueError(
@@ -216,6 +224,7 @@ def render_page(
     body: str,
     chrome: SiteChrome,
     updated: str,
+    chrome_i18n: dict[str, str] | None = None,
     schemas: Iterable[dict[str, Any]] = (),
     og_type: str = "website",
     translated: bool = False,
@@ -223,6 +232,13 @@ def render_page(
     """Wrap one rendered body in the extracted site chrome."""
     schema_blocks = "".join(
         f'<script type="application/ld+json">{json_ld(payload)}</script>' for payload in schemas
+    )
+    i18n_block = (
+        '<script type="application/json" id="chrome-i18n">'
+        + json.dumps(chrome_i18n, ensure_ascii=False, sort_keys=True)
+        + "</script>"
+        if chrome_i18n
+        else ""
     )
     return f"""<!doctype html>
 <html lang="en">
@@ -249,6 +265,7 @@ def render_page(
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/blog.css">
 {schema_blocks}
+{i18n_block}
 <script src="/assets/blog.js" defer></script>
 </head>
 <body class="blog-page">

--- a/src/benchmark_radar/blog_shell.py
+++ b/src/benchmark_radar/blog_shell.py
@@ -23,12 +23,13 @@ exists because the SPA machinery it referenced is absent:
 * the masthead RSS badge keeps the site-wide feed but with a root-relative
   href, so a locally served preview (or any non-canonical mirror) stays on
   the serving host; canonical and ``og:`` URLs keep the absolute SITE_URL;
-* the language toggle ships only on pages that store a reviewed Chinese
-  translation; ``blog.js`` drives it with the same visible contract
-  ``app.js`` uses (title, glyph, aria-pressed), and applies the same
-  reviewed translations to the chrome: the app.js ``I18N`` table is parsed
-  at build time and the subset the chrome needs is baked into the page,
-  so a Chinese reader sees 联系作者 and the ⓘ tooltips on a brief too;
+* the language toggle ships on every page, because the chrome itself is
+  always translatable: ``blog.js`` drives it with the same visible
+  contract ``app.js`` uses (title, glyph, aria-pressed) and applies the
+  same reviewed translations to the chrome — the app.js ``I18N`` table is
+  parsed at build time and the subset the chrome needs is baked into the
+  page, so a Chinese reader sees 联系作者 and the ⓘ tooltips on a brief
+  too. A body without a stored translation simply stays English;
 * the footer's build date is baked from the day the page describes.
 
 Nothing here writes files. It owns the record a brief is built into and the
@@ -168,6 +169,11 @@ def _adapt_header(header: str) -> str:
     attrs, inner = contact.group(1), contact.group(2)
     title = re.search(r'title="([^"]*)"', attrs)
     i18n_title = re.search(r'data-i18n-title="([^"]*)"', attrs)
+    # The chat-bubble svg carries no class: on the dashboard the outline comes
+    # from button.repo-badge svg, which an anchor badge does not match. The
+    # outline-icon class is the same mechanism the fork and issues icons use
+    # on link badges, so the bubble renders identically on a brief.
+    inner = inner.replace("<svg viewBox=", '<svg class="outline-icon" viewBox=', 1)
     header = header.replace(
         contact.group(0),
         '<a class="repo-badge" href="/#contact" aria-haspopup="dialog"'
@@ -177,17 +183,6 @@ def _adapt_header(header: str) -> str:
         1,
     )
     return header
-
-
-def _with_toggle(header: str, *, translated: bool) -> str:
-    if translated:
-        return header
-    return re.sub(
-        r'<button\b[^>]*\bid="lang-toggle"[^>]*>.*?</button>',
-        "",
-        header,
-        flags=re.S,
-    )
 
 
 def _page_footer(footer: str, updated: str) -> str:
@@ -227,7 +222,6 @@ def render_page(
     chrome_i18n: dict[str, str] | None = None,
     schemas: Iterable[dict[str, Any]] = (),
     og_type: str = "website",
-    translated: bool = False,
 ) -> str:
     """Wrap one rendered body in the extracted site chrome."""
     schema_blocks = "".join(
@@ -270,7 +264,7 @@ def render_page(
 </head>
 <body class="blog-page">
 <a class="skip-link" href="#main-content">Skip to content</a>
-{_with_toggle(chrome.header, translated=translated)}
+{chrome.header}
 {chrome.navigation}
 <main id="main-content" tabindex="-1"><div class="blog-view">{body}</div></main>
 {_page_footer(chrome.footer, updated)}

--- a/src/benchmark_radar/site_seo.py
+++ b/src/benchmark_radar/site_seo.py
@@ -69,11 +69,18 @@ def sitemap_tree(
     benchmark_slugs: Sequence[str] = (),
     *,
     view_paths: Sequence[str] | None = None,
+    blog_entries: Sequence[tuple[str, str | None]] = (),
 ) -> ET.ElementTree:
-    """Build one stable urlset covering views and benchmark pages.
+    """Build one stable urlset covering views, benchmark pages and daily briefs.
 
     ``view_paths`` is what the build actually wrote. Passing None lists every
     view, which is what a caller that does not write pages at all wants.
+
+    ``blog_entries`` is what the blog build reported, each with its own lastmod
+    rather than the site-wide one: a brief for a day three weeks ago did not
+    change when today's snapshot landed, and telling a crawler otherwise asks
+    it to refetch the whole archive on every deploy. A build that writes no
+    blog passes nothing and lists nothing, the same rule the views follow.
     """
     root = ET.Element(_q("urlset"))
     lastmod = _lastmod_date(snapshots)
@@ -83,6 +90,7 @@ def sitemap_tree(
     ]
     entries.append((BENCHMARK_DIRECTORY_PATH, lastmod))
     entries.extend((f"/benchmarks/{slug}/", lastmod) for slug in benchmark_slugs)
+    entries.extend(blog_entries)
     seen: set[str] = set()
     for path, entry_lastmod in entries:
         if path in seen:
@@ -101,10 +109,13 @@ def write_sitemap(
     benchmark_slugs: Sequence[str] = (),
     *,
     view_paths: Sequence[str] | None = None,
+    blog_entries: Sequence[tuple[str, str | None]] = (),
 ) -> Path:
     """Write a deterministic UTF-8 sitemap beside the published data."""
     output.parent.mkdir(parents=True, exist_ok=True)
-    tree = sitemap_tree(snapshots, benchmark_slugs, view_paths=view_paths)
+    tree = sitemap_tree(
+        snapshots, benchmark_slugs, view_paths=view_paths, blog_entries=blog_entries
+    )
     ET.indent(tree, space="  ")
     tree.write(output, encoding="utf-8", xml_declaration=True)
     return output

--- a/src/benchmark_radar/snapshots.py
+++ b/src/benchmark_radar/snapshots.py
@@ -12,6 +12,7 @@ from . import kw_bench
 from .app_pages import write_app_pages
 from .attention import fetch_attention_feeds
 from .benchmark_scores import DEFAULT_SCORES_PATH, load_scores, score_progression
+from .blog import write_blog
 from .corpus import (
     artifact_alias_map,
     build_corpus,
@@ -1142,15 +1143,22 @@ def rebuild_dashboard(
     # the same way it lists benchmark pages this build did not write either.
     # The Pages build, which does write the pages, passes what it wrote.
     view_paths: list[str] | None = None
+    blog_entries: list[tuple[str, str | None]] = []
     if feed_output is not None:
         app_pages = write_app_pages(value, sitemap_output.parent)
         view_paths = app_pages["paths"]
         write_feed(snapshots, feed_output)
+        # One page per collection day, plus the blog's own feed. Built from the
+        # same validated snapshots the dashboard is, in the same run, so a
+        # brief can never describe a day the published corpus has moved past.
+        blog = write_blog(snapshots, sitemap_output.parent)
+        blog_entries = blog["sitemap_entries"]
     write_sitemap(
         snapshots,
         sitemap_output,
         slugs,
         view_paths=view_paths,
+        blog_entries=blog_entries,
     )
     return value
 

--- a/tests/test_blog.py
+++ b/tests/test_blog.py
@@ -16,8 +16,26 @@ from benchmark_radar.blog_content import (
     KIND_NO_CHANGE,
     build_post,
 )
-from benchmark_radar.blog_shell import BLOG_ARCHIVE_PATH, BLOG_FEED_PATH, BLOG_PATH
+from benchmark_radar.blog_shell import (
+    _TODAY_HREFS,
+    BLOG_ARCHIVE_PATH,
+    BLOG_FEED_PATH,
+    BLOG_PATH,
+    extract_site_chrome,
+)
 from benchmark_radar.feed import SITE_URL
+
+# The blog chrome is extracted from the committed dashboard source, so the
+# tests exercise the real site/index.html rather than a hand-written fixture
+# that could drift from what ships.
+DASHBOARD_HTML = (Path(__file__).resolve().parents[1] / "site" / "index.html").read_text(
+    encoding="utf-8"
+)
+
+
+def write_blog_with_chrome(snapshots, tmp_path):
+    return write_blog(snapshots, tmp_path, dashboard_html=DASHBOARD_HTML)
+
 
 SNAPSHOT_DIR = Path(__file__).resolve().parents[1] / "data" / "snapshots"
 
@@ -203,14 +221,14 @@ def test_stored_chinese_is_published_with_a_toggle():
 def test_a_day_without_stored_chinese_publishes_english_only(tmp_path):
     post = build_post(_legacy())
     assert post.body_zh is None and post.title_zh is None
-    write_blog([_legacy()], tmp_path)
+    write_blog_with_chrome([_legacy()], tmp_path)
     page = (tmp_path / "blog" / "2026-07-23" / "index.html").read_text(encoding="utf-8")
     assert 'data-lang-content="zh"' not in page
     assert 'id="lang-toggle"' not in page
 
 
 def test_the_toggle_appears_only_where_a_translation_exists(tmp_path):
-    write_blog([_briefed(status="insight")], tmp_path)
+    write_blog_with_chrome([_briefed(status="insight")], tmp_path)
     page = (tmp_path / "blog" / "2026-08-30" / "index.html").read_text(encoding="utf-8")
     assert page.count('id="lang-toggle"') == 1
     assert 'data-lang-content="zh"' in page and 'data-lang-content="en"' in page
@@ -221,7 +239,7 @@ def test_the_toggle_appears_only_where_a_translation_exists(tmp_path):
 
 def test_write_blog_publishes_index_archive_feed_and_one_page_per_day(tmp_path):
     snapshots = [_snapshot(day) for day in _snapshot_days()]
-    report = write_blog(snapshots, tmp_path)
+    report = write_blog_with_chrome(snapshots, tmp_path)
     blog = tmp_path / "blog"
     assert report["post_count"] == len(snapshots)
     assert (blog / "index.html").exists()
@@ -233,7 +251,7 @@ def test_write_blog_publishes_index_archive_feed_and_one_page_per_day(tmp_path):
 
 def test_the_landing_page_shows_the_latest_days_and_the_archive_shows_all(tmp_path):
     snapshots = [_snapshot(day) for day in _snapshot_days()]
-    write_blog(snapshots, tmp_path)
+    write_blog_with_chrome(snapshots, tmp_path)
     latest = (tmp_path / "blog" / "index.html").read_text(encoding="utf-8")
     archive = (tmp_path / "blog" / "archive" / "index.html").read_text(encoding="utf-8")
     assert latest.count('class="blog-card"') == LATEST_POST_LIMIT
@@ -243,9 +261,9 @@ def test_the_landing_page_shows_the_latest_days_and_the_archive_shows_all(tmp_pa
 
 
 def test_a_rebuild_removes_pages_for_days_that_left_the_history(tmp_path):
-    write_blog([_briefed(), _legacy()], tmp_path)
+    write_blog_with_chrome([_briefed(), _legacy()], tmp_path)
     assert (tmp_path / "blog" / "2026-08-30" / "index.html").exists()
-    write_blog([_legacy()], tmp_path)
+    write_blog_with_chrome([_legacy()], tmp_path)
     assert not (tmp_path / "blog" / "2026-08-30").exists()
     assert (tmp_path / "blog" / "2026-07-23" / "index.html").exists()
 
@@ -253,8 +271,8 @@ def test_a_rebuild_removes_pages_for_days_that_left_the_history(tmp_path):
 def test_rebuilding_is_deterministic_and_never_mutates_the_snapshot(tmp_path):
     snapshots = [_snapshot(day) for day in _snapshot_days()]
     original = copy.deepcopy(snapshots)
-    write_blog(snapshots, tmp_path / "first")
-    write_blog(snapshots, tmp_path / "second")
+    write_blog_with_chrome(snapshots, tmp_path / "first")
+    write_blog_with_chrome(snapshots, tmp_path / "second")
     assert snapshots == original
     for page in sorted((tmp_path / "first" / "blog").rglob("*")):
         if page.is_file():
@@ -266,7 +284,7 @@ def test_rebuilding_is_deterministic_and_never_mutates_the_snapshot(tmp_path):
 
 
 def test_each_page_carries_its_own_canonical_and_blogposting_schema(tmp_path):
-    write_blog([_briefed(status="insight")], tmp_path)
+    write_blog_with_chrome([_briefed(status="insight")], tmp_path)
     page = (tmp_path / "blog" / "2026-08-30" / "index.html").read_text(encoding="utf-8")
     canonical = f"{SITE_URL}{BLOG_PATH}2026-08-30/"
     assert f'<link rel="canonical" href="{canonical}">' in page
@@ -285,7 +303,7 @@ def _schemas(page: str) -> list[dict]:
 
 
 def test_each_page_carries_a_breadcrumb_back_to_the_blog(tmp_path):
-    write_blog([_briefed()], tmp_path)
+    write_blog_with_chrome([_briefed()], tmp_path)
     page = (tmp_path / "blog" / "2026-08-30" / "index.html").read_text(encoding="utf-8")
     crumb = next(p for p in _schemas(page) if p.get("@type") == "BreadcrumbList")
     assert [item["item"] for item in crumb["itemListElement"]] == [
@@ -297,7 +315,7 @@ def test_each_page_carries_a_breadcrumb_back_to_the_blog(tmp_path):
 
 def test_sitemap_entries_cover_the_blog_and_date_each_brief_individually(tmp_path):
     snapshots = [_snapshot(day) for day in _snapshot_days()]
-    entries = write_blog(snapshots, tmp_path)["sitemap_entries"]
+    entries = write_blog_with_chrome(snapshots, tmp_path)["sitemap_entries"]
     paths = [path for path, _ in entries]
     assert paths[:2] == [BLOG_PATH, BLOG_ARCHIVE_PATH]
     assert len(paths) == len(snapshots) + 2
@@ -317,7 +335,7 @@ def test_the_blog_feed_lists_every_post_and_is_self_describing():
 
 def test_the_blog_feed_is_written_into_the_published_tree(tmp_path):
     snapshots = [_snapshot(day) for day in _snapshot_days()]
-    write_blog(snapshots, tmp_path)
+    write_blog_with_chrome(snapshots, tmp_path)
     channel = ET.parse(tmp_path / "blog" / "feed.xml").getroot().find("channel")
     assert len(channel.findall("item")) == len(snapshots)
 
@@ -413,3 +431,60 @@ def test_question_translations_match_the_dashboard_table():
         match = re.search(rf'"{re.escape(english)}":\s*\n?\s*"([^"]+)"', app_js)
         assert match, f"the dashboard does not translate {english!r}"
         assert match.group(1) == chinese
+
+
+def _nav_targets(fragment: str) -> list[str]:
+    """Href sequence of a section nav; the SPA's Today button maps to ``/``."""
+    nav = re.search(r'<nav class="view-nav".*?</nav>', fragment, re.S).group(0)
+    targets = []
+    for match in re.finditer(r"<(a|button)\b([^>]*)>", nav):
+        tag, attrs = match.group(1), match.group(2)
+        href = re.search(r'href="([^"]*)"', attrs)
+        if tag == "a":
+            assert href, f"nav anchor without href: {match.group(0)!r}"
+            targets.append(href.group(1))
+        else:
+            view = re.search(r'data-view="([^"]*)"', attrs)
+            assert view and view.group(1) in _TODAY_HREFS, attrs
+            targets.append(_TODAY_HREFS[view.group(1)])
+    return targets
+
+
+def test_blog_nav_lists_the_same_sections_in_the_same_order_as_the_dashboard(tmp_path):
+    # The nav is extracted from site/index.html, not restated; this fails
+    # loudly if the extractor breaks or the dashboard grows a section the
+    # blog silently stops carrying.
+    dashboard_targets = _nav_targets(DASHBOARD_HTML)
+    assert dashboard_targets, "the extractor found no nav in site/index.html"
+    write_blog_with_chrome([_briefed(), _legacy()], tmp_path)
+    page = (tmp_path / "blog" / "2026-08-30" / "index.html").read_text(encoding="utf-8")
+    assert _nav_targets(page) == dashboard_targets
+    assert 'class="nav-active" aria-current="page" href="/blog/"' in page
+
+
+def test_the_contact_button_becomes_the_dashboard_deep_link(tmp_path):
+    write_blog_with_chrome([_briefed()], tmp_path)
+    page = (tmp_path / "blog" / "2026-08-30" / "index.html").read_text(encoding="utf-8")
+    # The contact sheet itself lives inside the SPA; the blog links to the
+    # deep link that opens it on load instead of shipping a dead button.
+    assert '<a class="repo-badge" href="/#contact"' in page
+    assert 'id="badge-contact"' not in page
+
+
+def test_the_footer_build_date_is_baked_from_the_day_the_page_describes(tmp_path):
+    write_blog_with_chrome([_briefed(), _legacy()], tmp_path)
+    brief = (tmp_path / "blog" / "2026-08-30" / "index.html").read_text(encoding="utf-8")
+    legacy = (tmp_path / "blog" / "2026-07-23" / "index.html").read_text(encoding="utf-8")
+    assert '<p id="build-meta">Updated 2026-08-30</p>' in brief
+    assert '<p id="build-meta">Updated 2026-07-23</p>' in legacy
+    assert "Updated \u2014" not in brief
+
+
+def test_a_missing_dashboard_source_fails_visibly(tmp_path):
+    with pytest.raises(FileNotFoundError, match="dashboard source"):
+        write_blog([_briefed()], tmp_path)
+
+
+def test_the_extractor_fails_loudly_when_the_dashboard_changes_shape():
+    with pytest.raises(ValueError, match="masthead"):
+        extract_site_chrome("<html><body><p>no header here</p></body></html>")

--- a/tests/test_blog.py
+++ b/tests/test_blog.py
@@ -10,6 +10,7 @@ import pytest
 
 from benchmark_radar.blog import LATEST_POST_LIMIT, blog_feed_tree, build_posts, write_blog
 from benchmark_radar.blog_content import (
+    _QUESTION_ZH,
     KIND_BRIEF,
     KIND_EVIDENCE,
     KIND_NO_CHANGE,
@@ -186,7 +187,7 @@ def test_a_source_url_that_is_not_http_is_dropped():
     snapshot = _briefed()
     snapshot["briefing"]["citations"] = [{"title": "Bad", "url": "javascript:alert(1)"}]
     snapshot["questions"]["groups"][0]["answers"][0]["cited_evidence"] = []
-    assert all(url.startswith("https://") for _, url in build_post(snapshot).sources)
+    assert all(url.startswith("https://") for _, _, url in build_post(snapshot).sources)
 
 
 # --- bilingual behavior ---------------------------------------------------
@@ -319,3 +320,96 @@ def test_the_blog_feed_is_written_into_the_published_tree(tmp_path):
     write_blog(snapshots, tmp_path)
     channel = ET.parse(tmp_path / "blog" / "feed.xml").getroot().find("channel")
     assert len(channel.findall("item")) == len(snapshots)
+
+
+def _cited_day() -> dict:
+    """The newest snapshot whose briefing cites evidence by ID."""
+    for day in reversed(_snapshot_days()):
+        snapshot = _snapshot(day)
+        citations = (snapshot.get("briefing") or {}).get("citations") or []
+        if any(citation.get("id") for citation in citations):
+            return snapshot
+    raise AssertionError("no committed snapshot cites evidence by ID")
+
+
+def test_cited_evidence_keeps_the_id_the_prose_refers_to():
+    snapshot = _cited_day()
+    citations = snapshot["briefing"]["citations"]
+    body = build_post(snapshot).body_en
+    for citation in citations:
+        identifier = citation.get("id")
+        if not identifier:
+            continue
+        assert f'<span class="blog-cite-id">{identifier}</span>' in body
+
+
+def test_cited_ids_are_not_replaced_by_list_position():
+    """A briefing can cite E011 without listing ten earlier records."""
+    snapshot = _cited_day()
+    identifiers = [
+        citation["id"] for citation in snapshot["briefing"]["citations"] if citation.get("id")
+    ]
+    positions = [f"E{index:03d}" for index in range(1, len(identifiers) + 1)]
+    if identifiers == positions:
+        pytest.skip("this day's citation IDs happen to match their list positions")
+    body = build_post(snapshot).body_en
+    assert identifiers[-1] in body
+
+
+def test_cited_statistics_show_the_registry_id():
+    for day in reversed(_snapshot_days()):
+        snapshot = _snapshot(day)
+        stats = [
+            stat
+            for _, answer in _stored_answers(snapshot)
+            for stat in answer.get("cited_stats") or []
+            if stat.get("id")
+        ]
+        if not stats:
+            continue
+        body = build_post(snapshot).body_en
+        for stat in stats:
+            assert f'<span class="blog-cite-id">{stat["id"]}</span>' in body
+        return
+    pytest.skip("no committed snapshot cites a statistic by ID")
+
+
+def _stored_answers(snapshot: dict) -> list[tuple[str, dict]]:
+    return [
+        (str(group.get("title") or ""), answer)
+        for group in (snapshot.get("questions") or {}).get("groups") or []
+        for answer in group.get("answers") or []
+    ]
+
+
+def test_a_chinese_brief_translates_the_fixed_question_prompts():
+    for day in reversed(_snapshot_days()):
+        snapshot = _snapshot(day)
+        answers = _stored_answers(snapshot)
+        post = build_post(snapshot)
+        if not answers or post.body_zh is None:
+            continue
+        translated = [
+            (title, answer)
+            for title, answer in answers
+            if title in _QUESTION_ZH or str(answer.get("question")) in _QUESTION_ZH
+        ]
+        assert translated, f"{day} stores no prompt the dashboard translates"
+        for title, answer in translated:
+            for english in (title, str(answer.get("question"))):
+                if english in _QUESTION_ZH:
+                    assert _QUESTION_ZH[english] in post.body_zh
+                    assert f"<h3>{english}</h3>" not in post.body_zh
+        return
+    pytest.skip("no committed snapshot pairs stored answers with a translation")
+
+
+def test_question_translations_match_the_dashboard_table():
+    """One prompt cannot read one way on the dashboard and another on the blog."""
+    app_js = (Path(__file__).resolve().parents[1] / "site" / "assets" / "app.js").read_text(
+        encoding="utf-8"
+    )
+    for english, chinese in _QUESTION_ZH.items():
+        match = re.search(rf'"{re.escape(english)}":\s*\n?\s*"([^"]+)"', app_js)
+        assert match, f"the dashboard does not translate {english!r}"
+        assert match.group(1) == chinese

--- a/tests/test_blog.py
+++ b/tests/test_blog.py
@@ -28,13 +28,13 @@ from benchmark_radar.feed import SITE_URL
 # The blog chrome is extracted from the committed dashboard source, so the
 # tests exercise the real site/index.html rather than a hand-written fixture
 # that could drift from what ships.
-DASHBOARD_HTML = (Path(__file__).resolve().parents[1] / "site" / "index.html").read_text(
-    encoding="utf-8"
-)
+SITE_DIR = Path(__file__).resolve().parents[1] / "site"
+DASHBOARD_HTML = (SITE_DIR / "index.html").read_text(encoding="utf-8")
+APP_JS = (SITE_DIR / "assets" / "app.js").read_text(encoding="utf-8")
 
 
 def write_blog_with_chrome(snapshots, tmp_path):
-    return write_blog(snapshots, tmp_path, dashboard_html=DASHBOARD_HTML)
+    return write_blog(snapshots, tmp_path, dashboard_html=DASHBOARD_HTML, app_js=APP_JS)
 
 
 SNAPSHOT_DIR = Path(__file__).resolve().parents[1] / "data" / "snapshots"
@@ -475,8 +475,8 @@ def test_the_footer_build_date_is_baked_from_the_day_the_page_describes(tmp_path
     write_blog_with_chrome([_briefed(), _legacy()], tmp_path)
     brief = (tmp_path / "blog" / "2026-08-30" / "index.html").read_text(encoding="utf-8")
     legacy = (tmp_path / "blog" / "2026-07-23" / "index.html").read_text(encoding="utf-8")
-    assert '<p id="build-meta">Updated 2026-08-30</p>' in brief
-    assert '<p id="build-meta">Updated 2026-07-23</p>' in legacy
+    assert '<span data-i18n="Updated">Updated</span> 2026-08-30' in brief
+    assert '<span data-i18n="Updated">Updated</span> 2026-07-23' in legacy
     assert "Updated \u2014" not in brief
 
 
@@ -488,3 +488,35 @@ def test_a_missing_dashboard_source_fails_visibly(tmp_path):
 def test_the_extractor_fails_loudly_when_the_dashboard_changes_shape():
     with pytest.raises(ValueError, match="masthead"):
         extract_site_chrome("<html><body><p>no header here</p></body></html>")
+
+
+def test_the_chrome_i18n_table_is_baked_from_app_js_for_chinese_readers(tmp_path):
+    write_blog_with_chrome([_briefed()], tmp_path)
+    page = (tmp_path / "blog" / "2026-08-30" / "index.html").read_text(encoding="utf-8")
+    match = re.search(
+        r'<script type="application/json" id="chrome-i18n">(.*?)</script>', page, re.S
+    )
+    assert match, "the baked chrome-i18n table is missing"
+    table = json.loads(match.group(1))
+    # Same reviewed strings the dashboard applies: the contact label, the
+    # toggle states, and the badge aria templates.
+    assert table["Contact"] == "联系作者"
+    assert table["Switch to English"] == "切换到英文"
+    assert "{count}" in table["Star this repository on GitHub. {count} stars"]
+    assert table["Updated"] == "更新于"
+
+
+def test_nav_labels_without_a_reviewed_string_stay_english_like_the_dashboard(tmp_path):
+    # The dashboard's t() falls back to the key when the table lacks it, so
+    # short section labels stay English there; the blog must mirror that
+    # instead of inventing translations.
+    write_blog_with_chrome([_briefed()], tmp_path)
+    page = (tmp_path / "blog" / "2026-08-30" / "index.html").read_text(encoding="utf-8")
+    match = re.search(
+        r'<script type="application/json" id="chrome-i18n">(.*?)</script>', page, re.S
+    )
+    table = json.loads(match.group(1))
+    # Section labels carry reviewed translations (Blog → 博客), same as the
+    # dashboard's menubar in Chinese mode.
+    assert table["Blog"] == "博客"
+    assert table["CLI"] == "命令行"

--- a/tests/test_blog.py
+++ b/tests/test_blog.py
@@ -218,20 +218,25 @@ def test_stored_chinese_is_published_with_a_toggle():
     assert "该信息流经过关键词筛选" in post.body_zh
 
 
-def test_a_day_without_stored_chinese_publishes_english_only(tmp_path):
+def test_a_day_without_stored_chinese_publishes_english_body_with_the_toggle(tmp_path):
     post = build_post(_legacy())
     assert post.body_zh is None and post.title_zh is None
     write_blog_with_chrome([_legacy()], tmp_path)
     page = (tmp_path / "blog" / "2026-07-23" / "index.html").read_text(encoding="utf-8")
+    # No invented translation: the body ships English-only. The toggle stays,
+    # because the chrome itself is translatable on every page.
     assert 'data-lang-content="zh"' not in page
-    assert 'id="lang-toggle"' not in page
+    assert 'data-lang-content="en"' in page
+    assert 'id="lang-toggle"' in page
 
 
-def test_the_toggle_appears_only_where_a_translation_exists(tmp_path):
-    write_blog_with_chrome([_briefed(status="insight")], tmp_path)
-    page = (tmp_path / "blog" / "2026-08-30" / "index.html").read_text(encoding="utf-8")
-    assert page.count('id="lang-toggle"') == 1
-    assert 'data-lang-content="zh"' in page and 'data-lang-content="en"' in page
+def test_the_toggle_is_on_every_blog_page_like_the_dashboard(tmp_path):
+    write_blog_with_chrome([_briefed(status="insight"), _legacy()], tmp_path)
+    for slug in ("", "archive/", "2026-08-30/", "2026-07-23/"):
+        page = (tmp_path / "blog" / slug / "index.html").read_text(encoding="utf-8")
+        assert page.count('id="lang-toggle"') == 1, f"missing toggle on /blog/{slug}"
+    translated = (tmp_path / "blog" / "2026-08-30" / "index.html").read_text(encoding="utf-8")
+    assert 'data-lang-content="zh"' in translated and 'data-lang-content="en"' in translated
 
 
 # --- the published tree ---------------------------------------------------

--- a/tests/test_blog.py
+++ b/tests/test_blog.py
@@ -1,0 +1,321 @@
+"""The blog publishes one page per committed snapshot, and only from snapshots."""
+
+import copy
+import json
+import re
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+import pytest
+
+from benchmark_radar.blog import LATEST_POST_LIMIT, blog_feed_tree, build_posts, write_blog
+from benchmark_radar.blog_content import (
+    KIND_BRIEF,
+    KIND_EVIDENCE,
+    KIND_NO_CHANGE,
+    build_post,
+)
+from benchmark_radar.blog_shell import BLOG_ARCHIVE_PATH, BLOG_FEED_PATH, BLOG_PATH
+from benchmark_radar.feed import SITE_URL
+
+SNAPSHOT_DIR = Path(__file__).resolve().parents[1] / "data" / "snapshots"
+
+
+def _snapshot(day: str) -> dict:
+    return json.loads((SNAPSHOT_DIR / f"{day}.json").read_text(encoding="utf-8"))
+
+
+def _snapshot_days() -> list[str]:
+    return sorted(path.stem for path in SNAPSHOT_DIR.glob("*.json"))
+
+
+def _text(html: str) -> str:
+    return " ".join(re.sub(r"<[^>]+>", " ", html).split())
+
+
+def _briefed(status: str | None = None) -> dict:
+    """A snapshot carrying a complete stored briefing and one question answer."""
+    return {
+        "date": "2026-08-30",
+        "generated_at": "2026-08-30T02:00:00+00:00",
+        "evidence_items": [
+            {
+                "title": "A new evaluation suite",
+                "source": "arXiv",
+                "url": "https://arxiv.org/abs/2608.00001",
+            },
+            {"title": "No link here", "source": "GitHub Release"},
+        ],
+        "attention": {"observations": [{"id": "A1"}]},
+        "briefing": {
+            "status": status,
+            "bullets": ["Agentic artifacts rose to 26% of the captured feed."],
+            "bullets_zh": ["智能体成果占捕获信息流的 26%。"],
+            "caveat": "The feed is keyword-filtered.",
+            "caveat_zh": "该信息流经过关键词筛选。",
+            "model": "gpt-5.6-sol",
+            "input": {"coverage": {"evidence_injected": 1, "corpus_evidence_records": 2}},
+            "citations": [
+                {
+                    "title": "A new evaluation suite",
+                    "source": "arXiv",
+                    "url": "https://arxiv.org/abs/2608.00001",
+                }
+            ],
+        },
+        "questions": {
+            "groups": [
+                {
+                    "title": "What arrived today",
+                    "answers": [
+                        {
+                            "question": "What is new?",
+                            "question_zh": "有什么新内容？",
+                            "signal": "One suite landed.",
+                            "signal_zh": "出现了一个新套件。",
+                            "plain_english": "A single benchmark appeared.",
+                            "plain_chinese": "出现了一个 benchmark。",
+                            "takeaway": "Watch the next few days.",
+                            "counter_view": "One day is not a trend.",
+                            "confidence": "medium",
+                            "sufficient_evidence": False,
+                            "cited_stats": [
+                                {"label": "artifacts today", "value": 1, "unit": "count"}
+                            ],
+                            "cited_evidence": [
+                                {
+                                    "title": "A new evaluation suite",
+                                    "source": "arXiv",
+                                    "url": "https://arxiv.org/abs/2608.00001",
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        },
+    }
+
+
+def _legacy() -> dict:
+    """An early snapshot from before briefings were stored."""
+    return {
+        "date": "2026-07-23",
+        "generated_at": "2026-07-23T02:00:00+00:00",
+        "attention": {"observations": []},
+        "evidence_items": [
+            {"title": f"Record {index}", "source": "arXiv", "url": f"https://example.org/{index}"}
+            for index in range(25)
+        ],
+    }
+
+
+# --- one page per snapshot, whatever kind of day it was -------------------
+
+
+def test_every_committed_snapshot_gets_exactly_one_post():
+    days = _snapshot_days()
+    posts = build_posts([_snapshot(day) for day in days])
+    assert [post.slug for post in posts] == sorted(days, reverse=True)
+
+
+def test_committed_history_covers_all_three_kinds_of_day():
+    kinds = {post.kind for post in build_posts([_snapshot(day) for day in _snapshot_days()])}
+    assert kinds == {KIND_BRIEF, KIND_NO_CHANGE, KIND_EVIDENCE}
+
+
+def test_no_material_insight_day_is_published_as_its_own_report():
+    post = build_post(_briefed(status="no_material_insight"))
+    assert post.kind == KIND_NO_CHANGE
+    assert "Agentic artifacts rose" in _text(post.body_en)
+
+
+def test_missing_calendar_days_get_no_page():
+    """A gap in collection stays a gap; an empty post would be an invented day."""
+    posts = build_posts([_snapshot("2026-08-08"), _snapshot("2026-08-10")])
+    assert [post.slug for post in posts] == ["2026-08-10", "2026-08-08"]
+
+
+def test_duplicate_snapshot_dates_are_rejected():
+    with pytest.raises(ValueError, match="duplicate snapshot dates"):
+        build_posts([_briefed(), _briefed()])
+
+
+# --- what each kind of day is allowed to claim ----------------------------
+
+
+def test_briefed_day_renders_every_stored_field():
+    body = _text(build_post(_briefed(status="insight")).body_en)
+    assert "Agentic artifacts rose" in body
+    assert "What is new?" in body
+    assert "medium confidence" in body
+    assert "Not enough evidence" in body
+    assert "artifacts today: 1" in body
+    assert "Takeaway: Watch the next few days." in body
+    assert "Another reading: One day is not a trend." in body
+    assert "Briefing model: gpt-5.6-sol" in body
+    assert "It read 1 of 2 records." in body
+    assert "The feed is keyword-filtered." in body
+
+
+def test_legacy_day_is_labelled_a_deterministic_summary_not_a_briefing():
+    post = build_post(_legacy())
+    body = _text(post.body_en)
+    assert post.kind == KIND_EVIDENCE
+    assert "No briefing was stored for this day" in body
+    assert "deterministic summary of the 25 evidence records" in body
+    assert "not a synthesized briefing" in body
+    assert "Daily briefing" not in body
+
+
+def test_legacy_day_shows_the_first_ten_stored_records():
+    body = build_post(_legacy()).body_en
+    listed = re.findall(r"Record \d+", body)
+    assert listed == [f"Record {index}" for index in range(10)]
+
+
+def test_partial_briefing_never_invents_a_model_or_coverage():
+    """2026-08-05 stored bullets with no generator metadata; say so, do not guess."""
+    body = _text(build_post(_snapshot("2026-08-05")).body_en)
+    assert "without recording the model that produced it" in body
+    assert "Briefing model:" not in body
+    assert "0 of 0" not in body
+
+
+def test_a_source_url_that_is_not_http_is_dropped():
+    snapshot = _briefed()
+    snapshot["briefing"]["citations"] = [{"title": "Bad", "url": "javascript:alert(1)"}]
+    snapshot["questions"]["groups"][0]["answers"][0]["cited_evidence"] = []
+    assert all(url.startswith("https://") for _, url in build_post(snapshot).sources)
+
+
+# --- bilingual behavior ---------------------------------------------------
+
+
+def test_stored_chinese_is_published_with_a_toggle():
+    post = build_post(_briefed(status="insight"))
+    assert post.body_zh is not None
+    assert "智能体成果占捕获信息流的 26%" in post.body_zh
+    assert "该信息流经过关键词筛选" in post.body_zh
+
+
+def test_a_day_without_stored_chinese_publishes_english_only(tmp_path):
+    post = build_post(_legacy())
+    assert post.body_zh is None and post.title_zh is None
+    write_blog([_legacy()], tmp_path)
+    page = (tmp_path / "blog" / "2026-07-23" / "index.html").read_text(encoding="utf-8")
+    assert 'data-lang-content="zh"' not in page
+    assert 'id="lang-toggle"' not in page
+
+
+def test_the_toggle_appears_only_where_a_translation_exists(tmp_path):
+    write_blog([_briefed(status="insight")], tmp_path)
+    page = (tmp_path / "blog" / "2026-08-30" / "index.html").read_text(encoding="utf-8")
+    assert page.count('id="lang-toggle"') == 1
+    assert 'data-lang-content="zh"' in page and 'data-lang-content="en"' in page
+
+
+# --- the published tree ---------------------------------------------------
+
+
+def test_write_blog_publishes_index_archive_feed_and_one_page_per_day(tmp_path):
+    snapshots = [_snapshot(day) for day in _snapshot_days()]
+    report = write_blog(snapshots, tmp_path)
+    blog = tmp_path / "blog"
+    assert report["post_count"] == len(snapshots)
+    assert (blog / "index.html").exists()
+    assert (blog / "archive" / "index.html").exists()
+    assert (blog / "feed.xml").exists()
+    for snapshot in snapshots:
+        assert (blog / str(snapshot["date"]) / "index.html").exists()
+
+
+def test_the_landing_page_shows_the_latest_days_and_the_archive_shows_all(tmp_path):
+    snapshots = [_snapshot(day) for day in _snapshot_days()]
+    write_blog(snapshots, tmp_path)
+    latest = (tmp_path / "blog" / "index.html").read_text(encoding="utf-8")
+    archive = (tmp_path / "blog" / "archive" / "index.html").read_text(encoding="utf-8")
+    assert latest.count('class="blog-card"') == LATEST_POST_LIMIT
+    assert archive.count('class="blog-card"') == len(snapshots)
+    for snapshot in snapshots:
+        assert f"{BLOG_PATH}{snapshot['date']}/" in archive
+
+
+def test_a_rebuild_removes_pages_for_days_that_left_the_history(tmp_path):
+    write_blog([_briefed(), _legacy()], tmp_path)
+    assert (tmp_path / "blog" / "2026-08-30" / "index.html").exists()
+    write_blog([_legacy()], tmp_path)
+    assert not (tmp_path / "blog" / "2026-08-30").exists()
+    assert (tmp_path / "blog" / "2026-07-23" / "index.html").exists()
+
+
+def test_rebuilding_is_deterministic_and_never_mutates_the_snapshot(tmp_path):
+    snapshots = [_snapshot(day) for day in _snapshot_days()]
+    original = copy.deepcopy(snapshots)
+    write_blog(snapshots, tmp_path / "first")
+    write_blog(snapshots, tmp_path / "second")
+    assert snapshots == original
+    for page in sorted((tmp_path / "first" / "blog").rglob("*")):
+        if page.is_file():
+            twin = tmp_path / "second" / "blog" / page.relative_to(tmp_path / "first" / "blog")
+            assert page.read_bytes() == twin.read_bytes()
+
+
+# --- metadata a search engine and a reader both depend on -----------------
+
+
+def test_each_page_carries_its_own_canonical_and_blogposting_schema(tmp_path):
+    write_blog([_briefed(status="insight")], tmp_path)
+    page = (tmp_path / "blog" / "2026-08-30" / "index.html").read_text(encoding="utf-8")
+    canonical = f"{SITE_URL}{BLOG_PATH}2026-08-30/"
+    assert f'<link rel="canonical" href="{canonical}">' in page
+    posting = next(payload for payload in _schemas(page) if payload.get("@type") == "BlogPosting")
+    assert posting["url"] == canonical
+    assert posting["datePublished"] == "2026-08-30"
+    assert posting["citation"] == ["https://arxiv.org/abs/2608.00001"]
+    assert posting["inLanguage"] == ["en", "zh-Hans"]
+
+
+def _schemas(page: str) -> list[dict]:
+    return [
+        json.loads(block.replace("<\\/", "</"))
+        for block in re.findall(r'<script type="application/ld\+json">(.*?)</script>', page, re.S)
+    ]
+
+
+def test_each_page_carries_a_breadcrumb_back_to_the_blog(tmp_path):
+    write_blog([_briefed()], tmp_path)
+    page = (tmp_path / "blog" / "2026-08-30" / "index.html").read_text(encoding="utf-8")
+    crumb = next(p for p in _schemas(page) if p.get("@type") == "BreadcrumbList")
+    assert [item["item"] for item in crumb["itemListElement"]] == [
+        f"{SITE_URL}/",
+        f"{SITE_URL}{BLOG_PATH}",
+        f"{SITE_URL}{BLOG_PATH}2026-08-30/",
+    ]
+
+
+def test_sitemap_entries_cover_the_blog_and_date_each_brief_individually(tmp_path):
+    snapshots = [_snapshot(day) for day in _snapshot_days()]
+    entries = write_blog(snapshots, tmp_path)["sitemap_entries"]
+    paths = [path for path, _ in entries]
+    assert paths[:2] == [BLOG_PATH, BLOG_ARCHIVE_PATH]
+    assert len(paths) == len(snapshots) + 2
+    by_path = dict(entries)
+    assert by_path["/blog/2026-07-23/"] == "2026-07-23"
+    assert by_path["/blog/2026-09-01/"] == "2026-09-01"
+
+
+def test_the_blog_feed_lists_every_post_and_is_self_describing():
+    posts = build_posts([_snapshot(day) for day in _snapshot_days()])
+    channel = blog_feed_tree(posts).getroot().find("channel")
+    links = [item.find("link").text for item in channel.findall("item")]
+    assert links == [post.canonical for post in posts]
+    self_link = channel.find("{http://www.w3.org/2005/Atom}link")
+    assert self_link.get("href") == SITE_URL + BLOG_FEED_PATH
+
+
+def test_the_blog_feed_is_written_into_the_published_tree(tmp_path):
+    snapshots = [_snapshot(day) for day in _snapshot_days()]
+    write_blog(snapshots, tmp_path)
+    channel = ET.parse(tmp_path / "blog" / "feed.xml").getroot().find("channel")
+    assert len(channel.findall("item")) == len(snapshots)

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -2896,3 +2896,49 @@ def test_issue_332_the_freshest_releases_reach_page_one():
     )
     assert max(age_hours(i) for i in flat[:20]) > 24, "fixture no longer shows the old bug"
     assert max(age_hours(i) for i in page_one) <= 24
+
+
+# --- the blog's one and only footprint in the dashboard -------------------
+#
+# The blog is a separate set of documents. The dashboard gains exactly one
+# menubar link to it and nothing else: no view, no route, no seed, no dialog.
+# These pin that boundary, because the cheapest way to break the dashboard
+# while adding pages beside it is to let the new thing leak into its router.
+
+
+def test_the_dashboard_menubar_gains_exactly_one_blog_link():
+    nav = re.search(
+        r'<nav class="view-nav".*?</nav>', Path("site/index.html").read_text(encoding="utf-8"), re.S
+    ).group(0)
+    blog_links = re.findall(r"<a\b[^>]*href=\"/blog/\"[^>]*>", nav)
+    assert len(blog_links) == 1
+    assert "data-view" not in blog_links[0]
+
+
+def test_the_blog_link_is_not_a_client_route():
+    """app.js intercepts clicks on [data-view] only, so this must stay a real load."""
+    from benchmark_radar.app_pages import APP_VIEWS
+
+    assert "blog" not in APP_VIEWS
+    app_js = Path("site/assets/app.js").read_text(encoding="utf-8")
+    assert 'data-view="blog"' not in app_js
+    assert "VIEW_SEO" in app_js and '"/blog/"' not in app_js
+
+
+def test_the_blog_menubar_label_is_translated():
+    app_js = Path("site/assets/app.js").read_text(encoding="utf-8")
+    assert re.search(r'^\s*Blog: "[^"]+",$', app_js, re.M)
+
+
+def test_blog_styles_cannot_reach_the_dashboard():
+    """Every rule in blog.css is scoped to a class only generated blog pages carry."""
+    css = Path("site/assets/blog.css").read_text(encoding="utf-8")
+    selectors = [
+        part.strip()
+        for block in re.findall(r"([^{}]+)\{", re.sub(r"/\*.*?\*/", "", css, flags=re.S))
+        for part in block.split(",")
+        if part.strip() and not part.strip().startswith("@")
+    ]
+    assert selectors
+    assert all(selector.startswith(".blog-page") for selector in selectors)
+    assert "blog-page" not in Path("site/index.html").read_text(encoding="utf-8")

--- a/tests/test_site_seo.py
+++ b/tests/test_site_seo.py
@@ -144,3 +144,29 @@ def test_structured_data_describes_a_searchable_site_and_a_dataset():
     distributions = [entry["contentUrl"] for entry in dataset["distribution"]]
     assert dataset["url"] in distributions
     assert dataset["license"].endswith("/MIT")
+
+
+def test_sitemap_lists_the_blog_with_a_per_brief_lastmod():
+    """A brief from three weeks ago did not change when today's snapshot landed."""
+    root = sitemap_tree(
+        [{"generated_at": "2026-09-01T02:17:00+00:00"}],
+        view_paths=[],
+        blog_entries=[
+            ("/blog/", "2026-09-01"),
+            ("/blog/archive/", "2026-09-01"),
+            ("/blog/2026-09-01/", "2026-09-01"),
+            ("/blog/2026-08-10/", "2026-08-10"),
+        ],
+    ).getroot()
+    entries = {
+        node.find("sm:loc", NS).text: getattr(node.find("sm:lastmod", NS), "text", None)
+        for node in root.findall("sm:url", NS)
+    }
+    assert entries[f"{SITE_URL}/blog/"] == "2026-09-01"
+    assert entries[f"{SITE_URL}/blog/archive/"] == "2026-09-01"
+    assert entries[f"{SITE_URL}/blog/2026-08-10/"] == "2026-08-10"
+
+
+def test_a_build_that_writes_no_blog_lists_no_blog_urls():
+    root = sitemap_tree([{"generated_at": "2026-09-01T02:17:00+00:00"}]).getroot()
+    assert not [node.text for node in root.findall("sm:url/sm:loc", NS) if "/blog/" in node.text]

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -355,6 +355,9 @@ def test_rebuild_writes_the_sitemap_at_the_site_root(tmp_path, site_shell):
         f"{SITE_URL}/benchmarks/",
         f"{SITE_URL}/benchmarks/alpha-bench/",
         f"{SITE_URL}/benchmarks/zeta-bench/",
+        f"{SITE_URL}/blog/",
+        f"{SITE_URL}/blog/archive/",
+        f"{SITE_URL}/blog/2026-07-27/",
     ]
     lastmods = [node.text for node in root.findall("sm:url/sm:lastmod", ns)]
     assert lastmods == ["2026-07-27"] * len(urls)
@@ -1497,3 +1500,74 @@ def test_rebuild_dashboard_uses_an_empty_briefing_when_the_day_has_none(tmp_path
 
     # The dashboard renders its own absent state from this.
     assert json.loads(output.read_text())["days"][0]["briefing"] == {}
+
+
+def test_rebuild_publishes_a_brief_for_every_snapshot_and_lists_them(tmp_path, site_shell):
+    """The blog is built in the same run as the dashboard, from the same history."""
+    snapshot_dir = tmp_path / "snapshots"
+    write_snapshot(radar_run(26), snapshot_dir)
+    write_snapshot(radar_run(27), snapshot_dir)
+    site_dir = tmp_path / "site"
+    site_shell(site_dir)
+
+    rebuild_dashboard(
+        snapshot_dir,
+        site_dir / "data" / "radar.json",
+        feed_output=site_dir / "feed.xml",
+    )
+
+    for day in ("2026-07-26", "2026-07-27"):
+        assert (site_dir / "blog" / day / "index.html").exists()
+    assert (site_dir / "blog" / "index.html").exists()
+    assert (site_dir / "blog" / "archive" / "index.html").exists()
+
+    ns = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+    urls = [
+        node.text
+        for node in ET.parse(site_dir / "sitemap.xml").getroot().findall("sm:url/sm:loc", ns)
+    ]
+    assert f"{SITE_URL}/blog/" in urls
+    assert f"{SITE_URL}/blog/archive/" in urls
+    assert f"{SITE_URL}/blog/2026-07-27/" in urls
+
+
+def test_the_site_feed_and_the_blog_feed_stay_separate(tmp_path, site_shell):
+    """/feed.xml keeps pointing at the dashboard; /blog/feed.xml points at the pages."""
+    snapshot_dir = tmp_path / "snapshots"
+    write_snapshot(radar_run(27), snapshot_dir)
+    site_dir = tmp_path / "site"
+    site_shell(site_dir)
+
+    rebuild_dashboard(
+        snapshot_dir,
+        site_dir / "data" / "radar.json",
+        feed_output=site_dir / "feed.xml",
+    )
+
+    site_feed = ET.parse(site_dir / "feed.xml").getroot()
+    blog_feed = ET.parse(site_dir / "blog" / "feed.xml").getroot()
+    assert site_feed.findtext("./channel/title") == "Benchmark Radar"
+    assert [item.findtext("link") for item in site_feed.findall("./channel/item")] == [
+        f"{SITE_URL}/?date=2026-07-27"
+    ]
+    assert blog_feed.findtext("./channel/title") == "Benchmark Radar daily brief"
+    assert [item.findtext("link") for item in blog_feed.findall("./channel/item")] == [
+        f"{SITE_URL}/blog/2026-07-27/"
+    ]
+
+
+def test_a_data_only_rebuild_writes_no_blog(tmp_path):
+    """No feed output means no site build, so no pages and no blog URLs listed."""
+    snapshot_dir = tmp_path / "snapshots"
+    write_snapshot(radar_run(27), snapshot_dir)
+    output = tmp_path / "data" / "radar.json"
+
+    rebuild_dashboard(snapshot_dir, output)
+
+    assert not (tmp_path / "data" / "blog").exists()
+    ns = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+    urls = [
+        node.text
+        for node in ET.parse(output.parent / "sitemap.xml").getroot().findall("sm:url/sm:loc", ns)
+    ]
+    assert not [url for url in urls if "/blog/" in url]


### PR DESCRIPTION
## What this adds

A daily brief blog at `/blog/`, built from the committed snapshots. One page per
collection day, plus a landing page (latest 30), a full archive, and its own RSS
feed at `/blog/feed.xml`.

- `/blog/` and `/blog/archive/` list every brief.
- `/blog/YYYY-MM-DD/` is one day's report.
- `/blog/feed.xml` is a separate feed. The existing `/feed.xml` is unchanged.

The dashboard gains exactly one thing: a `Blog` link in the menubar after
Explore. It carries no `data-view`, so it is a normal page load and not an SPA
route. No existing view, control, or `styles.css` rule changes.

## Three kinds of day, each labelled

- **Daily brief** for a snapshot with a stored briefing: bullets, questions,
  cited statistics, confidence, counter-views, caveats, and provenance.
- **No material change** for a `no_material_insight` briefing, published
  unchanged. "Nothing moved enough to call it a change" is that day's report,
  and dropping it would leave a hole in the record.
- **Evidence summary** for the early snapshots from before briefings were
  stored. These show the day's counts and its first ten evidence records, and
  say on the page that they are a deterministic summary, not a synthesized
  briefing.

Nothing here calls a model or the network. Every word comes from the snapshot,
so `classify` stays safe in CI and a rebuild is byte-identical.

## Reader-facing details

- Citations show the stored `E###` and `S###` IDs. The prose cites by ID and the
  IDs are not contiguous, so a page that printed only titles could say `E011`
  while showing that document as item 3.
- Chinese is published when the snapshot stored a reviewed translation, with a
  toggle. Pages without one ship no toggle and no invented translation. Fixed
  question prompts reuse the dashboard's translations, and a test fails if the
  two tables disagree.
- Falling back to English on an untranslated brief does not overwrite a reader's
  stored language preference, which is shared with the dashboard.
- Each brief gets its own sitemap `lastmod`, so a deploy does not ask crawlers to
  refetch the whole archive.

## Verification

- Full CI sequence green on a clean `git worktree` checkout: ruff check, ruff
  format, normalize-external, classify, build-data-release, 1177 tests passing.
- Every route smoke-tested from the built site: `/blog/`, `/blog/archive/`,
  `/blog/feed.xml`, and per-day pages of all three kinds.
- Dashboard compared before and after at 1440x900 and 390x844. The only visible
  difference is the new menubar item.

`site/blog/` is generated and gitignored, like the rest of `site/data/`.

Please merge with a merge commit, not a squash, per the repository policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
