### PR TITLE
Credit the score sources on the citation page

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -983,6 +983,8 @@ const I18N = {
     "Copy it with your keyboard": "请用键盘复制",
     "Citation file (.cff)": "引用文件 (.cff)",
     "View the citation file": "查看引用文件",
+    "Benchmark score data comes from lab model reports and from":
+      "benchmark 分数数据来自各家实验室的模型报告，以及",
     CLI: "命令行",
     "This search covers all dates.": "此处搜索全部日期的结果。",
     "Still want today's results?": "仍要搜索今天的，请",
@@ -8504,6 +8506,44 @@ function finishUtilityClose(utility, ownsHistoryEntry) {
   writeUrl("replace");
 }
 
+// The catalogs the score layer reads. LLM Stats asks for credit visible to
+// readers with a link back; this is the mirror of SCORE_SOURCE_LINKS in
+// app_seeds.py, and the two must render the same sentence or the seed and the
+// hydrated card disagree.
+const SCORE_SOURCE_LINKS = [
+  ["LLM Stats", "https://llm-stats.com"],
+  ["Artificial Analysis", "https://artificialanalysis.ai"],
+  ["OpenCompass Hub", "https://hub.opencompass.org.cn"],
+];
+
+// Deliberately quiet: it closes the card as a footnote under the formats the
+// reader came for, so it carries no button styling and no heading.
+function citeCredit() {
+  const node = element("p", { className: "cite-credit" });
+  node.append(
+    document.createTextNode(
+      `${t("Benchmark score data comes from lab model reports and from")} `,
+    ),
+  );
+  SCORE_SOURCE_LINKS.forEach(([name, url], index) => {
+    if (index > 0) {
+      node.append(
+        document.createTextNode(
+          index === SCORE_SOURCE_LINKS.length - 1 ? ` ${t("and")} ` : ", ",
+        ),
+      );
+    }
+    node.append(
+      element("a", {
+        text: name,
+        attrs: { href: url, target: "_blank", rel: "noopener noreferrer" },
+      }),
+    );
+  });
+  node.append(document.createTextNode("."));
+  return node;
+}
+
 // Reachable at /cite/, so the card has a short link that can be pasted into a
 // paper, a README or a message instead of a reader hunting the footer for it.
 function openCite(updateUrl = true) {
@@ -8539,6 +8579,7 @@ function openCite(updateUrl = true) {
       text: t("View the citation file"),
       attrs: { href: CITE_CFF_URL, target: "_blank", rel: "noopener noreferrer" },
     }),
+    citeCredit(),
   ]);
   showModalDialog(dialog);
 }

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -3947,6 +3947,23 @@ dialog::backdrop {
   margin: 1.5rem 0;
 }
 
