### PR TITLE
feat: polish professional UI surfaces

### DIFF
--- a/design.md
+++ b/design.md
@@ -74,6 +74,39 @@ active indicator, and Back and Forward should restore meaningful states.
 Show a concise answer first, then offer the evidence and method behind it.
 Expansion should be clear and reversible.
 
+## Keep page titles close and quiet
+
+[Issue #581](https://github.com/ktwu01/benchmark-radar/issues/581) sets the
+Leaderboard heading as the spacing baseline. Every primary page title should
+start at the same compact distance below the menubar. Switching sections must
+not make the title jump down the page. Controls beside a title align to the top;
+a taller filter must not vertically center the title lower than its peers.
+
+Good:
+
+- `Leaderboard`, `Saturation`, `Trend`, and the Blog title share one top offset.
+- The Blog title uses the same scale as `Saturation`, even when it is longer.
+- `Trend` identifies the Trends page without a second label or open caveat.
+
+Bad:
+
+- Leaving the generic page padding on Saturation, Trends, or Blog while
+  Leaderboard uses compact spacing.
+- Stacking `Recent activity`, `Signals over time`, and “Counts describe
+  discovery volume, not scientific quality” before the reader reaches the
+  chart.
+- Stacking `Daily brief`, the Blog title, a descriptive paragraph, and a
+  collection-day count when the title already identifies the page.
+
+Use one title when one title is enough. Eyebrows, decks, counts, and caveats do
+not belong in the open title area merely because the data exists. If page-level
+coverage context remains necessary, put it in one closed, keyboard- and
+touch-accessible `(i)` immediately to the right of the title. Give the control
+an accessible name and keep its contents out of the layout while closed. A
+loading failure or empty state remains visible; it must never be hidden in the
+note. Figure-specific coverage and method text still follow the figure-caption
+rule below.
+
 Mobile layout must preserve the surface's primary task. On Today, matching
 results come first; the daily briefing follows as context for the scan date.
 

--- a/docs/technical-report/README.md
+++ b/docs/technical-report/README.md
@@ -37,6 +37,13 @@ two input JSON files. `--check` recomputes the export and fails if the exported
 file differs from those local inputs. Do not hand-edit the numbers or hashes.
 The script does not update manuscript prose or PDF files.
 
+The paper's main findings use its `scripts/audit_findings.py` exporter, which
+reads the same frozen index and every detail shard. Documentation, score, and
+date analyses retain the full source-record population; percentage-scale or
+model-report eligibility must not determine which records survive. Run both
+paper audits in `--check` mode, as documented in the paper README. The generated
+CSV and JSON provide all records and their available measurements.
+
 Verify the exported hashes against the paper README and preserve the release
 cutoff. For manuscript edits, rebuild and inspect the figures and manuscript using the
 [paper's build instructions](https://github.com/ktwu01/benchmark-radar-paper#build-locally).

--- a/principle.md
+++ b/principle.md
@@ -17,6 +17,47 @@ again after reading the unified index.
 **If a main surface contains only a few dozen benchmarks, assume records are
 missing and investigate. Do not present that subset as Benchmark Radar.**
 
+### Paper analyses must use the frozen full catalog
+
+For the paper, use the **frozen v0.11.0 release**, software commit
+`8f46bbfa91f5d9900c8b08a5d552c3df5c9597b0`, and verify the released input hashes.
+Do not substitute current `main`, the live website, or a newer collection.
+The 1,259+ baseline is a coverage alarm, not a replacement for the record count
+computed from that frozen catalog.
+
+This requirement applies separately to every main results table and analysis,
+including documentation, reported scores, headroom, and dates. Reading the full
+index and then selecting only model reports does not satisfy it. Neither does
+placing the full census in an appendix while the main findings describe only
+a few dozen report benchmarks. Trace each reduction through the actual joins,
+source predicates, and measurement requirements before accepting a result.
+
+Every analysis must export the complete source-record ID set, preserve available
+measurements, and report per-source coverage in its main table. Unknown units
+can prevent a headroom calculation; they cannot remove numeric scores from the
+score analysis. Unknown dates, documents, or organizations remain unknown on
+their records. A narrow statistic may supplement the full-catalog analysis only
+when its eligibility and missing evidence are explicit. Never invent a scale,
+merge similarly named records, or inflate a count to meet the coverage baseline.
+
+Keep the units of every count explicit. **Benchmark records, cited documents,
+scored models, organizations, and score observations are different quantities.**
+Only benchmark-record counts reconcile to the full catalog. A document count or
+a count of eligible records must never answer the question “how many benchmarks
+does the product cover?” Generate paper table cells and repeated quantitative
+claims from the same audited frozen inputs; check their consistency before
+building and delivering the PDF.
+
+Every numeric value below 100 appearing in the rendered paper must emit:
+`less than 100 is abnormal, ref to https://github.com/ktwu01/benchmark-radar/blob/main/principle.md`.
+Check PDF text and rendered figure images, including page numbers, citations,
+dates, model versions, percentages, and individual source counts; do not silently
+exempt categories. Report the page, number, and surrounding text for review.
+This is a warning requirement, not permission to alter the frozen evidence.
+Missing PDF extraction or OCR tools must fail visibly. Regression tests must
+verify warning emission and prevent the removed report-subset exporter and
+`example-data.tex` from returning.
+
 Check which sources, records, and fields disappeared at each join or filter.
 A successful render, plausible Pareto frontier, or passing test does not excuse
 missing most of the population. Each surface starts from the same catalog;

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -475,6 +475,7 @@ const I18N = {
     Today: "今日",
     Leaderboard: "排行榜",
     Trends: "趋势",
+    Trend: "趋势",
     Explore: "探索",
     Blog: "博客",
     Rubric: "评分标准",

--- a/site/assets/blog.css
+++ b/site/assets/blog.css
@@ -2,12 +2,8 @@
    and only compose its existing tokens into a reading layout. Nothing here
    applies to the dashboard: every rule is scoped to .blog-page, which only the
    generated blog documents carry. */
-.blog-page .masthead-end {
-  display: flex;
-}
-
 .blog-page .blog-view {
-  padding: clamp(2.25rem, 4vw, 3.75rem) 0 6rem;
+  padding: clamp(1.25rem, 2vw, 1.75rem) 0 6rem;
 }
 
 .blog-page .blog-hero {
@@ -19,6 +15,7 @@
 
 .blog-page .blog-hero h1 {
   max-width: 920px;
+  font-size: clamp(1.25rem, 2vw, 1.5rem);
 }
 
 .blog-page .blog-lede {

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -109,7 +109,6 @@ a {
 }
 
 .masthead,
-.view-nav,
 main,
 footer {
   width: min(1680px, calc(100% - 48px));
@@ -117,15 +116,30 @@ footer {
 }
 
 .masthead {
+  position: sticky;
+  top: 0;
+  z-index: 50;
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 1.25rem;
   min-height: 80px;
   border-bottom: 1px solid var(--edge);
+  background: color-mix(in srgb, var(--canvas) 96%, transparent);
+  backdrop-filter: blur(12px);
+}
+
+.masthead-main {
+  display: flex;
+  flex: 1 1 auto;
+  min-width: 0;
+  align-items: center;
+  gap: 0.9rem;
 }
 
 .brand {
   display: inline-flex;
+  flex: 0 0 auto;
   gap: 0.85rem;
   align-items: center;
   color: var(--ink);
@@ -134,10 +148,10 @@ footer {
 
 .brand strong {
   display: block;
-  font-family: var(--display);
-  font-size: clamp(1.25rem, 3vw, 1.75rem);
-  font-weight: 500;
-  letter-spacing: 0.01em;
+  font-family: var(--utility);
+  font-size: 0.975rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
   line-height: 1;
 }
 
@@ -415,16 +429,14 @@ button.repo-badge svg {
 }
 
 .view-nav {
-  position: sticky;
-  top: 0;
-  z-index: 50;
   display: flex;
+  flex: 0 1 auto;
+  min-width: 0;
   align-items: stretch;
   gap: 0.3rem;
   padding-block: 0.5rem;
-  border-bottom: 1px solid var(--line);
-  background: color-mix(in srgb, var(--canvas) 96%, transparent);
-  backdrop-filter: blur(12px);
+  overflow-x: auto;
+  scrollbar-width: thin;
 }
 
 .view-nav button,
@@ -476,13 +488,11 @@ main {
   padding: clamp(2.25rem, 4vw, 3.75rem) 0 6rem;
 }
 
-/* The leaderboard's primary object is the figure, so its top chrome is a
-   budget rather than a canvas: on a 1440x900 laptop the chart began at
-   y=1356, entirely below the fold, behind KPI cards and accordions that
-   summarise it. Those moved below the figure; this recovers the last of the
-   gap so the visualization is visibly underway on load. */
+/* Primary page titles stay close to the shared masthead so switching sections
+   does not make the heading jump down the page. */
 #leaderboard-view,
-#saturation-view {
+#saturation-view,
+#trends-view {
   padding-top: clamp(1.25rem, 2vw, 1.75rem);
 }
 
@@ -4245,7 +4255,6 @@ footer {
 
 @media (max-width: 760px) {
   .masthead,
-  .view-nav,
   main,
   footer {
     width: min(100% - 28px, 1440px);
@@ -4261,15 +4270,24 @@ footer {
   }
 
   .masthead {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
     min-height: 64px;
     padding-block: 0.75rem;
-    /* Brand plus the four-square grid exceed 320px-class viewports, so the
-       controls drop to a second row instead of overflowing off-screen. */
-    flex-wrap: wrap;
     row-gap: 0.5rem;
   }
 
+  .masthead-main {
+    display: contents;
+  }
+
+  .brand {
+    grid-column: 1;
+    min-width: 0;
+  }
+
   .masthead-end {
+    grid-column: 2;
     grid-template-columns: repeat(4, 44px);
     gap: 0.5rem;
   }
@@ -4284,8 +4302,9 @@ footer {
   }
 
   .view-nav {
-    overflow-x: auto;
-    scrollbar-width: thin;
+    grid-column: 1 / -1;
+    grid-row: 2;
+    width: 100%;
   }
 
   .view-nav button,
@@ -5112,7 +5131,7 @@ dialog {
 /* Score browsing leads the page; adoption remains a separate view below it. */
 .score-browse-header {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   flex-wrap: wrap;
   gap: 1rem;
@@ -5124,6 +5143,7 @@ dialog {
   max-width: none;
 }
 .score-filter { display: flex; align-items: center; gap: .6rem; margin-bottom: 1.25rem; }
+.score-browse-header > .score-filter { margin-bottom: 0; }
 .score-filter input[type="range"] {
   flex: 1 1 auto;
   min-width: 5rem;

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -1,16 +1,16 @@
 :root {
   color-scheme: light;
-  --panel: #f7f9fa;
-  --canvas: #e7ecef;
+  --panel: #f9fbfc;
+  --canvas: #edf1f3;
   --ink: #15242a;
   --muted: #5f7078;
-  --line: #bdc9ce;
+  --line: #cbd5da;
   /* Borders and dividers, deliberately not `--ink`. The page used the text
      colour to draw every card edge and row separator, so a screen of data read
      as a grid of hard near-black boxes and the rules competed with the words
      inside them (issue #333). One step darker than `--line` so a card edge
      still reads as an edge against `--panel`, nowhere near the ink. */
-  --edge: #aebbc1;
+  --edge: #b8c5cc;
   /* One corner radius for every panel, card, table and control. */
   --radius: 10px;
   --radius-sm: 6px;
@@ -32,7 +32,7 @@
   --body: "Avenir Next", Avenir, "Segoe UI", sans-serif;
   --display: var(--body);
   --utility: "SFMono-Regular", "Cascadia Code", "Roboto Mono", monospace;
-  --shadow: 0 16px 50px rgb(27 48 56 / 8%);
+  --shadow: 0 3px 16px rgb(27 48 56 / 5%);
 }
 
 [hidden] {
@@ -45,6 +45,7 @@
 
 html {
   scroll-behavior: smooth;
+  scroll-padding-top: 5rem;
 }
 
 /* Nothing on this page is meant to be reached by scrolling sideways: every
@@ -119,7 +120,7 @@ footer {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  min-height: 72px;
+  min-height: 80px;
   border-bottom: 1px solid var(--edge);
 }
 
@@ -135,8 +136,8 @@ footer {
   display: block;
   font-family: var(--display);
   font-size: clamp(1.25rem, 3vw, 1.75rem);
-  font-weight: 400;
-  letter-spacing: 0.025em;
+  font-weight: 500;
+  letter-spacing: 0.01em;
   line-height: 1;
 }
 
@@ -414,17 +415,25 @@ button.repo-badge svg {
 }
 
 .view-nav {
+  position: sticky;
+  top: 0;
+  z-index: 50;
   display: flex;
   align-items: stretch;
+  gap: 0.3rem;
+  padding-block: 0.5rem;
   border-bottom: 1px solid var(--line);
+  background: color-mix(in srgb, var(--canvas) 96%, transparent);
+  backdrop-filter: blur(12px);
 }
 
 .view-nav button,
 .view-nav a {
   min-width: 112px;
-  padding: 0.85rem 1.25rem;
+  min-height: 44px;
+  padding: 0.8rem 1.15rem;
   border: 0;
-  border-right: 1px solid var(--line);
+  border-radius: var(--radius-sm);
   background: transparent;
   color: var(--muted);
   font-family: var(--utility);
@@ -432,6 +441,12 @@ button.repo-badge svg {
   letter-spacing: 0.05em;
   text-align: center;
   text-decoration: none;
+  transition: background 140ms ease, color 140ms ease;
+}
+
+.view-nav :is(button, a):not(.nav-active):hover {
+  background: var(--panel);
+  color: var(--ink);
 }
 
 .view-nav .nav-active {
@@ -559,12 +574,25 @@ input {
   min-height: 44px;
   padding: 0.55rem 2.25rem 0.55rem 0.75rem;
   border: 1px solid var(--line);
-  border-radius: 0;
+  border-radius: var(--radius-sm);
   background-color: var(--panel);
   color: var(--ink);
   font-family: var(--body);
   font-size: 0.9rem;
   letter-spacing: normal;
+}
+
+input[type="search"] {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 24 24' fill='none' stroke='%235f7078' stroke-width='1.7' stroke-linecap='round'%3E%3Ccircle cx='10.5' cy='10.5' r='6.5'/%3E%3Cpath d='m16 16 4.5 4.5'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: 0.8rem center;
+  padding-left: 2.5rem;
+}
+
+input:not([type="range"]):focus-visible,
+select:focus-visible {
+  border-color: var(--blue);
+  box-shadow: 0 0 0 3px rgb(37 94 168 / 10%);
 }
 
 .content-grid {
@@ -678,15 +706,17 @@ input {
    "why it matters" support beneath it, and a quiet metadata chip row. */
 .briefing-insight + .briefing-insight {
   margin-top: 1.35rem;
+  padding-top: 1.1rem;
+  border-top: 1px solid var(--line);
 }
 
 .briefing-insight-head {
   margin: 0 0 0.3rem;
   font-family: var(--display);
-  font-size: 1.12rem;
+  font-size: 1.02rem;
   font-weight: 600;
   letter-spacing: -0.01em;
-  line-height: 1.25;
+  line-height: 1.4;
 }
 
 .briefing-insight-body {
@@ -1017,11 +1047,12 @@ a.briefing-chip-sources:focus-visible {
 .record-summary {
   display: grid;
   grid-template-columns: 26px 38px minmax(0, 1fr) 150px;
-  gap: 1rem;
+  gap: 0.85rem;
   align-items: start;
-  padding: 1.5rem 0;
+  padding: 1.25rem 0;
   cursor: pointer;
   list-style: none;
+  transition: background 140ms ease;
 }
 
 /* Model card rows carry no rank number, so they have three children where a
@@ -1041,13 +1072,14 @@ a.briefing-chip-sources:focus-visible {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 48px;
-  height: 48px;
+  width: 26px;
+  height: 26px;
+  margin-top: 0.2rem;
   border: 1px solid var(--line);
   border-radius: 50%;
   color: var(--blue-deep);
   font-family: var(--utility);
-  font-size: 2.2rem;
+  font-size: 1.35rem;
   line-height: 1;
   transition:
     transform 140ms ease,
@@ -1065,8 +1097,9 @@ a.briefing-chip-sources:focus-visible {
 
 /* The whole row is the click target; a subtle wash announces the affordance
    before the chevron is noticed (issue #248). */
-.record-summary:hover {
-  background: color-mix(in srgb, var(--panel) 55%, transparent);
+.record-summary:hover,
+.record-summary:focus-visible {
+  background: color-mix(in srgb, var(--blue) 4%, var(--panel));
 }
 
 .record-card[open] {
@@ -1121,6 +1154,7 @@ a.briefing-chip-sources:focus-visible {
 }
 
 .signal-rank {
+  padding-top: 0.35rem;
   color: var(--orange);
   font-family: var(--utility);
   font-size: 0.78rem;
@@ -1130,8 +1164,26 @@ a.briefing-chip-sources:focus-visible {
   overflow-wrap: anywhere;
   margin: 0.2rem 0 0.55rem;
   font-family: var(--display);
-  font-size: 1.45rem;
-  line-height: 1.05;
+  font-size: 1.2rem;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+#today-list {
+  padding-inline: 1.1rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--panel);
+}
+
+#today-list:empty {
+  display: none;
+}
+
+#today-view .section-title {
+  margin-bottom: 0.75rem;
+  border-bottom: 0;
+  padding-bottom: 0;
 }
 
 .record-heading p {
@@ -1960,6 +2012,7 @@ td a {
 .today-filters .search-field input {
   width: 100%;
   min-width: 0;
+  background-color: white;
 }
 
 .today-filters .date-field {
@@ -2541,6 +2594,7 @@ td a {
   margin: 0;
   padding: 0;
   border: 1px solid var(--line);
+  border-radius: var(--radius);
   background: var(--panel);
 }
 
@@ -2549,8 +2603,14 @@ td a {
   grid-template-columns: 2rem minmax(0, 16rem) minmax(0, 1fr) 6.5rem;
   gap: 0.75rem;
   align-items: center;
-  padding: 0.3rem 0.85rem;
+  padding: 0.55rem 0.85rem;
   border-bottom: 1px solid var(--line);
+  transition: background 140ms ease;
+}
+
+.leaderboard-top-row:hover,
+.leaderboard-top-row:focus-within {
+  background: color-mix(in srgb, var(--blue) 4%, var(--panel));
 }
 
 .leaderboard-top-row:last-child {
@@ -2646,23 +2706,16 @@ td a {
   margin: 1.75rem 0 2.5rem;
 }
 
-/* --canvas rather than --panel: against the main area the brighter surface
-   read as an overlay sitting on top of the page rather than part of it
-   (issue #298). The search field keeps its white fill and heavy border, so
-   the control the panel exists for still carries the contrast. */
+/* A slate search rail connects the light page to the dark score chart. The
+   white search field remains its strongest affordance. */
 .benchmark-navigator {
   position: sticky;
-  top: 1rem;
-  max-height: calc(100vh - 2rem);
+  top: 5rem;
+  max-height: calc(100vh - 6rem);
   overflow-y: auto;
   padding: 1.25rem;
   border: 1px solid var(--edge);
-  /* A real grey, not the page background. At --canvas the panel was the exact
-     colour of the page behind it, so beside the near-black figure it read as
-     something floating on the page rather than part of it. The search field
-     keeps its white fill and heavy border, so the control the panel exists for
-     still carries the contrast. */
-  background: #c3ccd1;
+  background: #e0e7eb;
   box-shadow: var(--shadow);
 }
 
@@ -2753,7 +2806,7 @@ td a {
   width: 100%;
   padding: 0.7rem 2.2rem 0.7rem 0.75rem;
   border: 1px solid #536168;
-  border-radius: 0;
+  border-radius: var(--radius-sm);
   background: #162228;
   color: #f3f6f7;
 }
@@ -4082,7 +4135,7 @@ dialog::backdrop {
 
 .stale-banner {
   margin: 0;
-  padding: 0.6rem 0;
+  padding: 0.6rem max(24px, calc((100% - 1680px) / 2));
   border-bottom: 1px solid var(--edge);
   font-family: var(--utility);
   font-size: 0.75rem;
@@ -4209,6 +4262,7 @@ footer {
 
   .masthead {
     min-height: 64px;
+    padding-block: 0.75rem;
     /* Brand plus the four-square grid exceed 320px-class viewports, so the
        controls drop to a second row instead of overflowing off-screen. */
     flex-wrap: wrap;
@@ -4216,13 +4270,13 @@ footer {
   }
 
   .masthead-end {
-    grid-template-columns: repeat(4, 2.1rem);
+    grid-template-columns: repeat(4, 44px);
     gap: 0.5rem;
   }
 
   .repo-badge {
-    width: 2.1rem;
-    height: 2.1rem;
+    width: 44px;
+    height: 44px;
   }
 
   .repo-badge::after {
@@ -4231,6 +4285,7 @@ footer {
 
   .view-nav {
     overflow-x: auto;
+    scrollbar-width: thin;
   }
 
   .view-nav button,
@@ -4314,6 +4369,27 @@ footer {
   .record-summary {
     grid-template-columns: 24px 30px minmax(0, 1fr);
     gap: 0.65rem;
+  }
+
+  .record-summary::before {
+    width: 24px;
+    height: 24px;
+  }
+
+  .record-card h3 {
+    font-size: 1.05rem;
+  }
+
+  #today-list {
+    padding-inline: 0.7rem;
+  }
+
+  input[type="search"] {
+    font-size: 1rem;
+  }
+
+  .stale-banner {
+    padding-inline: 14px;
   }
 
   /* Needed because `.record-summary.record-summary-unranked` carries two
@@ -4545,13 +4621,13 @@ footer {
 
 .benchmark-search-input {
   width: 100%;
-  padding: 0.6rem 0.7rem;
+  padding: 0.6rem 0.7rem 0.6rem 2.5rem;
   /* Ink, not `--edge`. This border is the affordance that tells a reader the
      panel's whole point is to be typed into -- it is not a divider, so the
      softening the rest of the page got would read here as "disabled". */
   border: 2px solid var(--ink);
   border-radius: var(--radius-sm);
-  background: white;
+  background-color: white;
   color: inherit;
   font: inherit;
   font-size: 0.95rem;
@@ -4610,26 +4686,29 @@ footer {
 
 .benchmark-result {
   display: flex;
+  flex-shrink: 0;
   flex-direction: column;
   gap: 0.2rem;
   width: 100%;
-  padding: 0.5rem 0.6rem;
-  border: 1px solid var(--border);
+  min-height: 44px;
+  padding: 0.65rem 0.7rem;
+  border: 1px solid transparent;
   border-radius: 6px;
-  background: var(--surface);
+  background: var(--panel);
   color: inherit;
   text-align: left;
   cursor: pointer;
+  transition: border-color 140ms ease, background 140ms ease;
 }
 
 .benchmark-result:hover,
 .benchmark-result:focus-visible {
-  border-color: var(--accent);
+  border-color: var(--blue);
 }
 
 .benchmark-result[aria-pressed="true"] {
-  border-color: var(--accent);
-  background: var(--surface-strong, var(--surface));
+  border-color: var(--blue);
+  background: color-mix(in srgb, var(--blue) 9%, var(--panel));
 }
 
 .benchmark-result-name {
@@ -4654,15 +4733,15 @@ footer {
 /* Openness is a statement about what we know, so `unknown` is neutral rather
    than a warning. Only a positive verdict gets emphasis. */
 .benchmark-openness {
-  border: 1px solid var(--border);
+  border: 1px solid var(--line);
   border-radius: 999px;
   padding: 0.05rem 0.45rem;
   font-size: 0.72rem;
 }
 
 .benchmark-openness-open {
-  border-color: var(--accent);
-  color: var(--accent);
+  border-color: var(--blue);
+  color: var(--blue);
 }
 
 /* Issue #240 collapse defaults: the findings panel and the adoption table are
@@ -4993,12 +5072,9 @@ footer {
   border-radius: var(--radius-sm);
 }
 
-/* The selected navigation item is the only solid dark block on the page, so
-   leaving it square made it the one hard-cornered shape among rounded ones.
-   Rounded at the top only: it sits on the nav's bottom rule and reads as a tab
-   attached to the page below it, not as a floating chip. */
+/* The active view keeps the familiar ink fill within the shared navigation. */
 .view-nav .nav-active {
-  border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+  border-radius: var(--radius-sm);
 }
 
 dialog {
@@ -5040,7 +5116,7 @@ dialog {
   justify-content: space-between;
   flex-wrap: wrap;
   gap: 1rem;
-  margin-bottom: .5rem;
+  margin-bottom: 1rem;
 }
 .score-browse-header h1 {
   margin: 0;
@@ -5048,20 +5124,65 @@ dialog {
   max-width: none;
 }
 .score-filter { display: flex; align-items: center; gap: .6rem; margin-bottom: 1.25rem; }
-.score-filter input[type="range"] { flex: 1 1 auto; max-width: 20rem; accent-color: var(--blue); }
+.score-filter input[type="range"] {
+  flex: 1 1 auto;
+  min-width: 5rem;
+  max-width: 20rem;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  accent-color: var(--blue);
+  cursor: pointer;
+}
 .score-filter output {
+  padding: .25rem .55rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--panel);
+  color: var(--blue-deep);
+  text-align: center;
   font-variant-numeric: tabular-nums;
   font-weight: 600;
   min-width: 2.5rem;
 }
 /* Time × score × the selected raw count. */
-.benchmark-skyline { margin: 0 0 2rem; }
+.benchmark-skyline {
+  margin: 0 0 2rem;
+  padding: clamp(1rem, 2vw, 1.5rem);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius);
+  background: var(--panel);
+  box-shadow: var(--shadow);
+}
+.skyline-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: .5rem 1.5rem;
+  margin-top: 1rem;
+  padding: .55rem .85rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--canvas);
+}
+.skyline-toolbar .score-filter {
+  flex: 1 1 36rem;
+  margin: 0;
+  font-size: .85rem;
+}
+.skyline-toolbar .skyline-height-control {
+  margin: 0;
+  min-width: 0;
+  max-width: 100%;
+}
 .skyline-heading { display: flex; justify-content: space-between; align-items: center; gap: 1rem; }
 .skyline-heading h2 { font-size: 1.5rem; margin: 0; }
 .skyline-subtitle { margin: .15rem 0 0; color: var(--muted); font-size: 1rem; }
 .skyline-count { color: #876014; font-size: .9rem; font-weight: 600; white-space: nowrap; }
 .skyline-height-control { display: flex; align-items: center; gap: .6rem; margin-top: .85rem; color: var(--muted); font-size: .875rem; }
-.skyline-height-control select { max-width: 100%; padding: .4rem 1.7rem .4rem .6rem; color: var(--ink); background: var(--panel); border: 1px solid var(--edge); border-radius: 6px; font: inherit; }
+.skyline-height-control select { min-width: 0; max-width: 100%; padding: .4rem 1.7rem .4rem .6rem; color: var(--ink); background: var(--panel); border: 1px solid var(--edge); border-radius: 6px; font: inherit; }
 .skyline-chart { overflow-x: auto; margin-top: .5rem; }
 .skyline-chart svg { display: block; width: 100%; min-width: 1100px; max-width: 1300px; margin: 0 auto; }
 .skyline-chart svg.skyline-has-undated { min-width: 1500px; max-width: 1830px; }
@@ -5156,9 +5277,14 @@ dialog {
 .skyline-swatch-unknown { background: var(--panel); border: 1.5px solid var(--muted); }
 .skyline-swatch-proxy { background: var(--panel); border: 1.5px dashed var(--muted); }
 .skyline-source-coverage { margin: .25rem 0 .7rem; color: var(--muted); font-size: .8rem; }
-.skyline-caption { position: relative; padding-right: 2.5rem; margin-top: .7rem; }
+.skyline-caption {
+  position: relative;
+  padding: .75rem 2.5rem 0 0;
+  margin-top: .7rem;
+  border-top: 1px solid var(--line);
+}
 .skyline-caption .skyline-method { margin: 0; }
-.skyline-caption .skyline-method > summary { position: absolute; top: .1rem; right: 0; }
+.skyline-caption .skyline-method > summary { position: absolute; top: .85rem; right: 0; }
 .skyline-method-body { margin-top: .9rem; padding: .25rem 1rem; border-left: 2px solid var(--line); color: var(--muted); font-size: .875rem; max-width: 85ch; }
 .skyline-method:not([open]) > .skyline-method-body { display: none; }
 .skyline-method-body p { margin: .5rem 0; line-height: 1.6; }
@@ -5168,6 +5294,12 @@ dialog {
   .skyline-count { margin: .3rem 0; }
   .score-filter { flex-wrap: wrap; }
   .score-filter > span { flex-basis: 100%; }
+  .skyline-toolbar .skyline-height-control {
+    flex-direction: column;
+    align-items: stretch;
+    gap: .25rem;
+    width: 100%;
+  }
 }
 .score-source-heading { font-size: .8rem; margin: 1rem 0 .4rem; color: var(--muted); }
 .score-browse-result { align-items: flex-start; flex-direction: column; gap: .25rem; }

--- a/site/index.html
+++ b/site/index.html
@@ -210,12 +210,41 @@
     <a class="skip-link" href="#main-content" data-i18n="Skip to content">Skip to content</a>
 
     <header class="masthead">
-      <a class="brand" href="/" aria-label="Benchmark Radar home">
-        <span class="brand-mark" aria-hidden="true">
-          <span></span>
-        </span>
-        <strong>Benchmark Radar</strong>
-      </a>
+      <div class="masthead-main">
+        <a class="brand" href="/" aria-label="Benchmark Radar home">
+          <span class="brand-mark" aria-hidden="true">
+            <span></span>
+          </span>
+          <strong>Benchmark Radar</strong>
+        </a>
+        <nav class="view-nav" aria-label="Dashboard views" data-i18n-aria="Dashboard views">
+          <button type="button" class="nav-active" data-view="today" aria-controls="today-view" aria-current="page" data-i18n="Today">Today</button>
+          <a
+            href="/cli/"
+            id="cli-nav"
+            aria-haspopup="dialog"
+            aria-controls="cli-dialog"
+            aria-expanded="false"
+            data-i18n="CLI"
+          >
+            CLI
+          </a>
+          <!-- Real links, not tab buttons. Each one is this same dashboard served
+               at its own path with that view already open and its rows already in the
+               HTML, so a crawler and a reader with a slow connection both get content
+               from the first response. app.js intercepts the click and keeps the
+               navigation client-side for anyone whose script has loaded. -->
+          <a href="/leaderboard/" data-view="leaderboard" aria-controls="leaderboard-view" data-i18n="Leaderboard">
+            Leaderboard
+          </a>
+          <a href="/saturation/" data-view="saturation" aria-controls="saturation-view" data-i18n="Saturation">Saturation</a>
+          <a href="/trends/" data-view="trends" aria-controls="trends-view" data-i18n="Trends">Trends</a>
+          <!-- The blog is a set of documents, not a dashboard view, so this link
+               carries no data-view: app.js only intercepts clicks on elements that
+               have one, and a brief has to arrive as a full page load. -->
+          <a href="/blog/" data-i18n="Blog">Blog</a>
+        </nav>
+      </div>
       <div class="masthead-end" aria-label="Site utilities" data-i18n-aria="Site utilities">
         <a
           class="repo-badge feed-badge"
@@ -291,34 +320,6 @@
     </header>
 
     <p class="stale-banner" id="stale-banner" hidden></p>
-
-    <nav class="view-nav" aria-label="Dashboard views" data-i18n-aria="Dashboard views">
-      <button type="button" class="nav-active" data-view="today" aria-controls="today-view" aria-current="page" data-i18n="Today">Today</button>
-      <a
-        href="/cli/"
-        id="cli-nav"
-        aria-haspopup="dialog"
-        aria-controls="cli-dialog"
-        aria-expanded="false"
-        data-i18n="CLI"
-      >
-        CLI
-      </a>
-      <!-- Real links, not tab buttons. Each one is this same dashboard served
-         at its own path with that view already open and its rows already in the
-         HTML, so a crawler and a reader with a slow connection both get content
-         from the first response. app.js intercepts the click and keeps the
-         navigation client-side for anyone whose script has loaded. -->
-      <a href="/leaderboard/" data-view="leaderboard" aria-controls="leaderboard-view" data-i18n="Leaderboard">
-        Leaderboard
-      </a>
-      <a href="/saturation/" data-view="saturation" aria-controls="saturation-view" data-i18n="Saturation">Saturation</a>
-      <a href="/trends/" data-view="trends" aria-controls="trends-view" data-i18n="Trends">Trends</a>
-      <!-- The blog is a set of documents, not a dashboard view, so this link
-           carries no data-view: app.js only intercepts clicks on elements that
-           have one, and a brief has to arrive as a full page load. -->
-      <a href="/blog/" data-i18n="Blog">Blog</a>
-    </nav>
 
     <main id="main-content" tabindex="-1">
       <section class="view" id="today-view" aria-label="Today">
@@ -796,11 +797,7 @@
 
       <section class="view" id="trends-view" aria-labelledby="trends-heading" hidden>
         <header class="view-heading">
-          <div>
-            <p class="eyebrow" data-i18n="Recent activity">Recent activity</p>
-            <h1 id="trends-heading" data-i18n="Signals over time">Signals over time</h1>
-          </div>
-          <p class="heading-note" data-i18n="trends.heading.note">Counts describe discovery volume, not scientific quality.</p>
+          <h1 id="trends-heading" data-i18n="Trend">Trend</h1>
         </header>
 
         <div class="domain-panel">

--- a/site/index.html
+++ b/site/index.html
@@ -483,24 +483,26 @@
               <p class="skyline-subtitle" data-i18n="Which difficult benchmarks have been tested most">Which difficult benchmarks have been tested most</p>
             </div>
           </div>
-          <label class="score-filter" for="leaderboard-score-filter">
-            <span data-i18n="Show benchmarks with highest reported score below:">Show benchmarks with highest reported score below:</span>
-            <input id="leaderboard-score-filter" name="lscore" type="range" min="10" max="100" step="10" value="70" list="score-filter-steps" data-score-filter aria-controls="benchmark-skyline-chart">
-            <output id="leaderboard-score-value" for="leaderboard-score-filter">70</output>
-          </label>
-          <datalist id="score-filter-steps">
-            <option value="10"></option><option value="20"></option><option value="30"></option>
-            <option value="40"></option><option value="50"></option><option value="60"></option>
-            <option value="70"></option><option value="80"></option><option value="90"></option>
-            <option value="100" label="All"></option>
-          </datalist>
-          <label class="skyline-height-control" for="benchmark-skyline-height">
-            <span data-i18n="Height">Height</span>
-            <select id="benchmark-skyline-height">
-              <option value="models" data-i18n="Models with reported scores">Models with reported scores</option>
-              <option value="documents" data-i18n="Source documents">Source documents</option>
-            </select>
-          </label>
+          <div class="skyline-toolbar">
+            <label class="score-filter" for="leaderboard-score-filter">
+              <span data-i18n="Show benchmarks with highest reported score below:">Show benchmarks with highest reported score below:</span>
+              <input id="leaderboard-score-filter" name="lscore" type="range" min="10" max="100" step="10" value="70" list="score-filter-steps" data-score-filter aria-controls="benchmark-skyline-chart">
+              <output id="leaderboard-score-value" for="leaderboard-score-filter">70</output>
+            </label>
+            <datalist id="score-filter-steps">
+              <option value="10"></option><option value="20"></option><option value="30"></option>
+              <option value="40"></option><option value="50"></option><option value="60"></option>
+              <option value="70"></option><option value="80"></option><option value="90"></option>
+              <option value="100" label="All"></option>
+            </datalist>
+            <label class="skyline-height-control" for="benchmark-skyline-height">
+              <span data-i18n="Height">Height</span>
+              <select id="benchmark-skyline-height">
+                <option value="models" data-i18n="Models with reported scores">Models with reported scores</option>
+                <option value="documents" data-i18n="Source documents">Source documents</option>
+              </select>
+            </label>
+          </div>
           <div class="frontier-chart skyline-chart" id="benchmark-skyline-chart" tabindex="0" role="region" aria-label="Benchmark Frontier chart" data-i18n-aria="Benchmark Frontier chart"></div>
           <div class="skyline-caption">
             <div id="benchmark-skyline-legend" aria-label="Chart legend" data-i18n-aria="Chart legend"></div>

--- a/src/benchmark_radar/blog.py
+++ b/src/benchmark_radar/blog.py
@@ -155,15 +155,14 @@ def _index_page(
         title, heading, description = _INDEX_TITLE, _INDEX_HEADING, _INDEX_DESCRIPTION
         action = f'<a class="secondary-link" href="{BLOG_ARCHIVE_PATH}">Full archive</a>'
         crumb = "Blog"
-    count = (
-        f"{len(shown)} of {len(posts)} collection days"
-        if not archive and len(shown) < len(posts)
-        else f"{len(posts)} collection days"
-    )
+    details = ""
+    if archive:
+        details = (
+            f'<p class="blog-lede">{esc(description)}</p>'
+            f'<p class="blog-meta">{len(posts)} collection days</p>'
+        )
     body = f"""<header class="blog-hero">
-  <p class="eyebrow">Daily brief</p><h1>{esc(heading)}</h1>
-  <p class="blog-lede">{esc(description)}</p>
-  <p class="blog-meta">{esc(count)}</p>
+  <h1>{esc(heading)}</h1>{details}
   <div class="blog-actions">{action}
     <a class="secondary-link" href="{BLOG_FEED_PATH}">RSS</a></div>
 </header>
@@ -284,7 +283,7 @@ def _chrome_i18n_script(chrome: SiteChrome, app_js: str) -> dict[str, str]:
     them with the same contract. Keys come from the chrome itself, so a new
     badge or nav label is covered without touching this function.
     """
-    chrome_html = chrome.header + chrome.navigation + chrome.footer
+    chrome_html = chrome.header + chrome.footer
     keys = set(re.findall(r'data-i18n(?:-title|-aria)?="([^"]+)"', chrome_html))
     keys.update(_TOGGLE_I18N_KEYS)
     keys.update(_BADGE_I18N_KEYS)

--- a/src/benchmark_radar/blog_shell.py
+++ b/src/benchmark_radar/blog_shell.py
@@ -94,10 +94,9 @@ class BlogPost:
 
 @dataclass(frozen=True)
 class SiteChrome:
-    """The masthead, section nav, and footer extracted from ``index.html``."""
+    """The masthead and footer extracted from ``index.html``."""
 
     header: str
-    navigation: str
     footer: str
 
 
@@ -177,6 +176,8 @@ def _adapt_navigation(nav: str) -> str:
 
 def _adapt_header(header: str) -> str:
     header = _strip_comments(header)
+    navigation = _region(header, r'<nav class="view-nav".*?</nav>', "section nav")
+    header = header.replace(navigation, _adapt_navigation(navigation), 1)
     # Same host-relative rule as the section nav: the badge keeps the site
     # feed, but a local preview or mirror must not eject to the canonical
     # domain on click.
@@ -219,13 +220,11 @@ def _page_footer(footer: str, updated: str) -> str:
 
 
 def extract_site_chrome(dashboard_html: str) -> SiteChrome:
-    """Pull the shared masthead, nav, and footer out of ``site/index.html``."""
+    """Pull the shared masthead and footer out of ``site/index.html``."""
     header = _region(dashboard_html, r'<header class="masthead">.*?</header>', "masthead")
-    navigation = _region(dashboard_html, r'<nav class="view-nav".*?</nav>', "section nav")
     footer = _region(dashboard_html, r"<footer>.*?</footer>", "footer")
     return SiteChrome(
         header=_adapt_header(header),
-        navigation=_adapt_navigation(navigation),
         footer=_strip_comments(footer),
     )
 
@@ -284,7 +283,6 @@ def render_page(
 <body class="blog-page">
 <a class="skip-link" href="#main-content">Skip to content</a>
 {chrome.header}
-{chrome.navigation}
 <main id="main-content" tabindex="-1"><div class="blog-view">{body}</div></main>
 {_page_footer(chrome.footer, updated)}
 </body>

--- a/tests/test_app_pages.py
+++ b/tests/test_app_pages.py
@@ -270,6 +270,9 @@ def test_each_generated_page_marks_its_navigation_entry_current(tmp_path):
     }
     for path, identifying_attribute in ids.items():
         page = (tmp_path / path / "index.html").read_text(encoding="utf-8")
+        header = re.search(r'<header class="masthead".*?</header>', page, re.S).group(0)
+        assert page.count('<nav class="view-nav"') == 1
+        assert '<nav class="view-nav"' in header
         opening = re.search(
             rf"<(?:a|button)\b(?=[^>]*{re.escape(identifying_attribute)})[^>]*>", page
         )

--- a/tests/test_blog.py
+++ b/tests/test_blog.py
@@ -481,6 +481,16 @@ def test_blog_nav_lists_the_same_sections_in_the_same_order_as_the_dashboard(tmp
     assert 'class="nav-active" aria-current="page" href="/blog/"' in page
 
 
+def test_blog_index_leads_with_one_title_without_repeating_its_metadata(tmp_path):
+    write_blog_with_chrome([_briefed(), _legacy()], tmp_path)
+    page = (tmp_path / "blog" / "index.html").read_text(encoding="utf-8")
+    hero = re.search(r'<header class="blog-hero">.*?</header>', page, re.S).group(0)
+    assert "<h1>What changed in AI evaluation, and why it matters</h1>" in hero
+    assert "Daily brief" not in hero
+    assert "One page per collection day" not in hero
+    assert "collection days" not in hero
+
+
 def test_dashboard_and_blog_share_the_reduced_chrome_contract(tmp_path):
     write_blog_with_chrome([_briefed()], tmp_path)
     page = (tmp_path / "blog" / "2026-08-30" / "index.html").read_text(encoding="utf-8")
@@ -495,6 +505,8 @@ def test_dashboard_and_blog_share_the_reduced_chrome_contract(tmp_path):
     for document in (DASHBOARD_HTML, page):
         assert _nav_targets(document) == expected
         header = re.search(r'<header class="masthead".*?</header>', document, re.S).group(0)
+        assert document.count('<nav class="view-nav"') == 1
+        assert '<nav class="view-nav"' in header
         numbered = []
         for anchor in re.finditer(r"<a\b([^>]*)>(.*?)</a>", header, re.S):
             if "data-count" not in anchor.group(2):

--- a/tests/test_saturation_view.py
+++ b/tests/test_saturation_view.py
@@ -267,7 +267,7 @@ def test_the_search_field_carries_the_panel_weight_through_affordance():
 
     field = styles.split(".benchmark-search-input {", 1)[1].split("}", 1)[0]
     assert "border: 2px solid var(--ink)" in field
-    assert "background: white" in field
+    assert "background-color: white" in field
 
     label = styles.split(".benchmark-search-label {", 1)[1].split("}", 1)[0]
     assert "font-size: 0.78rem" in label, "the label must not grow"

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1316,6 +1316,7 @@ def test_static_html_references_existing_local_assets():
         "data/radar.json",
         "blog/",
         "leaderboard/",
+        "saturation/",
         "trends/",
         "explore/",
         "rubric/",

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -437,7 +437,14 @@ def test_top_right_utilities_use_shared_icon_geometry_and_contact_control():
     assert ".repo-badges" not in styles
     assert 'class="repo-badge-glyph" id="lang-toggle-label">中<' in html
     assert 'class="brand-icon github-icon"' in html
-    assert "grid-template-columns: repeat(4, 2.1rem)" in styles
+    assert "grid-template-columns: repeat(4, 44px)" in styles
+    mobile_badge = (
+        styles.split("@media (max-width: 760px)", 1)[1]
+        .split(".repo-badge {", 1)[1]
+        .split("}", 1)[0]
+    )
+    assert "width: 44px" in mobile_badge
+    assert "height: 44px" in mobile_badge
     assert "flex: 0 0 1.5rem" in styles
     assert ".repo-badge svg," in styles
 

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -269,6 +269,22 @@ def test_visible_navigation_items_use_the_same_active_state():
     assert '.view-nav button[aria-current="page"]' not in styles
 
 
+def test_primary_section_titles_share_compact_spacing_and_trends_uses_one_title():
+    html = Path("site/index.html").read_text(encoding="utf-8")
+    styles = Path("site/assets/styles.css").read_text(encoding="utf-8")
+    compact = styles.split("#leaderboard-view,", 1)[1].split("}", 1)[0]
+    assert "#saturation-view," in compact
+    assert "#trends-view" in compact
+    score_header = styles.split(".score-browse-header {", 1)[1].split("}", 1)[0]
+    assert "align-items: flex-start" in score_header
+    assert ".score-browse-header > .score-filter { margin-bottom: 0; }" in styles
+    trends = html.split('id="trends-view"', 1)[1].split("</section>", 1)[0]
+    assert '<h1 id="trends-heading" data-i18n="Trend">Trend</h1>' in trends
+    assert "Recent activity" not in trends
+    assert "Signals over time" not in trends
+    assert "Counts describe discovery volume" not in trends
+
+
 def test_recommendation_threshold_does_not_gate_inclusion_and_rows_carry_no_badge():
     script = Path("site/assets/app.js").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- polish navigation, controls, cards, search, and Benchmark Frontier layout
- place the dashboard menubar beside the Benchmark Radar brand across dashboard and Blog routes
- tighten Leaderboard, Saturation, Trend, and Blog title spacing and simplify verbose headings per #581
- keep generated Blog and dashboard routes on the shared masthead contract with regression coverage
- document the title-spacing and collapsed-context rules in design.md

## Validation
- Ruff check: passed
- Ruff format check: passed
- Focused UI, Blog, and generated-page tests: 213 passed
- Chrome QA: verified Blog → Trends navigation and equal 28px title offsets across Leaderboard, Saturation, Trend, and Blog
- CLI/data generators were not part of the focused validation.