### PR TITLE
Update paper and simplify the report data-refresh guide

### DIFF
--- a/docs/technical-report/README.md
+++ b/docs/technical-report/README.md
@@ -117,31 +117,24 @@ integrated manuscript, supplied a contribution statement, and accepted
 accountability for the work, as described in
 `docs/designs/technical-report-collaboration-scoring.md` and issue #447.
 
-## Section 6.2 saturation audit
+## Historical score audit
 
-The appendix tables come from `saturation-audit-6.2.json`, generated from the
-curated score archive and the model-report registry with:
+`saturation-audit-6.2.json` records an analysis used by an earlier manuscript.
+Its arithmetic can be reproduced from the score archive and model-report
+registry with:
 
 ```bash
 python3 -m benchmark_radar.saturation_audit
 ```
 
-Regenerate that file and update the appendix tables together.
-
-### Independent reproduction
-
-On 2026-09-05, a Codex-assisted maintainer review regenerated the audit from the
-two canonical YAML files. It reproduced four counts: eight raw near-ceiling
-readings; no raw-best setup spanning two dates; four benchmarks with a different
-repeated setup; and one of those four within five points. The review also checked
-the HMMT sample against Table 7 of the
-[DeepSeek-V4 primary report](https://arxiv.org/html/2606.19348): HMMT 2026 Feb,
-Pass@1, Think Max is 94.8 for DeepSeek-V4-Flash and 95.2 for
-DeepSeek-V4-Pro. Those values match the `deepseek_v4_technical_report` and
-`deepseek_v4_model_card` rows in `data/benchmark_scores.yml`.
-
-The audit was regenerated again at v0.10.0 and the output was byte-identical, so
-the finding still holds at the current cutoff.
+The current paper removes the saturation appendix. Matching instrument/protocol
+labels and report dates does not establish identical experimental conditions or
+independent repeated evaluations. For example, the HMMT group combines Flash
+and Pro scores shown together in the
+[DeepSeek-V4 report](https://arxiv.org/html/2606.19348); that report also specifies
+a different math prompt for Pro-Max. The historical helper and artifact remain
+available for inspection, but reproducing their numbers does not validate a
+protocol-controlled saturation claim. They no longer supply tables to the paper.
 
 ## Audited inputs
 

--- a/docs/technical-report/README.md
+++ b/docs/technical-report/README.md
@@ -1,160 +1,34 @@
 # Benchmark Radar technical report
 
-The [paper repository](https://github.com/ktwu01/benchmark-radar-paper) holds the
-LaTeX source, built PDF, and all figures. It is mounted here as the `latex/` Git
-submodule, pinned to a reviewed paper commit. This directory keeps the software
-audit notes and frozen deposit metadata. `latex/main.tex` remains the single
-source of manuscript prose; edit it directly.
+The manuscript, PDF, figures, and Overleaf instructions live in
+**[benchmark-radar-paper](https://github.com/ktwu01/benchmark-radar-paper)**,
+mounted here as the `latex/` Git submodule.
 
-For Overleaf setup and the writing workflow, see the
-[paper README](https://github.com/ktwu01/benchmark-radar-paper#write-together-in-overleaf).
-Overleaf sync is manual and updates the paper repository. Updating this
-repository requires a separate PR that advances the submodule pointer.
+## Refresh the paper's numbers with Python
 
-## Get the paper
+The exporter stays in this software repository. It reads
+`site/data/benchmark-index.json` and `site/data/radar.json`, then writes directly
+to `docs/technical-report/latex/figure-data.tex` inside the paper submodule.
 
-New clones should use `git clone --recurse-submodules`. In an existing checkout
-or a new clean worktree, run this from the repository root:
+First rebuild and audit the inputs using the
+[clean-checkout CI sequence](../../AGENTS.md#before-opening-a-pull-request).
+From that Benchmark Radar checkout's root:
 
 ```bash
 git submodule update --init --recursive
-```
-
-The submodule checks out a specific commit. Before editing it locally, create a
-branch inside it with `git switch -c paper/my-revision`. Commit and push the
-paper changes there first, then commit the `docs/technical-report/latex` pointer
-in this repository. The paper README includes the update commands.
-
-The current manuscript evaluates software version 0.10.0, its full collection and
-publication pipeline, the public collection sources, the 1,283-entry web search
-surface, and the public data snapshot dated 2026-09-06.
-
-## Build
-
-Requires a TeX distribution with `latexmk` (TinyTeX or TeX Live).
-
-```bash
-cd docs/technical-report/latex
-make
-```
-
-That writes `latex/main.pdf`, tracked in the paper repository so the report
-reads directly on GitHub. Commit the rebuilt PDF alongside any change to `main.tex`,
-then update the parent repository's submodule pointer.
-
-## arXiv upload
-
-```bash
-cd docs/technical-report/latex
-make arxiv
-```
-
-That writes `arxiv.tar.gz`. arXiv runs no BibTeX pass of its own, so the tarball
-ships the built `main.bbl` rather than `references.bib`, together with
-`figure-data.tex` and the native figure sources. All images, including the
-use-case screenshots, live in the paper repository's `figures/` directory, so the
-package needs no parent-repository files.
-Unpack the tarball and build it once on its own before uploading.
-
-## Figures
-
-The four PDF figures in `latex/figures/` now have native TikZ sources with
-matching `.tex` names. `make` rebuilds them before the manuscript; `make figures`
-builds just those four PDFs. Their shared styles live in
-`figures/figure-style.tex`. TeX Live's `pgf` (TikZ) and `helvet` packages are
-required in addition to the manuscript's existing dependencies. No ReportLab,
-PDF-page extraction, or downloaded ZIP is needed.
-
-`figure-data.tex` is a checked-in, dated export of numbers, shared by the figures
-and the corresponding manuscript counts. Normal builds use that file so a
-manuscript rebuild does not silently pick up a new corpus. To refresh it, first
-run the six-step clean-checkout CI sequence in `AGENTS.md`, then:
-
-```bash
+git -C docs/technical-report/latex switch -c paper/refresh-figure-data
 python scripts/export_report_figure_data.py
 python scripts/export_report_figure_data.py --check
-make -C docs/technical-report/latex
+git -C docs/technical-report/latex diff -- figure-data.tex
 ```
 
-Review the cutoff, related prose and tables, all four figures, and the rendered
-manuscript together; commit `figure-data.tex`, the four figure PDFs, and
-`main.pdf` with the source changes. The exporter writes only numbers and input
-hashes, never manuscript prose. Missing inputs and incomplete corpus counts fail
-visibly. Source-composition bars show the five largest normalized discovery
-labels plus every remaining observation; these are not benchmark catalog source
-counts. `make clean` preserves the tracked PDFs and removes build intermediates.
+The export contains the data cutoff, numerical macros, and SHA-256 hashes of the
+two input JSON files. `--check` recomputes the export and fails if the exported
+file differs from those local inputs. Do not hand-edit the numbers or hashes.
+The script does not update manuscript prose or PDF files.
 
-The reconstruction follows the legacy drawing routines in commit `6270ff3` and
-the checked-in PDFs. The supplied `Benchmark_Radar (1).zip` contained PDFs but no
-drawing sources. Rebuilding the catalog confirmed 1,283 records across four
-sources: the older 1,259 figure omitted 24 model-report benchmarks without scores,
-and the unused search illustration still said 1,242. Both now use the same full
-catalog count as the manuscript. The search illustration remains unembedded.
-
-The graphical abstract (`figures/abstract_overview.png`) is an authored raster
-asset, not one of these four generated diagrams.
-
-The use-case screenshots are included in `latex/figures/` so Overleaf and
-standalone builds work. The original evidence remains in `assets/use-case-492/`.
-
-## Deposit
-
-The published v0.9.0 PDF at
-`output/pdf/benchmark-radar-technical-report-v0.9.0.pdf` is frozen. It is the
-artifact behind DOI 10.5281/zenodo.22167102 and must stay byte-for-byte
-unchanged. Nothing in this repository writes to that path; do not overwrite it
-by hand.
-
-A new deposit copies the reviewed `latex/main.pdf` to
-`output/pdf/benchmark-radar-technical-report-v<version>.pdf` and updates
-`zenodo-metadata.json` in the same change. Prepare release metadata only when a
-report version is approved for deposit.
-
-## Byline and credit
-
-The byline is provisional until each contributor has reviewed and approved the
-integrated manuscript, supplied a contribution statement, and accepted
-accountability for the work, as described in
-`docs/designs/technical-report-collaboration-scoring.md` and issue #447.
-
-## Historical score audit
-
-`saturation-audit-6.2.json` records an analysis used by an earlier manuscript.
-Its arithmetic can be reproduced from the score archive and model-report
-registry with:
-
-```bash
-python3 -m benchmark_radar.saturation_audit
-```
-
-The current paper removes the saturation appendix. Matching instrument/protocol
-labels and report dates does not establish identical experimental conditions or
-independent repeated evaluations. For example, the HMMT group combines Flash
-and Pro scores shown together in the
-[DeepSeek-V4 report](https://arxiv.org/html/2606.19348); that report also specifies
-a different math prompt for Pro-Max. The historical helper and artifact remain
-available for inspection, but reproducing their numbers does not validate a
-protocol-controlled saturation claim. They no longer supply tables to the paper.
-
-## Audited inputs
-
-The report derives its quantitative claims from versioned source evidence and
-the catalog artifacts rebuilt from it:
-
-- `site/data/radar.json` (generated from the dated snapshots)
-- `site/data/benchmark-index.json` (generated from normalized catalogs)
-- `data/snapshots/2026-09-06.json`
-- `data/model_cards.yml`
-- `data/benchmark_scores.yml`
-- `site/data/models.json`
-- `config.yml`
-
-Rebuild and review the report when these inputs or the report text change.
-
-## Licensing
-
-The software remains under the MIT License. The technical report and original
-editorial content use CC BY-NC 4.0. Commercial republication, resale, paid
-newsletters, dataset packaging, or commercial product integration requires
-prior written permission from Koutian Wu. Third-party source material remains
-under its original terms.
+Review the changed numbers and cutoff, update affected prose, and rebuild and
+inspect the figures and manuscript using the
+[paper's build instructions](https://github.com/ktwu01/benchmark-radar-paper#build-locally).
+Commit and push the reviewed changes in the paper repository first, then commit
+the updated `docs/technical-report/latex` submodule pointer in Benchmark Radar.


### PR DESCRIPTION
Updates the paper submodule to `32dd625`, which removes the unsupported saturation appendix and unrelated Chinese bibliography entry. Replaces the stale technical-report README with two things: a direct link to the paper repository and the Python workflow for refreshing its numbers.

The README identifies the two generated JSON inputs, the exporter in this repository, and its `figure-data.tex` output inside the submodule. It covers input SHA-256 hashes, `--check`, review and rebuild, and committing the paper changes before advancing the parent pointer. Paper writing, Overleaf, and build details are linked to the standalone repository.

Depends on https://github.com/ktwu01/benchmark-radar-paper/pull/1; merge the paper PR first. That PR includes the rebuilt and visually inspected 19-page PDF, scientific assessment, and standalone arXiv build validation.

Validation:
- All six CI steps passed in a fresh detached worktree at `a6aaa5a` with the new paper commit: ruff check, ruff format check, normalize-catalog, classify, build-data-release, and 1,314 tests. Rebuilt catalog: 1,283 source records across four sources.
- For the subsequent README-only edit at `9756bf9`, reran lint, format, and whitespace checks. Ran the documented exporter and `--check` against those freshly rebuilt inputs, verified both output SHA-256 comments against the input bytes, then restored the reviewed figure-data file.
- The README edit does not refresh published numbers or PDFs. The frozen v0.9.0 deposit and metadata remain unchanged.
