### PR TITLE
Simplify dashboard navigation and repository badges

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -1034,8 +1034,6 @@ const I18N = {
       " · 最近 18 个月窗口内发布的 {count} 项已经出现在三家及以上有明确日期的机构中。在解读原始排名之前，先看它们的轨迹变化。",
     "Show all {count} benchmarks": "显示全部 {count} 个benchmark",
     "Star this repository on GitHub. {count} stars": "在 GitHub 上给这个仓库点 Star。{count} 个 star",
-    "Fork this repository on GitHub. {count} forks": "在 GitHub 上 fork 这个仓库。{count} 个 fork",
-    "Open a new issue on GitHub. {count} issues open": "在 GitHub 上提交新 issue。当前有 {count} 个 open issue",
   },
 };
 
@@ -8548,19 +8546,16 @@ const REPO_SLUG = "ktwu01/benchmark-radar";
 // The visible badge reads "★ Star 12", which a screen reader would announce as
 // a bare statistic. The accessible name states the action and keeps the count
 // as context, so the control sounds like the invitation it is.
-const BADGE_ACTIONS = {
-  "badge-stars": (count) => t("Star this repository on GitHub. {count} stars", { count }),
-  "badge-forks": (count) => t("Fork this repository on GitHub. {count} forks", { count }),
-  "badge-issues": (count) => t("Open a new issue on GitHub. {count} issues open", { count }),
-};
-
-function setBadgeCount(id, value) {
-  const badge = byId(id);
+function setStarBadgeCount(value) {
+  const badge = byId("badge-stars");
   const node = badge?.querySelector("[data-count]");
   if (!node) return;
   const count = Number(value || 0).toLocaleString();
   node.textContent = count;
-  badge.setAttribute("aria-label", BADGE_ACTIONS[id](count));
+  badge.setAttribute(
+    "aria-label",
+    t("Star this repository on GitHub. {count} stars", { count }),
+  );
 }
 
 async function renderRepoBadges() {
@@ -8572,21 +8567,7 @@ async function renderRepoBadges() {
     });
     if (!response.ok) return;
     const repo = await response.json();
-    setBadgeCount("badge-stars", repo.stargazers_count);
-    setBadgeCount("badge-forks", repo.forks_count);
-    // open_issues_count includes pull requests, so building the count from it
-    // overstates how many issues are actually open. Ask search for issues only,
-    // and leave the badge blank if that fails rather than showing the inflated
-    // number.
-    const issues = await fetch(
-      `https://api.github.com/search/issues?q=${encodeURIComponent(
-        `repo:${REPO_SLUG} is:issue is:open`,
-      )}&per_page=1`,
-      { headers: { Accept: "application/vnd.github+json" } },
-    );
-    if (issues.ok) {
-      setBadgeCount("badge-issues", (await issues.json()).total_count);
-    }
+    setStarBadgeCount(repo.stargazers_count);
   } catch (error) {
     console.debug("Repository badge counts unavailable", error);
   }

--- a/site/index.html
+++ b/site/index.html
@@ -341,6 +341,17 @@
 
     <nav class="view-nav" aria-label="Dashboard views" data-i18n-aria="Dashboard views">
       <button type="button" class="nav-active" data-view="today" aria-controls="today-view" aria-current="page" data-i18n="Today">Today</button>
+      <!-- CLI is the primary utility, so it stays immediately after Today. -->
+      <a
+        href="/cli/"
+        id="cli-nav"
+        aria-haspopup="dialog"
+        aria-controls="cli-dialog"
+        aria-expanded="false"
+        data-i18n="CLI"
+      >
+        CLI
+      </a>
       <!-- Real links, not tab buttons. Each one is this same dashboard served
          at its own path with that view already open and its rows already in the
          HTML, so a crawler and a reader with a slow connection both get content
@@ -361,8 +372,8 @@
       >
         Explore
       </a>
-      <!-- These remain the same pop-up panels readers already use, but their
-           hrefs give each one a server-rendered, indexable entry point. -->
+      <!-- Rubric remains the same pop-up panel readers already use, but its
+           href gives it a server-rendered, indexable entry point. -->
       <a
         href="/rubric/"
         id="rubric-nav"
