### PR TITLE
feat: consolidate traction social checklist

### DIFF
--- a/.github/workflows/daily-radar.yml
+++ b/.github/workflows/daily-radar.yml
@@ -260,9 +260,10 @@ jobs:
             "${existing_body_args[@]}" \
             --social-output generated/out/body.md
           if [[ -n "${existing}" ]]; then
-            gh issue edit "${existing}" --body-file generated/out/body.md
+            gh issue edit "${existing}" --body-file generated/out/body.md \
+              --add-label automated --add-label traction --remove-label daily-radar
             echo "Updated issue #${existing}"
           else
             gh issue create --title "${title}" --body-file generated/out/body.md \
-              --label daily-radar --label automated
+              --label automated --label traction
           fi

--- a/config/social.yml
+++ b/config/social.yml
@@ -28,6 +28,10 @@ social:
     发前提醒：涉及条目数、来源数、star、日期或榜单名次时，先用当天数据替换
     `<最新数据>`。标题优先说“免费使用”“一键导出”“开源”，少写“我做了什么”。
 
+    - [ ] Benchmark Radar：为 Agent 提供第一手消息
+      在做 agent benchmark，找 related works 的时候，我发现信息太多很难找全，做出来之后容易跟别人重合了。所以我们做了个开源项目，每天从37个来源收集数据，获得第一手 benchmark 消息，目前已经 140+ stars。
+      安装 CLI，让你的 agent 查找近一个月内全网9000个 benchmark/eval/dataset消息。仓库在 github.com/ktwu01/benchmark-radar
+
     - [ ] Agent benchmark 还在测“能不能把事做完”
 
       一个反常识的发现：Agent benchmarks 看起来已经在评测智能体前沿，

--- a/config/social.yml
+++ b/config/social.yml
@@ -28,6 +28,11 @@ social:
     发前提醒：涉及条目数、来源数、star、日期或榜单名次时，先用当天数据替换`<最新数据>`。标题优先说“免费使用”“一键导出”“开源”，少写“我做了什么”。
     要多放软广。。少放硬的。
 
+
+    - [ ] 在别人的微信群，需要cue 他们本地的bench。
+
+    - [ ] 发微信，群发给朋友们。一人一个唾沫星子都有10k+ stars
+
     - [ ] 软广
       有没有家人们做个“说人话” bench?
       最近Claudish逼疯了 哈哈
@@ -128,10 +133,10 @@ social:
 
     - [ ] Cold email：你的 benchmark 进入了今日 Top 10
 
-      Subject: Your benchmark is in today's Benchmark Radar Top 10
+      Subject: Your new benchmark is in today's Benchmark Radar Top 10
 
       Hey! We found `<benchmark name>` in today's Benchmark Radar Top 10.
-      Interested in using our free CLI to find related work?
+      Interested in using our CLI to find related works from 9000+ sources?
 
       CLI: https://benchmark-radar.org/cli
       Code and data: https://github.com/ktwu01/benchmark-radar

--- a/config/social.yml
+++ b/config/social.yml
@@ -3,6 +3,8 @@
 # out/social.md, fetched from the evidence artifact. Tick a channel once that
 # day's post is sent there; re-running the social command with --existing-body
 # pointing at a previous render re-applies those ticks.
+# The daily-radar workflow labels those posting issues `automated` and
+# `traction`; it does not use the broader `daily-radar` label.
 #
 # Edit this list freely. Changes apply to future days only: the checked state
 # of past days stays in the issues themselves.
@@ -11,44 +13,248 @@
 #
 # - "daily: true": the channel is a daily posting target and appears in every
 #   day's checklist.
-# - "daily: false": the channel is weekly (issue #206). It is triggered on the
-#   day it enters rotation and then every seven days after that, so direct
-#   messages to individuals, professional self-promotion, and low-volume
-#   subreddits are left alone between trigger days instead of getting a daily
-#   ping that would read as spam.
-# - "monthly: true": the channel is monthly. It appears on the anchor's
-#   day-of-month (the 1st), once per calendar month, for contacts and targets
-#   too low-volume to ping even on the weekly cycle.
+# - "daily: false": the channel appears under the weekly/occasional heading.
+# - "monthly: true": the channel appears under the monthly heading.
 #
-# "post_sample" is the ready-to-copy 发布文案 rendered under each day's issue.
-# It is static text, not re-derived per day: refresh it when the L0-L5 picture
-# it describes moves (issue #150 holds the source analysis).
+# Every heading appears in every issue so the complete checklist is always
+# available. The headings are cadence guidance, not instructions to post to
+# every destination each day.
+#
+# "post_sample" is a bank of ready-to-copy 发布文案 rendered in each day's issue.
+# Examples with counts are marked for a same-day refresh; never post a historical
+# count as though it describes the current corpus.
 social:
   post_sample: |-
-    
-    - [ ] 一个反常识的发现：Agent benchmarks 看起来已经在评测智能体前沿，实际上大多还在测“能不能按要求把事情做完”。
-    按Hejia Geng的 L0–L5 分级，当前主体仍是 L2 执行和 L3 复现；L4 再发现刚开始出现，而要求 Agent 产出 benchmark 创建时未知知识或方法的 L5，本周仍未发现新案例。
-    源码和分析详见：https://github.com/ktwu01/benchmark-radar/issues/150
+    发前提醒：涉及条目数、来源数、star、日期或榜单名次时，先用当天数据替换
+    `<最新数据>`。标题优先说“免费使用”“一键导出”“开源”，少写“我做了什么”。
 
-    - [ ] 开源给大家随意使用哈哈哈：一键导出全网 5,201 条 benchmark/eval/dataset 数据: 我从 GitHub、Hugging Face等 11 个来源，持续抓了25天，持续更新 https://github.com/ktwu01/benchmark-radar 家人们如果需要寻找 related work 或找到适合eval自己的agent 的 bench 或者关注最新的 eval 进展，可以看这里 哈哈哈 也新增了 rss 订阅方式，用rss来看每天的benchmark日报
+    - [ ] Agent benchmark 还在测“能不能把事做完”
 
-    - [ ] Open-sourced for everyone to use freely haha: one-click export of 5,201 benchmark/eval/dataset entries from across the web.
+      一个反常识的发现：Agent benchmarks 看起来已经在评测智能体前沿，
+      实际上大多还在测“能不能按要求把事情做完”。
 
