### PR TITLE
Require explicit request before touching main or the paper pointer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,8 +74,11 @@ Applies to `README*`, `docs/**`, `.github/ISSUE_TEMPLATE/**`, `site/**`,
   signal. Avoid jargon-heavy summaries that only say what changed; explain why
   the change matters to someone reading, reviewing, or sharing the project.
 
-## Pull request merges
+## Branches and pull requests
 
+- Keep work on the task branch. Update local or remote `main`, or merge a pull
+  request, only when the user explicitly requests it. Creating or updating a PR
+  does not authorize a merge.
 - Do not squash-merge pull requests.
 - Merge pull requests with a merge commit so Git preserves branch ancestry and recognizes the branch as merged.
 
@@ -178,9 +181,12 @@ inputs retain their source spelling.
 
 The paper lives in `ktwu01/benchmark-radar-paper`, mounted as a Git submodule at
 `docs/technical-report/latex`. Initialize it with
-`git submodule update --init --recursive`, including in clean worktrees. Commit
-and push paper edits in that repository first, then commit the reviewed submodule
-pointer here. Overleaf sync changes the paper repository, not this pinned pointer.
+`git submodule update --init --recursive`, including in clean worktrees. Keep
+paper-only edits and PRs in the paper repository by default. Update the parent
+Benchmark Radar repository, including its submodule pointer, only when the user
+explicitly requests it. For a requested pointer update, push the reviewed paper
+commit first, then commit the pointer here. Overleaf sync changes the paper
+repository, not this pinned pointer.
 
 - Report source: `docs/technical-report/latex/main.tex`. This is the single
   source of truth for the report. Edit it directly. Nothing generates it from

--- a/docs/technical-report/README.md
+++ b/docs/technical-report/README.md
@@ -47,5 +47,7 @@ CSV and JSON provide all records and their available measurements.
 Verify the exported hashes against the paper README and preserve the release
 cutoff. For manuscript edits, rebuild and inspect the figures and manuscript using the
 [paper's build instructions](https://github.com/ktwu01/benchmark-radar-paper#build-locally).
-Commit and push the reviewed changes in the paper repository first, then commit
-the updated `docs/technical-report/latex` submodule pointer in Benchmark Radar.
+Commit and push the reviewed changes in the paper repository. Keep paper-only
+work there by default. Update Benchmark Radar's `docs/technical-report/latex`
+submodule pointer only when the user explicitly requests it, after pushing the
+reviewed paper commit.


### PR DESCRIPTION
## Summary
- AGENTS.md: rename "Pull request merges" section to "Branches and pull requests" and require explicit user request before updating local/remote `main` or merging a PR
- AGENTS.md / docs/technical-report/README.md: require explicit user request before updating the `docs/technical-report/latex` submodule pointer in this repo (paper-only edits stay in the paper repo by default)

## Test plan
- Docs-only change; no build/test impact.