### PR TITLE
fix: include sunblaze-ucb in organization discovery

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -221,10 +221,10 @@ sources:
     required: false
     registry_path: data/priority_github_organizations.yml
     tiers: [priority, standard, probation]
-    max_organizations: 360
+    max_organizations: 361
     page_size: 30
     max_pages_per_organization: 1
-    max_requests: 360
+    max_requests: 361
     attempts: 2
     timeout_seconds: 30
 

--- a/data/priority_github_organizations.yml
+++ b/data/priority_github_organizations.yml
@@ -1,5 +1,6 @@
 # Public GitHub organizations used only to improve candidate discovery.
-# Generated from 24 recorded GitHub Search API responses on 2026-08-27; see docs/source-coverage-audit.zh-CN.md for method and limits.
+# Initially generated from 24 recorded GitHub Search API responses on 2026-08-27; see docs/source-coverage-audit.zh-CN.md for method and limits.
+# Later additions record their individual review evidence below.
 schema_version: 1
 generated_at: '2026-08-27'
 selection_rule: Public GitHub Organizations identified by non-fork repositories returned by recorded AI,
@@ -15486,3 +15487,16 @@ organizations:
       - llm
   added_at: '2026-08-27'
   review_after: '2026-11-27'
+- login: sunblaze-ucb
+  display_name: sunblaze-ucb
+  tier: standard
+  source_evidence: https://github.com/sunblaze-ucb
+  selection_evidence:
+    issue: https://github.com/ktwu01/benchmark-radar/issues/555
+    review_basis: The Vero README documents a benchmark for repository-level implementation and
+      proof synthesis by AI agents, with proof-only and code-and-proof evaluation modes.
+    sample_repositories:
+    - full_name: sunblaze-ucb/vero
+      url: https://github.com/sunblaze-ucb/vero
+  added_at: '2026-09-06'
+  review_after: '2026-12-06'


### PR DESCRIPTION
`sunblaze-ucb` was missing from the reviewed GitHub organization registry. Add it at the `standard` tier with Vero's repository, the review rationale, issue reference, and review dates so it can participate in future organization discovery. Raise both the organization and request limits from 360 to 361; otherwise the appended entry would fall outside the scan limit.

This addresses the maintainer's first checklist item in #555. The existing creation-time window and relevance checks still apply, so this change does not backfill the historical Vero repository or resolve the broader backfill request.

Validation on a clean detached worktree at commit `6f2d9a1`, in CI order:

- `ruff check .`
- `ruff format --check .`
- `benchmark-radar normalize-external`
- `benchmark-radar classify`
- `benchmark-radar build-data-release`
- `pytest -q`

All six steps passed; pytest reported **1236 passed**. Registry validation also confirmed that `sunblaze-ucb` is included within the configured scan and request limits.
