### PR TITLE
Pin the technical paper to the v0.11.0 data release

### DIFF
--- a/docs/technical-report/README.md
+++ b/docs/technical-report/README.md
@@ -4,19 +4,29 @@ The manuscript, PDF, figures, and Overleaf instructions live in
 **[benchmark-radar-paper](https://github.com/ktwu01/benchmark-radar-paper)**,
 mounted here as the `latex/` Git submodule.
 
-## Refresh the paper's numbers with Python
+## Frozen paper data: v0.11.0
+
+All paper data is cut off at the
+[v0.11.0 release](https://github.com/ktwu01/benchmark-radar/releases/tag/v0.11.0),
+software commit `8f46bbfa91f5d9900c8b08a5d552c3df5c9597b0`, with discovery
+through **2026-09-07**. The release includes the frozen input archive, checksums,
+and paper PDF. Follow the [paper's cutoff rule](latex/README.md#data-cutoff-rule-v0110).
+Routine paper edits must not incorporate newer inputs or advance the cutoff.
+The existing audit remains valid for unchanged inputs.
+
+## Reproduce the paper's numbers with Python
 
 The exporter stays in this software repository. It reads
 `site/data/benchmark-index.json` and `site/data/radar.json`, then writes directly
 to `docs/technical-report/latex/figure-data.tex` inside the paper submodule.
 
-First rebuild and audit the inputs using the
+Use a clean checkout at the release commit above, then rebuild the inputs using the
 [clean-checkout CI sequence](../../AGENTS.md#before-opening-a-pull-request).
 From that Benchmark Radar checkout's root:
 
 ```bash
 git submodule update --init --recursive
-git -C docs/technical-report/latex switch -c paper/refresh-figure-data
+git -C docs/technical-report/latex switch -c paper/reproduce-v0.11.0
 python scripts/export_report_figure_data.py
 python scripts/export_report_figure_data.py --check
 git -C docs/technical-report/latex diff -- figure-data.tex
@@ -27,8 +37,8 @@ two input JSON files. `--check` recomputes the export and fails if the exported
 file differs from those local inputs. Do not hand-edit the numbers or hashes.
 The script does not update manuscript prose or PDF files.
 
-Review the changed numbers and cutoff, update affected prose, and rebuild and
-inspect the figures and manuscript using the
+Verify the exported hashes against the paper README and preserve the release
+cutoff. For manuscript edits, rebuild and inspect the figures and manuscript using the
 [paper's build instructions](https://github.com/ktwu01/benchmark-radar-paper#build-locally).
 Commit and push the reviewed changes in the paper repository first, then commit
 the updated `docs/technical-report/latex` submodule pointer in Benchmark Radar.


### PR DESCRIPTION
Pin the technical-report submodule to the paper revision that cites the published v0.11.0 release, and make the parent README use the same fixed September 7 cutoff. The paper README, manuscript, and rebuilt PDF identify release commit `8f46bbf` and the frozen data assets; the existing quantitative inputs remain unchanged.

Release: https://github.com/ktwu01/benchmark-radar/releases/tag/v0.11.0
Paper changes: https://github.com/ktwu01/benchmark-radar-paper/pull/1

Validation: all six CI steps passed in a clean detached checkout of this branch with the submodule initialized; 1,314 tests passed. All 1,332 released data files match the existing audit hashes. The paper and independently extracted submission package compile, and the published PDF matches the pushed manuscript PDF byte for byte.
