### PR TITLE
Describe the score sources accurately in both READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,13 @@ and [Hacker News](https://news.ycombinator.com), plus first-party lab feeds from
 [IBM Research](https://research.ibm.com), [Databricks](https://www.databricks.com),
 [LangChain](https://www.langchain.com/blog), and [Meituan Engineering](https://tech.meituan.com).
 
-The frontier-model score layer, including the SWE-bench Verified timeline above,
-is built on benchmark data collected by [LLM Stats](https://llm-stats.com).
-Thank you for keeping that data open.
+The frontier-model scores draw on three kinds of source. Lab model reports and
+system cards supply the SWE-bench Verified timeline shown above. Nearly all the
+remaining model scores come from [Artificial Analysis](https://artificialanalysis.ai)
+and [LLM Stats](https://llm-stats.com), and every score keeps a citation to the
+source it was read from. Thank you both for publishing that data openly. The
+wider benchmark catalog adds [OpenCompass Hub](https://hub.opencompass.org.cn)
+as a fourth source.
 
 A special thank you to [Xiaopai Liu](https://github.com/liuxiaopai-ai)
 ([@bourneliu66](https://x.com/bourneliu66)) for the shout-out on X, and to his

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -129,7 +129,7 @@ npx skills add ktwu01/benchmark-radar
 
 每日信息流也接入了 [Crossref](https://www.crossref.org) 的公开 DOI 元数据。
 
-前沿模型分数层（包括上方的 SWE-bench Verified 时间线）基于 [LLM Stats](https://llm-stats.com) 采集的 benchmark 数据构建，感谢他们把这些数据公开出来。
+前沿模型分数综合了三类来源。上方的 SWE-bench Verified 时间线来自各家实验室的模型报告和 system card；其余的模型分数几乎都来自 [Artificial Analysis](https://artificialanalysis.ai) 和 [LLM Stats](https://llm-stats.com)，每条分数都保留了原始来源引用。感谢两家把数据公开出来。更大范围的 benchmark 目录还有第四类来源 [OpenCompass Hub](https://hub.opencompass.org.cn)。
 
 特别感谢 [Xiaopai Liu](https://github.com/liuxiaopai-ai)（[@bourneliu66](https://x.com/bourneliu66)）在 X 上为 Benchmark Radar 宣传，也感谢他的每日 builder 简报 [BuilderPulse](https://github.com/BuilderPulse/BuilderPulse)。
 


### PR DESCRIPTION
The acknowledgement paragraph said the frontier-model score layer "is built on benchmark data collected by LLM Stats." That was inaccurate on two counts, both checked against the repo's own data.

**LLM Stats is one of three sources, not the basis.** `site/data/models.json` source counts are Artificial Analysis 594, LLM Stats 339, model reports 53.

**The SWE-bench Verified timeline is not LLM Stats data.** The README GIF links to `/saturation/?lfrontier=swe_bench_verified`, which resolves to the record whose `source` is `model_reports` (lab system cards). A separate `llm-stats-swe-bench-verified` record exists, but it is not the timeline the sentence pointed at.

## Changes

Both READMEs now say the scores draw on three kinds of source, name lab model reports as the SWE-bench timeline's actual source, credit Artificial Analysis and LLM Stats for nearly all remaining model scores, and add OpenCompass Hub as the wider catalog's fourth source. Line 51 already named all four; the acknowledgement had dropped OpenCompass.

## On the LLM Stats license

Their [terms](https://llm-stats.com/legal/terms-of-service) are more permissive than the old wording implied: reuse and modification are allowed, including commercially, with attribution as the only condition. Credit must be "in a place visible to your users, with a link back to llm-stats.com."

That condition is not currently met on the website itself, where no page links back. A follow-up PR adds the credit to the `/cite/` page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)