### PR TITLE
ci: publish contributor scores with Radar App

### DIFF
--- a/.github/workflows/contributor-points.yml
+++ b/.github/workflows/contributor-points.yml
@@ -87,9 +87,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Create Radar App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.RADAR_APP_ID }}
+          private-key: ${{ secrets.RADAR_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: benchmark-radar
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: main
+          token: ${{ steps.app-token.outputs.token }}
       - name: Build ledger
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## What changed

Use the existing Radar GitHub App token for the contributor-points checkout, so its generated ledger commit can pass the protected-main ruleset.

## Verification

- `ruff check .`
- `ruff format --check .`
- `benchmark-radar normalize-external`
- `benchmark-radar classify`
- `benchmark-radar build-data-release`
- `pytest -q` (`1193 passed`)