@@ -373,16 +384,6 @@
         hidden
       >
         Rubric
-      </a>
-      <a
-        href="/cli/"
-        id="cli-nav"
-        aria-haspopup="dialog"
-        aria-controls="cli-dialog"
-        aria-expanded="false"
-        data-i18n="CLI"
-      >
-        CLI
       </a>
     </nav>
 

--- a/site/index.html
+++ b/site/index.html
@@ -269,9 +269,9 @@
           <span class="repo-badge-label" data-i18n="Contact">Contact</span>
         </button>
         <!--
-          Each badge is a call to action, not a link to a roster. The live counts
-          come from GitHub's public repository API; starring still opens the repo
-          itself, where the visitor can click GitHub's Star control.
+          Each badge is a call to action, not a link to a roster. The live Star
+          count comes from GitHub's public repository API; starring still opens
+          the repo itself, where the visitor can click GitHub's Star control.
         -->
         <div class="repo-badges" id="repo-badges" aria-label="Support this repository">
           <a
@@ -299,6 +299,8 @@
             rel="noopener noreferrer"
             title="Fork this repository"
             data-i18n-title="Fork this repository"
+            aria-label="Fork this repository"
+            data-i18n-aria="Fork this repository"
           >
             <svg class="outline-icon" viewBox="0 0 24 24" aria-hidden="true">
               <circle cx="12" cy="18" r="3"></circle>
@@ -308,7 +310,6 @@
               <path d="M6 9v2c0 .6.5 1.2 1.2 1.7l3.6 2.4"></path>
             </svg>
             <span class="repo-badge-label" data-i18n="Fork">Fork</span>
-            <span class="repo-badge-count" data-count>—</span>
           </a>
           <a
             class="repo-badge"
@@ -318,6 +319,8 @@
             rel="noopener noreferrer"
             title="Open a new issue"
             data-i18n-title="Open a new issue"
+            aria-label="Open a new issue"
+            data-i18n-aria="Open a new issue"
           >
             <svg class="outline-icon" viewBox="0 0 24 24" aria-hidden="true">
               <circle cx="12" cy="12" r="9"></circle>
@@ -329,7 +332,6 @@
               ></circle>
             </svg>
             <span class="repo-badge-label" data-i18n="Issues">Issues</span>
-            <span class="repo-badge-count" data-count>—</span>
           </a>
         </div>
       </div>

--- a/site/index.html
+++ b/site/index.html
@@ -348,7 +348,17 @@
         Leaderboard
       </a>
       <a href="/trends/" data-view="trends" aria-controls="trends-view" data-i18n="Trends">Trends</a>
-      <a href="/explore/" data-view="map" aria-controls="map-view" data-i18n="Explore">Explore</a>
+      <!-- Explore and Rubric remain available at their direct routes but are
+           temporarily hidden from the menu bar. -->
+      <a
+        href="/explore/"
+        data-view="map"
+        aria-controls="map-view"
+        data-i18n="Explore"
+        hidden
+      >
+        Explore
+      </a>
       <!-- These remain the same pop-up panels readers already use, but their
            hrefs give each one a server-rendered, indexable entry point. -->
       <a
@@ -358,6 +368,7 @@
         aria-controls="rubric-dialog"
         aria-expanded="false"
         data-i18n="Rubric"
+        hidden
       >
         Rubric
       </a>

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -191,6 +191,8 @@ def test_offline_cli_route_is_in_the_view_bar_behind_a_short_link():
     assert 'id="cli-nav"' in nav
     assert 'href="/cli/"' in nav
     assert 'aria-controls="cli-dialog"' in nav
+    assert nav.index('data-view="today"') < nav.index('id="cli-nav"')
+    assert nav.index('id="cli-nav"') < nav.index('data-view="leaderboard"')
     assert 'id="cli-dialog"' in html
     assert 'id="cli-content"' in html
     assert 'state.cli = pathUtility === "cli"' in script

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1199,25 +1199,32 @@ def test_today_view_shows_total_corpus_counts_by_category():
 
 
 def test_badge_accessible_names_state_the_action():
