### PR TITLE
Fix citation authors and stale UI names

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ technical report:
 
 ```bibtex
 @misc{wu_2026_22167102,
-  author       = {Wu, Koutian},
+  author       = {Wu, Koutian and Zhou, Junjie},
   title        = {Benchmark Radar v0.9.0: Technical Report},
   month        = aug,
   year         = {2026},

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -97,7 +97,7 @@ npx skills add ktwu01/benchmark-radar
 
 ```bibtex
 @misc{wu_2026_22167102,
-  author       = {Wu, Koutian},
+  author       = {Wu, Koutian and Zhou, Junjie},
   title        = {Benchmark Radar v0.9.0: Technical Report},
   month        = aug,
   year         = {2026},

--- a/design.md
+++ b/design.md
@@ -69,9 +69,8 @@ active indicator, and Back and Forward should restore meaningful states.
 Show a concise answer first, then offer the evidence and method behind it.
 Expansion should be clear and reversible.
 
-Mobile layout must preserve the same priority. Do not bury a daily briefing
-below a long result list because the desktop result column appears first in the
-document.
+Mobile layout must preserve the surface's primary task. On Today, matching
+results come first; the daily briefing follows as context for the scan date.
 
 Explain a shared limitation once near the affected group. Do not repeat “not
 comparable” or “not enough history” in every card.

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -7983,16 +7983,15 @@ function openContact(updateUrl = true) {
   if (!dialog.open) dialog.showModal();
 }
 
-// The published technical report. These strings are the citation itself, so
-// they are held verbatim rather than assembled from parts: a citation the page
-// rebuilds on the fly is a citation that can drift from CITATION.cff.
+// The published technical report. Contract tests keep these copyable strings
+// aligned with CITATION.cff and the server-rendered citation route.
 const CITE_DOI_URL = "https://doi.org/10.5281/zenodo.22167102";
 const CITE_CFF_URL = "https://github.com/ktwu01/benchmark-radar/blob/main/CITATION.cff";
 const CITE_APA =
-  "Wu, K. (2026). Benchmark Radar v0.9.0: Technical Report (Version 0.9.0). " + CITE_DOI_URL;
+  "Wu, K., & Zhou, J. (2026). Benchmark Radar v0.9.0: Technical Report (Version 0.9.0). " + CITE_DOI_URL;
 const CITE_BIBTEX = [
   "@techreport{Wu_Benchmark_Radar_v0_9_0_2026,",
-  "author = {Wu, Koutian},",
+  "author = {Wu, Koutian and Zhou, Junjie},",
   "doi = {10.5281/zenodo.22167102},",
   "month = aug,",
   "title = {{Benchmark Radar v0.9.0: Technical Report}},",
@@ -8502,8 +8501,8 @@ function setStarCount(value) {
   badge.setAttribute("aria-label", t("Star this repository on GitHub. {count} stars", { count }));
 }
 
-async function renderRepoBadges() {
-  // Counts are decoration: the badges link out and stay usable if this fails,
+async function renderStarCount() {
+  // The count is decoration: the badge links out and stays usable if this fails,
   // so a rate-limited API must never surface as an error state.
   try {
     const response = await fetch(`https://api.github.com/repos/${REPO_SLUG}`, {
@@ -8513,7 +8512,7 @@ async function renderRepoBadges() {
     const repo = await response.json();
     setStarCount(repo.stargazers_count);
   } catch (error) {
-    console.debug("Repository badge counts unavailable", error);
+    console.debug("Repository star count unavailable", error);
   }
 }
 
@@ -8727,7 +8726,7 @@ async function initialize() {
     syncNavState();
   }
   // Independent of the data file, so badges still render on an error state.
-  renderRepoBadges();
+  renderStarCount();
   // The citation and the CLI setup route are fixed text, not readings of the
   // corpus. Someone arriving from a paper's reference link or looking for the
   // offline route should still get them on a build whose data file is broken,

--- a/site/assets/blog.js
+++ b/site/assets/blog.js
@@ -128,7 +128,7 @@ if (langToggle) {
 }
 showLanguage(savedLanguage());
 
-// Repository star count. Mirrors app.js's renderRepoBadges: a rate-limited API
+// Repository star count. Mirrors app.js's renderStarCount: a rate-limited API
 // must never surface as an error because the GitHub link still works blank.
 const REPO_SLUG = "ktwu01/benchmark-radar";
 
@@ -141,7 +141,7 @@ function setStarCount(value) {
   badge.setAttribute("aria-label", t("Star this repository on GitHub. {count} stars", { count }));
 }
 
-async function renderRepoBadges() {
+async function renderStarCount() {
   try {
     const response = await fetch(`https://api.github.com/repos/${REPO_SLUG}`, {
       headers: { Accept: "application/vnd.github+json" },
@@ -150,10 +150,10 @@ async function renderRepoBadges() {
     const repo = await response.json();
     setStarCount(repo.stargazers_count);
   } catch (error) {
-    console.debug("Repository badge counts unavailable", error);
+    console.debug("Repository star count unavailable", error);
   }
 }
-renderRepoBadges();
+renderStarCount();
 
 // The footer's share control, same behavior as the dashboard's.
 const shareButton = document.getElementById("share-radar");

--- a/site/index.html
+++ b/site/index.html
@@ -192,6 +192,7 @@
          and the BibTeX entry in both READMEs). -->
     <meta name="citation_title" content="Benchmark Radar">
     <meta name="citation_author" content="Wu, Koutian">
+    <meta name="citation_author" content="Zhou, Junjie">
     <meta name="citation_publication_date" content="2026">
     <meta name="citation_dataset_url" content="https://benchmark-radar.org/data/radar.json">
     <link rel="cite-as" href="https://github.com/ktwu01/benchmark-radar">

--- a/src/benchmark_radar/blog.py
+++ b/src/benchmark_radar/blog.py
@@ -47,7 +47,7 @@ from .site_shell import breadcrumb_schema, esc, webpage_schema
 
 LATEST_POST_LIMIT = 30
 
-# The dashboard's toggle and repo badges translate these at runtime; the
+# The dashboard's toggle and star count translate these at runtime; the
 # chrome's own data-i18n keys cover everything else.
 _TOGGLE_I18N_KEYS = ("Switch to Chinese (中文)", "Switch to English")
 _BADGE_I18N_KEYS = ("Star this repository on GitHub. {count} stars",)

--- a/src/benchmark_radar/blog_shell.py
+++ b/src/benchmark_radar/blog_shell.py
@@ -190,9 +190,8 @@ def _adapt_header(header: str) -> str:
     attrs, inner = contact.group(1), contact.group(2)
     title = re.search(r'title="([^"]*)"', attrs)
     i18n_title = re.search(r'data-i18n-title="([^"]*)"', attrs)
-    # The chat-bubble svg carries the outline-icon class from index.html (same
-    # mechanism fork and issues use on link badges). Ensure it is present so
-    # the bubble renders as an outline when transformed into an anchor badge.
+    # The chat-bubble svg carries the outline-icon class from index.html. Ensure
+    # it is present when the button is transformed into an anchor badge.
     inner = _ensure_outline_icon(inner)
     header = header.replace(
         contact.group(0),

--- a/src/benchmark_radar/citation.py
+++ b/src/benchmark_radar/citation.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from . import __version__
 
 PUBLICATION_YEAR = "2026"
-AUTHORS_APA = "Wu, K., Zhou, J., et al."
+AUTHORS_APA = "Wu, K., & Zhou, J."
 DOI = "10.5281/zenodo.22167102"
 CITE_URL = "https://benchmark-radar.org/#cite"
 

--- a/src/benchmark_radar/site_pages.py
+++ b/src/benchmark_radar/site_pages.py
@@ -1,13 +1,12 @@
 """Static per-benchmark pages: one crawlable URL per benchmark (issue #424).
 
-The dashboard is one HTML document whose four views share a single path, so a
-catalog of 1,100+ benchmarks exposes four indexable URLs to a search engine.
-Each per-benchmark shard already answers the reader's questions about one
-benchmark, but only as JSON consumed by JavaScript. This module renders that
-same evidence as plain HTML, one page per slug, readable with JavaScript
-disabled. It turns the catalog's data advantage into a search advantage: every
-benchmark gets its own title, description, canonical URL, and structured data,
-and the sitemap publishes all of them.
+The dashboard provides collection-level views, while each catalog benchmark
+still needs its own crawlable URL. Each per-benchmark shard already answers the
+reader's questions about one benchmark, but only as JSON consumed by
+JavaScript. This module renders that same evidence as plain HTML, one page per
+slug, readable with JavaScript disabled. Every benchmark gets its own title,
+description, canonical URL, and structured data, and the sitemap publishes all
+of them.
 
 The pages derive from the shards exactly as the shards derive from the crawl
 CSVs, so they are generated and gitignored, never committed. The build calls

--- a/tests/test_query_surfaces.py
+++ b/tests/test_query_surfaces.py
@@ -572,7 +572,7 @@ def test_cli_ends_human_output_with_citation_reminder(tmp_path: Path, capsys) ->
     assert exit_code == 0
     assert "please cite it" in output
     assert (
-        f"Wu, K., Zhou, J., et al. (2026). Benchmark Radar v{__version__}: Technical Report "
+        f"Wu, K., & Zhou, J. (2026). Benchmark Radar v{__version__}: Technical Report "
         f"(Version {__version__}). https://doi.org/10.5281/zenodo.22167102"
     ) in output
     assert "https://benchmark-radar.org/#cite" in output

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -113,6 +113,12 @@ def test_citation_metadata_prefers_the_technical_report():
     assert f'url: "{TECHNICAL_REPORT}"' in text
 
 
+def test_public_bibtex_names_both_report_authors():
+    author = "author       = {Wu, Koutian and Zhou, Junjie}"
+    for readme in (README, README_ZH):
+        assert author in readme.read_text(encoding="utf-8")
+
+
 def test_readmes_offer_a_short_agent_setup_prompt():
     # Regression: local-query setup should be one copy-paste command, not a second
     # maintainer manual (issue #436).

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -164,6 +164,11 @@ def test_citation_formats_are_one_click_away_behind_a_short_link():
     for fragment in ("10.5281/zenodo.22167102", "Benchmark Radar v0.9.0: Technical Report"):
         assert fragment in cff
         assert fragment in script
+    assert "given-names: Junjie" in cff
+    assert '"Wu, K., & Zhou, J. (2026)' in script
+    assert '"author = {Wu, Koutian and Zhou, Junjie},"' in script
+    assert html.count('name="citation_author"') == 2
+    assert '<meta name="citation_author" content="Zhou, Junjie">' in html
 
 
 def test_offline_cli_route_is_in_the_view_bar_behind_a_short_link():


### PR DESCRIPTION
## Summary

- add Junjie Zhou as the second author across public citation surfaces
- keep Today results first on mobile and align `design.md` with that product choice
- rename the remaining repository-badge helper to star-count language and remove stale Fork/Issues comments
- update the obsolete per-benchmark page module description

## Verification

Clean worktree, in CI order:

- `ruff check .`
- `ruff format --check .`
- `benchmark-radar normalize-external`
- `benchmark-radar classify`
- `benchmark-radar build-data-release`
- `pytest -q` — 1195 passed