+/* The source credit closes the citation card, so it is deliberately quiet: a
+   footnote under the formats a reader came for, not a section competing with
+   them. LLM Stats asks for credit visible to readers with a link back, and a
+   line nobody can find would not honor that, so it stays legible while staying
+   small. */
+.cite-credit {
+  margin: 1.6rem 0 0;
+  color: var(--muted);
+  font-size: 0.78rem;
+  line-height: 1.5;
+}
+
+.cite-credit a {
+  color: inherit;
+  text-decoration: underline;
+}
+
 .copy-label {
   margin: 0 0 0.5rem;
   color: var(--muted);

--- a/src/benchmark_radar/app_seeds.py
+++ b/src/benchmark_radar/app_seeds.py
@@ -586,6 +586,17 @@ url = {https://zenodo.org/records/22167102},
 year = {2026}
 }"""
 
+# The catalogs the score layer reads. LLM Stats asks for credit visible to
+# readers with a link back, and the citation card is where a reader goes to ask
+# where this data came from, so the credit lives there rather than in a file
+# only contributors open.
+SCORE_SOURCE_LINKS: tuple[tuple[str, str], ...] = (
+    ("LLM Stats", "https://llm-stats.com"),
+    ("Artificial Analysis", "https://artificialanalysis.ai"),
+    ("OpenCompass Hub", "https://hub.opencompass.org.cn"),
+)
+CITE_CREDIT_LEAD = "Benchmark score data comes from lab model reports and from"
+
 CLI_SKILL_URL = (
     "https://github.com/ktwu01/benchmark-radar/blob/main/skills/benchmark-radar/SKILL.md"
 )
@@ -612,6 +623,16 @@ def _copy_block(label: str, value: str, hint: str, hide_label: bool = False) -> 
     )
 
 
+def _cite_credit() -> str:
+    """The sentence both renderers draw, so the seed and app.js cannot drift."""
+    links = [
+        f'<a href="{esc(url)}" target="_blank" rel="noopener noreferrer">{esc(name)}</a>'
+        for name, url in SCORE_SOURCE_LINKS
+    ]
+    joined = f"{', '.join(links[:-1])} and {links[-1]}"
+    return f"{esc(CITE_CREDIT_LEAD)} {joined}."
+
+
 def _cite_seed() -> dict[str, str]:
     blocks = "".join(
         (
@@ -630,6 +651,7 @@ def _cite_seed() -> dict[str, str]:
         '<a class="secondary-link dialog-link" '
         f'href="{esc(CITE_CFF_URL)}" target="_blank" rel="noopener noreferrer">'
         "View the citation file</a>"
+        f'<p class="cite-credit">{_cite_credit()}</p>'
     )
     return {'<div id="cite-content"></div>': (f'<div id="cite-content" data-seed>{content}</div>')}
 

--- a/tests/test_app_pages.py
+++ b/tests/test_app_pages.py
@@ -22,6 +22,7 @@ from benchmark_radar.app_pages import (
     render_app_page,
     write_app_pages,
 )
+from benchmark_radar.app_seeds import SCORE_SOURCE_LINKS
 from benchmark_radar.feed import SITE_URL
 from benchmark_radar.site_shell import esc
 
@@ -376,6 +377,42 @@ def test_seeded_copy_controls_have_names_values_and_fallback_hints(tmp_path):
             assert 'aria-label="' in attributes
             assert '<code class="copy-text">' in content
             assert '<span class="copy-status">' in content
+
+
+def test_cite_page_credits_its_score_sources_with_links(tmp_path):
+    """LLM Stats grants reuse on one condition: credit visible to readers with
+    a link back. The README is not where readers are; the citation card is. If
+    this assertion ever fails, the site is out of compliance, not just untidy.
+    """
+    _write(tmp_path, _dashboard())
+    page = (tmp_path / "cite" / "index.html").read_text(encoding="utf-8")
+    for name, url in SCORE_SOURCE_LINKS:
+        assert f'href="{url}"' in page, f"{name} lost its link back"
+        assert f">{name}</a>" in page
+    # Lab model reports are publications, not a site, so they are named without
+    # a link -- but they must still be named, because they supply scores too.
+    assert "lab model reports" in page
+
+
+def test_cite_credit_is_the_same_sentence_in_both_renderers():
+    """The seed is what a crawler and a script-disabled reader get; app.js
+    overwrites it on first paint. A credit in only one of them is a credit that
+    half the readers never see, so the source list has to match exactly.
+    """
+    script = (SITE / "assets" / "app.js").read_text(encoding="utf-8")
+    for name, url in SCORE_SOURCE_LINKS:
+        assert f'["{name}", "{url}"]' in script, f"app.js and the seed disagree on {name}"
+    assert "citeCredit()" in script
+    assert 'className: "cite-credit"' in script
+
+
+def test_cite_credit_strings_are_translated():
+    """Nothing else catches an untranslated t() key: it falls back to English
+    silently, so the zh reader sees a stray English sentence.
+    """
+    script = (SITE / "assets" / "app.js").read_text(encoding="utf-8")
+    assert '"Benchmark score data comes from lab model reports and from":' in script
+    assert "benchmark 分数数据来自各家实验室的模型报告，以及" in script
 
 
 def test_no_page_ships_a_second_url_for_itself(tmp_path):


### PR DESCRIPTION
LLM Stats grants reuse, including commercial use, on one condition: credit `llm-stats.com` "in a place visible to your users, with a link back" ([terms](https://llm-stats.com/legal/terms-of-service)). The only link lived in the README, and no page on benchmark-radar.org linked back. The citation card is where a reader goes to ask where this data came from, so the credit closes that card.

## What it looks like

A single muted sentence, last in the panel, after "View the citation file":

> Benchmark score data comes from lab model reports and from LLM Stats, Artificial Analysis and OpenCompass Hub.

Deliberately quiet by request: no heading, no card, no border, no button styling. It is a footnote under the formats a reader came for, not a section competing with them. Lab model reports are named without a link because they are publications rather than one site, but they are named, since they supply scores too.

## Both renderers, one sentence

`site/cite/index.html` is generated and gitignored, and the panel is rendered twice: the Python seed in `app_seeds.py` is what crawlers and script-disabled readers get, and `openCite()` in `app.js` overwrites it on first paint. A credit in only one of them is a credit half the readers never see, so both draw from one source list and a test asserts they agree.

## Verification

Six-step CI sequence on a clean detached worktree, not the working copy, since gitignored build artifacts on disk mask failures CI hits:

- `ruff check` and `ruff format --check` pass
- `normalize-catalog`, `classify`, `build-data-release` all run
- **1329 passed** on the clean checkout

Three tests fail in my local working copy (`test_catalog_coverage`, `test_models_registry`, `test_score_filters`), but they fail identically on unmodified `main` and all pass on the clean checkout. Stale generated artifacts, not this change.

Also confirmed:

- `llm-stats.com` is present in the generated no-JS seed, which is what crawlers receive
- Served the built site and checked the panel in a browser: credit renders last, exactly once (the JS render replaces the seed rather than duplicating it), links inline and clickable
- The copy-button count is still 3, so `test_seeded_copy_controls_...` is unaffected
- Both new `t()` keys resolve in the zh table; `and` reuses the existing entry

New tests cover the compliance link, seed/JS agreement, and the zh translations, since nothing previously caught an untranslated string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)