### PR TITLE
UI: make the shared chrome simpler

### DIFF
--- a/.github/workflows/contributor-points.yml
+++ b/.github/workflows/contributor-points.yml
@@ -87,9 +87,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Create Radar App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.RADAR_APP_ID }}
+          private-key: ${{ secrets.RADAR_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: benchmark-radar
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: main
+          token: ${{ steps.app-token.outputs.token }}
       - name: Build ledger
         env:
           GH_TOKEN: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ written in the
 
 ## More
 
+- [Design principles](design.md)
 - [Scoring rubric](https://benchmark-radar.org/rubric/)
 - [Model-card adoption data](data/model_cards.yml)
 - [Public corpus schema](docs/cumulative-corpus.schema.json)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -65,6 +65,7 @@ npx skills add ktwu01/benchmark-radar
 
 ## 更多
 
+- [设计原则](design.md)
 - [评分规则](https://benchmark-radar.org/rubric/)
 - [模型卡采用数据](data/model_cards.yml)
 - [公开语料 schema](docs/cumulative-corpus.schema.json)

--- a/design.md
+++ b/design.md
@@ -1,0 +1,155 @@
+# Design principles
+
+Benchmark Radar helps people find benchmarks, understand what changed, and
+inspect the evidence. Every part of the product should make one of those tasks
+easier.
+
+## Start with the reader's question
+
+The first screen should answer:
+
+- What am I looking at?
+- Why does it matter?
+- What should I inspect next?
+
+Lead with the result or insight. Counts, methods, and pipeline details support
+the answer; they are not the answer.
+
+Design for two readers at once. A newcomer should understand the point without
+knowing benchmark jargon. An expert should be able to inspect sources,
+protocols, dates, and limitations.
+
+## Choose the simplest sufficient design
+
+Use the fewest concepts, controls, and layers needed to answer the reader's
+question.
+
+Before adding something, ask whether an existing page, filter, or detail view
+already does the job. A new topic does not need a new tab. A collected field
+does not need a card. An available count does not need a badge.
+
+Each element must earn its place through a clear user task. Remove duplicate
+labels, repeated caveats, decorative precision, and actions that are already
+available in context.
+
+Simplicity must not hide evidence. Provenance, uncertainty, protocols,
+accessible names, downloads, and citations are part of the product's trust.
+
+## Give each surface one job
+
+| Surface | Primary job |
+| --- | --- |
+| Today | Explain what appeared recently and why it matters |
+| Search | Find possible benchmarks across the corpus |
+| Leaderboard | Compare attention, adoption, or reported scores as separate modes |
+| Trends | Show change across comparable time windows |
+| Blog | Publish dated, shareable analysis |
+| CLI and Skill | Let people and agents query local data |
+
+One answer or action should dominate each surface. Secondary controls should
+remain available without competing with it.
+
+## Treat navigation as scarce space
+
+Global navigation is for frequent, distinct tasks. A useful route does not
+automatically deserve a tab.
+
+Prefer a filter, mode, contextual link, or detail view when the task already
+has a home. Rubrics, methods, citations, contact, and contribution links should
+appear where readers need them.
+
+Removing a route from global navigation does not require deleting the route.
+Demote it first when it still has expert or contextual value.
+
+Navigation is also state. Direct links must work, one state should have one
+active indicator, and Back and Forward should restore meaningful states.
+
+## Put insight before detail
+
+Show a concise answer first, then offer the evidence and method behind it.
+Expansion should be clear and reversible.
+
+Mobile layout must preserve the same priority. Do not bury a daily briefing
+below a long result list because the desktop result column appears first in the
+document.
+
+Explain a shared limitation once near the affected group. Do not repeat “not
+comparable” or “not enough history” in every card.
+
+## Keep evidence layers distinct
+
+| Layer | Meaning | What the interface must show |
+| --- | --- | --- |
+| Radar | Daily discovery evidence | Source and date; label it as a signal |
+| Catalog | Normalized external records | Provenance and source identity |
+| Curated measurements | Reviewed adoption and score history | Protocol, date, and comparability |
+
+Search returns candidates, not recommendations. Recent attention, model-card
+adoption, and model scores answer different questions and must not share an
+unlabelled ranking.
+
+Show empty, partial, stale, and incomparable states plainly. Do not replace
+missing evidence with guessed content.
+
+## Load only what the current task needs
+
+A view should respond without downloading unrelated data. Opening a route or
+dialog must not wait for the complete research corpus.
+
+Give each surface a bounded payload and a visible failure state. Tables and
+charts may scroll inside their containers; the page itself must not overflow
+horizontally.
+
+## Keep one source of truth
+
+Server-rendered pages and hydrated pages must show the same facts. Shared
+navigation, citations, labels, and public metadata should come from one owner
+or have parity tests.
+
+Do not fix source-data problems in generated files. Do not copy the same public
+fact into Python, JavaScript, and Markdown without naming its canonical source.
+
+## Measure tasks, not clicks
+
+Use behavior data to learn whether a surface helps readers finish a task. For a
+navigation destination, review:
+
+- intentional selections;
+- direct visits;
+- useful next actions;
+- quick returns, errors, and loading time;
+- differences between mobile and desktop.
+
+Set the observation window and decision threshold before reading the results.
+Low use may justify removing an item from global navigation, but it does not
+make a trust-critical or direct-linked capability useless.
+
+Use one analytics system. Review its audience policy, consent requirements,
+data collection, and masking settings before relying on its data.
+
+## Require evidence for additions
+
+Before adding a field, control, model, route, or layer, name:
+
+- the user question it answers;
+- evidence that the problem exists;
+- the source of truth;
+- what success looks like;
+- its mobile, accessibility, performance, and trust costs;
+- what it replaces if it competes for attention.
+
+Defer fields with no owner for collection, display, and maintenance.
+
+## Review checklist
+
+Before merging a user-facing change, check:
+
+- Can a newcomer explain the page after seeing the first screen?
+- Can an expert reach the provenance, protocol, and caveats?
+- Is one answer or action clearly primary?
+- Did a new choice replace or demote an old one?
+- Are Radar, Catalog, adoption, and scores still distinguishable?
+- Do the first response and hydrated page agree?
+- Does it work at 320px with long content, keyboard navigation, direct URLs,
+  Back and Forward, slow loading, and empty or error states?
+- Does it load only the data needed for the current task?

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -371,13 +371,8 @@ const I18N = {
     Data: "数据",
     Contact: "联系",
     "Privacy notice": "隐私声明",
-    "Support this repository": "支持这个仓库",
     "Open the repository and star it": "打开仓库并给个 Star",
     Star: "Star",
-    "Fork this repository": "Fork 这个仓库",
-    Fork: "Fork",
-    "Open a new issue": "新建 Issue",
-    Issues: "Issues",
     "Dashboard views": "仪表盘视图",
     Today: "今日",
     Leaderboard: "排行榜",
@@ -1032,8 +1027,6 @@ const I18N = {
       " · 最近 18 个月窗口内发布的 {count} 项已经出现在三家及以上有明确日期的机构中。在解读原始排名之前，先看它们的轨迹变化。",
     "Show all {count} benchmarks": "显示全部 {count} 个benchmark",
     "Star this repository on GitHub. {count} stars": "在 GitHub 上给这个仓库点 Star。{count} 个 star",
-    "Fork this repository on GitHub. {count} forks": "在 GitHub 上 fork 这个仓库。{count} 个 fork",
-    "Open a new issue on GitHub. {count} issues open": "在 GitHub 上提交新 issue。当前有 {count} 个 open issue",
   },
 };
 
@@ -1560,13 +1553,11 @@ function applyCurrentSeo() {
   applySeo(utility ? UTILITY_SEO[utility] : VIEW_SEO[state.view] || VIEW_SEO.today);
 }
 
-// Every navigation item uses one visual active state, even though the four
-// views use aria-current while Rubric is a dialog trigger with aria-expanded.
-// Keeping that distinction in ARIA and normalizing it here prevents element
-// type (button versus anchor) from deciding which item looks selected.
+// Every visible navigation item uses one visual active state. Explore and
+// Rubric remain direct routes, so opening either leaves the global nav without
+// a false current item.
 function syncNavState() {
   const utility = activeUtility();
-  const rubricActive = utility === "rubric";
   document.querySelectorAll("[data-view]").forEach((item) => {
     const active = !utility && item.dataset.view === state.view;
     item.classList.toggle("nav-active", active);
@@ -1576,13 +1567,6 @@ function syncNavState() {
       item.removeAttribute("aria-current");
     }
   });
-  const rubricNav = byId("rubric-nav");
-  if (rubricNav?.classList) {
-    rubricNav.classList.toggle("nav-active", rubricActive);
-    rubricNav.setAttribute("aria-expanded", String(rubricActive));
-    if (rubricActive) rubricNav.setAttribute("aria-current", "page");
-    else rubricNav.removeAttribute("aria-current");
-  }
   const cliNav = byId("cli-nav");
   if (cliNav?.classList) {
     cliNav.classList.toggle("nav-active", utility === "cli");
@@ -8441,29 +8425,6 @@ function bindEvents() {
     rubricOwnsHistoryEntry = false;
     finishUtilityClose("rubric", owned);
   });
-  // Reachable without a record in hand, for a reader who wants the method
-  // before they trust any single row.
-  byId("rubric-nav").addEventListener("click", (event) => {
-    if (
-      event.currentTarget.matches("a")
-      && (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey)
-    ) return;
-    if (!compatibleDashboard(state.data)) {
-      // Push the clean path with its dashboard background recorded, then load
-      // the generated page. Its seeded rubric survives the data failure, and
-      // closing it can return to the view that opened it.
-      event.preventDefault();
-      state.contact = false;
-      state.cite = false;
-      state.cli = false;
-      state.rubric = "current";
-      writeUrl("push");
-      window.location.reload();
-      return;
-    }
-    event.preventDefault();
-    openRubric();
-  });
   byId("badge-contact").addEventListener("click", openContact);
   byId("contact-close").addEventListener("click", () => byId("contact-dialog").close());
   byId("contact-dialog").addEventListener("click", (event) => {
@@ -8532,19 +8493,13 @@ const REPO_SLUG = "ktwu01/benchmark-radar";
 // The visible badge reads "★ Star 12", which a screen reader would announce as
 // a bare statistic. The accessible name states the action and keeps the count
 // as context, so the control sounds like the invitation it is.
-const BADGE_ACTIONS = {
-  "badge-stars": (count) => t("Star this repository on GitHub. {count} stars", { count }),
-  "badge-forks": (count) => t("Fork this repository on GitHub. {count} forks", { count }),
-  "badge-issues": (count) => t("Open a new issue on GitHub. {count} issues open", { count }),
-};
-
-function setBadgeCount(id, value) {
-  const badge = byId(id);
+function setStarCount(value) {
+  const badge = byId("badge-stars");
   const node = badge?.querySelector("[data-count]");
   if (!node) return;
   const count = Number(value || 0).toLocaleString();
   node.textContent = count;
-  badge.setAttribute("aria-label", BADGE_ACTIONS[id](count));
+  badge.setAttribute("aria-label", t("Star this repository on GitHub. {count} stars", { count }));
 }
 
 async function renderRepoBadges() {
@@ -8556,21 +8511,7 @@ async function renderRepoBadges() {
     });
     if (!response.ok) return;
     const repo = await response.json();
-    setBadgeCount("badge-stars", repo.stargazers_count);
-    setBadgeCount("badge-forks", repo.forks_count);
-    // open_issues_count includes pull requests, so building the count from it
-    // overstates how many issues are actually open. Ask search for issues only,
-    // and leave the badge blank if that fails rather than showing the inflated
-    // number.
-    const issues = await fetch(
-      `https://api.github.com/search/issues?q=${encodeURIComponent(
-        `repo:${REPO_SLUG} is:issue is:open`,
-      )}&per_page=1`,
-      { headers: { Accept: "application/vnd.github+json" } },
-    );
-    if (issues.ok) {
-      setBadgeCount("badge-issues", (await issues.json()).total_count);
-    }
+    setStarCount(repo.stargazers_count);
   } catch (error) {
     console.debug("Repository badge counts unavailable", error);
   }

--- a/site/assets/blog.js
+++ b/site/assets/blog.js
@@ -128,24 +128,17 @@ if (langToggle) {
 }
 showLanguage(savedLanguage());
 
-// Repository badge counts. Mirrors app.js's renderRepoBadges: same endpoints,
-// same rule that counts are decoration, so a rate-limited API must never
-// surface as an error state — the badges link out and stay usable blank.
+// Repository star count. Mirrors app.js's renderRepoBadges: a rate-limited API
+// must never surface as an error because the GitHub link still works blank.
 const REPO_SLUG = "ktwu01/benchmark-radar";
 
-const BADGE_ACTIONS = {
-  "badge-stars": "Star this repository on GitHub. {count} stars",
-  "badge-forks": "Fork this repository on GitHub. {count} forks",
-  "badge-issues": "Open a new issue on GitHub. {count} issues open",
-};
-
-function setBadgeCount(id, value) {
-  const badge = document.getElementById(id);
+function setStarCount(value) {
+  const badge = document.getElementById("badge-stars");
   const node = badge?.querySelector("[data-count]");
   if (!node) return;
   const count = Number(value || 0).toLocaleString();
   node.textContent = count;
-  badge.setAttribute("aria-label", t(BADGE_ACTIONS[id], { count }));
+  badge.setAttribute("aria-label", t("Star this repository on GitHub. {count} stars", { count }));
 }
 
 async function renderRepoBadges() {
@@ -155,21 +148,7 @@ async function renderRepoBadges() {
     });
     if (!response.ok) return;
     const repo = await response.json();
-    setBadgeCount("badge-stars", repo.stargazers_count);
-    setBadgeCount("badge-forks", repo.forks_count);
-    // open_issues_count includes pull requests, so building the count from it
-    // overstates how many issues are actually open. Ask search for issues only,
-    // and leave the badge blank if that fails rather than showing the inflated
-    // number.
-    const issues = await fetch(
-      `https://api.github.com/search/issues?q=${encodeURIComponent(
-        `repo:${REPO_SLUG} is:issue is:open`,
-      )}&per_page=1`,
-      { headers: { Accept: "application/vnd.github+json" } },
-    );
-    if (issues.ok) {
-      setBadgeCount("badge-issues", (await issues.json()).total_count);
-    }
+    setStarCount(repo.stargazers_count);
   } catch (error) {
     console.debug("Repository badge counts unavailable", error);
   }

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -231,18 +231,11 @@ th {
 
 .masthead-end {
   display: grid;
-  /* RSS, language, contact, then the star/fork/issues group. */
-  grid-template-columns: repeat(6, 2.6rem);
+  /* RSS, language, contact, and GitHub stars. */
+  grid-template-columns: repeat(4, 2.6rem);
   gap: 0.7rem;
   align-items: center;
   justify-content: flex-end;
-}
-
-.repo-badges {
-  display: flex;
-  grid-column: span 3;
-  gap: 0.7rem;
-  align-items: center;
 }
 
 .repo-badge {
@@ -313,14 +306,14 @@ th {
    every viewport above the 760px breakpoint and the page slid left and right
    with nothing to show for it (issue #333). Anchored to the badge's right edge
    the label stays on the page whether it is showing or not. */
-.repo-badges > .repo-badge:last-child::after {
+.masthead-end > .repo-badge:last-child::after {
   right: 0;
   left: auto;
   transform: translate(0, -0.2rem);
 }
 
-.repo-badges > .repo-badge:last-child:hover::after,
-.repo-badges > .repo-badge:last-child:focus-visible::after {
+.masthead-end > .repo-badge:last-child:hover::after,
+.masthead-end > .repo-badge:last-child:focus-visible::after {
   transform: translate(0, 0);
 }
 
@@ -362,8 +355,8 @@ button.repo-badge svg {
   stroke: none;
 }
 
-/* Outline icons (globe, fork, issues) use stroke rather than fill, matching
-   the button badge icons. Applies to link and button badges alike so every
+/* Outline icons use stroke rather than fill, matching the button badge icons.
+   Applies to link and button badges alike so every
    top-right icon renders at the same size (issue #213). */
 .repo-badge svg.outline-icon {
   fill: none;
@@ -446,20 +439,16 @@ button.repo-badge svg {
   color: white;
 }
 
-/* Rubric and CLI have real page paths, but still open the familiar dialog
-   panels. Their inactive blue distinguishes that interaction from a dashboard
-   view switch. */
-#rubric-nav:not(.nav-active),
+/* CLI has a real page path, but still opens the familiar dialog panel. Its
+   inactive blue distinguishes that interaction from a dashboard view switch. */
 #cli-nav:not(.nav-active) {
   color: var(--blue-deep);
 }
 
-#rubric-nav::after,
 #cli-nav::after {
   content: " ⓘ";
 }
 
-#rubric-nav:not(.nav-active):hover,
 #cli-nav:not(.nav-active):hover {
   background: var(--panel);
 }
@@ -631,9 +620,6 @@ input {
   /* Right-aligned when it shares the heading's line, and pushed to the right
      edge rather than left-aligned when `.section-title` wraps it onto its own. */
   margin-left: auto;
-}
-
-.results-meta span {
 }
 
 #today-sort {
@@ -4185,7 +4171,7 @@ footer {
   }
 
   .content-grid {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .benchmark-workbench {
@@ -4224,20 +4210,14 @@ footer {
 
   .masthead {
     min-height: 64px;
-    /* Brand plus the seven-square grid exceed 320px-class viewports, so the
+    /* Brand plus the four-square grid exceed 320px-class viewports, so the
        controls drop to a second row instead of overflowing off-screen. */
     flex-wrap: wrap;
     row-gap: 0.5rem;
   }
 
   .masthead-end {
-    /* 6 * 2.1rem + 5 * 0.5rem gaps = 241px, so the full row still fits a
-       320px-wide phone once it wraps below the brand (issue #213 squares). */
-    grid-template-columns: repeat(6, 2.1rem);
-    gap: 0.5rem;
-  }
-
-  .repo-badges {
+    grid-template-columns: repeat(4, 2.1rem);
     gap: 0.5rem;
   }
 
@@ -4266,6 +4246,15 @@ footer {
 
   .view {
     padding-top: 2rem;
+  }
+
+  .results-meta {
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  #today-sort {
+    white-space: normal;
   }
 
   .view-heading {

--- a/site/index.html
+++ b/site/index.html
@@ -268,70 +268,24 @@
           </svg>
           <span class="repo-badge-label" data-i18n="Contact">Contact</span>
         </button>
-        <!--
-          Each badge is a call to action, not a link to a roster. The live counts
-          come from GitHub's public repository API; starring still opens the repo
-          itself, where the visitor can click GitHub's Star control.
-        -->
-        <div class="repo-badges" id="repo-badges" aria-label="Support this repository">
-          <a
-            class="repo-badge"
-            id="badge-stars"
-            href="https://github.com/ktwu01/benchmark-radar"
-            target="_blank"
-            rel="noopener noreferrer"
-            title="Open the repository and star it"
-            data-i18n-title="Open the repository and star it"
-          >
-            <svg class="brand-icon github-icon" viewBox="0 0 24 24" aria-hidden="true">
-              <path
-                d="M12 2.5a9.5 9.5 0 0 0-3 18.52c.48.09.65-.21.65-.46v-1.67c-2.67.58-3.23-1.13-3.23-1.13-.44-1.12-1.07-1.42-1.07-1.42-.87-.6.07-.59.07-.59.96.07 1.47.99 1.47.99.86 1.47 2.25 1.05 2.8.8.09-.62.34-1.05.61-1.29-2.13-.24-4.37-1.07-4.37-4.75 0-1.05.38-1.91.99-2.58-.1-.24-.43-1.22.09-2.54 0 0 .81-.26 2.63.98A9.16 9.16 0 0 1 12 7.96c.82 0 1.65.11 2.42.33 1.82-1.24 2.63-.98 2.63-.98.52 1.32.19 2.3.09 2.54.61.67.99 1.53.99 2.58 0 3.69-2.25 4.5-4.39 4.74.35.3.65.88.65 1.78v2.63c0 .25.17.55.66.46A9.5 9.5 0 0 0 12 2.5Z"
-              ></path>
-            </svg>
-            <span class="repo-badge-label" data-i18n="Star">Star</span>
-            <span class="repo-badge-count" data-count>—</span>
-          </a>
-          <a
-            class="repo-badge"
-            id="badge-forks"
-            href="https://github.com/ktwu01/benchmark-radar/fork"
-            target="_blank"
-            rel="noopener noreferrer"
-            title="Fork this repository"
-            data-i18n-title="Fork this repository"
-          >
-            <svg class="outline-icon" viewBox="0 0 24 24" aria-hidden="true">
-              <circle cx="12" cy="18" r="3"></circle>
-              <circle cx="6" cy="6" r="3"></circle>
-              <circle cx="18" cy="6" r="3"></circle>
-              <path d="M18 9v2c0 .6-.5 1.2-1.2 1.7l-3.6 2.4"></path>
-              <path d="M6 9v2c0 .6.5 1.2 1.2 1.7l3.6 2.4"></path>
-            </svg>
-            <span class="repo-badge-label" data-i18n="Fork">Fork</span>
-            <span class="repo-badge-count" data-count>—</span>
-          </a>
-          <a
-            class="repo-badge"
-            id="badge-issues"
-            href="https://github.com/ktwu01/benchmark-radar/issues/new"
-            target="_blank"
-            rel="noopener noreferrer"
-            title="Open a new issue"
-            data-i18n-title="Open a new issue"
-          >
-            <svg class="outline-icon" viewBox="0 0 24 24" aria-hidden="true">
-              <circle cx="12" cy="12" r="9"></circle>
-              <circle
-                cx="12"
-                cy="12"
-                r="3"
-                style="fill: currentColor; stroke: none"
-              ></circle>
-            </svg>
-            <span class="repo-badge-label" data-i18n="Issues">Issues</span>
-            <span class="repo-badge-count" data-count>—</span>
-          </a>
-        </div>
+        <!-- GitHub has one job here: open the repository and show its star count. -->
+        <a
+          class="repo-badge"
+          id="badge-stars"
+          href="https://github.com/ktwu01/benchmark-radar"
+          target="_blank"
+          rel="noopener noreferrer"
+          title="Open the repository and star it"
+          data-i18n-title="Open the repository and star it"
+        >
+          <svg class="brand-icon github-icon" viewBox="0 0 24 24" aria-hidden="true">
+            <path
+              d="M12 2.5a9.5 9.5 0 0 0-3 18.52c.48.09.65-.21.65-.46v-1.67c-2.67.58-3.23-1.13-3.23-1.13-.44-1.12-1.07-1.42-1.07-1.42-.87-.6.07-.59.07-.59.96.07 1.47.99 1.47.99.86 1.47 2.25 1.05 2.8.8.09-.62.34-1.05.61-1.29-2.13-.24-4.37-1.07-4.37-4.75 0-1.05.38-1.91.99-2.58-.1-.24-.43-1.22.09-2.54 0 0 .81-.26 2.63.98A9.16 9.16 0 0 1 12 7.96c.82 0 1.65.11 2.42.33 1.82-1.24 2.63-.98 2.63-.98.52 1.32.19 2.3.09 2.54.61.67.99 1.53.99 2.58 0 3.69-2.25 4.5-4.39 4.74.35.3.65.88.65 1.78v2.63c0 .25.17.55.66.46A9.5 9.5 0 0 0 12 2.5Z"
+            ></path>
+          </svg>
+          <span class="repo-badge-label" data-i18n="Star">Star</span>
+          <span class="repo-badge-count" data-count>—</span>
+        </a>
       </div>
     </header>
 
@@ -339,32 +293,6 @@
 
     <nav class="view-nav" aria-label="Dashboard views" data-i18n-aria="Dashboard views">
       <button type="button" class="nav-active" data-view="today" aria-controls="today-view" aria-current="page" data-i18n="Today">Today</button>
-      <!-- Real links, not tab buttons. Each one is this same dashboard served
-         at its own path with that view already open and its rows already in the
-         HTML, so a crawler and a reader with a slow connection both get content
-         from the first response. app.js intercepts the click and keeps the
-         navigation client-side for anyone whose script has loaded. -->
-      <a href="/leaderboard/" data-view="leaderboard" aria-controls="leaderboard-view" data-i18n="Leaderboard">
-        Leaderboard
-      </a>
-      <a href="/trends/" data-view="trends" aria-controls="trends-view" data-i18n="Trends">Trends</a>
-      <a href="/explore/" data-view="map" aria-controls="map-view" data-i18n="Explore">Explore</a>
-      <!-- The blog is a set of documents, not a dashboard view, so this link
-           carries no data-view: app.js only intercepts clicks on elements that
-           have one, and a brief has to arrive as a full page load. -->
-      <a href="/blog/" data-i18n="Blog">Blog</a>
-      <!-- These remain the same pop-up panels readers already use, but their
-           hrefs give each one a server-rendered, indexable entry point. -->
-      <a
-        href="/rubric/"
-        id="rubric-nav"
-        aria-haspopup="dialog"
-        aria-controls="rubric-dialog"
-        aria-expanded="false"
-        data-i18n="Rubric"
-      >
-        Rubric
-      </a>
       <a
         href="/cli/"
         id="cli-nav"
@@ -375,6 +303,19 @@
       >
         CLI
       </a>
+      <!-- Real links, not tab buttons. Each one is this same dashboard served
+         at its own path with that view already open and its rows already in the
+         HTML, so a crawler and a reader with a slow connection both get content
+         from the first response. app.js intercepts the click and keeps the
+         navigation client-side for anyone whose script has loaded. -->
+      <a href="/leaderboard/" data-view="leaderboard" aria-controls="leaderboard-view" data-i18n="Leaderboard">
+        Leaderboard
+      </a>
+      <a href="/trends/" data-view="trends" aria-controls="trends-view" data-i18n="Trends">Trends</a>
+      <!-- The blog is a set of documents, not a dashboard view, so this link
+           carries no data-view: app.js only intercepts clicks on elements that
+           have one, and a brief has to arrive as a full page load. -->
+      <a href="/blog/" data-i18n="Blog">Blog</a>
     </nav>
 
     <main id="main-content" tabindex="-1">

--- a/src/benchmark_radar/app_pages.py
+++ b/src/benchmark_radar/app_pages.py
@@ -46,6 +46,7 @@ from .site_shell import breadcrumb_schema, esc, json_ld, webpage_schema
 # Published in this order. "map" is the view key; its path is /explore/.
 APP_VIEWS: tuple[str, ...] = ("leaderboard", "trends", "map")
 UTILITY_PAGES: tuple[str, ...] = ("cli", "cite", "rubric")
+UNLISTED_ROUTES = frozenset({"map", "rubric"})
 
 HEAD_SEO_OPEN = "<!-- br:head-seo -->"
 HEAD_SEO_CLOSE = "<!-- /br:head-seo -->"
@@ -230,7 +231,7 @@ def _with_active_attributes(opening_tag: str) -> str:
 def _activate_navigation(document: str, page: str, *, utility: bool = False) -> str:
     """Ship an honest active navigation state before app.js runs."""
     if utility:
-        element_id = {"cli": "cli-nav", "rubric": "rubric-nav", "cite": "cite-open"}[page]
+        element_id = {"cli": "cli-nav", "cite": "cite-open"}[page]
         selector = re.compile(rf'<(?:a|button)\b(?=[^>]*\bid="{element_id}")[^>]*>')
     else:
         selector = re.compile(rf'<(?:a|button)\b(?=[^>]*\bdata-view="{page}")[^>]*>')
@@ -287,7 +288,8 @@ def render_app_page(
     )
     document = _open_on(document, view)
     document = _deactivate_home_navigation(document)
-    document = _activate_navigation(document, view)
+    if view not in UNLISTED_ROUTES:
+        document = _activate_navigation(document, view)
     for anchor, replacement in seeds.items():
         document = _replace_once(document, anchor, replacement, what=f"{view} seed container")
     return document
@@ -308,7 +310,8 @@ def render_utility_page(
         what="page JSON-LD marker",
     )
     document = _deactivate_home_navigation(document)
-    document = _activate_navigation(document, page, utility=True)
+    if page not in UNLISTED_ROUTES:
+        document = _activate_navigation(document, page, utility=True)
     document = _open_dialog(document, page)
     for anchor, replacement in seeds.items():
         document = _replace_once(document, anchor, replacement, what=f"{page} seed container")

--- a/src/benchmark_radar/blog.py
+++ b/src/benchmark_radar/blog.py
@@ -50,11 +50,7 @@ LATEST_POST_LIMIT = 30
 # The dashboard's toggle and repo badges translate these at runtime; the
 # chrome's own data-i18n keys cover everything else.
 _TOGGLE_I18N_KEYS = ("Switch to Chinese (中文)", "Switch to English")
-_BADGE_I18N_KEYS = (
-    "Star this repository on GitHub. {count} stars",
-    "Fork this repository on GitHub. {count} forks",
-    "Open a new issue on GitHub. {count} issues open",
-)
+_BADGE_I18N_KEYS = ("Star this repository on GitHub. {count} stars",)
 # The footer's build date prefix is baked in per page, after the keys were
 # collected from the raw extracted chrome, so it is listed here.
 _FOOTER_I18N_KEYS = ("Updated",)

--- a/src/benchmark_radar/blog_shell.py
+++ b/src/benchmark_radar/blog_shell.py
@@ -13,10 +13,8 @@ exists because the SPA machinery it referenced is absent:
 * the Today control is a view-switching button in the SPA and becomes the
   plain link to ``/`` it already is for crawlers;
 * view-only attributes (``data-view``, ``aria-controls``, ``aria-expanded``)
-  are dropped from the section nav, and the blog's own link is marked
-  active. Element ids stay: styles.css keys the dialog-trigger treatment of
-  Rubric and CLI (the inactive blue and the "ⓘ" marker) off #rubric-nav and
-  #cli-nav, so a brief's tabs must carry the same ids to look the same;
+  are dropped from the section nav, and the blog's own link is marked active.
+  The CLI id stays because styles.css uses it for the dialog-trigger treatment;
 * the Contact button opens a sheet that only exists inside the SPA, so it
   becomes a link to ``/#contact`` — the dashboard deep link that opens the
   same sheet on load;
@@ -119,8 +117,8 @@ def _strip_comments(fragment: str) -> str:
 
 
 def _drop_spa_attributes(fragment: str) -> str:
-    # Ids stay on purpose: styles.css styles #rubric-nav and #cli-nav by id,
-    # so stripping them would silently turn those tabs into plain links.
+    # The CLI id stays on purpose: styles.css uses it to distinguish the dialog
+    # trigger from dashboard view links.
     return re.sub(r'\s(?:data-view|aria-controls|aria-expanded)="[^"]*"', "", fragment)
 
 

--- a/tests/test_app_pages.py
+++ b/tests/test_app_pages.py
@@ -243,10 +243,8 @@ def test_each_generated_page_marks_its_navigation_entry_current(tmp_path):
     ids = {
         "leaderboard": 'data-view="leaderboard"',
         "trends": 'data-view="trends"',
-        "explore": 'data-view="map"',
         "cli": 'id="cli-nav"',
         "cite": 'id="cite-open"',
-        "rubric": 'id="rubric-nav"',
     }
     for path, identifying_attribute in ids.items():
         page = (tmp_path / path / "index.html").read_text(encoding="utf-8")
@@ -258,6 +256,18 @@ def test_each_generated_page_marks_its_navigation_entry_current(tmp_path):
         assert 'aria-current="page"' in opening.group(0)
         if path in {"cli", "cite", "rubric"}:
             assert 'aria-expanded="true"' in opening.group(0)
+
+
+def test_unlisted_explore_and_rubric_routes_have_no_false_current_tab(tmp_path):
+    _write(tmp_path, _dashboard())
+    for path in ("explore", "rubric"):
+        page = (tmp_path / path / "index.html").read_text(encoding="utf-8")
+        nav = re.search(r'<nav class="view-nav".*?</nav>', page, re.S).group(0)
+        assert 'aria-current="page"' not in nav
+    explore = (tmp_path / "explore" / "index.html").read_text(encoding="utf-8")
+    rubric = (tmp_path / "rubric" / "index.html").read_text(encoding="utf-8")
+    assert '<section class="view" id="map-view"' in explore
+    assert '<dialog id="rubric-dialog"' in rubric and " open" in rubric
 
 
 def test_exactly_one_heading_is_visible_per_page(tmp_path):

--- a/tests/test_blog.py
+++ b/tests/test_blog.py
@@ -481,29 +481,34 @@ def test_blog_nav_lists_the_same_sections_in_the_same_order_as_the_dashboard(tmp
     assert 'class="nav-active" aria-current="page" href="/blog/"' in page
 
 
-def test_blog_nav_preserves_main_visibility_and_priority(tmp_path):
+def test_dashboard_and_blog_share_the_reduced_chrome_contract(tmp_path):
     write_blog_with_chrome([_briefed()], tmp_path)
     page = (tmp_path / "blog" / "2026-08-30" / "index.html").read_text(encoding="utf-8")
-    nav = re.search(r'<nav class="view-nav".*?</nav>', page, re.S).group(0)
-    assert _nav_targets(nav) == [
+    expected = [
         "/",
+        "/cli/",
         "/leaderboard/",
         "/trends/",
-        "/explore/",
         "/blog/",
-        "/rubric/",
-        "/cli/",
     ]
-    for identity in ('href="/explore/"', 'id="rubric-nav"'):
-        opening = re.search(rf"<a\b(?=[^>]*{re.escape(identity)})[^>]*>", nav).group(0)
-        assert " hidden" not in opening
+    for document in (DASHBOARD_HTML, page):
+        assert _nav_targets(document) == expected
+        header = re.search(r'<header class="masthead".*?</header>', document, re.S).group(0)
+        numbered = []
+        for anchor in re.finditer(r"<a\b([^>]*)>(.*?)</a>", header, re.S):
+            if "data-count" not in anchor.group(2):
+                continue
+            badge_id = re.search(r'id="([^"]+)"', anchor.group(1))
+            assert badge_id
+            numbered.append(badge_id.group(1))
+        assert numbered == ["badge-stars"]
 
 
-def test_blog_fetches_repo_badges_like_the_dashboard():
+def test_blog_fetches_only_the_star_count_like_the_dashboard():
     script = (SITE_DIR / "assets" / "blog.js").read_text(encoding="utf-8")
     assert "repo.stargazers_count" in script
-    assert "repo.forks_count" in script
-    assert "api.github.com/search/issues" in script
+    assert "repo.forks_count" not in script
+    assert "api.github.com/search/issues" not in script
 
 
 def test_the_contact_button_becomes_the_dashboard_deep_link(tmp_path):

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -116,7 +116,7 @@ def test_priority_score_is_reachably_explained():
     # number does not have to hunt elsewhere for its definition.
     assert 'id="rubric-dialog"' in html
     assert 'id="rubric-content"' in html
-    assert 'id="rubric-nav"' in html
+    assert 'id="rubric-nav"' not in html
     assert "score-explain" in script
     assert "openRubric" in script
     assert "How is this scored?" in script
@@ -242,23 +242,22 @@ def test_only_one_sheet_is_open_at_a_time():
     assert guard.index("cliOwnsHistoryEntry = false;") < guard.index("other.close();")
 
 
-def test_every_navigation_item_uses_the_same_active_state():
+def test_visible_navigation_items_use_the_same_active_state():
     html = Path("site/index.html").read_text(encoding="utf-8")
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
     styles = Path("site/assets/styles.css").read_text(encoding="utf-8")
 
-    # Today is a button, the three routed views are anchors, and Rubric opens a
-    # dialog. Their element types and ARIA semantics must not change the visual
-    # selected state.
-    assert 'aria-controls="rubric-dialog"' in html
-    assert 'aria-expanded="false"' in html
+    # Explore and Rubric keep direct routes without claiming a global tab.
+    nav = html.split('<nav class="view-nav"', 1)[1].split("</nav>", 1)[0]
+    assert 'href="/explore/"' not in nav
+    assert 'href="/rubric/"' not in nav
+    assert 'aria-expanded="false"' in nav
     today = re.search(r'<button\b(?=[^>]*data-view="today")[^>]*>', html)
     assert today and "nav-active" in today.group(0)
     assert 'aria-current="page"' in today.group(0)
     assert "function syncNavState()" in script
     assert 'item.classList.toggle("nav-active", active);' in script
-    assert 'rubricNav.classList.toggle("nav-active", rubricActive);' in script
-    assert 'rubricNav.setAttribute("aria-expanded", String(rubricActive));' in script
+    assert 'rubricNav.classList.toggle("nav-active", rubricActive);' not in script
     assert script.count("syncNavState();") >= 3
     assert ".view-nav .nav-active {" in styles
     assert '.view-nav button[aria-current="page"]' not in styles
@@ -421,13 +420,13 @@ def test_top_right_utilities_use_shared_icon_geometry_and_contact_control():
     assert 'id="badge-discord"' not in html
     assert 'id="lang-toggle"' in html
     assert 'class="repo-badge"' in html
-    assert "grid-template-columns: repeat(6, 2.6rem)" in styles
+    assert "grid-template-columns: repeat(4, 2.6rem)" in styles
     assert "width: 2.6rem" in styles
     assert "height: 2.6rem" in styles
-    assert "grid-column: span 3" in styles
+    assert ".repo-badges" not in styles
     assert 'class="repo-badge-glyph" id="lang-toggle-label">中<' in html
     assert 'class="brand-icon github-icon"' in html
-    assert "grid-template-columns: repeat(6, 2.1rem)" in styles
+    assert "grid-template-columns: repeat(4, 2.1rem)" in styles
     assert "flex: 0 0 1.5rem" in styles
     assert ".repo-badge svg," in styles
 
@@ -644,7 +643,7 @@ def test_utility_routes_have_distinct_metadata_and_accessible_active_state():
         assert "description:" in entry
         assert f'canonical: "{path}"' in entry
     assert "applySeo(utility ? UTILITY_SEO[utility]" in script
-    assert 'rubricNav.setAttribute("aria-current", "page")' in script
+    assert 'rubricNav.setAttribute("aria-current", "page")' not in script
     assert 'cliNav.setAttribute("aria-current", "page")' in script
     assert 'citeOpen?.setAttribute("aria-expanded", String(utility === "cite"))' in script
     assert 'citeOpen?.setAttribute("aria-current", "page")' in script
@@ -710,15 +709,14 @@ def test_newer_successful_data_requests_cannot_be_overwritten_by_late_responses(
     assert "Full data request was superseded by a bootstrap response" in ensure_full
 
 
-def test_failed_data_rubric_navigation_keeps_its_background_route():
+def test_rubric_remains_a_direct_route_without_a_navigation_control():
+    html = Path("site/index.html").read_text(encoding="utf-8")
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
-    handler = script.split('byId("rubric-nav").addEventListener', 1)[1].split(
-        'byId("badge-contact")', 1
-    )[0]
 
-    assert 'state.rubric = "current";' in handler
-    assert 'writeUrl("push");' in handler
-    assert "window.location.reload();" in handler
+    assert 'id="rubric-nav"' not in html
+    assert 'canonical: "/rubric/"' in script
+    assert 'state.rubric = pathUtility === "rubric"' in script
+    assert 'openRubric(null, state.rubric === "current" ? null : state.rubric, false)' in script
 
 
 def test_hydrated_expansion_controls_announce_the_action_they_will_take():
@@ -999,7 +997,8 @@ def test_trend_map_is_keyboard_accessible_and_coordinates_today_filters():
     html = Path("site/index.html").read_text(encoding="utf-8")
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
 
-    assert 'data-view="map"' in html
+    assert 'id="map-view"' in html
+    assert 'canonical: "/explore/"' in script
     assert 'id="map-canvas"' in html
     assert "state.data.corpus" in script
     assert "HAS_TOPIC" in script
@@ -1041,8 +1040,8 @@ def test_corpus_view_progressively_discloses_the_complete_relationship_map():
     html = Path("site/index.html").read_text(encoding="utf-8")
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
 
-    assert 'data-view="map"' in html
-    assert 'data-i18n="Explore">Explore</a>' in html
+    nav = html.split('<nav class="view-nav"', 1)[1].split("</nav>", 1)[0]
+    assert 'href="/explore/"' not in nav
     assert 'id="map-insights"' in html
     assert '<details class="relationship-explorer" id="relationship-explorer">' in html
     assert "renderMapInsights(corpus)" in script
@@ -1141,19 +1140,18 @@ def test_supporting_attention_provider_is_not_hard_coded():
     assert "Hacker News #${record.source_id}" not in script
 
 
-def test_repo_badges_invite_an_action_rather_than_listing_a_roster():
+def test_header_keeps_one_github_action_and_issues_remain_reachable():
     html = Path("site/index.html").read_text(encoding="utf-8")
 
-    # Each badge sends the reader somewhere they can act. Linking to
-    # /stargazers, /forks, or the issue list showed them a roster instead.
-    assert 'href="https://github.com/ktwu01/benchmark-radar/fork"' in html
-    assert 'href="https://github.com/ktwu01/benchmark-radar/issues/new"' in html
+    # The header keeps one GitHub destination. Issue links remain in context.
     assert 'href="https://github.com/ktwu01/benchmark-radar"' in html
+    assert "https://github.com/ktwu01/benchmark-radar/issues" in html
+    assert 'id="badge-forks"' not in html
+    assert 'id="badge-issues"' not in html
     assert "/stargazers" not in html
     assert "benchmark-radar/forks" not in html
 
-    for label in (">Star<", ">Fork<", ">Issues<"):
-        assert label in html
+    assert ">Star<" in html
 
     # Starring has no GET endpoint, so the star badge opens the repository and
     # the reader clicks Star there. Asserting the absence of a fabricated
@@ -1183,13 +1181,10 @@ def test_today_view_shows_total_corpus_counts_by_category():
 def test_badge_accessible_names_state_the_action():
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
 
-    assert "BADGE_ACTIONS" in script
-    for fragment in (
-        "Star this repository on GitHub",
-        "Fork this repository on GitHub",
-        "Open a new issue on GitHub",
-    ):
-        assert fragment in script
+    assert "function setStarCount" in script
+    assert "Star this repository on GitHub" in script
+    assert "Fork this repository on GitHub" not in script
+    assert "Open a new issue on GitHub" not in script
     assert 'badge.setAttribute("aria-label"' in script
 
 
@@ -2768,9 +2763,19 @@ def test_issue_333_the_page_never_scrolls_sideways():
     # 1. A hover label centred under the last masthead badge. `visibility:
     #    hidden` does not take a box out of layout, so it widened the document
     #    even while it was invisible.
-    anchored = _css_rule(styles, ".repo-badges > .repo-badge:last-child::after {")
+    anchored = _css_rule(styles, ".masthead-end > .repo-badge:last-child::after {")
     assert "right: 0;" in anchored
     assert "left: auto;" in anchored
+
+    # The responsive one-column grid must be allowed to shrink below a long
+    # record's intrinsic width. A bare 1fr track let real benchmark names widen
+    # a 390px page to 455px.
+    responsive = styles.split("@media (max-width: 1050px)", 1)[1].split(
+        "@media (max-width: 760px)", 1
+    )[0]
+    assert "grid-template-columns: minmax(0, 1fr);" in responsive
+    mobile = styles.split("@media (max-width: 760px)", 1)[1]
+    assert "#today-sort" in mobile and "white-space: normal;" in mobile
 
     # 2. Crawled README banners made of box-drawing characters are a single
     #    unbreakable run, and one of them pushed a 720px column to 1349px.

--- a/tests/test_site_seo.py
+++ b/tests/test_site_seo.py
@@ -105,14 +105,15 @@ def test_published_head_and_robots_match_the_generated_sitemap():
     for _, path in INDEXABLE_VIEWS:
         assert f'canonical: "{path}"' in script
 
-    # Root-relative in the dashboard: the same document is served at each of
-    # these paths, so the links must resolve identically from all of them.
+    # Global navigation and contextual utilities use root-relative links. The
+    # generated Explore and Rubric routes remain indexable without global tabs.
     assert 'href="/leaderboard/"' in html
     assert 'href="/trends/"' in html
-    assert 'href="/explore/"' in html
     assert 'href="/cli/"' in html
-    assert 'href="/rubric/"' in html
     assert 'href="/cite/"' in html
+    nav = html.split('<nav class="view-nav"', 1)[1].split("</nav>", 1)[0]
+    assert 'href="/explore/"' not in nav
+    assert 'href="/rubric/"' not in nav
 
     # robots.txt points at the sitemap URL the build actually writes.
     sitemap_url = f"{SITE_URL}/sitemap.xml"


### PR DESCRIPTION
Closes #532.

## Summary
- keep only RSS, language, Contact, and GitHub stars in the header
- remove the Fork and Issues-count UI, translations, API reads, and old tests
- reduce global navigation to Today, CLI, Leaderboard, Trends, and Blog
- keep Explore and Rubric available at direct URLs
- keep `site/index.html` as the Dashboard and Blog chrome source
- add shared chrome contract tests and fix the reproduced mobile overflow
- add the project design principles

## Verification
- clean-worktree CI sequence passed
- 1194 tests passed
- visually checked Dashboard and Blog at desktop and 390px