### PR TITLE
Add Saturation tab with full-catalog search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ graphify-out/
 # reason as the benchmark pages: the generator and inputs are reviewed, not a
 # stale HTML copy.
 /site/leaderboard/
+/site/saturation/
 # One page per collection day, written by the same `classify` run from the
 # committed snapshots. The whole tree is replaced on every build, so a
 # committed copy would be a stale brief reviewed as if it were the day's

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ web. It pulls evidence from 37 public sources every day, and keeps updating.
 **Find a benchmark in seconds, then see how model scores change over time. Click
 the GIF below to watch SWE-bench Verified move toward saturation.**
 
-<a href="https://benchmark-radar.org/leaderboard/?lfrontier=swe_bench_verified">
+<a href="https://benchmark-radar.org/saturation/?lfrontier=swe_bench_verified">
   <img src="assets/swe-bench-verified.gif" alt="Animated demo of searching for SWE-bench Verified and viewing its model scores over time" width="720" />
 </a>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,7 +23,7 @@ github.com/ktwu01/benchmark-radar，每天更新，并支持一键导出数据
 **几秒找到一个 benchmark，再看模型成绩如何随时间变化。点击下面的动图，查看
 SWE-bench Verified 的 saturation 过程。**
 
-<a href="https://benchmark-radar.org/leaderboard/?lfrontier=swe_bench_verified">
+<a href="https://benchmark-radar.org/saturation/?lfrontier=swe_bench_verified">
   <img src="assets/swe-bench-verified.gif" alt="搜索 SWE-bench Verified 并查看模型成绩随时间变化的动画演示" width="720" />
 </a>
 

--- a/design.md
+++ b/design.md
@@ -45,7 +45,8 @@ accessible names, downloads, and citations are part of the product's trust.
 | --- | --- |
 | Today | Explain what appeared recently and why it matters |
 | Search | Find possible benchmarks across the corpus |
-| Leaderboard | Compare attention, adoption, or reported scores as separate modes |
+| Leaderboard | Compare Benchmark Frontier, recorded score counts and documentation |
+| Saturation | Find benchmarks and inspect their reported scores over time |
 | Trends | Show change across comparable time windows |
 | Blog | Publish dated, shareable analysis |
 | CLI and Skill | Let people and agents query local data |
@@ -112,10 +113,11 @@ most of the corpus. Name the source instead: "Artificial Analysis", "LLM Stats",
 "OpenCompass Hub", "Model reports". Preserve the evidence fields above for
 each source. Missing measurements do not remove benchmark records.
 
-A figure and the list beside it answer the same question over the same rows. If
-a chart shows a dozen benchmarks while the list underneath says 790, the chart
-is wrong, not the list. Prefer the count and unit the reader can already see on
-the page ("1,259 benchmarks · 4 sources") over a private subset.
+Each figure and browser starts from the complete catalog and states its own
+filter scope. Leaderboard's slider filters only Benchmark Frontier. Saturation
+shares that slider for browsing; a search queries the full catalog without
+changing the cutoff. Clearing the query restores filtered browsing. Prefer the
+count and unit the reader can already see over a private subset.
 
 When a measurement cannot span the population, restrict the calculation, not
 the represented records. Keep benchmarks with unknown or incompatible values

--- a/principle.md
+++ b/principle.md
@@ -19,8 +19,22 @@ missing and investigate. Do not present that subset as Benchmark Radar.**
 
 Check which sources, records, and fields disappeared at each join or filter.
 A successful render, plausible Pareto frontier, or passing test does not excuse
-missing most of the population. A chart and the browser beside it must use the
-same record universe and respond consistently to the user's filters.
+missing most of the population. Each surface starts from the same catalog;
+filters apply to the surface the reader is using, as described below.
+
+## Leaderboard and Saturation share a cutoff; search bypasses it
+
+Both tabs use the same score slider, initially 70. On Leaderboard it filters
+only Benchmark Frontier and its coverage counts. The score ranking keeps its
+numeric-score and date eligibility but does not follow the slider.
+
+Saturation contains the benchmark browser and complete reported score histories.
+With an empty search it applies the shared cutoff across all years, retaining
+unscored records as unknown rather than inventing scores. With a search query it
+searches the entire catalog, including every source, year and unscored record,
+without applying the cutoff. Searching does not change the slider; clearing the
+query restores filtered browsing. Selecting a result keeps its complete history,
+even when it lies outside the current browsing cutoff.
 
 ## One corpus, one record contract, equal treatment of sources
 
@@ -119,7 +133,7 @@ A numeric score cutoff may hide records whose known scores are at or above it.
 Records without scores cannot be classified as above or below the cutoff;
 Frontier excludes them with its separate reported-score requirement. Show the
 full population and account for the visible records, pre-2024 records, records
-excluded for missing scores, and records hidden by score or search. Count each
+excluded for missing scores, and records hidden by score. Count each
 record once so the categories reconcile.
 
 ## Calculate only what the evidence supports
@@ -155,7 +169,7 @@ must preserve the filtered benchmark IDs.
 
 Use `log1p(count)` for height and raw counts for ticks, tooltips and dominance.
 Derive the maximum from the entire scored 2024+ cohort for the selected measure,