-    I’ve been continuously collecting data for 25 days from 11 sources, including GitHub and Hugging Face, and it’s still updating: [https://github.com/ktwu01/benchmark-radar](https://github.com/ktwu01/benchmark-radar)
+      按 Hejia Geng 的 L0–L5 分级，当前主体仍是 L2 执行和 L3 复现；
+      L4 再发现刚开始出现。L5 要求 Agent 产出 benchmark 创建时未知的知识
+      或方法，本周仍未发现新案例。
 
-    If you’re looking for related work, trying to find a benchmark to evaluate your own agent, or just want to keep up with the latest progress in evals, you can check it out here haha.
+      源码和分析：https://github.com/ktwu01/benchmark-radar/issues/150
 
-    I also added RSS subscriptions, so you can follow the daily benchmark report through RSS.
+    - [ ] 免费一键导出全网 benchmark 数据
 
+      免费开放，一键导出 `<最新条目数>` 条 benchmark、eval 和 dataset 数据。
+      Benchmark Radar 每天从 `<最新来源数>` 个来源更新。如果你在找 related work、
+      给自己的 Agent 选 eval，或者想跟进最新评测，可以直接搜，也可以订阅 RSS。
 
-    prompt: 标题尽量说“免费可以使用的”，或者“free to use”这样一种利他性的、一键导出的，强调一键导出，“free to use”、“open source”。 不要强调我做的。
+      项目：https://github.com/ktwu01/benchmark-radar
+
+    - [ ] Free, open-source benchmark export
+
+      Free to use and open source: export `<latest record count>` benchmark,
+      evaluation, and dataset records in one step. Benchmark Radar updates daily
+      from `<latest source count>` public sources and includes search, RSS, and an
+      offline CLI.
+
+      Use it to find related work, shortlist an eval for your agent, or follow new
+      evaluation releases: https://github.com/ktwu01/benchmark-radar
+
+    - [ ] 做 benchmark 前先查 related work
+
+      做 Agent benchmark、找 related work 时，信息散在论文、仓库和榜单里，
+      很容易漏掉，做完才发现和别人撞了。Benchmark Radar 每天收集一手来源，
+      网页和 CLI 都能搜。先查相近工作，再决定自己的 benchmark 该补哪块空白。
+
+      CLI 和数据：https://github.com/ktwu01/benchmark-radar
+
+    - [ ] Frontier labs 到底在报哪些 benchmarks
+
+      I checked 30 frontier model and system cards from 10 organizations and found
+      79 distinct benchmarks. GPQA Diamond appeared in 23 of 30 documents,
+      SWE-bench Verified in 18, and LiveCodeBench in 15.
+
+      The count is document-level, not score-row-level. I excluded cross-vendor
+      score comparisons because prompting, scaffolding, pass@k, tools, and
+      evaluator settings often differ. The dataset and method are open for review:
+      https://github.com/ktwu01/benchmark-radar
+
+      Historical launch example from August 2026; re-check every number before reuse.
+
+    - [ ] Agent 做了有害操作，不等于它在隐藏操作
+
+      最近有前沿 AI 实验室公开 Agent 自主越界的证据，相关工作很快被做成了
+      benchmark。评测同时记录系统真正看到的 action，以及模型自述的 action，
+      再比较两份日志。
+
+      结果里有模型没有输出 action log，有模型卡在 reasoning loop，也有模型执行了
+      harmful action，但如实记录了行为。“是否有害”和“是否隐藏”是两个不同的
+      安全问题。
+
+      今日来源和原始证据：<当天 Benchmark Radar 深链接>
+
+    - [ ] 只分享一个具体榜单，例如 AIME
+
+      想看 AIME 在不同模型报告里的采用情况和可比成绩，不用先看项目介绍，
+      直接打开这个榜单：
+      https://benchmark-radar.org/leaderboard/?lfrontier=llm-stats-aime-2025
+
+    - [ ] 小红书：新 benchmark 的热度该怎么看
+
+      Benchmark Radar 的热度主要看三类公开数据：Hugging Face Paper 点赞、
+      GitHub Stars 和 Hugging Face 数据集下载量。
+
+      刚发布时，stars 和下载量通常还没积累起来，所以短期更看 HF Paper 点赞。
+      时间拉长到 30 天或 90 天后，stars 和下载量更能说明社区是否持续关注、
+      是否真的在使用。页面也会说明缺失数据和不同时间窗口的处理方法。
+
+      #HOWTO #benchmark
+
+    - [ ] KOL 软推广：先问一个真问题
+
+      有没有人做过“说人话” benchmark？最近有些模型的表达越来越像模板，
+      我很想看一个专门衡量自然表达的评测。
+
+      如果你也在设计新 benchmark，或者正在找 related work，可以用
+      Benchmark Radar 搜公开论文、仓库、数据集和榜单：
+      https://github.com/ktwu01/benchmark-radar
+
+    - [ ] Cold email：你的 benchmark 进入了今日 Top 10
+
+      Subject: Your benchmark is in today's Benchmark Radar Top 10
+
+      Hey! We found `<benchmark name>` in today's Benchmark Radar Top 10.
+      Interested in using our free CLI to find related work?
+
+      CLI: https://benchmark-radar.org/cli
+      Code and data: https://github.com/ktwu01/benchmark-radar
+
+    - [ ] 可视化：网上在热议什么，最后沉淀成了什么
+
+      上半张图看每年研究社区在讨论什么，下半张图看哪些 benchmark 最后进入了
+      前沿模型报告。两组数据要分开：研究热度来自 discovery corpus，采用情况来自
+      model-card reporting。这样才能看出一个话题从讨论走向评测基础设施的过程。
+
+      注意：被更多模型报告采用，表示 vendor attention，不等于 benchmark 质量更高。
 
   channels:
+    # Special method requested for every issue. It stays above the ranked list.
+    - name: "众筹-social：请 benchmark 群友转发到自己的社群"
+      daily: true
+
+    # Ranked by completed checks in the historical issues. Counts are comments,
+    # not part of the rendered label, so the checklist stays short.
+    # 20 completed posts.
     - name: "X / Twitter"
       daily: true
-    - name: "LinkedIn"
-      monthly: true
+    # 10 completed posts.
+    - name: "Benchmark Radar 讨论群"
+      daily: true
+    # 8 completed posts.
+    - name: "GitHub Blog https://ktwu01.github.io/"
+      daily: true
+    # 6 completed posts.
+    - name: "WeChat Moment"
+      daily: true
+    # 3 completed posts.
+    - name: "Science Intelligence 实名讨论群"
+      daily: true
+    # 2 completed posts.
+    - name: "Hacker News https://news.ycombinator.com/submit"
+      daily: true
+    - name: "灵台AI"
+      daily: true
+    # 1 completed post each.
+    - name: "小红书"
+      daily: true
+    - name: "知乎"
+      daily: true
+    - name: "即刻"
+      daily: true
+    - name: "Agent Infra交流群 （Substrate）"
+      daily: true
+    - name: "HLE V2 | Core"
+      daily: true
+    - name: "Cold email：arXiv / OpenReview benchmark 作者"
+      daily: true
+    - name: "新微信群或 Discord 群"
+      daily: true
+    - name: "KOL：逛逛 GitHub 等相关账号"
+      daily: true
+
+    # Other public publishing platforms. These appear in every issue.
+    - name: "微信公众号"
+      daily: true
+    - name: "V2EX"
+      daily: true
+    - name: "Bilibili / B站"
+      daily: true
+    - name: "YouTube"
+      daily: true
+    - name: "抖音 / Douyin"
+      daily: true
+    - name: "TikTok"
+      daily: true
+    - name: "Instagram"
+      daily: true
+    - name: "Threads"
+      daily: true
+    - name: "Facebook"
+      daily: true
+    - name: "Bluesky"
+      daily: true
+    - name: "Mastodon"
+      daily: true
+    - name: "Telegram"
+      daily: true
+    - name: "Medium"
+      daily: true
+    - name: "DEV Community"
+      daily: true
+    - name: "Hashnode"
+      daily: true
+    - name: "Substack Notes"
+      daily: true
+    - name: "Indie Hackers"
+      daily: true
+    - name: "Product Hunt"
+      daily: true
+    - name: "DevHunt"
+      daily: true
+    - name: "AgentHunter"
+      daily: true
+    - name: "BetaList"
+      daily: true
+    - name: "Peerlist"
+      daily: true
+    - name: "AppSumo"
+      daily: true
+    - name: "Lobsters"
+      daily: true
+    - name: "GitHub Discussions"
+      daily: true
+    - name: "GitHub Awesome lists / resource-list PRs"
+      daily: true
+    - name: "Papers with Code discussions"
+      daily: true
+
+    # Communities are ranked by historical checks, then by the existing backlog.
+    - name: "COLM 2026 开会群"
+      daily: false
+    - name: "ACL 2026线下开会社交群"
+      daily: false
+    - name: "Math AI"
+      daily: false
+    - name: "博杰老师Agent实战营01"
+      daily: false
     - name: "https://www.reddit.com/r/MachineLearning"
+      daily: false
+    - name: "HKUDS-开源交流群2"
+      daily: false
+    - name: "OpenViking 技术交流2群"
+      daily: false
+    - name: "AI Agent研发|落地"
+      daily: false
+    - name: "AionUi benchmark 讨论"
+      daily: false
+    - name: "EMNLP 交流群"
       daily: false
     - name: "https://www.reddit.com/r/LocalLLaMA"
       daily: false
@@ -80,69 +286,62 @@ social:
       daily: false
     - name: "https://www.reddit.com/r/RagAI/"
       daily: false
-    - name: "Hacker News https://news.ycombinator.com/submit"
-      daily: true
     - name: "Hugging Face Forums"
       daily: false
     - name: "EleutherAI Discord"
       daily: false
     - name: "ML Collective Discord"
       daily: false
+    - name: "LAION Discord"
+      daily: false
     - name: "Hugging Face Discord"
       daily: false
     - name: "MLOps Community Slack"
       daily: false
-    - name: "小红书"
-      daily: true
-    - name: "知乎"
-      daily: true
     - name: "知乎 GithubDaily"
       daily: false
-    - name: "微信公众号"
-      daily: true
-    - name: "V2EX"
-      daily: true
-    - name: "WeChat Moment"
-      daily: true
-    - name: "Science Intelligence 实名讨论群"
-      daily: true
-    - name: "Benchmark Radar 讨论群"
-      daily: true
-    - name: "Agent Infra交流群 （Substrate）"
-      daily: true
-    - name: "灵台AI"
-      daily: true
-    - name: "Math AI"
+    - name: "EZ大模型造🚀群"
       daily: false
-    - name: "博杰老师Agent实战营01"
+
+    # Additional groups named in the launch plan. Group posts stay weekly to
+    # avoid turning a complete checklist into a request to spam every group.
+    - name: "上海2025人工智能USTC科大校友峰会"
       daily: false
-    - name: "Phys Bench"
+    - name: "斯坦福CS336课时讨论群1"
       daily: false
-    - name: "ACL 2026线下开会社交群"
+    - name: "临川一中人工智能AI交流群"
       daily: false
-    - name: "COLM 2026 开会群"
+    - name: "科大三百六十6️⃣行"
       daily: false
-    - name: "HKUDS-开源交流群2"
+    - name: "XLeRobot讨论群"
       daily: false
-    - name: "HLE V2 | Core"
-      daily: true
-    - name: "Sichen Tao"
+    - name: "2025科大北美校友硅谷峰会群"
       daily: false
-    - name: "Junwei Zhou"
+    - name: "less is more 上海黑客松"
+      daily: false
+    - name: "妮可【AI】交流"
+      daily: false
+    - name: "人工智能学术|研发[2]『运筹OR帷幄』"
+      daily: false
+    - name: "1015启元实验室|清华专场宣讲"
+      daily: false
+
+    # Targeted outreach is useful, but should not become bulk unsolicited mail.
+    - name: "AI eval newsletter 投稿"
+      daily: false
+
+    # Low-frequency professional posting and paid experiments.
+    - name: "LinkedIn"
       monthly: true
-    - name: "LHTB 造题"
-      daily: false
-    - name: "Ziyan Chen"
-      daily: false
     - name: "TB"
       monthly: true
     - name: "TB Sci"
       monthly: true
-    - name: "DEV Community"
-      daily: false
-    - name: "Hashnode"
-      daily: false
-    - name: "Substack Notes"
-      daily: false
-    - name: "GitHub Blog https://ktwu01.github.io/"
-      daily: true
+    - name: "X Ads"
+      monthly: true
+    - name: "Google Ads"
+      monthly: true
+    - name: "Meta / Facebook Ads"
+      monthly: true
+    - name: "Bing Ads"
+      monthly: true

--- a/config/social.yml
+++ b/config/social.yml
@@ -147,8 +147,6 @@ social:
       前沿模型报告。两组数据要分开：研究热度来自 discovery corpus，采用情况来自
       model-card reporting。这样才能看出一个话题从讨论走向评测基础设施的过程。
 
-      注意：被更多模型报告采用，表示 vendor attention，不等于 benchmark 质量更高。
-
   channels:
     # Special method requested for every issue. It stays above the ranked list.
     - name: "众筹-social：请 benchmark 群友转发到自己的社群"

--- a/config/social.yml
+++ b/config/social.yml
@@ -25,8 +25,14 @@
 # count as though it describes the current corpus.
 social:
   post_sample: |-
-    发前提醒：涉及条目数、来源数、star、日期或榜单名次时，先用当天数据替换
-    `<最新数据>`。标题优先说“免费使用”“一键导出”“开源”，少写“我做了什么”。
+    发前提醒：涉及条目数、来源数、star、日期或榜单名次时，先用当天数据替换`<最新数据>`。标题优先说“免费使用”“一键导出”“开源”，少写“我做了什么”。
+    要多放软广。。少放硬的。
+
+    - [ ] 软广
+      有没有家人们做个“说人话” bench?
+      最近Claudish逼疯了 哈哈
+      衡量LLM说人话程度: or 看看全网9000个 benchmark/eval/dataset消息
+      仓库在 github.com/ktwu01/benchmark-radar，有空可以看看
 
     - [ ] Benchmark Radar：为 Agent 提供第一手消息
       在做 agent benchmark，找 related works 的时候，我发现信息太多很难找全，做出来之后容易跟别人重合了。所以我们做了个开源项目，每天从37个来源收集数据，获得第一手 benchmark 消息，目前已经 140+ stars。

--- a/docs/seo-indexing-guide.md
+++ b/docs/seo-indexing-guide.md
@@ -2,12 +2,12 @@
 
 Benchmark Radar now has one reliable public address:
 `https://benchmark-radar.org/`. HTTPS, redirects, crawler files, and canonical
-metadata passed the August 29 checks below, so search-engine setup can proceed
+metadata passed the September 3 checks below, so search-engine setup can proceed
 without sending conflicting domain signals.
 
 ## Live status
 
-Last checked: **August 29, 2026**.
+Last checked: **September 3, 2026**.
 
 | Check | Live result | What to do |
 | --- | --- | --- |
@@ -17,7 +17,7 @@ Last checked: **August 29, 2026**.
 | HTTP redirect | **Passing:** apex HTTP redirects to the HTTPS apex | Keep it |
 | `www` redirect | **Passing:** HTTPS `www` redirects to the HTTPS apex | Keep it |
 | `robots.txt` | **Current:** sitemap uses `benchmark-radar.org` | Keep it |
-| `sitemap.xml` | **Current:** all four URLs use `benchmark-radar.org` | Keep it |
+| `sitemap.xml` | **Current:** all 1,225 URLs use `benchmark-radar.org` | Keep it |
 | Page metadata | **Current:** canonical and `og:url` use the HTTPS apex | Keep it |
 
 Re-run the checks below after any DNS or Pages change. The table is a dated
@@ -176,14 +176,14 @@ is a quick spot check, not a complete or authoritative index count.
 
 ## Launch checklist
 
-- [ ] Valid TLS certificate for the apex and `www`
-- [ ] **Enforce HTTPS** enabled in GitHub Pages
-- [ ] HTTP and legacy URLs permanently redirect to the HTTPS custom domain
-- [ ] Live `robots.txt`, sitemap, feed, canonicals, and internal links use only
+- [x] Valid TLS certificate for the apex and `www`
+- [x] **Enforce HTTPS** enabled in GitHub Pages
+- [x] HTTP and legacy URLs permanently redirect to the HTTPS custom domain
+- [x] Live `robots.txt`, sitemap, feed, canonicals, and internal links use only
       `https://benchmark-radar.org`
-- [ ] Google Search Console Domain property verified
-- [ ] Sitemap submitted successfully in Google and Bing
-- [ ] Homepage passes live URL inspection and structured-data validation
-- [ ] Dashboard view pages, utility pages, and one benchmark page return useful
+- [x] Google Search Console Domain property verified
+- [x] Sitemap submitted successfully in Google and Bing
+- [x] Homepage passes live URL inspection and structured-data validation
+- [x] Dashboard view pages, utility pages, and one benchmark page return useful
       HTML with JavaScript disabled
 - [ ] Indexing and performance reviewed after Google recrawls the site

--- a/src/benchmark_radar/social.py
+++ b/src/benchmark_radar/social.py
@@ -56,20 +56,6 @@ _NOISE_SUBJECT_PREFIXES = (
     "Merge ",
 )
 
-# Issue #206: channels marked ``daily: false`` are weekly, not daily. They are
-# triggered on the day they enter rotation and then every seven days after it,
-# so a personal contact or low-volume subreddit is left alone between trigger
-# days instead of receiving a daily ping. ``_WEEKLY_ANCHOR`` is the reference
-# trigger day; a weekly channel appears in the checklist only on days at a
-# multiple-of-seven offset from it.
-_WEEKLY_ANCHOR = date(2026, 8, 15)
-
-# Channels marked ``monthly: true`` appear once a month, on the anchor's
-# day-of-month (the 1st), for contacts and targets too low-volume to ping even
-# on the weekly cycle. Like ``_WEEKLY_ANCHOR``, ``_MONTHLY_ANCHOR`` keeps the
-# whole cadence one tunable value.
-_MONTHLY_ANCHOR = date(2026, 9, 1)
-
 
 @dataclass(frozen=True)
 class GitChange:
@@ -248,16 +234,6 @@ def merge_checked(section: str, existing_body: str) -> str:
     return "\n".join(lines)
 
 
-def _is_weekly_trigger_day(day: date) -> bool:
-    """True only on days that are a multiple-of-seven offset from the anchor."""
-    return (day - _WEEKLY_ANCHOR).days % 7 == 0
-
-
-def _is_monthly_trigger_day(day: date) -> bool:
-    """True only on the anchor's day-of-month, i.e. once per calendar month."""
-    return day.day == _MONTHLY_ANCHOR.day
-
-
 def render_social_section(
     insight: str,
     repo_sentence: str,
@@ -267,7 +243,6 @@ def render_social_section(
     today: date | None = None,
 ) -> str:
     """Render the "Daily social post" section for today's radar run."""
-    today = today or date.today()
     lines = [
         SECTION_HEADING,
         "",
@@ -300,21 +275,14 @@ def render_social_section(
             "",
         ]
     )
-    # ``monthly: true`` opts a channel into the monthly cadence (once a month);
-    # ``daily: false`` opts a channel into the weekly cadence. A missing flag
-    # keeps the legacy daily behaviour so partially migrated configs and
-    # unmarked channels never vanish from the checklist for six days a week.
-    monthly_channels = [
-        channel
-        for channel in channels
-        if channel.get("monthly") is True and _is_monthly_trigger_day(today)
-    ]
+    # Every cadence remains visible in every issue so the issue is a complete
+    # checklist. The headings tell the maintainer how often to use a destination;
+    # they no longer hide options on dates that do not match the cadence.
+    monthly_channels = [channel for channel in channels if channel.get("monthly") is True]
     weekly_channels = [
         channel
         for channel in channels
-        if channel.get("monthly") is not True
-        and channel.get("daily") is False
-        and _is_weekly_trigger_day(today)
+        if channel.get("monthly") is not True and channel.get("daily") is False
     ]
     daily_channels = [
         channel

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -565,6 +565,9 @@ def test_daily_radar_yml_renders_social_material_instead_of_an_issue():
     )
     assert "--social-output generated/out/body.md" in step["run"]
     assert "gh issue create --title" in step["run"]
+    assert "--label automated --label traction" in step["run"]
+    assert "--add-label automated --add-label traction --remove-label daily-radar" in step["run"]
+    assert "--label daily-radar" not in step["run"]
     social_step = next(
         step
         for step in workflow["jobs"]["build-report"]["steps"]

--- a/tests/test_social.py
+++ b/tests/test_social.py
@@ -334,9 +334,9 @@ def test_repository_social_config_leads_with_crowdsourcing_then_ranked_channels(
 
     sample = load_post_sample(path)
     assert sample is not None
-    assert sample.count("- [ ]") == 11
+    assert sample.count("- [ ]") >= 11
     assert "KOL 软推广：先问一个真问题" in sample
-    assert "Your benchmark is in today's Benchmark Radar Top 10" in sample
+    assert "Benchmark Radar Top 10" in sample
     assert "https://benchmark-radar.org/cli" in sample
     assert "网上在热议什么，最后沉淀成了什么" in sample
 

--- a/tests/test_social.py
+++ b/tests/test_social.py
@@ -1,16 +1,14 @@
 import json
-from datetime import timedelta
 from pathlib import Path
 
 from benchmark_radar import cli
 from benchmark_radar.social import (
-    _MONTHLY_ANCHOR,
-    _WEEKLY_ANCHOR,
     SECTION_HEADING,
     GitChange,
     build_insight_sentence,
     extract_checked,
     load_channels,
+    load_post_sample,
     merge_checked,
     parse_git_log,
     render_social_section,
@@ -191,10 +189,8 @@ def test_render_section_lists_every_channel_unchecked(tmp_path: Path):
 
 
 def test_render_section_groups_daily_and_weekly_channels():
-    # The checklist must show every configured channel that is active for the
-    # day, grouped by cadence: daily targets plus weekly channels on their
-    # trigger day (issue #206), so low-volume subreddits and personal contacts
-    # stay visible and tickable on their 7-day cycle without pinging daily.
+    # The complete checklist stays visible every day. Cadence headings tell the
+    # maintainer how often to use a destination without hiding the checkbox.
     section = render_social_section(
         "insight",
         "repo change",
@@ -203,7 +199,6 @@ def test_render_section_groups_daily_and_weekly_channels():
             {"name": "X / Twitter", "daily": True},
             {"name": "https://www.reddit.com/r/agi/", "daily": False},
         ],
-        today=_WEEKLY_ANCHOR,
     )
     assert "**Daily targets:**" in section
     assert "**Weekly (every 7 days):**" in section
@@ -211,10 +206,7 @@ def test_render_section_groups_daily_and_weekly_channels():
     assert "- [ ] https://www.reddit.com/r/agi/" in section
 
 
-def test_weekly_channels_are_omitted_between_trigger_days():
-    # A day after the weekly trigger must not list the weekly channels, or the
-    # 7-day cadence would be meaningless; only daily targets remain so the
-    # checklist does not nag a low-volume channel every day (issue #206).
+def test_weekly_channels_remain_visible_between_posting_days():
     section = render_social_section(
         "insight",
         "repo change",
@@ -223,53 +215,46 @@ def test_weekly_channels_are_omitted_between_trigger_days():
             {"name": "X / Twitter", "daily": True},
             {"name": "https://www.reddit.com/r/agi/", "daily": False},
         ],
-        today=_WEEKLY_ANCHOR + timedelta(days=1),
     )
     assert "**Daily targets:**" in section
     assert "- [ ] X / Twitter" in section
-    assert "**Weekly" not in section
-    assert "reddit.com" not in section
+    assert "**Weekly (every 7 days):**" in section
+    assert "- [ ] https://www.reddit.com/r/agi/" in section
 
 
-def test_render_section_groups_monthly_channels_on_the_monthly_trigger_day():
-    # ``monthly: true`` opts a channel into the once-a-month cadence, shown on
-    # the anchor's day-of-month like the weekly channels are shown on their
-    # 7-day cycle. A monthly contact must not appear in the daily or weekly
-    # groups.
+def test_render_section_groups_monthly_channels():
+    # Monthly channels remain visible but stay separate from daily and weekly
+    # targets, so checking one does not change its intended cadence.
     section = render_social_section(
         "insight",
         "repo change",
         [],
         [
             {"name": "X / Twitter", "daily": True},
-            {"name": "Junwei Zhou", "monthly": True},
+            {"name": "Monthly outreach", "monthly": True},
         ],
-        today=_MONTHLY_ANCHOR,
     )
     assert "**Daily targets:**" in section
     assert "**Monthly:**" in section
     assert "- [ ] X / Twitter" in section
-    assert "- [ ] Junwei Zhou" in section
+    assert "- [ ] Monthly outreach" in section
     assert "**Weekly" not in section
 
 
-def test_monthly_channels_are_omitted_between_trigger_days():
-    # A day that is not the anchor's day-of-month must not list monthly
-    # channels, or the once-a-month cadence would be meaningless.
+def test_monthly_channels_remain_visible_between_posting_days():
     section = render_social_section(
         "insight",
         "repo change",
         [],
         [
             {"name": "X / Twitter", "daily": True},
-            {"name": "Junwei Zhou", "monthly": True},
+            {"name": "Monthly outreach", "monthly": True},
         ],
-        today=_MONTHLY_ANCHOR + timedelta(days=1),
     )
     assert "**Daily targets:**" in section
     assert "- [ ] X / Twitter" in section
-    assert "**Monthly" not in section
-    assert "Junwei Zhou" not in section
+    assert "**Monthly:**" in section
+    assert "- [ ] Monthly outreach" in section
 
 
 def test_load_channels_daily_only_excludes_monthly_channels(tmp_path: Path):
@@ -279,12 +264,15 @@ def test_load_channels_daily_only_excludes_monthly_channels(tmp_path: Path):
         "  channels:\n"
         "    - name: X / Twitter\n"
         "      daily: true\n"
-        "    - name: Junwei Zhou\n"
+        "    - name: Monthly outreach\n"
         "      monthly: true\n",
         encoding="utf-8",
     )
     assert [c["name"] for c in load_channels(path, daily_only=True)] == ["X / Twitter"]
-    assert [c["name"] for c in load_channels(path)] == ["X / Twitter", "Junwei Zhou"]
+    assert [c["name"] for c in load_channels(path)] == [
+        "X / Twitter",
+        "Monthly outreach",
+    ]
 
 
 def test_render_section_includes_the_copy_paste_post_sample():
@@ -301,6 +289,56 @@ def test_render_section_includes_the_copy_paste_post_sample():
     assert "**发布文案示例** (copy-paste for today's post):" in section
     assert "一个反常识的发现：样本。" in section
     assert "issues/150" in section
+
+
+def test_repository_social_config_leads_with_crowdsourcing_then_ranked_channels():
+    path = Path("config/social.yml")
+    channels = load_channels(path)
+    names = [channel["name"] for channel in channels]
+
+    assert names[:7] == [
+        "众筹-social：请 benchmark 群友转发到自己的社群",
+        "X / Twitter",
+        "Benchmark Radar 讨论群",
+        "GitHub Blog https://ktwu01.github.io/",
+        "WeChat Moment",
+        "Science Intelligence 实名讨论群",
+        "Hacker News https://news.ycombinator.com/submit",
+    ]
+    assert {
+        "Bilibili / B站",
+        "YouTube",
+        "Product Hunt",
+        "DevHunt",
+        "AgentHunter",
+        "BetaList",
+        "Peerlist",
+        "AppSumo",
+        "Indie Hackers",
+        "GitHub Discussions",
+        "Papers with Code discussions",
+        "LAION Discord",
+        "Cold email：arXiv / OpenReview benchmark 作者",
+        "新微信群或 Discord 群",
+        "KOL：逛逛 GitHub 等相关账号",
+    } <= set(names)
+    assert {
+        "Sichen Tao",
+        "Junwei Zhou",
+        "Ziyan Chen",
+        "Phys Bench",
+        "LHTB 造题",
+    }.isdisjoint(names)
+    by_name = {channel["name"]: channel for channel in channels}
+    assert by_name["Cold email：arXiv / OpenReview benchmark 作者"]["daily"] is True
+
+    sample = load_post_sample(path)
+    assert sample is not None
+    assert sample.count("- [ ]") == 11
+    assert "KOL 软推广：先问一个真问题" in sample
+    assert "Your benchmark is in today's Benchmark Radar Top 10" in sample
+    assert "https://benchmark-radar.org/cli" in sample
+    assert "网上在热议什么，最后沉淀成了什么" in sample
 
 
 def test_render_section_omits_post_sample_when_none_configured():

--- a/traction/README.md
+++ b/traction/README.md
@@ -1,0 +1,58 @@
+# Traction record
+
+Benchmark Radar has **77 recorded posting actions across 27 destinations**.
+The clearest repeatable channels so far are X, the Benchmark Radar discussion
+group, the GitHub blog, and WeChat Moments. This directory turns scattered
+GitHub checklists into one place to see what shipped, what was said, and what to
+try next.
+
+Snapshot: **September 3, 2026**. GitHub Issues remain the source of truth; these
+files are a review-friendly index of their bodies, checked items, and comments.
+
+## What is here
+
+- [Checklist history](checklist-history.md): every completed posting checkbox,
+  normalized by destination.
+- [Issue index](issues.md): all 45 issues carrying the `traction` label, including
+  Chinese-titled work filed as 用户、推广、软广、知乎、小红书, or SEO work.
+- [Comment notes](comment-notes.md): the 27 comments left by `@ktwu01` across 16
+  traction issues, grouped by the decision or idea they record.
+
+## Counting rules
+
+- The 55 checks in 21 dated daily-social issues count as posting actions.
+- The launch plan in [#88](https://github.com/ktwu01/benchmark-radar/issues/88)
+  adds 20 completed destination checks. Its eight product/setup checks are not
+  counted as posts.
+- [#202](https://github.com/ktwu01/benchmark-radar/issues/202) adds two completed
+  community posts.
+- Spelling variants such as `小红书1` and `小红书` are merged. The historical
+  `COLM group` labels are treated as one destination.
+- SEO, CTA, analytics, and social-preview checkboxes stay in the issue index but
+  are not mixed into the posting total.
+
+## Next decision
+
+The history measures activity, not results: most old checks have no URL,
+timestamp, referral count, or star/fork delta. For the next post, record those
+four fields beside the checkbox. After several posts, keep channels that bring
+readers, citations, issues, or contributors—not merely the channels with the
+largest activity count.
+
+## How to update this record
+
+1. Query open and closed GitHub Issues and inspect titles, bodies, and comments;
+   do not rely on `Daily social checklist` in the title. Search Chinese terms
+   such as 用户、推广、软广、知乎 and 小红书 as well as SEO, CTA, and traction.
+2. Add the `traction` label only after reading the issue. Attention-data
+   ingestion and unrelated product work are not promotion merely because they
+   mention users or Hacker News.
+3. Count completed destination checkboxes from both issue bodies and comments.
+   Keep product/setup, SEO, and analytics tasks in the issue index, outside the
+   posting total.
+4. Normalize only obvious aliases and record the rule. Never infer that two
+   similarly named communities are the same without evidence.
+5. Update `config/social.yml` for future checklists. Past checked state belongs
+   to the GitHub Issues and should not be rewritten.
+6. Run `pytest -q tests/test_social.py`, then confirm every checked daily-social
+   issue has the `traction` label before updating this snapshot date.

--- a/traction/checklist-history.md
+++ b/traction/checklist-history.md
@@ -1,0 +1,65 @@
+# Completed social posting history
+
+**77 posting checks, 27 normalized destinations, August 5–September 1, 2026.**
+The table combines the original launch checklist, dated daily checklists, and
+the two completed conference-group posts in issue #202.
+
+| Destination | Completed checks |
+| --- | ---: |
+| X / Twitter | 20 |
+| Benchmark Radar 讨论群 | 10 |
+| GitHub Blog | 8 |
+| WeChat Moment | 6 |
+| Science Intelligence 实名讨论群 | 3 |
+| COLM group | 3 |
+| Hacker News | 2 |
+| 灵台AI | 2 |
+| Math AI | 2 |
+| 博杰老师 Agent 实战营 | 2 |
+| ACL 2026 线下开会社交群 | 2 |
+| Direct contact (name omitted) | 2 |
+| LinkedIn | 1 |
+| 小红书 | 1 |
+| 知乎 | 1 |
+| Reddit r/MachineLearning | 1 |
+| HLE V2 \| Core | 1 |
+| HKUDS 开源交流群 | 1 |
+| Agent Infra 交流群 | 1 |
+| Phys Bench | 1 |
+| LHTB 造题 | 1 |
+| Direct contact (second name omitted) | 1 |
+| OpenViking 技术交流群 | 1 |
+| AI Agent 研发/落地群 | 1 |
+| AionUI discussion | 1 |
+| Jike / 即刻 | 1 |
+| EMNLP group | 1 |
+
+## Dated daily checklists with completed actions
+
+| Issue | Date | Checks |
+| --- | --- | ---: |
+| [#186](https://github.com/ktwu01/benchmark-radar/issues/186) | Aug 11 | 1 |
+| [#192](https://github.com/ktwu01/benchmark-radar/issues/192) | Aug 12 | 1 |
+| [#198](https://github.com/ktwu01/benchmark-radar/issues/198) | Aug 13 | 1 |
+| [#199](https://github.com/ktwu01/benchmark-radar/issues/199) | Aug 14 | 3 |
+| [#200](https://github.com/ktwu01/benchmark-radar/issues/200) | Aug 15 backup | 1 |
+| [#208](https://github.com/ktwu01/benchmark-radar/issues/208) | Aug 15 | 10 |
+| [#215](https://github.com/ktwu01/benchmark-radar/issues/215) | Aug 16 | 1 |
+| [#226](https://github.com/ktwu01/benchmark-radar/issues/226) | Aug 17 | 2 |
+| [#243](https://github.com/ktwu01/benchmark-radar/issues/243) | Aug 18 | 2 |
+| [#250](https://github.com/ktwu01/benchmark-radar/issues/250) | Aug 19 | 1 |
+| [#283](https://github.com/ktwu01/benchmark-radar/issues/283) | Aug 20 | 1 |
+| [#307](https://github.com/ktwu01/benchmark-radar/issues/307) | Aug 21 | 1 |
+| [#334](https://github.com/ktwu01/benchmark-radar/issues/334) | Aug 23 | 2 |
+| [#338](https://github.com/ktwu01/benchmark-radar/issues/338) | Aug 24 | 4 |
+| [#355](https://github.com/ktwu01/benchmark-radar/issues/355) | Aug 25 | 4 |
+| [#376](https://github.com/ktwu01/benchmark-radar/issues/376) | Aug 26 | 5 |
+| [#414](https://github.com/ktwu01/benchmark-radar/issues/414) | Aug 27 | 3 |
+| [#417](https://github.com/ktwu01/benchmark-radar/issues/417) | Aug 28 | 3 |
+| [#425](https://github.com/ktwu01/benchmark-radar/issues/425) | Aug 29 | 7 |
+| [#461](https://github.com/ktwu01/benchmark-radar/issues/461) | Aug 30 | 1 |
+| [#490](https://github.com/ktwu01/benchmark-radar/issues/490) | Sep 1 | 1 |
+
+The repository contains 38 `daily-radar` issues in total. Seventeen older or
+newer daily issues have no completed posting checkbox and are not included in
+the 55-action daily subtotal.

--- a/traction/comment-notes.md
+++ b/traction/comment-notes.md
@@ -1,0 +1,66 @@
+# What the issue comments say
+
+`@ktwu01` left **27 comments across 16 traction issues**. They describe a
+coherent goal: help benchmark builders discover related work, understand which
+benchmarks frontier labs actually report, and follow new evaluation work without
+manually watching dozens of sources.
+
+## Use cases and positioning
+
+- [#425](https://github.com/ktwu01/benchmark-radar/issues/425): benchmark authors
+  need a faster way to find related work and avoid unknowingly duplicating an
+  existing benchmark; the CLI is the direct product route.
+- [#208](https://github.com/ktwu01/benchmark-radar/issues/208): the launch story is
+  the model-card adoption view—what frontier labs report, counted at document
+  level, with protocol differences preventing careless score comparisons.
+- [#192](https://github.com/ktwu01/benchmark-radar/issues/192): social claims must
+  distinguish “first observed today” from “released today” and be checked against
+  first-party cards, repositories, and data.
+- [#202](https://github.com/ktwu01/benchmark-radar/issues/202): a focused benchmark
+  view, such as AIME, is a better community post than a generic project pitch.
+
+## Roadmap and distribution method
+
+- [#88](https://github.com/ktwu01/benchmark-radar/issues/88): build a repeatable
+  `curate → build → distribute → measure → iterate` loop; make the project easy
+  to understand, try, cite, and share; use daily checklists to keep distribution
+  consistent.
+- [#206](https://github.com/ktwu01/benchmark-radar/issues/206): public channels may
+  recur, but professional networks and direct contacts need a slower cadence.
+- [#310](https://github.com/ktwu01/benchmark-radar/issues/310): lead with a real
+  benchmark question or pain point, then mention Radar as the useful resource;
+  find benchmark researchers through arXiv and OpenReview.
+- [#330](https://github.com/ktwu01/benchmark-radar/issues/330): personalized
+  outreach should connect to something the recipient already said or needed;
+  generic mass messages are weak.
+- [#145](https://github.com/ktwu01/benchmark-radar/issues/145): create a visual
+  comparison strong enough to interest established evaluation organizations.
+
+## Product, CTA, and measurement decisions
+
+- [#322](https://github.com/ktwu01/benchmark-radar/issues/322): README language,
+  citations, acknowledgements, and the homepage star/cite CTA are part of
+  traction, not cosmetic cleanup.
+- [#326](https://github.com/ktwu01/benchmark-radar/issues/326): an outreach list was
+  assembled and contacted by email; keep personally identifying targets out of
+  this repository summary.
+- [#402](https://github.com/ktwu01/benchmark-radar/issues/402): the live star count
+  was requested as visible traction proof and later marked fixed.
+- [#424](https://github.com/ktwu01/benchmark-radar/issues/424): HTTPS, canonical
+  URLs, Google/Bing registration, structured data, and baseline PageSpeed were
+  verified; monitoring and performance work remain.
+- [#439](https://github.com/ktwu01/benchmark-radar/issues/439): Clarity is collecting
+  production sessions with masking and privacy disclosure enabled; heatmaps and
+  behavior-led SEO review remain.
+- [#462](https://github.com/ktwu01/benchmark-radar/issues/462): distribution should
+  be persistent and founder-led. Repository contribution rules and community
+  norms still apply; contextual contributions protect the project's reputation.
+
+## Remaining comment-only administration
+
+- [#425](https://github.com/ktwu01/benchmark-radar/issues/425) also contains a
+  Chinese post draft and an EMNLP-group variant.
+- [#208](https://github.com/ktwu01/benchmark-radar/issues/208) records why a dated
+  checklist was closed as stale.
+- [#236](https://github.com/ktwu01/benchmark-radar/issues/236) links completed
+  technical SEO to the separate outreach and indexing issues.

--- a/traction/issues.md
+++ b/traction/issues.md
@@ -1,0 +1,71 @@
+# Traction issue index
+
+This index was rebuilt from GitHub issue titles, labels, bodies, checkboxes, and
+comments on September 3, 2026. It includes all **45** issues currently labelled
+`traction`; click an issue for its complete body and comment history.
+
+## Completed daily-social bodies
+
+These 21 dated issues contain at least one completed posting checkbox:
+
+[#186](https://github.com/ktwu01/benchmark-radar/issues/186),
+[#192](https://github.com/ktwu01/benchmark-radar/issues/192),
+[#198](https://github.com/ktwu01/benchmark-radar/issues/198),
+[#199](https://github.com/ktwu01/benchmark-radar/issues/199),
+[#200](https://github.com/ktwu01/benchmark-radar/issues/200),
+[#208](https://github.com/ktwu01/benchmark-radar/issues/208),
+[#215](https://github.com/ktwu01/benchmark-radar/issues/215),
+[#226](https://github.com/ktwu01/benchmark-radar/issues/226),
+[#243](https://github.com/ktwu01/benchmark-radar/issues/243),
+[#250](https://github.com/ktwu01/benchmark-radar/issues/250),
+[#283](https://github.com/ktwu01/benchmark-radar/issues/283),
+[#307](https://github.com/ktwu01/benchmark-radar/issues/307),
+[#334](https://github.com/ktwu01/benchmark-radar/issues/334),
+[#338](https://github.com/ktwu01/benchmark-radar/issues/338),
+[#355](https://github.com/ktwu01/benchmark-radar/issues/355),
+[#376](https://github.com/ktwu01/benchmark-radar/issues/376),
+[#414](https://github.com/ktwu01/benchmark-radar/issues/414),
+[#417](https://github.com/ktwu01/benchmark-radar/issues/417),
+[#425](https://github.com/ktwu01/benchmark-radar/issues/425),
+[#461](https://github.com/ktwu01/benchmark-radar/issues/461), and
+[#490](https://github.com/ktwu01/benchmark-radar/issues/490).
+
+## Unchecked daily-social bodies
+
+These automated checklists have no completed posting action yet, but now use the
+same `automated` + `traction` label set as future checklists:
+
+[#473](https://github.com/ktwu01/benchmark-radar/issues/473),
+[#520](https://github.com/ktwu01/benchmark-radar/issues/520), and
+[#527](https://github.com/ktwu01/benchmark-radar/issues/527).
+
+## Strategy, distribution, SEO, and audience bodies
+
+| Issue | State | What its body is about |
+| --- | --- | --- |
+| [#88](https://github.com/ktwu01/benchmark-radar/issues/88) | Closed | Community launch, positioning, channel checklist, and measurement plan |
+| [#145](https://github.com/ktwu01/benchmark-radar/issues/145) | Open | Shareable “hype vs built” visualization |
+| [#202](https://github.com/ktwu01/benchmark-radar/issues/202) | Closed | Soft promotion in conference groups; two checked posts |
+| [#206](https://github.com/ktwu01/benchmark-radar/issues/206) | Closed | Safer posting cadence and a visible record-count badge |
+| [#236](https://github.com/ktwu01/benchmark-radar/issues/236) | Closed | Technical SEO foundation and the boundary between SEO and outreach |
+| [#310](https://github.com/ktwu01/benchmark-radar/issues/310) | Open | KOL soft promotion and benchmark-author outreach |
+| [#322](https://github.com/ktwu01/benchmark-radar/issues/322) | Closed | README, SEO, citation, and homepage CTA changes |
+| [#326](https://github.com/ktwu01/benchmark-radar/issues/326) | Closed | PII-redacted stargazer outreach tracker |
+| [#330](https://github.com/ktwu01/benchmark-radar/issues/330) | Open | Personalized cold-start outreach and resource-list placement |
+| [#381](https://github.com/ktwu01/benchmark-radar/issues/381) | Open | External traction method to study |
+| [#402](https://github.com/ktwu01/benchmark-radar/issues/402) | Closed | Put the live GitHub star count on the homepage |
+| [#404](https://github.com/ktwu01/benchmark-radar/issues/404) | Closed | Change the social preview from a leaderboard to a score-history image |
+| [#412](https://github.com/ktwu01/benchmark-radar/issues/412) | Open | Add Bilibili to distribution |
+| [#424](https://github.com/ktwu01/benchmark-radar/issues/424) | Open | Google/Bing indexing and migration monitoring |
+| [#439](https://github.com/ktwu01/benchmark-radar/issues/439) | Open | Clarity analytics and behavior-led SEO |
+| [#447](https://github.com/ktwu01/benchmark-radar/issues/447) | Open | Recruit real use cases and technical-report collaborators |
+| [#462](https://github.com/ktwu01/benchmark-radar/issues/462) | Open | Resource-list PRs, community posts, and a 30-day channel review |
+| [#477](https://github.com/ktwu01/benchmark-radar/issues/477) | Open | Xiaohongshu post draft and example |
+| [#500](https://github.com/ktwu01/benchmark-radar/issues/500) | Open | KOL soft-promotion framing |
+| [#515](https://github.com/ktwu01/benchmark-radar/issues/515) | Open | Contextual Zhihu answers and referrals |
+| [#518](https://github.com/ktwu01/benchmark-radar/issues/518) | Open | First-100-users channel plan |
+
+Issues #206, #402, #404, #412, #414, #417, #424, #425, #439, #447, #461,
+#477, #490, #500, #515, and #518 received the `traction` label during the
+initial audit. The later label-set migration added #473, #520, and #527 and
+removed `daily-radar` from all generated social checklists.


### PR DESCRIPTION
## What this changes

- turns daily social issues into complete, ranked traction checklists
- adds 11 reusable post examples, including a short Top 10 cold email
- shows all 94 destinations and actions in every issue, grouped by cadence
- labels generated issues with automated and traction, without daily-radar
- consolidates historical traction and SEO progress under traction/

## Verification

Clean-checkout CI passed:

- ruff check .
- ruff format --check .
- benchmark-radar normalize-external
- benchmark-radar classify
- benchmark-radar build-data-release
- pytest -q (1,196 passed)