+    html = Path("site/index.html").read_text(encoding="utf-8")
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
 
-    assert "BADGE_ACTIONS" in script
-    for fragment in (
-        "Star this repository on GitHub",
-        "Fork this repository on GitHub",
-        "Open a new issue on GitHub",
-    ):
-        assert fragment in script
-    assert 'badge.setAttribute("aria-label"' in script
+    assert "Star this repository on GitHub" in script
+    for fragment in ("Fork this repository", "Open a new issue"):
+        assert f'aria-label="{fragment}"' in html
+    assert 'badge.setAttribute(\n    "aria-label",' in script
 
 
-def test_repo_badge_counts_are_visible():
+def test_only_the_repo_star_badge_shows_a_count():
     css = Path("site/assets/styles.css").read_text(encoding="utf-8")
     html = Path("site/index.html").read_text(encoding="utf-8")
+    script = Path("site/assets/app.js").read_text(encoding="utf-8")
 
     # Issue #402: the GitHub API count should be useful to sighted visitors,
     # not only present as clipped text for screen readers.
     assert 'id="badge-stars"' in html
+    star_badge = html.split('id="badge-stars"', 1)[1].split("</a>", 1)[0]
+    fork_badge = html.split('id="badge-forks"', 1)[1].split("</a>", 1)[0]
+    issue_badge = html.split('id="badge-issues"', 1)[1].split("</a>", 1)[0]
+    assert "data-count" in star_badge
+    assert "data-count" not in fork_badge
+    assert "data-count" not in issue_badge
+    assert html.count('class="repo-badge-count"') == 1
+    assert "repo.forks_count" not in script
+    assert "api.github.com/search/issues" not in script
     assert ".repo-badge-count" in css
     assert (
         "clip-path: inset(50%)"

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -63,6 +63,20 @@ def test_site_has_accessible_landmarks_and_views():
     assert "explorer-view" not in parser.ids
 
 
+def test_explore_and_rubric_are_hidden_from_the_menu_but_keep_direct_links():
+    html = Path("site/index.html").read_text(encoding="utf-8")
+    navigation = html.split('<nav class="view-nav"', 1)[1].split("</nav>", 1)[0]
+
+    for identifying_attribute, href in (
+        ('data-view="map"', "/explore/"),
+        ('id="rubric-nav"', "/rubric/"),
+    ):
+        opening = re.search(rf"<a\b(?=[^>]*{re.escape(identifying_attribute)})[^>]*>", navigation)
+        assert opening
+        assert re.search(r"\shidden(?:\s|>)", opening.group(0))
+        assert f'href="{href}"' in opening.group(0)
+
+
 def test_every_html_entry_point_loads_clarity_once_and_discloses_analytics():
     html_paths = sorted(Path("site").glob("*.html"))
     assert html_paths
@@ -1046,7 +1060,7 @@ def test_corpus_view_progressively_discloses_the_complete_relationship_map():
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
 
     assert 'data-view="map"' in html
-    assert 'data-i18n="Explore">Explore</a>' in html
+    assert re.search(r'data-i18n="Explore"[^>]*>\s*Explore\s*</a>', html)
     assert 'id="map-insights"' in html
     assert '<details class="relationship-explorer" id="relationship-explorer">' in html
     assert "renderMapInsights(corpus)" in script


### PR DESCRIPTION
## Result

- Orders the visible menu as Today, CLI, Leaderboard, then Trends.
- Hides Explore and Rubric from the dashboard menu bar.
- Keeps `/explore/` and `/rubric/` published and functional for direct access.
- Keeps the repository Star count, while removing count bubbles from Fork and Issues.
- Removes the now-unused Fork and open-Issue count requests.
- Adds regression coverage for the navigation order and badge visibility.

## Verification

- `ruff check .`
- `ruff format --check .`
- `benchmark-radar normalize-external`
- `benchmark-radar classify`
- `benchmark-radar build-data-release`
- `pytest -q` — 1,142 passed
- Desktop and 390px-wide browser checks
- Direct `/explore/` and `/rubric/` route checks

Fixes #512