-before the score and search filters. Do not cap it at 20, 100 or any fixed value.
+before the score cutoff. Do not cap it at 20, 100 or any fixed value.
 The wall projection uses the same selected count as the main chart; unverified
 score scales retain hollow projections and remain outside Pareto calculations.
 

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -346,6 +346,7 @@ function rerenderCurrentView() {
   renderTodayDateOptions();
   if (state.view === "today") renderToday();
   if (state.view === "leaderboard") renderLeaderboard();
+  if (state.view === "saturation") renderSaturation();
   if (state.view === "trends") renderTrends();
   if (state.view === "map") renderTrendMap();
   renderStaleBanner();
@@ -382,7 +383,9 @@ const I18N = {
     "Scores and citations from model reports. Each score keeps its document, test version, protocol and publication date.": "这些成绩和引用来自模型报告。每条成绩都保留来源文档、测试版本、测试条件和发布日期。",
     "No numeric scores recorded for this benchmark.": "这条 benchmark 尚未记录数值成绩。",
     "Benchmark Frontier: {n} individual benchmarks from all sources. Dated benchmarks run left to right from 2024. Undated benchmarks remain visible by score. Gold rings mark the measured Pareto frontier.": "Benchmark 前沿：全部来源的 {n} 个独立标记。日期从 2024 年起向右排列，日期未知的仍按分数显示。金色环标出有测量依据的 Pareto 前沿。",
-    "{unscored} without scores excluded · {older} before 2024 · {hidden} hidden by score or search": "未报告成绩的 {unscored} 个已排除 · {older} 个早于 2024 年 · 分数或搜索筛选隐藏 {hidden} 个",
+    "{unscored} without scores excluded · {older} before 2024 · {hidden} hidden by score": "未报告成绩的 {unscored} 个已排除 · {older} 个早于 2024 年 · 分数筛选隐藏 {hidden} 个",
+    "Saturation": "饱和度",
+    "Searching all benchmarks (filters paused)": "搜索全部 benchmark（暂不筛选）",
     "No comparable score": "没有可比较的分数",
     "Benchmark date": "Benchmark 日期",
     "Highest reported score · 0–100": "最高报告分数 · 0–100",
@@ -1356,7 +1359,7 @@ function readUrl() {
   const params = backgroundLocation?.searchParams || currentParams;
   const requestedView = params.get("view");
   // Legacy Explorer permalinks resolve to the filterable Today list.
-  const legacyView = ["trends", "map", "leaderboard"].includes(requestedView)
+  const legacyView = ["trends", "map", "leaderboard", "saturation"].includes(requestedView)
     ? requestedView
     : "";
   // The path is the view, and that is what keeps Back and Forward honest: the
@@ -1394,8 +1397,11 @@ function readUrl() {
   state.lscore = scoreCutoff(params.get("lscore"));
   state.lheight = ["cards", "documents"].includes(params.get("lheight")) ? "documents" : "models";
   state.benchmarkVisibleLimit = BENCHMARK_SEARCH_LIMIT;
+  state.benchmarkQuery = (params.get("bq") || "").trim();
   state.lfrontier = params.get("lfrontier") || "";
   state.lfrontierExplicit = Boolean(state.lfrontier);
+  // Existing benchmark permalinks follow the score history to its new tab.
+  if (state.view === "leaderboard" && state.lfrontierExplicit) state.view = "saturation";
   const rawHash = window.location.hash.slice(1);
   const hashParams = new URLSearchParams(rawHash);
   // A first-class utility path wins over every legacy fragment. This keeps a
@@ -1466,6 +1472,10 @@ function writeUrl(mode = "replace") {
     if (state.ldomain) params.set("ldomain", state.ldomain);
     if (state.lorg) params.set("lorg", state.lorg);
     if (state.lera) params.set("lera", state.lera);
+  }
+  if (!utility && state.view === "saturation") {
+    params.set("lscore", state.lscore);
+    if (state.benchmarkQuery) params.set("bq", state.benchmarkQuery);
     // A benchmark auto-picked as the default is not the reader's choice, so it
     // stays out of the URL until they select one themselves.
     if (state.lfrontierExplicit && state.lfrontier) {
@@ -1595,10 +1605,16 @@ const VIEW_SEO = {
     canonical: "/",
   },
   leaderboard: {
-    title: "AI benchmarks by highest reported score | Benchmark Radar",
+    title: "AI benchmark frontier and rankings | Benchmark Radar",
     description:
-      "Browse AI benchmark scores from every source. Start with highest reported scores below 70 on the chart scale, inspect their sources, or browse all scored benchmarks.",
+      "Explore Benchmark Frontier by highest reported score, and compare benchmarks by recorded scores and source documents across the catalog.",
     canonical: "/leaderboard/",
+  },
+  saturation: {
+    title: "AI benchmark saturation and score histories | Benchmark Radar",
+    description:
+      "Browse benchmarks by highest reported score or search the complete catalog. Inspect reported scores over time with their sources, dates, and test conditions.",
+    canonical: "/saturation/",
   },
   trends: {
     title: "AI benchmark discovery trends over time | Benchmark Radar",
@@ -1725,7 +1741,7 @@ function syncNavState() {
 // popstate), where writing history again would either duplicate the entry or
 // fight the entry being restored.
 function setView(view, update = true, mode = "push") {
-  if (view !== "leaderboard" && selectedFrontierPoint) {
+  if (selectedFrontierPoint || describedFrontierPoint) {
     clearFrontierPointSelection();
   }
   state.view = view;
@@ -1740,6 +1756,15 @@ function setView(view, update = true, mode = "push") {
 function selectFrontier(benchmarkId) {
   state.lfrontier = benchmarkId;
   state.lfrontierExplicit = true;
+}
+
+function openSaturation(benchmarkId) {
+  selectFrontier(benchmarkId);
+  setView("saturation");
+  renderSaturation();
+  if (window.matchMedia("(max-width: 1050px)").matches) {
+    byId("adoption-frontier").scrollIntoView({ behavior: "smooth", block: "start" });
+  }
 }
 
 function categoryColor(category, index = 0) {
@@ -4273,7 +4298,7 @@ function frontierAdvances(entry) {
 }
 
 function frontierDefaultEntry(board) {
-  return scoreBrowseRows(board)[0];
+  return saturationRows()[0];
 }
 
 const BENCHMARK_TASK_SHAPES = {
@@ -4518,10 +4543,10 @@ function benchmarkResultRow(record, { navigate = false, inert = false } = {}) {
     selectFrontier(record.slug);
     if (navigate) {
       // setView toggles visibility and the URL; it does not draw. On a first
-      // visit the leaderboard has never rendered, so switching to it without
+      // visit Saturation has never rendered, so switching to it without
       // this leaves the reader on an empty panel.
-      setView("leaderboard");
-      renderLeaderboard();
+      setView("saturation");
+      renderSaturation();
       return;
     }
     renderBenchmarkSearch();
@@ -4532,7 +4557,7 @@ function benchmarkResultRow(record, { navigate = false, inert = false } = {}) {
 }
 
 // Each row keeps its source identity. The score cutoff decides membership;
-// recorded numeric observations determine rank, without a source preference.
+// recorded numeric observations determine order, without a source preference.
 function scoreSourceLabel(source) {
   return t(catalogSourceMeta(source).name);
 }
@@ -4550,11 +4575,24 @@ function matchesScoreFilter(summary) {
   return matchesScoreCutoff(summary, state.lscore);
 }
 
-function scoreBrowseRows() {
+function scoreBrowseRows(cutoff = state.lscore) {
   return scorePopulation(state.benchmarkIndex || [])
-    .filter((row) => (row.date === null || row.date >= SKYLINE_START_DATE) && matchesScoreFilter(row.summary))
+    .filter((row) => !matchesScoreCutoff(row.summary, 100) || matchesScoreCutoff(row.summary, cutoff))
     .sort((a, b) => (b.summary?.numeric_count || 0) - (a.summary?.numeric_count || 0)
-      || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
+      || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+}
+
+function saturationRows() {
+  const matches = benchmarkQueryIds();
+  // Search is a lookup across the whole catalog. It temporarily bypasses the
+  // browsing cutoff without changing the shared slider value.
+  const rows = scoreBrowseRows(matches ? 100 : state.lscore);
+  return matches ? rows.filter((row) => matches.has(row.id)) : rows;
+}
+
+function scoreRankingRows() {
+  return scoreBrowseRows(100)
+    .filter((row) => (row.date === null || row.date >= SKYLINE_START_DATE) && matchesScoreCutoff(row.summary, 100))
     .map((row, index) => ({ ...row, rank: index + 1 }));
 }
 
@@ -4570,33 +4608,46 @@ function scoreBrowseResultRow(row) {
     className: "benchmark-result score-browse-result",
     attrs: { type: "button", "aria-pressed": row.id === state.lfrontier ? "true" : "false" },
   }, [
-    element("span", { className: "benchmark-result-name", text: `${row.rank}. ${row.name}` }),
-    element("span", { className: "benchmark-result-facts", text: `${scoreSourceLabel(row.source)} · ${row.date
-      ? `${t(benchmarkDateLabel(row))} ${formatDate(row.date, { dateStyle: "medium" })}` : t("Date unknown")}` }),
+    element("span", { className: "benchmark-result-name", text: row.name }),
+    element("span", { className: "benchmark-result-facts", text: [scoreSourceLabel(row.source),
+      row.date ? `${t(benchmarkDateLabel(row))} ${formatDate(row.date, { dateStyle: "medium" })}` : t("Date unknown"),
+      matchesScoreCutoff(row.summary, 100) ? "" : t("No score reported"),
+    ].filter(Boolean).join(" · ") }),
   ]);
   button.addEventListener("click", () => {
-    selectFrontier(row.id);
-    renderAdoptionFrontier(catalogDocumentBoard());
-    writeUrl("push");
+    openSaturation(row.id);
   });
   return button;
 }
 
 function setScoreFilter(value) {
   state.lscore = scoreCutoff(value);
-  state.benchmarkVisibleLimit = BENCHMARK_SEARCH_LIMIT;
-  // An intentional permalink stays visible outside the filtered list.
-  // Only the automatic opening selection follows a filter change.
-  if (!state.lfrontierExplicit) state.lfrontier = "";
-  renderAdoptionFrontier(catalogDocumentBoard());
+  syncScoreFilters();
+  if (state.view === "saturation") {
+    if (!state.benchmarkQuery) {
+      state.benchmarkVisibleLimit = BENCHMARK_SEARCH_LIMIT;
+      // An explicit selection keeps its complete history outside the cutoff.
+      if (!state.lfrontierExplicit) state.lfrontier = "";
+      renderSaturation();
+    }
+  } else {
+    renderBenchmarkSkyline();
+  }
   writeUrl();
+}
+
+function syncScoreFilters(value = state.lscore) {
+  for (const view of ["leaderboard", "saturation"]) {
+    byId(`${view}-score-filter`).value = value;
+    byId(`${view}-score-value`).textContent = value >= 100 ? t("All") : value;
+  }
 }
 
 function renderScoreSelectionNote() {
   const item = scorePopulation(state.benchmarkIndex || []).find((row) => row.id === state.lfrontier);
   const summary = item?.summary;
-  const outside = Boolean(state.lfrontierExplicit && item && (!matchesScoreFilter(summary)
-    || (item.date && item.date < SKYLINE_START_DATE)));
+  const outside = Boolean(state.lfrontierExplicit && item
+    && !saturationRows().some((row) => row.id === item.id));
   const note = byId("frontier-filter-note");
   note.hidden = !outside;
   note.textContent = outside ? t("Outside current filter") : "";
@@ -4606,7 +4657,7 @@ function renderScoreSelectionNote() {
 }
 
 function renderScoreRanking(rows) {
-  const visible = state.scoreRankingExpanded ? rows.slice(0, state.benchmarkVisibleLimit) : rows.slice(0, 5);
+  const visible = rows.slice(0, state.scoreRankingExpanded ? BENCHMARK_SEARCH_LIMIT : 5);
   const maximum = rows[0]?.summary?.numeric_count || 1;
   replaceChildren(byId("score-ranking-list"), visible.map((row) => {
     const button = element("button", {
@@ -4617,9 +4668,7 @@ function renderScoreRanking(rows) {
       element("small", { text: `${scoreSourceLabel(row.source)} · ${scoreSummaryLabel(row.summary)}` }),
     ]);
     button.addEventListener("click", () => {
-      selectFrontier(row.id);
-      renderAdoptionFrontier(catalogDocumentBoard());
-      writeUrl("push");
+      openSaturation(row.id);
     });
     return element("li", { className: "leaderboard-top-row" }, [
       element("span", { className: "leaderboard-top-rank", text: String(row.rank).padStart(2, "0") }),
@@ -4646,34 +4695,29 @@ function renderBenchmarkSearch() {
   const container = byId("benchmark-search-results");
   const status = byId("benchmark-search-status");
   if (!container || !status || !state.data) return;
-  const board = catalogDocumentBoard();
-  let rows = scoreBrowseRows(board);
-  const matches = benchmarkQueryIds(board);
-  if (matches) rows = rows.filter((row) => matches.has(row.id));
+  byId("benchmark-search-input").value = state.benchmarkQuery;
+  const rows = saturationRows();
   const shown = rows.slice(0, state.benchmarkVisibleLimit);
   replaceChildren(container, shown.map(scoreBrowseResultRow));
-  renderScoreRanking(rows);
   const loading = !state.benchmarkIndexLoaded;
   const failed = state.benchmarkIndexLoaded && !state.benchmarkIndex;
   const coverage = loading ? t("Still checking the benchmark registry…")
     : failed ? t("The benchmark catalog could not be loaded.") : "";
   status.textContent = [t("{shown} of {total} matches")
     .replace("{shown}", shown.length.toLocaleString())
-    .replace("{total}", rows.length.toLocaleString()), coverage].filter(Boolean).join(" · ");
+    .replace("{total}", rows.length.toLocaleString()),
+    state.benchmarkQuery ? t("Searching all benchmarks (filters paused)") : "", coverage].filter(Boolean).join(" · ");
   if (!rows.length) {
     container.append(element("p", { className: "empty-state", text: loading
-      ? t("Loading benchmark details…") : t("No scored benchmarks match these filters.") }));
-    if (state.lscore < 100) {
-      const all = element("button", { className: "clear-button", text: t("All scored"), attrs: { type: "button" } });
+      ? t("Loading benchmark details…") : t("No benchmarks match these filters.") }));
+    if (!state.benchmarkQuery && state.lscore < 100) {
+      const all = element("button", { className: "clear-button", text: t("All"), attrs: { type: "button" } });
       all.addEventListener("click", () => setScoreFilter(100));
       container.append(all);
     }
   }
   const more = byId("benchmark-search-more");
   more.hidden = shown.length >= rows.length;
-  byId("leaderboard-score-filter").value = state.lscore;
-  byId("leaderboard-score-value").textContent = state.lscore >= 100 ? t("All") : state.lscore;
-  renderBenchmarkSkyline();
 }
 
 function skylineChart(model, cutoff) {
@@ -5061,7 +5105,7 @@ function renderBenchmarkSkyline(cutoff = state.lscore) {
   }
   // Selection in another chart survives a slider preview.
   if (host.contains(selectedFrontierPoint) || host.contains(describedFrontierPoint)) clearFrontierPointSelection();
-  const model = skylineModel(state.benchmarkIndex, cutoff, benchmarkQueryIds(), state.lheight);
+  const model = skylineModel(state.benchmarkIndex, cutoff, null, state.lheight);
   const svg = skylineChart(model, cutoff);
   const sourceCounts = [...new Set(model.all.map((row) => row.source))].map((source) =>
     `${scoreSourceLabel(source)}: ${model.visible.filter((row) => row.source === source).length.toLocaleString()} / ${model.all.filter((row) => row.source === source).length.toLocaleString()}`);
@@ -5087,7 +5131,7 @@ function renderBenchmarkSkyline(cutoff = state.lscore) {
   byId("benchmark-skyline-count").textContent = t("{visible} of {n} benchmarks shown · {s} sources in corpus", {
     visible: model.visible.length.toLocaleString(), n: model.population.toLocaleString(), s: model.sources,
   });
-  byId("benchmark-skyline-note").textContent = t("{unscored} without scores excluded · {older} before 2024 · {hidden} hidden by score or search", {
+  byId("benchmark-skyline-note").textContent = t("{unscored} without scores excluded · {older} before 2024 · {hidden} hidden by score", {
     unscored: model.unscored.toLocaleString(), older: model.beforeStart.toLocaleString(),
     hidden: (model.hidden - model.beforeStart - model.unscored).toLocaleString(),
   });
@@ -5100,20 +5144,21 @@ function initBenchmarkSearch() {
   const onInput = debounce(() => {
     state.benchmarkQuery = input.value.trim();
     state.benchmarkVisibleLimit = BENCHMARK_SEARCH_LIMIT;
-    renderBenchmarkSearch();
+    renderSaturation();
+    writeUrl();
   });
   input.addEventListener("input", onInput);
   loadBenchmarkIndex().then((records) => {
     // Loading and failure remain explicit; no source-specific fallback corpus.
     state.benchmarkIndex = records;
     state.benchmarkIndexLoaded = true;
-    renderBenchmarkSearch();
     // A ?lfrontier=<slug> permalink can only resolve once the index fetch has
     // settled either way: a resolved index confirms the slug, a failed one
     // turns the panel's loading state into an explicit unavailability note
     // (see renderAdoptionFrontier).
     // Rebuild the document counts and navigation after the common index loads.
     if (state.view === "leaderboard") renderLeaderboard();
+    if (state.view === "saturation") renderSaturation();
   });
 }
 
@@ -5919,10 +5964,10 @@ function setCanonicalFrontierChrome(visible) {
   }
 }
 
-// The picker and ranking share the filtered catalog, with source names for provenance.
+// The picker follows Saturation's browser, including the full-catalog search.
 function frontierPickerGroups(scored) {
-  return [[t("Ranked by data points"), scoreBrowseRows().map((row) => [
-    row.id, `${row.rank}. ${row.name} · ${scoreSourceLabel(row.source)}`,
+  return [[t("Browse all benchmarks"), scored.map((row) => [
+    row.id, `${row.name} · ${scoreSourceLabel(row.source)}`,
   ])]];
 }
 
@@ -6073,7 +6118,7 @@ function renderBenchmarkNavigator(board) {
   const host = byId("benchmark-shortlist");
   const info = byId("benchmark-example-info");
   if (info) replaceChildren(info, []);
-  if (host) replaceChildren(host, scoreBrowseRows(board).slice(0, 3).map(scoreBrowseResultRow));
+  if (host) replaceChildren(host, saturationRows().slice(0, 3).map(scoreBrowseResultRow));
 }
 
 function renderFrontierTaskPreview(entry) {
@@ -6751,7 +6796,7 @@ function frontierPointSizes(offTheLine) {
 // reveal it was drawn for: same-selection repaints inside the window replay
 // the entrance from its start rather than cutting it off, and once the window
 // closes the selection counts as seen, so later repaints render finished.
-// The key commits only while the Leaderboard is the visible view: a redraw
+// The key commits only while Saturation is the visible view: a redraw
 // into a hidden panel must not spend an entrance the reader has yet to see.
 const FRONTIER_ENTRANCE_MS =
   FRONTIER_SWEEP_DELAY_MS + FRONTIER_SWEEP_MS + FRONTIER_POINT_FADE_MS + 120;
@@ -6760,7 +6805,7 @@ let frontierEntranceTimer = null;
 let drawnFrontierEntranceKey = null;
 
 function frontierShouldAnimate(key) {
-  if (state.view !== "leaderboard") return false;
+  if (state.view !== "saturation") return false;
   // Remember what is actually on screen: the completion callback below may
   // fire after the reader has moved to another benchmark.
   drawnFrontierEntranceKey = key;
@@ -6778,7 +6823,7 @@ function frontierShouldAnimate(key) {
         frontierEntranceTimer = setTimeout(spendOrDefer, FRONTIER_ENTRANCE_MS);
         return;
       }
-      if (state.view === "leaderboard" && drawnFrontierEntranceKey === key) {
+      if (state.view === "saturation" && drawnFrontierEntranceKey === key) {
         completedFrontierEntranceKey = key;
       }
     };
@@ -7187,7 +7232,9 @@ function clearAdoptionFrontier(message) {
 }
 
 function renderAdoptionFrontier(board) {
-  const scored = scoreBrowseRows();
+  const scored = saturationRows();
+  const defaultEntry = frontierDefaultEntry(board);
+  if (!state.lfrontierExplicit) state.lfrontier = defaultEntry?.id || "";
   renderBenchmarkNavigator(board);
   if (!state.benchmarkIndex) {
     renderCatalogShell(board, scored, {
@@ -7197,12 +7244,10 @@ function renderAdoptionFrontier(board) {
     });
     return;
   }
-  const defaultEntry = frontierDefaultEntry(board);
-  if (!state.lfrontierExplicit) state.lfrontier = defaultEntry?.id || "";
   if (!state.lfrontier) {
     renderCatalogShell(board, scored, {
       eyebrow: "", heading: t("Reported benchmark scores"), badge: "",
-      message: t("No scored benchmarks match these filters."),
+      message: t("No benchmarks match these filters."),
     });
     return;
   }
@@ -7268,9 +7313,7 @@ function findingCard(finding, board) {
       attrs: { type: "button" },
     });
     jump.addEventListener("click", () => {
-      selectFrontier(target.benchmark_id);
-      renderAdoptionFrontier(board);
-      writeUrl("push");
+      openSaturation(target.benchmark_id);
       byId("adoption-frontier").scrollIntoView({ behavior: "smooth", block: "start" });
     });
     children.push(jump);
@@ -7405,9 +7448,7 @@ function leaderboardRow(entry) {
         attrs: { type: "button" },
       });
   frontierButton?.addEventListener("click", () => {
-    selectFrontier(entry.benchmark_id);
-    renderAdoptionFrontier(board);
-    writeUrl("push");
+    openSaturation(entry.benchmark_id);
     byId("adoption-frontier").scrollIntoView({ behavior: "smooth", block: "start" });
   });
 
@@ -7553,17 +7594,24 @@ function syncLeaderboardNav() {
   if (navButton) navButton.hidden = false;
 }
 
+function renderSaturation() {
+  syncScoreFilters();
+  renderAdoptionFrontier(catalogDocumentBoard());
+}
+
 function renderLeaderboard() {
   initBenchmarkSearch();
+  syncScoreFilters();
+  renderBenchmarkSkyline();
+  renderScoreRanking(scoreRankingRows());
   const board = catalogDocumentBoard();
   syncLeaderboardNav();
-  if (!board) { renderBenchmarkSearch(); renderAdoptionFrontier(null); return; }
+  if (!board) return;
 
   byId("leaderboard-measures").textContent = board.measures || "";
   renderLeaderboardTop(board);
   renderLeaderboardFilters(board);
   renderBenchmarkFindings(state.data.model_card_leaderboard);
-  renderAdoptionFrontier(board);
 
   const topEntries = (board.entries || []).filter((entry) => entry.card_count > 0);
 
@@ -8454,6 +8502,7 @@ function bindEvents() {
       setView(view);
       if (view === "today") renderToday();
       if (view === "leaderboard") renderLeaderboard();
+      if (view === "saturation") renderSaturation();
       if (view === "trends") renderTrends();
       if (view === "map") renderTrendMap();
     });
@@ -8491,18 +8540,16 @@ function bindEvents() {
   });
   byId("score-ranking-more").addEventListener("click", () => {
     state.scoreRankingExpanded = !state.scoreRankingExpanded;
-    renderBenchmarkSearch();
+    renderScoreRanking(scoreRankingRows());
   });
-  const scoreFilter = byId("leaderboard-score-filter");
-  // The readout tracks the thumb; the list re-filters once the drag settles.
-  scoreFilter.addEventListener("input", (event) => {
-    const value = scoreCutoff(event.target.value);
-    byId("leaderboard-score-value").textContent = value >= 100 ? t("All") : value;
-    // The chart previews the drag; the list still settles on release, because
-    // re-filtering it would also rebuild the frontier chart on every tick.
-    renderBenchmarkSkyline(value);
+  document.querySelectorAll("[data-score-filter]").forEach((scoreFilter) => {
+    scoreFilter.addEventListener("input", (event) => {
+      const value = scoreCutoff(event.target.value);
+      syncScoreFilters(value);
+      if (state.view === "leaderboard") renderBenchmarkSkyline(value);
+    });
+    scoreFilter.addEventListener("change", (event) => setScoreFilter(event.target.value));
   });
-  scoreFilter.addEventListener("change", (event) => setScoreFilter(event.target.value));
   byId("benchmark-skyline-height").addEventListener("change", (event) => {
     state.lheight = event.target.value;
     renderBenchmarkSkyline();
@@ -8574,7 +8621,7 @@ function bindEvents() {
     const isNarrow = window.innerWidth <= 760;
     if (isNarrow === wasNarrow) return;
     wasNarrow = isNarrow;
-    if (state.data) renderAdoptionFrontier(catalogDocumentBoard());
+    if (state.data && state.view === "saturation") renderSaturation();
   });
   document.addEventListener("keydown", (event) => {
     // A <dialog>'s native Escape-close is the keydown's default action (its
@@ -8960,7 +9007,8 @@ async function initialize() {
   const legacyUtilityHash = ["cli", "cite", "rubric"].some(
     (utility) => initialHash === utility || initialHashParams.has(utility),
   );
-  if (initialParams.has("view") || legacyUtilityHash) writeUrl("replace");
+  if (initialParams.has("view") || legacyUtilityHash
+    || (state.view === "saturation" && viewFromPath(window.location.pathname) === "leaderboard")) writeUrl("replace");
   bindEvents();
   const initializationNavigationSequence = viewNavigationSequence;
   const initializationRefreshSequence = successfulDataRefreshSequence;
@@ -9003,6 +9051,7 @@ async function initialize() {
     // handlers render another view when the reader opens it.
     if (state.view === "today") renderToday();
     if (state.view === "leaderboard") renderLeaderboard();
+    if (state.view === "saturation") renderSaturation();
     if (state.view === "trends") renderTrends();
     if (state.view === "map") renderTrendMap();
 

--- a/site/assets/skyline.js
+++ b/site/assets/skyline.js
@@ -48,7 +48,7 @@ export function benchmarkDateLabel(row) {
       : "First LLM score reported";
 }
 
-// This is the population used by BOTH the chart and the browser. Keeping a
+// This is the population used by the chart, rankings and browser. Keeping a
 // row does not require a score, date, adoption count, or join to another source.
 export function scoreBrowserSummary(record) {
   const summary = record.score_summary;
@@ -129,7 +129,7 @@ export function skylineModel(catalog = [], cutoff = 70, matchingIds = null, heig
     row.pareto = !comparable(row) ? null : !eligible.some((other) => other.score <= row.score && other.heightCount >= row.heightCount
       && (other.score < row.score || other.heightCount > row.heightCount));
   }
-  // Cutoff membership is shared with score browsing. Normalized reversed
+  // The figure's cutoff is independent of Saturation search. Normalized reversed
   // metrics remain explicit in the tooltip; they never change source scores.
   const visible = withinDates.filter((row) => (!matchingIds || matchingIds.has(row.id))
     && matchesScoreCutoff(row.summary, cutoff));

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -466,7 +466,8 @@ main {
    y=1356, entirely below the fold, behind KPI cards and accordions that
    summarise it. Those moved below the figure; this recovers the last of the
    gap so the visualization is visibly underway on load. */
-#leaderboard-view {
+#leaderboard-view,
+#saturation-view {
   padding-top: clamp(1.25rem, 2vw, 1.75rem);
 }
 
@@ -4181,10 +4182,7 @@ footer {
 
   .benchmark-navigator {
     position: static;
-  }
-
-  .frontier-panel {
-    order: -1;
+    max-height: min(50vh, 24rem);
   }
 
   .health-panel {

--- a/site/index.html
+++ b/site/index.html
@@ -114,7 +114,7 @@
           "@type": "SearchAction",
           "target": {
             "@type": "EntryPoint",
-            "urlTemplate": "https://benchmark-radar.org/leaderboard/?lq={search_term_string}"
+            "urlTemplate": "https://benchmark-radar.org/saturation/?bq={search_term_string}"
           },
           "query-input": "required name=search_term_string"
         }
@@ -312,6 +312,7 @@
       <a href="/leaderboard/" data-view="leaderboard" aria-controls="leaderboard-view" data-i18n="Leaderboard">
         Leaderboard
       </a>
+      <a href="/saturation/" data-view="saturation" aria-controls="saturation-view" data-i18n="Saturation">Saturation</a>
       <a href="/trends/" data-view="trends" aria-controls="trends-view" data-i18n="Trends">Trends</a>
       <!-- The blog is a set of documents, not a dashboard view, so this link
            carries no data-view: app.js only intercepts clicks on elements that
@@ -472,18 +473,7 @@
 
       <section class="view" id="leaderboard-view" aria-labelledby="leaderboard-heading" hidden>
         <div class="score-browse-header">
-          <h1 id="leaderboard-heading" data-i18n="Reported benchmark scores">Reported benchmark scores</h1>
-          <label class="score-filter" for="leaderboard-score-filter">
-            <span data-i18n="Show benchmarks with highest reported score below:">Show benchmarks with highest reported score below:</span>
-            <input id="leaderboard-score-filter" name="lscore" type="range" min="10" max="100" step="10" value="70" list="score-filter-steps" aria-controls="benchmark-skyline-chart score-ranking-list">
-            <output id="leaderboard-score-value" for="leaderboard-score-filter">70</output>
-          </label>
-          <datalist id="score-filter-steps">
-            <option value="10"></option><option value="20"></option><option value="30"></option>
-            <option value="40"></option><option value="50"></option><option value="60"></option>
-            <option value="70"></option><option value="80"></option><option value="90"></option>
-            <option value="100" label="All"></option>
-          </datalist>
+          <h1 id="leaderboard-heading" data-i18n="Leaderboard">Leaderboard</h1>
         </div>
 
         <section class="benchmark-skyline" id="benchmark-skyline" aria-labelledby="benchmark-skyline-heading">
@@ -493,6 +483,17 @@
               <p class="skyline-subtitle" data-i18n="Which difficult benchmarks have been tested most">Which difficult benchmarks have been tested most</p>
             </div>
           </div>
+          <label class="score-filter" for="leaderboard-score-filter">
+            <span data-i18n="Show benchmarks with highest reported score below:">Show benchmarks with highest reported score below:</span>
+            <input id="leaderboard-score-filter" name="lscore" type="range" min="10" max="100" step="10" value="70" list="score-filter-steps" data-score-filter aria-controls="benchmark-skyline-chart">
+            <output id="leaderboard-score-value" for="leaderboard-score-filter">70</output>
+          </label>
+          <datalist id="score-filter-steps">
+            <option value="10"></option><option value="20"></option><option value="30"></option>
+            <option value="40"></option><option value="50"></option><option value="60"></option>
+            <option value="70"></option><option value="80"></option><option value="90"></option>
+            <option value="100" label="All"></option>
+          </datalist>
           <label class="skyline-height-control" for="benchmark-skyline-height">
             <span data-i18n="Height">Height</span>
             <select id="benchmark-skyline-height">
@@ -530,101 +531,6 @@
           <p id="score-ranking-empty" class="empty-state" data-i18n="No scored benchmarks match these filters." hidden>No scored benchmarks match these filters.</p>
           <button id="score-ranking-more" class="leaderboard-top-more" type="button" data-i18n="Show more" hidden>Show more</button>
         </section>
-
-        <div class="benchmark-workbench">
-          <!-- A tool region, not a content section. The examples used to be a
-               titled block with two subheadings and eight cards, which outranked
-               the search box it was meant to support; they are now one line of
-               chips for a reader who has nothing in mind to type. -->
-          <aside class="benchmark-navigator" aria-labelledby="benchmark-search-heading">
-            <div class="benchmark-search">
-              <h2 class="benchmark-search-label" id="benchmark-search-heading">
-                <label for="benchmark-search-input"
-                       data-i18n="Browse all benchmarks">Browse all benchmarks</label>
-              </h2>
-              <input id="benchmark-search-input" type="search" autocomplete="off"
-                     class="benchmark-search-input"
-                     data-i18n-placeholder="Search benchmarks, tasks, domains…"
-                     placeholder="Search benchmarks, tasks, domains…" />
-              <p id="benchmark-search-status" class="benchmark-search-status"></p>
-              <div id="benchmark-search-results"></div>
-              <button id="benchmark-search-more" class="clear-button" type="button" data-i18n="Show more" hidden>Show more</button>
-              <div class="benchmark-example-heading" hidden>
-                <p class="benchmark-example-lead" data-i18n="Jump to a benchmark">Jump to a benchmark</p>
-                <span id="benchmark-example-info"></span>
-              </div>
-              <div id="benchmark-shortlist" class="benchmark-shortlist" hidden></div>
-            </div>
-          </aside>
-
-          <section class="frontier-panel" id="adoption-frontier" aria-labelledby="frontier-heading">
-            <div class="frontier-heading-row">
-              <div>
-                <p class="eyebrow" id="frontier-eyebrow" data-i18n="Scores over time">Scores over time</p>
-                <!-- The title owns its own (i): the provenance note used to sit on a
-                     second heading inside the scores block, which repeated the source
-                     name already shown in the badge and pushed the chart down the
-                     page (issue #298). -->
-                <div class="frontier-title-row">
-                  <h2 id="frontier-heading" data-i18n="Benchmark reported scores over time">Benchmark reported scores over time</h2>
-                  <span id="frontier-heading-info"></span>
-                  <details class="frontier-explainer-sub" id="frontier-explainer-sub">
-                    <summary data-i18n="How to read this chart">How to read this chart</summary>
-                    <p class="section-note" data-i18n="frontier.explainer.sub">
-                      Every value that could be read verbatim from a cited document, placed at the date
-                      that document was published rather than at any evaluation date. The line directly
-                      links actual observations that set a new reported record among the values shown; it
-                      neither holds a score between reports nor extends past the final record. Test versions
-                      and run conditions can differ, so this is a reported-record path, not a like-for-like
-                      trend. When no newer number could be read, the gap is marked rather than drawn through.
-                      Whether a benchmark has saturated stays a reading you make, not a score this panel prints.
-                    </p>
-                  </details>
-                </div>
-                <p class="frontier-subline" id="frontier-subline" hidden></p>
-              </div>
-              <div class="frontier-controls">
-                <span class="frontier-stage" id="frontier-stage"></span>
-                <label class="frontier-picker">
-                  All tracked benchmarks
-                  <select id="frontier-benchmark" name="lfrontier"></select>
-                </label>
-              </div>
-            </div>
-            <p id="frontier-filter-note" class="section-note" role="status" hidden></p>
-            <p id="frontier-highest-score" class="section-note" hidden></p>
-            <div class="frontier-catalog" id="frontier-catalog" hidden></div>
-            <div class="frontier-chart" id="frontier-chart"></div>
-            <!-- Legend below the figure it explains: above it, it pushed the
-                 chart down to explain marks the reader had not seen yet. -->
-            <div class="frontier-legend" id="frontier-legend" aria-label="Chart legend"></div>
-            <div class="frontier-org-key" id="frontier-org-key" aria-label="Reporting organization color key"></div>
-            <div class="score-readout" id="frontier-score-readout"></div>
-            <div class="frontier-evidence" id="frontier-evidence">
-              <aside class="frontier-context" aria-labelledby="frontier-task-heading">
-                <div id="frontier-task-preview"></div>
-                <details class="pareto-readiness">
-                  <summary data-i18n="pareto.readiness.summary">What would it take to chart best score against lowest cost?</summary>
-                  <p data-i18n="pareto.readiness.note1">
-                    Two scores can only be compared when each one records which version of
-                    the test it used, which slice of it, whether a high number is good or bad,
-                    which model, what software ran it, how much thinking time it was given,
-                    what it cost, how long it took, when it was published, and where the number
-                    came from. The test and the way it was run have to match; the model, cost,
-                    time and date are free to differ, because those are what the chart compares.
-                    This site records that a model card mentioned a benchmark. It does not yet
-                    record those measurements.
-                  </p>
-                  <p data-i18n="pareto.readiness.note2">
-                    Once they exist, this chart could plot cost or speed against score, and draw
-                    a line through only the results that nothing else beats on both at once. A
-                    date slider would then show how that line moved over time.
-                  </p>
-                </details>
-              </aside>
-            </div>
-          </section>
-        </div>
 
         <section class="leaderboard-top" aria-labelledby="leaderboard-adoption-heading">
           <div class="leaderboard-top-heading">
@@ -777,6 +683,113 @@
             </aside>
           </div>
         </details>
+      </section>
+
+      <section class="view" id="saturation-view" aria-labelledby="saturation-heading" hidden>
+        <div class="score-browse-header">
+          <h1 id="saturation-heading" data-i18n="Saturation">Saturation</h1>
+          <label class="score-filter" for="saturation-score-filter">
+            <span data-i18n="Show benchmarks with highest reported score below:">Show benchmarks with highest reported score below:</span>
+            <input id="saturation-score-filter" name="lscore" type="range" min="10" max="100" step="10" value="70" list="score-filter-steps" data-score-filter aria-controls="benchmark-search-results frontier-benchmark">
+            <output id="saturation-score-value" for="saturation-score-filter">70</output>
+          </label>
+        </div>
+
+        <div class="benchmark-workbench">
+          <!-- A tool region, not a content section. The examples used to be a
+               titled block with two subheadings and eight cards, which outranked
+               the search box it was meant to support; they are now one line of
+               chips for a reader who has nothing in mind to type. -->
+          <aside class="benchmark-navigator" aria-labelledby="benchmark-search-heading">
+            <div class="benchmark-search">
+              <h2 class="benchmark-search-label" id="benchmark-search-heading">
+                <label for="benchmark-search-input"
+                       data-i18n="Browse all benchmarks">Browse all benchmarks</label>
+              </h2>
+              <input id="benchmark-search-input" type="search" autocomplete="off"
+                     class="benchmark-search-input"
+                     data-i18n-placeholder="Search benchmarks, tasks, domains…"
+                     placeholder="Search benchmarks, tasks, domains…" />
+              <p id="benchmark-search-status" class="benchmark-search-status"></p>
+              <div id="benchmark-search-results"></div>
+              <button id="benchmark-search-more" class="clear-button" type="button" data-i18n="Show more" hidden>Show more</button>
+              <div class="benchmark-example-heading" hidden>
+                <p class="benchmark-example-lead" data-i18n="Jump to a benchmark">Jump to a benchmark</p>
+                <span id="benchmark-example-info"></span>
+              </div>
+              <div id="benchmark-shortlist" class="benchmark-shortlist" hidden></div>
+            </div>
+          </aside>
+
+          <section class="frontier-panel" id="adoption-frontier" aria-labelledby="frontier-heading">
+            <div class="frontier-heading-row">
+              <div>
+                <p class="eyebrow" id="frontier-eyebrow" data-i18n="Scores over time">Scores over time</p>
+                <!-- The title owns its own (i): the provenance note used to sit on a
+                     second heading inside the scores block, which repeated the source
+                     name already shown in the badge and pushed the chart down the
+                     page (issue #298). -->
+                <div class="frontier-title-row">
+                  <h2 id="frontier-heading" data-i18n="Benchmark reported scores over time">Benchmark reported scores over time</h2>
+                  <span id="frontier-heading-info"></span>
+                  <details class="frontier-explainer-sub" id="frontier-explainer-sub">
+                    <summary data-i18n="How to read this chart">How to read this chart</summary>
+                    <p class="section-note" data-i18n="frontier.explainer.sub">
+                      Every value that could be read verbatim from a cited document, placed at the date
+                      that document was published rather than at any evaluation date. The line directly
+                      links actual observations that set a new reported record among the values shown; it
+                      neither holds a score between reports nor extends past the final record. Test versions
+                      and run conditions can differ, so this is a reported-record path, not a like-for-like
+                      trend. When no newer number could be read, the gap is marked rather than drawn through.
+                      Whether a benchmark has saturated stays a reading you make, not a score this panel prints.
+                    </p>
+                  </details>
+                </div>
+                <p class="frontier-subline" id="frontier-subline" hidden></p>
+              </div>
+              <div class="frontier-controls">
+                <span class="frontier-stage" id="frontier-stage"></span>
+                <label class="frontier-picker">
+                  All tracked benchmarks
+                  <select id="frontier-benchmark" name="lfrontier"></select>
+                </label>
+              </div>
+            </div>
+            <p id="frontier-filter-note" class="section-note" role="status" hidden></p>
+            <p id="frontier-highest-score" class="section-note" hidden></p>
+            <div class="frontier-catalog" id="frontier-catalog" hidden></div>
+            <div class="frontier-chart" id="frontier-chart"></div>
+            <!-- Legend below the figure it explains: above it, it pushed the
+                 chart down to explain marks the reader had not seen yet. -->
+            <div class="frontier-legend" id="frontier-legend" aria-label="Chart legend"></div>
+            <div class="frontier-org-key" id="frontier-org-key" aria-label="Reporting organization color key"></div>
+            <div class="score-readout" id="frontier-score-readout"></div>
+            <div class="frontier-evidence" id="frontier-evidence">
+              <aside class="frontier-context" aria-labelledby="frontier-task-heading">
+                <div id="frontier-task-preview"></div>
+                <details class="pareto-readiness">
+                  <summary data-i18n="pareto.readiness.summary">What would it take to chart best score against lowest cost?</summary>
+                  <p data-i18n="pareto.readiness.note1">
+                    Two scores can only be compared when each one records which version of
+                    the test it used, which slice of it, whether a high number is good or bad,
+                    which model, what software ran it, how much thinking time it was given,
+                    what it cost, how long it took, when it was published, and where the number
+                    came from. The test and the way it was run have to match; the model, cost,
+                    time and date are free to differ, because those are what the chart compares.
+                    This site records that a model card mentioned a benchmark. It does not yet
+                    record those measurements.
+                  </p>
+                  <p data-i18n="pareto.readiness.note2">
+                    Once they exist, this chart could plot cost or speed against score, and draw
+                    a line through only the results that nothing else beats on both at once. A
+                    date slider would then show how that line moved over time.
+                  </p>
+                </details>
+              </aside>
+            </div>
+          </section>
+        </div>
+
       </section>
 
       <section class="view" id="trends-view" aria-labelledby="trends-heading" hidden>

--- a/src/benchmark_radar/app_pages.py
+++ b/src/benchmark_radar/app_pages.py
@@ -45,7 +45,7 @@ from .feed import SITE_URL
 from .site_shell import breadcrumb_schema, esc, json_ld, webpage_schema
 
 # Published in this order. "map" is the view key; its path is /explore/.
-APP_VIEWS: tuple[str, ...] = ("leaderboard", "trends", "map")
+APP_VIEWS: tuple[str, ...] = ("leaderboard", "saturation", "trends", "map")
 UTILITY_PAGES: tuple[str, ...] = ("cli", "cite", "rubric")
 UNLISTED_ROUTES = frozenset({"map", "rubric"})
 
@@ -64,6 +64,7 @@ HOME_NAV_INACTIVE = (
 # Breadcrumb names, matching the navigation labels a reader clicked to get here.
 VIEW_LABELS = {
     "leaderboard": "Leaderboard",
+    "saturation": "Saturation",
     "trends": "Trends",
     "map": "Explore",
 }

--- a/src/benchmark_radar/app_seeds.py
+++ b/src/benchmark_radar/app_seeds.py
@@ -104,9 +104,9 @@ def _leaderboard_seed(
     board = dashboard.get("model_card_leaderboard") or {}
     ranked = [entry for entry in (board.get("entries") or []) if (entry.get("card_count") or 0) > 0]
     entries = ranked[:LEADERBOARD_TOP_LIMIT]
-    browse_seed = _score_browser_seed(dashboard, catalog_index)
+    ranking_seed = _score_ranking_seed(dashboard, catalog_index)
     if not entries:
-        return browse_seed
+        return ranking_seed
     # Scaled against the top row on screen rather than the top row overall,
     # because that is what the renderer scales against.
     top = max(int(entry["card_count"]) for entry in entries)
@@ -159,7 +159,7 @@ def _leaderboard_seed(
             '<p class="leaderboard-deck visually-hidden" id="leaderboard-measures" data-seed>'
             f"{esc(measures)}</p>"
         )
-    return {**seed, **browse_seed}
+    return {**seed, **ranking_seed}
 
 
 def _browser_score_summary(record: dict[str, Any]) -> dict[str, Any] | None:
@@ -222,10 +222,8 @@ def _benchmark_date(
     return None, None
 
 
-def _score_browser_seed(
-    dashboard: dict[str, Any], catalog_index: list[dict[str, Any]]
-) -> dict[str, str]:
-    """The default list rendered by renderBenchmarkSearch, at DEFAULT_SCORE_CUTOFF."""
+def _catalog_score_rows(catalog_index: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """The complete population and ordering used by scoreBrowseRows."""
     rows = [
         {
             "id": record["slug"],
@@ -236,73 +234,63 @@ def _score_browser_seed(
         }
         for record in catalog_index
     ]
+    rows.sort(key=lambda row: (-(row["summary"] or {}).get("numeric_count", 0), row["id"]))
+    return rows
+
+
+def _has_reported_score(row: dict[str, Any]) -> bool:
+    summary = row["summary"] or {}
+    value = summary.get("display_max")
+    return (
+        summary.get("numeric_count", 0) > 0
+        and isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(value)
+    )
+
+
+_SCORE_SOURCE_NAMES = {
+    "model_reports": "Model reports",
+    "llm_stats": "LLM Stats",
+    "artificial_analysis": "Artificial Analysis",
+    "opencompass_hub": "OpenCompass Hub",
+}
+
+
+def _score_browser_seed(
+    dashboard: dict[str, Any], catalog_index: list[dict[str, Any]]
+) -> dict[str, str]:
+    """Saturation's empty-search browser, with the shared default cutoff."""
+    if not catalog_index:
+        return {}
     rows = [
         row
-        for row in rows
-        if (row["date"][0] is None or row["date"][0] >= "2024-01-01")
-        and (row["summary"] or {}).get("numeric_count", 0) > 0
-        and isinstance((row["summary"] or {}).get("display_max"), (int, float))
-        and not isinstance(row["summary"]["display_max"], bool)
-        and math.isfinite(row["summary"]["display_max"])
-        and row["summary"]["display_max"] < DEFAULT_SCORE_CUTOFF
+        for row in _catalog_score_rows(catalog_index)
+        if not _has_reported_score(row) or row["summary"]["display_max"] < DEFAULT_SCORE_CUTOFF
     ]
-    rows.sort(key=lambda row: (-(row["summary"] or {}).get("numeric_count", 0), row["id"]))
     shown = rows[:50]
-    if not shown:
-        return {}
-    names = {
-        "model_reports": "Model reports",
-        "llm_stats": "LLM Stats",
-        "artificial_analysis": "Artificial Analysis",
-        "opencompass_hub": "OpenCompass Hub",
-    }
     content = ""
-    ranking = ""
-    for rank, row in enumerate(shown, 1):
-        summary = row["summary"] or {}
-        value = (
-            _display_value(summary["display_max"])
-            if summary.get("display_max") is not None
-            else None
-        )
-        unit = summary.get("unit")
-        suffix = "%" if unit == "percent" else f" {unit}" if unit else ""
-        factor = " · raw score ×100" if summary.get("display_multiplier") == 100 else ""
-        highest = f"Highest {value}{suffix}{factor}" if value is not None else "No score reported"
-        label = names.get(row["source"], row["source"])
+    for index, row in enumerate(shown):
+        label = _SCORE_SOURCE_NAMES.get(row["source"], row["source"])
         dated, basis = row["date"]
         date_label = f"{basis} {_medium_date(dated)}" if dated else "Date unknown"
-        count = (
-            _metric_label(summary["numeric_count"], "data point")
-            if summary.get("numeric_count")
-            else "No score reported"
-        )
-        pressed = "true" if rank == 1 else "false"
+        facts = f"{label} · {date_label}"
+        if not _has_reported_score(row):
+            facts += " · No score reported"
+        pressed = "true" if index == 0 else "false"
         content += (
             '<button class="benchmark-result score-browse-result" '
             f'type="button" aria-pressed="{pressed}">'
-            f'<span class="benchmark-result-name">{rank}. {esc(row["name"])}</span>'
-            f'<span class="benchmark-result-facts">{esc(label + " · " + date_label)}</span>'
+            f'<span class="benchmark-result-name">{esc(row["name"])}</span>'
+            f'<span class="benchmark-result-facts">{esc(facts)}</span>'
             "</button>"
         )
-        if rank <= 5:
-            maximum = (shown[0]["summary"] or {}).get("numeric_count") or 1
-            width = summary.get("numeric_count", 0) / maximum * 100
-            ranking += (
-                '<li class="leaderboard-top-row">'
-                f'<span class="leaderboard-top-rank">{rank:02}</span>'
-                '<span class="leaderboard-top-name">'
-                f'<button class="score-ranking-link" type="button" aria-pressed="{pressed}">'
-                f"<span>{esc(row['name'])}</span>"
-                f"<small>{esc(label + ' · ' + highest)}</small></button></span>"
-                '<span class="leaderboard-top-bar"><span class="leaderboard-top-bar-fill" '
-                f'style="width:{width:.1f}%"></span></span>'
-                f'<span class="leaderboard-top-count">{esc(count)}</span></li>'
-            )
+    if not rows:
+        content = (
+            '<p class="empty-state">No benchmarks match these filters.</p>'
+            '<button class="clear-button" type="button">All</button>'
+        )
     seeds = {
-        '<ol class="leaderboard-top-list" id="score-ranking-list"></ol>': (
-            f'<ol class="leaderboard-top-list" id="score-ranking-list" data-seed>{ranking}</ol>'
-        ),
         '<div id="benchmark-search-results"></div>': (
             f'<div id="benchmark-search-results" data-seed>{content}</div>'
         ),
@@ -311,15 +299,55 @@ def _score_browser_seed(
             f"{len(shown):,} of {len(rows):,} matches</p>"
         ),
     }
-    if len(rows) > 5:
-        button = (
-            '<button id="score-ranking-more" class="leaderboard-top-more" type="button" '
-            'data-i18n="Show more" hidden>Show more</button>'
-        )
-        seeds[button] = button.replace(" hidden>", " data-seed>")
     if len(rows) > 50:
         button = (
             '<button id="benchmark-search-more" class="clear-button" type="button" '
+            'data-i18n="Show more" hidden>Show more</button>'
+        )
+        seeds[button] = button.replace(" hidden>", " data-seed>")
+    return seeds
+
+
+def _score_ranking_seed(
+    dashboard: dict[str, Any], catalog_index: list[dict[str, Any]]
+) -> dict[str, str]:
+    """The score ranking keeps its scored 2024+ cohort, independent of the slider."""
+    rows = [
+        row
+        for row in _catalog_score_rows(catalog_index)
+        if _has_reported_score(row) and (row["date"][0] is None or row["date"][0] >= "2024-01-01")
+    ]
+    if not rows:
+        return {}
+    maximum = rows[0]["summary"]["numeric_count"]
+    ranking = ""
+    for rank, row in enumerate(rows[:5], 1):
+        summary = row["summary"]
+        value = _display_value(summary["display_max"])
+        unit = summary.get("unit")
+        suffix = "%" if unit == "percent" else f" {unit}" if unit else ""
+        label = _SCORE_SOURCE_NAMES.get(row["source"], row["source"])
+        count = _metric_label(summary["numeric_count"], "data point")
+        width = summary["numeric_count"] / maximum * 100
+        ranking += (
+            '<li class="leaderboard-top-row">'
+            f'<span class="leaderboard-top-rank">{rank:02}</span>'
+            '<span class="leaderboard-top-name">'
+            '<button class="score-ranking-link" type="button" aria-pressed="false">'
+            f"<span>{esc(row['name'])}</span>"
+            f"<small>{esc(label + ' · ' + value + suffix)}</small></button></span>"
+            '<span class="leaderboard-top-bar"><span class="leaderboard-top-bar-fill" '
+            f'style="width:{width:.1f}%"></span></span>'
+            f'<span class="leaderboard-top-count">{esc(count)}</span></li>'
+        )
+    seeds = {
+        '<ol class="leaderboard-top-list" id="score-ranking-list"></ol>': (
+            f'<ol class="leaderboard-top-list" id="score-ranking-list" data-seed>{ranking}</ol>'
+        ),
+    }
+    if len(rows) > 5:
+        button = (
+            '<button id="score-ranking-more" class="leaderboard-top-more" type="button" '
             'data-i18n="Show more" hidden>Show more</button>'
         )
         seeds[button] = button.replace(" hidden>", " data-seed>")
@@ -533,6 +561,7 @@ def view_seeds(
     """Every view's seed, keyed by view. An empty dict means nothing to publish."""
     return {
         "leaderboard": _leaderboard_seed(dashboard, catalog_index or []),
+        "saturation": _score_browser_seed(dashboard, catalog_index or []),
         "trends": _trends_seed(dashboard, palette),
         "map": _map_seed(dashboard),
     }

--- a/src/benchmark_radar/site_pages.py
+++ b/src/benchmark_radar/site_pages.py
@@ -256,7 +256,7 @@ def _page_html(slug: str, shard: dict[str, Any]) -> str:
         scores_html = (
             '<p class="caveat">No reported scores are on record for this benchmark yet.</p>'
         )
-    interactive = f"{SITE_URL}/leaderboard/?lfrontier={slug}"
+    interactive = f"{SITE_URL}/saturation/?lfrontier={slug}"
     nav = _benchmark_nav(interactive)
     return f"""<!doctype html>
 <html lang="en">
@@ -345,7 +345,7 @@ def _directory_html(entries: list[tuple[str, str]]) -> str:
   <h1>Benchmark directory</h1>
   <p class="lede">Every benchmark in the catalog, each with its own page covering
     what it tests, who published it, and which scores are on record. The
-    interactive dashboard is <a href="{SITE_URL}/leaderboard/">here</a>.</p>
+    interactive dashboard is <a href="{SITE_URL}/saturation/">here</a>.</p>
   <p class="count">{count}</p>
   <ul>{links}</ul>
 </main>

--- a/src/benchmark_radar/site_seo.py
+++ b/src/benchmark_radar/site_seo.py
@@ -30,6 +30,7 @@ SITEMAP_NAMESPACE = "http://www.sitemaps.org/schemas/sitemap/0.9"
 INDEXABLE_VIEWS: tuple[tuple[str, str], ...] = (
     ("Today", "/"),
     ("Leaderboard", "/leaderboard/"),
+    ("Saturation", "/saturation/"),
     ("Trends", "/trends/"),
     ("Explore", "/explore/"),
     ("CLI", "/cli/"),

--- a/tests/score_filters_harness.mjs
+++ b/tests/score_filters_harness.mjs
@@ -49,9 +49,10 @@ state.benchmarkIndex = [
   {slug:'missing',name:'Missing',source:'llm_stats',score_summary:summary(null,0)},
 ];
 state.lscore = 70;
-const scoreNames = ['scoreRecord','matchesScoreFilter','scoreBrowseRows','frontierDefaultEntry','catalogDisplayFactor'];
+const scoreNames = ['scoreRecord','matchesScoreFilter','scoreBrowseRows','saturationRows','scoreRankingRows','benchmarkQueryIds','searchBenchmarkIndex','foldName','frontierDefaultEntry','catalogDisplayFactor'];
+state.benchmarkQuery = '';
 const scores = new Function('state', 'scorePopulation', 'matchesScoreCutoff', 'SKYLINE_START_DATE', `${scoreNames.map(fn).join('\n')}\nreturn {${scoreNames.join(',')}};`)(state, scorePopulation, matchesScoreCutoff, SKYLINE_START_DATE);
-assert.deepEqual(scores.scoreBrowseRows().map(r=>[r.id,r.rank]), [['external',1],['curated',2]]);
+assert.deepEqual(scores.scoreBrowseRows().map(r=>r.id), ['external','curated','missing']);
 assert.equal(scores.frontierDefaultEntry(state.data.model_card_leaderboard).id,'external');
 assert.equal(scores.matchesScoreFilter(summary(69.999)),true);
 assert.equal(scores.matchesScoreFilter(summary(70)),false);
@@ -59,12 +60,39 @@ assert.equal(scores.matchesScoreFilter(summary(60,0)),false);
 assert.equal(scores.matchesScoreFilter(summary(0)),true,'zero is a reported score');
 assert.equal(scores.matchesScoreFilter(null),false);
 state.lscore=100;
-assert.deepEqual(scores.scoreBrowseRows().map(r=>r.id), ['at100','over70','external','curated']);
+assert.deepEqual(scores.scoreBrowseRows().map(r=>r.id), ['at100','over70','external','curated','missing']);
 state.lscore=90;
-assert.deepEqual(scores.scoreBrowseRows().map(r=>r.id), ['over70','external','curated']);
+assert.deepEqual(scores.scoreBrowseRows().map(r=>r.id), ['over70','external','curated','missing']);
 // An intermediate step the old three-option filter could not express.
 state.lscore=40;
-assert.deepEqual(scores.scoreBrowseRows().map(r=>r.id), []);
+assert.deepEqual(scores.scoreBrowseRows().map(r=>r.id), ['missing']);
+// Searching bypasses the slider without losing old or unscored source records.
+state.lscore=70;
+state.benchmarkIndex.push(
+  {slug:'old95',name:'Old high score',aliases:['NeedleBench'],source:'artificial_analysis',released:'2020-01-01',score_summary:summary(95,3)},
+  {slug:'unscored',name:'Unscored lookup',aliases:['NeedleBench'],source:'opencompass_hub'},
+);
+for (const row of state.benchmarkIndex) row.categories = ['lookup'];
+const fixtureRecords = state.benchmarkIndex;
+const ranking = scores.scoreRankingRows().map(row=>row.id);
+assert.deepEqual(ranking,['at100','over70','external','curated']);
+const browsing = scores.saturationRows().map(row=>row.id);
+assert(!browsing.includes('old95'));
+assert(browsing.includes('unscored'));
+state.benchmarkQuery='NeedleBench';
+assert.deepEqual(scores.saturationRows().map(row=>row.id),['old95','unscored']);
+assert.equal(state.lscore,70,'search must not reset the shared slider');
+state.benchmarkQuery='lookup';
+assert.equal(scores.saturationRows().length,fixtureRecords.length);
+assert.equal(new Set(scores.saturationRows().map(row=>row.source)).size,4);
+state.benchmarkQuery='not in catalog';
+assert.deepEqual(scores.saturationRows(),[]);
+state.benchmarkQuery='';
+assert.deepEqual(scores.saturationRows().map(row=>row.id),browsing,'clearing search restores the cutoff');
+state.lscore=10;
+assert.deepEqual(scores.scoreRankingRows().map(row=>row.id),ranking,'the ranking never follows the slider');
+state.lscore=100;
+assert.deepEqual(new Set(scores.saturationRows().map(row=>row.id)),new Set(fixtureRecords.map(row=>row.slug)));
 state.lscore=70;
 state.benchmarkIndex=null;
 assert.deepEqual(scores.scoreBrowseRows().map(r=>r.id), [],'a missing index cannot fall back to a preferred source');
@@ -340,8 +368,8 @@ for(const [heightMetric,fullMode] of fullModes) for(const cutoff of [10,30,70,10
   assert(current.visible.every(row=>Number.isFinite(row.displayScore) && row.summary.numeric_count>0),
     'every displayed benchmark has a numeric reported score, even with All selected');
   assert(current.hidden-current.beforeStart-current.unscored>=0,'exclusion counts must not overlap');
-  assert.deepEqual(current.visible.map(row=>row.id).sort(), scores.scoreBrowseRows().map(row=>row.id).sort(),
-    'chart and browser must show exactly the same filtered record IDs');
+  assert.deepEqual(current.visible.map(row=>row.id).sort(), scores.scoreRankingRows().filter(row=>matchesScoreCutoff(row.summary,cutoff)).map(row=>row.id).sort(),
+    'the figure is the cutoff slice of the independently ranked scored cohort');
   const rendered=chart(current,cutoff);
   const drawn=flatten(rendered);
   const marks=drawn.filter(node=>'data-benchmark-id' in node.attrs);
@@ -481,3 +509,46 @@ const searchable = [
 assert.deepEqual(nameSearch(searchable,'HLE').map(row=>row.slug),['exact','prefix']);
 assert.deepEqual(nameSearch(searchable,'science').map(row=>row.slug),['domain']);
 assert.deepEqual(nameSearch(searchable.map(row=>({...row,source:'another_source'})),'HLE').map(row=>row.slug),['exact','prefix']);
+
+// Execute the shared slider handler against both sets of controls.
+state.benchmarkIndex = fixtureRecords;
+const controls = new Map(['leaderboard-score-filter','leaderboard-score-value','saturation-score-filter','saturation-score-value'].map(id=>[id,{}]));
+let skylineRenders=0, saturationRenders=0, urlWrites=0;
+const filters = new Function('state','byId','t','renderBenchmarkSkyline','renderSaturation','writeUrl',`
+  const BENCHMARK_SEARCH_LIMIT = 50;
+  ${fn('scoreCutoff')}
+  ${fn('syncScoreFilters')}
+  ${fn('setScoreFilter')}
+  return {setScoreFilter,syncScoreFilters};
+`)(state,id=>controls.get(id),text=>text,()=>skylineRenders++,()=>saturationRenders++,()=>urlWrites++);
+state.view='leaderboard';
+state.benchmarkQuery='';
+state.lfrontier='old95';
+state.lfrontierExplicit=true;
+state.benchmarkVisibleLimit=100;
+filters.setScoreFilter(40);
+assert.equal(skylineRenders,1);
+assert.equal(saturationRenders,0);
+assert.equal(state.benchmarkVisibleLimit,100);
+assert.equal(state.lfrontier,'old95');
+for (const view of ['leaderboard','saturation']) assert.equal(controls.get(`${view}-score-filter`).value,40);
+state.view='saturation';
+filters.setScoreFilter(60);
+assert.equal(saturationRenders,1);
+assert.equal(skylineRenders,1);
+assert.equal(state.benchmarkVisibleLimit,50);
+assert.equal(state.lfrontier,'old95','selected histories remain complete outside the browsing cutoff');
+state.benchmarkQuery='NeedleBench';
+state.benchmarkVisibleLimit=100;
+filters.setScoreFilter(10);
+assert.equal(saturationRenders,1,'the slider must not rebuild an unfiltered search');
+assert.equal(state.benchmarkVisibleLimit,100,'changing the paused filter must not reset search pagination');
+assert.deepEqual(scores.saturationRows().map(row=>row.id),['old95','unscored']);
+assert.equal(state.lscore,10);
+state.benchmarkQuery='';
+assert(!scores.saturationRows().some(row=>row.id==='old95'));
+filters.setScoreFilter(100);
+assert.equal(controls.get('leaderboard-score-value').textContent,'All');
+assert.equal(controls.get('saturation-score-value').textContent,'All');
+assert.equal(urlWrites,4);
+console.log('Shared slider, independent rankings, and full-catalog Saturation searches passed.');

--- a/tests/test_app_pages.py
+++ b/tests/test_app_pages.py
@@ -141,7 +141,10 @@ def _write(tmp_path: Path, dashboard: dict) -> dict:
     (tmp_path / "data" / "benchmark-index.json").write_text(
         json.dumps(
             {
-                "benchmarks": [],
+                "benchmarks": [
+                    {"slug": f"benchmark-{i}", "name": entry["name"], "source": "model_reports"}
+                    for i, entry in enumerate(entries)
+                ],
                 "document_registry": {**board, "entries": entries},
             }
         )
@@ -154,6 +157,7 @@ def test_view_seo_is_read_from_the_script_the_browser_uses():
     assert {view: entry["canonical"] for view, entry in seo.items()} == {
         "today": "/",
         "leaderboard": "/leaderboard/",
+        "saturation": "/saturation/",
         "trends": "/trends/",
         "map": "/explore/",
     }
@@ -211,6 +215,7 @@ def test_every_view_is_published_at_its_own_path(tmp_path):
     report = _write(tmp_path, _dashboard())
     assert report["paths"] == [
         "/leaderboard/",
+        "/saturation/",
         "/trends/",
         "/explore/",
         "/cli/",
@@ -243,6 +248,7 @@ def test_only_the_named_view_is_open(tmp_path):
     _write(tmp_path, _dashboard())
     for path, open_id in (
         ("leaderboard", "leaderboard-view"),
+        ("saturation", "saturation-view"),
         ("trends", "trends-view"),
         ("explore", "map-view"),
     ):
@@ -257,6 +263,7 @@ def test_each_generated_page_marks_its_navigation_entry_current(tmp_path):
     _write(tmp_path, _dashboard())
     ids = {
         "leaderboard": 'data-view="leaderboard"',
+        "saturation": 'data-view="saturation"',
         "trends": 'data-view="trends"',
         "cli": 'id="cli-nav"',
         "cite": 'id="cite-open"',
@@ -289,7 +296,7 @@ def test_exactly_one_heading_is_visible_per_page(tmp_path):
     """Four h1s live in the document, one per view, and three are inside hidden
     sections. A page with two visible h1s or none is a page whose outline lies."""
     _write(tmp_path, _dashboard())
-    for path in ("leaderboard", "trends", "explore"):
+    for path in ("leaderboard", "saturation", "trends", "explore"):
         page = (tmp_path / path / "index.html").read_text(encoding="utf-8")
         open_section = re.search(
             r'<section class="view" id="[\w-]+"(?![^>]*hidden)[^>]*>(.*?)\n      </section>',
@@ -370,7 +377,7 @@ def test_seeded_copy_controls_have_names_values_and_fallback_hints(tmp_path):
 
 def test_no_page_ships_a_second_url_for_itself(tmp_path):
     _write(tmp_path, _dashboard())
-    for path in ("leaderboard", "trends", "explore", "cli", "cite", "rubric"):
+    for path in ("leaderboard", "saturation", "trends", "explore", "cli", "cite", "rubric"):
         page = (tmp_path / path / "index.html").read_text(encoding="utf-8")
         assert "?view=" not in page
 
@@ -472,7 +479,7 @@ def test_rebuilding_the_same_data_produces_the_same_bytes(tmp_path):
     first, second = tmp_path / "first", tmp_path / "second"
     _write(first, _dashboard())
     _write(second, _dashboard())
-    for path in ("leaderboard", "trends", "explore", "cli", "cite", "rubric"):
+    for path in ("leaderboard", "saturation", "trends", "explore", "cli", "cite", "rubric"):
         assert (first / path / "index.html").read_bytes() == (
             second / path / "index.html"
         ).read_bytes()
@@ -605,7 +612,7 @@ def test_every_seeded_container_is_one_the_renderer_already_owns(tmp_path):
     script = (SITE / "assets" / "app.js").read_text(encoding="utf-8")
 
     seen = set()
-    for path in ("leaderboard", "trends", "explore"):
+    for path in ("leaderboard", "saturation", "trends", "explore"):
         page = (tmp_path / path / "index.html").read_text(encoding="utf-8")
         ids = re.findall(r'id="([a-z-]+)"[^>]*\bdata-seed\b', page)
         assert ids, path

--- a/tests/test_blog.py
+++ b/tests/test_blog.py
@@ -488,6 +488,7 @@ def test_dashboard_and_blog_share_the_reduced_chrome_contract(tmp_path):
         "/",
         "/cli/",
         "/leaderboard/",
+        "/saturation/",
         "/trends/",
         "/blog/",
     ]

--- a/tests/test_leaderboard_workbench.py
+++ b/tests/test_leaderboard_workbench.py
@@ -49,7 +49,7 @@ def test_the_frontier_opens_on_the_benchmark_the_page_ranks_first():
     """The highest observation-count candidate is both rank 1 and the default chart."""
     script = source("site/assets/app.js")
     default = script.split("function frontierDefaultEntry(board)", 1)[1].split("\n}", 1)[0]
-    assert "scoreBrowseRows(board)[0]" in default
+    assert "saturationRows()[0]" in default
     assert "if (!state.lfrontierExplicit) state.lfrontier = defaultEntry?.id" in script
 
 
@@ -120,7 +120,7 @@ def test_trajectory_points_expose_and_pin_record_details():
     assert 'record.unit === "percent" ? "%" : ` ${record.unit}`' in script
     assert 'role: "group"' in script
     assert 'event.key === "Escape" && selectedFrontierPoint' in script
-    assert 'view !== "leaderboard" && selectedFrontierPoint' in script
+    assert "if (selectedFrontierPoint || describedFrontierPoint)" in script
     assert 'pinned ? "dialog" : "tooltip"' in script
     assert 'details.urlLabel || t("Open source record ↗")' in script
     # Resolved from the point's own chart, not by a document-wide id: the
@@ -305,7 +305,7 @@ def test_search_selection_updates_the_detail_panel():
     # Issue #245 added a `navigate` path for rows rendered outside the
     # leaderboard, where updating the panel in place would look like the click
     # did nothing. It must not replace the in-place update the panel relies on.
-    assert 'setView("leaderboard")' in row
+    assert 'setView("saturation")' in row
 
 
 def test_crawled_scores_are_partitioned_by_source_with_no_merge_path():
@@ -707,7 +707,7 @@ def test_a_benchmark_without_documents_or_scores_uses_its_own_catalog_detail():
     assert "picker.prepend(option(record.slug" in detail
 
 
-def test_score_ranking_leads_the_workbench_and_adoption_follows():
+def test_leaderboard_keeps_its_rankings_and_saturation_owns_the_workbench():
     """The tab is called Leaderboard and the ranking was the sixth block on it.
 
     A reader opening it passed a method note, an evidence strip, a findings
@@ -728,13 +728,17 @@ def test_score_ranking_leads_the_workbench_and_adoption_follows():
     # accordion and the full 80-row table. It now begins at y=824.
     order = [
         'id="score-ranking-list"',
-        'class="benchmark-workbench"',
         'class="leaderboard-top"',
         'id="leaderboard-insights"',
         'id="benchmark-findings"',
         'id="adoption-table"',
         'aria-labelledby="leaderboard-cards-heading"',
     ]
+    leaderboard = html.split('id="leaderboard-view"', 1)[1].split('id="saturation-view"', 1)[0]
+    saturation = html.split('id="saturation-view"', 1)[1].split('id="trends-view"', 1)[0]
+    assert 'class="benchmark-workbench"' not in leaderboard
+    assert 'class="benchmark-workbench"' in saturation
+    assert 'id="score-ranking-list"' not in saturation
     positions = [html.index(marker) for marker in order]
     assert positions == sorted(positions), (
         "leaderboard blocks are out of order: "
@@ -783,7 +787,7 @@ def test_issue_256_the_figure_region_carries_no_pipeline_coverage_count():
     navigator = script.split("function renderBenchmarkNavigator(board)", 1)[1].split(
         "\nfunction ", 1
     )[0]
-    assert "scoreBrowseRows(board)" in navigator
+    assert "saturationRows()" in navigator
     assert "score read from a document" not in navigator
     # The keys the helper used are still live for the search rows and the score
     # readout, so removing the helper must not have taken them with it.

--- a/tests/test_saturation_view.py
+++ b/tests/test_saturation_view.py
@@ -188,7 +188,7 @@ def test_the_picker_uses_the_full_population_cutoff_contract():
     # their membership together with strict numeric boundaries and all sources.
     assert "matchesScoreCutoff(summary, state.lscore)" in membership
     picker = script.split("function frontierPickerGroups(scored)", 1)[1].split("\n}", 1)[0]
-    assert "scoreBrowseRows()" in picker
+    assert "scored.map((row)" in picker
     assert "renderFrontierPicker(scored, state.lfrontier);" in script
 
 
@@ -200,7 +200,7 @@ def test_the_picker_and_the_search_both_cover_both_layers():
     assert "scorePopulation(" in rows
     assert "a.source.localeCompare" not in rows
     render = script.split("function renderBenchmarkSearch()", 1)[1].split("\nfunction ", 1)[0]
-    assert "benchmarkQueryIds(board)" in render
+    assert "saturationRows()" in render
     query = script.split("function benchmarkQueryIds()", 1)[1].split("\n}", 1)[0]
     assert "searchCuratedEntries" not in query
     assert "searchBenchmarkIndex(state.benchmarkIndex || [], state.benchmarkQuery)" in query
@@ -219,7 +219,7 @@ def test_catalog_search_matches_aliases_without_source_preference():
 def test_missing_catalog_fails_without_a_preferred_source_fallback():
     script = source("site/assets/app.js")
     render = script.split("function renderBenchmarkSearch()", 1)[1].split("\nfunction ", 1)[0]
-    assert "let rows = scoreBrowseRows(board);" in render
+    assert "const rows = saturationRows();" in render
     query = script.split("function benchmarkQueryIds()", 1)[1].split("\n}", 1)[0]
     assert "state.benchmarkIndex || []" in query
     assert "const failed = state.benchmarkIndexLoaded && !state.benchmarkIndex" in render
@@ -282,7 +282,7 @@ def test_shortcuts_use_the_same_score_ranking_as_the_picker():
     navigator = script.split("function renderBenchmarkNavigator(board)", 1)[1].split(
         "\nfunction ", 1
     )[0]
-    assert "scoreBrowseRows(board).slice(0, 3).map(scoreBrowseResultRow)" in navigator
+    assert "saturationRows().slice(0, 3).map(scoreBrowseResultRow)" in navigator
     assert "card_count" not in navigator
 
 
@@ -620,8 +620,7 @@ def test_a_finding_can_move_the_chart_to_the_benchmark_it_is_about():
         "\nfunction renderBenchmarkFindings", 1
     )[0]
 
-    assert "selectFrontier(target.benchmark_id)" in card
-    assert "renderAdoptionFrontier(board)" in card
+    assert "openSaturation(target.benchmark_id)" in card
     # Corpus-scope findings name no benchmark, so there is nothing to focus.
     assert "finding.benchmark_id" in card
 
@@ -721,7 +720,7 @@ def test_issue_312_the_saturation_view_reveals_left_to_right():
     # crawled catalog settling mid-reveal replays rather than cancels it.
     assert "function frontierShouldAnimate(key)" in script
     gate = script.split("function frontierShouldAnimate(key)", 1)[1].split("\n}", 1)[0]
-    assert 'if (state.view !== "leaderboard") return false;' in gate
+    assert 'if (state.view !== "saturation") return false;' in gate
     assert "completedFrontierEntranceKey === key" in gate
     # And the completion callback rechecks visibility and the drawn selection:
     # leaving mid-reveal -- to another view, another benchmark, or a hidden
@@ -729,7 +728,7 @@ def test_issue_312_the_saturation_view_reveals_left_to_right():
     assert "const spendOrDefer = () => {" in gate
     assert 'document.visibilityState !== "visible"' in gate
     assert "drawnFrontierEntranceKey === key" in gate
-    assert 'state.view === "leaderboard" && drawnFrontierEntranceKey === key' in gate
+    assert 'state.view === "saturation" && drawnFrontierEntranceKey === key' in gate
     assert "const FRONTIER_SWEEP_MS = 3600;" in script
     assert "FRONTIER_SWEEP_DELAY_MS + FRONTIER_SWEEP_MS + FRONTIER_POINT_FADE_MS" in script
     assert "frontierShouldAnimate(`catalog:${record.slug}`)" in script

--- a/tests/test_score_filters.py
+++ b/tests/test_score_filters.py
@@ -8,7 +8,12 @@ from pathlib import Path
 
 import pytest
 
-from benchmark_radar.app_seeds import _benchmark_date, _display_value, _score_browser_seed
+from benchmark_radar.app_seeds import (
+    _benchmark_date,
+    _display_value,
+    _score_browser_seed,
+    _score_ranking_seed,
+)
 from benchmark_radar.score_summary import score_summary
 
 
@@ -179,12 +184,13 @@ def test_seed_ranks_score_points_without_source_preference():
             "score_summary": summary(20, 70),
         },
     ]
-    seeds = _score_browser_seed(data, index)
+    seeds = _score_ranking_seed(data, index)
     markup = seeds['<ol class="leaderboard-top-list" id="score-ranking-list"></ol>']
     assert markup.index("External") < markup.index("Curated")
     assert "9 data points" in markup
     assert "2 data points" in markup
-    assert "Excluded" not in markup
+    assert markup.index("Excluded") < markup.index("External")
+    assert "20 data points" in markup
     assert "LLM Stats" in markup
 
 
@@ -196,7 +202,7 @@ def test_browser_date_and_score_filter_contracts():
     )
 
 
-def test_seed_excludes_unscored_but_keeps_zero_scores_and_unjoined_records():
+def test_saturation_seed_keeps_unscored_zero_scores_and_unjoined_records():
     data = {
         "model_card_leaderboard": {"entries": []},
         "benchmark_score_progression": {
@@ -227,11 +233,11 @@ def test_seed_excludes_unscored_but_keeps_zero_scores_and_unjoined_records():
     seeds = _score_browser_seed(data, index)
     rendered = "".join(seeds.values())
     assert "unjoined" in rendered
-    assert "Unknown score" not in rendered
-    assert "No score reported" not in rendered
+    assert "Unknown score" in rendered
+    assert "No score reported" in rendered
     assert "Zero score" in rendered
     assert "Above cutoff" not in rendered
-    assert "2 of 2 matches" in rendered
+    assert "3 of 3 matches" in rendered
 
 
 def test_seed_and_browser_format_scores_identically():
@@ -247,7 +253,23 @@ def test_seed_and_browser_format_scores_identically():
     assert json.loads(result.stdout) == [_display_value(value) for value in values]
 
 
-def test_seed_uses_release_then_earliest_score_and_applies_inclusive_2024_cutoff():
+def test_saturation_page_keeps_its_browser_when_default_cutoff_has_no_matches():
+    index = [
+        {
+            "slug": "high",
+            "name": "Above cutoff",
+            "source": "llm_stats",
+            "score_summary": score_summary([{"value": 95}]),
+        },
+    ]
+    markup = "".join(_score_browser_seed({}, index).values())
+    assert "0 of 0 matches" in markup
+    assert "No benchmarks match these filters." in markup
+    assert ">All</button>" in markup
+    assert "Above cutoff" not in markup
+
+
+def test_saturation_seed_preserves_dates_without_the_frontier_date_cutoff():
     assert _benchmark_date({"released": "2025-01-01", "first_reported_at": "2023-01-01"}) == (
         "2025-01-01",
         "Released",
@@ -302,14 +324,14 @@ def test_seed_uses_release_then_earliest_score_and_applies_inclusive_2024_cutoff
     for record in index:
         record["score_summary"] = score_summary([{"value": 50}])
     markup = "".join(_score_browser_seed({}, index).values())
-    assert "Old release" not in markup
-    assert "Old score" not in markup
+    assert "Old release" in markup
+    assert "Old score" in markup
     assert "Boundary release" in markup
     assert "Dated score" in markup
     assert "First LLM score reported Jan 1, 2024" in markup
     assert "Undated evidence" in markup
     assert "Date unknown" in markup
-    assert "3 of 3 matches" in markup
+    assert "5 of 5 matches" in markup
 
 
 def test_seed_preserves_score_entry_proxy_and_prefers_release_or_publication():
@@ -348,5 +370,5 @@ def test_seed_preserves_score_entry_proxy_and_prefers_release_or_publication():
         record["score_summary"] = score_summary([{"value": 50}])
     markup = "".join(_score_browser_seed({}, index).values())
     assert "First dated LLM score (model-release proxy) Feb 29, 2024" in markup
-    assert "Pre-2024 score entry" not in markup
-    assert "1 of 1 matches" in markup
+    assert "Pre-2024 score entry" in markup
+    assert "2 of 2 matches" in markup

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -396,8 +396,13 @@ def test_each_view_serializes_only_the_filters_it_reads():
     for key in ("date", "q", "kind", "category", "source", "organization", "event"):
         assert f'params.set("{key}"' in today
 
-    leaderboard = body.split('if (!utility && state.view === "leaderboard")', 1)[1]
-    for key in ("lq", "ldomain", "lorg", "lera", "lfrontier"):
+    leaderboard, saturation = body.split('if (!utility && state.view === "leaderboard")', 1)[
+        1
+    ].split('if (!utility && state.view === "saturation")', 1)
+    assert 'params.set("lfrontier"' not in leaderboard
+    for key in ("lscore", "bq", "lfrontier"):
+        assert f'params.set("{key}"' in saturation
+    for key in ("lq", "ldomain", "lorg", "lera", "lscore"):
         assert f'params.set("{key}"' in leaderboard
 
     assert 'if (!utility && state.view === "map" && state.entity) params.set("entity"' in body
@@ -601,6 +606,33 @@ readUrl();
 writeUrl("replace");
 results.legacyView = window.location.pathname + window.location.search;
 
+results.legacyBenchmarks = [];
+for (const url of [
+  "/leaderboard/?lfrontier=bench-95&lscore=70",
+  "/?view=leaderboard&lfrontier=bench-95&lscore=70",
+]) {{
+  install(url);
+  readUrl();
+  writeUrl("replace");
+  results.legacyBenchmarks.push(window.location.pathname + window.location.search);
+}}
+
+install("/saturation/?lscore=40&bq=bench-95&lfrontier=bench-95&lq=agent&lheight=documents");
+readUrl();
+writeUrl("replace");
+results.saturation = {{
+  url: window.location.pathname + window.location.search,
+  view: state.view, query: state.benchmarkQuery, cutoff: state.lscore,
+  selected: state.lfrontier, explicit: state.lfrontierExplicit,
+}};
+state.view = "leaderboard";
+writeUrl("push");
+results.sharedCutoff = window.location.pathname + window.location.search;
+state.view = "saturation";
+state.benchmarkQuery = "";
+writeUrl("replace");
+results.clearedSearch = window.location.pathname + window.location.search;
+
 install("/#rubric=2");
 readUrl();
 writeUrl("replace");
@@ -628,6 +660,23 @@ console.log(JSON.stringify(results));
     routes = json.loads(result.stdout)
 
     assert routes["legacyView"] == "/leaderboard/?lscore=70&lq=agent"
+    assert (
+        routes["legacyBenchmarks"]
+        == [
+            "/saturation/?lscore=70&lfrontier=bench-95",
+        ]
+        * 2
+    )
+    assert routes["saturation"] == {
+        "url": "/saturation/?lscore=40&bq=bench-95&lfrontier=bench-95",
+        "view": "saturation",
+        "query": "bench-95",
+        "cutoff": 40,
+        "selected": "bench-95",
+        "explicit": True,
+    }
+    assert routes["sharedCutoff"] == "/leaderboard/?lscore=40&lheight=documents&lq=agent"
+    assert routes["clearedSearch"] == "/saturation/?lscore=40&lfrontier=bench-95"
     assert routes["legacyRubric"] == "/rubric/?version=2"
     assert routes["legacyReturns"] is False
     assert routes["openCli"] == "/cli/"
@@ -2463,7 +2512,7 @@ def test_a_benchmark_name_search_reaches_the_registry_not_only_the_daily_feed():
     # visitor arrives at an empty leaderboard: 0 chart children, 0 table rows.
     for row in ("function benchmarkResultRow(record",):
         body = script.split(row, 1)[1].split("\nfunction ", 1)[0]
-        assert 'setView("leaderboard");\n      renderLeaderboard();' in body, row
+        assert 'setView("saturation");\n      renderSaturation();' in body, row
 
     # And the empty list stops advising a filter change that cannot help when
     # the thing being searched for was found in the registry instead.
@@ -2629,14 +2678,25 @@ def test_heading_outline_and_scale_stay_quiet():
         html,
         re.S,
     )
-    assert {name for name, _, _ in sections} == {"today", "leaderboard", "map", "trends"}
+    assert {name for name, _, _ in sections} == {
+        "today",
+        "leaderboard",
+        "saturation",
+        "map",
+        "trends",
+    }
     for name, _, body in sections:
         assert body.count("<h1") == 1, name
     visible = [name for name, attrs, _ in sections if " hidden" not in attrs]
     assert visible == ["today"], visible
 
     assert '<h1 id="today-heading" class="today-heading" data-i18n="Today\'s radar">' in html
-    for heading_id in ("leaderboard-heading", "map-heading", "trends-heading"):
+    for heading_id in (
+        "leaderboard-heading",
+        "saturation-heading",
+        "map-heading",
+        "trends-heading",
+    ):
         assert f'<h1 id="{heading_id}"' in html
 
     # The today h1 renders exactly like the counts caption beside it: the shared

--- a/tests/test_site_pages.py
+++ b/tests/test_site_pages.py
@@ -117,13 +117,13 @@ def test_page_has_unique_title_and_canonical(tmp_path):
     )
 
 
-def test_interactive_view_link_lands_on_the_leaderboard_with_the_slug(tmp_path):
+def test_interactive_view_link_lands_on_saturation_with_the_slug(tmp_path):
     output = _generated_pages(tmp_path, _shard("alpha-bench", "Alpha Bench"))
     page = _page_text(output, "alpha-bench")
     # The permalink needs the leaderboard page, not a bare lfrontier query on
     # the root, which opens the default Today view and cannot resolve the slug.
-    assert 'href="https://benchmark-radar.org/leaderboard/?lfrontier=alpha-bench"' in page
-    assert "?lfrontier=alpha-bench" not in page.replace("/leaderboard/?lfrontier=alpha-bench", "")
+    assert 'href="https://benchmark-radar.org/saturation/?lfrontier=alpha-bench"' in page
+    assert "?lfrontier=alpha-bench" not in page.replace("/saturation/?lfrontier=alpha-bench", "")
 
 
 def test_description_is_present_and_derived_from_the_shard(tmp_path):
@@ -257,6 +257,7 @@ def test_sitemap_includes_benchmark_pages_when_slugs_passed(tmp_path):
     assert urls == [
         f"{SITE_URL}/",
         f"{SITE_URL}/leaderboard/",
+        f"{SITE_URL}/saturation/",
         f"{SITE_URL}/trends/",
         f"{SITE_URL}/explore/",
         f"{SITE_URL}/cli/",
@@ -272,7 +273,7 @@ def test_sitemap_includes_benchmark_pages_when_slugs_passed(tmp_path):
             "sm:url/sm:lastmod", {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
         )
     ]
-    assert lastmods == ["2026-08-21"] * 10
+    assert lastmods == ["2026-08-21"] * 11
 
 
 def test_write_benchmark_pages_fails_loudly_without_shards(tmp_path):

--- a/tests/test_site_seo.py
+++ b/tests/test_site_seo.py
@@ -16,6 +16,7 @@ def test_sitemap_covers_every_indexable_view():
     assert urls == [
         f"{SITE_URL}/",
         f"{SITE_URL}/leaderboard/",
+        f"{SITE_URL}/saturation/",
         f"{SITE_URL}/trends/",
         f"{SITE_URL}/explore/",
         f"{SITE_URL}/cli/",
@@ -137,7 +138,7 @@ def test_structured_data_describes_a_searchable_site_and_a_dataset():
     target = website["potentialAction"]["target"]["urlTemplate"]
     # The search endpoint is the leaderboard's real lq filter, not a pretend one.
     assert "{search_term_string}" in target
-    assert "/leaderboard/?lq={search_term_string}" in target
+    assert "/saturation/?bq={search_term_string}" in target
     assert website["potentialAction"]["query-input"] == "required name=search_term_string"
 
     dataset = next(block for block in blocks if block["@type"] == "Dataset")


### PR DESCRIPTION
The score cutoff was narrowing benchmark lookup and score rankings together. Keep Frontier and rankings on Leaderboard, move browsing and complete score histories to `/saturation/`, and limit the Leaderboard slider to Frontier. Follow-up to #561.

Both tabs share the existing slider (default 70, 10–100, All at 100). Saturation search covers the full catalog across every source and year, including unscored benchmarks, while leaving the slider unchanged. Clearing the query restores filtered browsing. Existing benchmark permalinks follow the histories to Saturation, and result/picker labels use names without list-position numbers.

On mobile, search appears above the chart and selecting a result scrolls to its history.

Validation:

- All six required CI steps passed from a clean detached checkout with Python 3.12 and Node 22: `ruff check .`, `ruff format --check .`, `normalize-catalog`, `classify`, `build-data-release`, and `pytest -q` (1,311 passed). The rebuilt catalog contains 1,283 records across 4 sources.
- Browser checks covered shared slider state, HumanEval at 95.1 under a 70 cutoff, unscored results, clearing search, pagination, old links, Back/Forward, and desktop/mobile layout.
