### PR TITLE
Cite the arXiv paper across all citation surfaces

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,6 +7,16 @@ authors:
     given-names: Koutian
   - family-names: Zhou
     given-names: Junjie
+  - family-names: Shang
+    given-names: Ergan
+  - family-names: Wang
+    given-names: Jiayu
+  - family-names: Han
+    given-names: Pengqian
+  - family-names: Wang
+    given-names: Junkai
+  - family-names: Xu
+    given-names: Wanghan
 repository-code: "https://github.com/ktwu01/benchmark-radar"
 url: "https://benchmark-radar.org/"
 license: MIT
@@ -16,17 +26,24 @@ abstract: >-
   A daily evidence-first radar and machine-readable corpus for AI benchmarks,
   evaluations, datasets, model-card reporting, and data quality.
 preferred-citation:
-  type: report
-  title: "Benchmark Radar v0.9.0: Technical Report"
+  type: article
+  title: "Benchmark Radar: A Living Database and Search Engine for AI Benchmarks and Evaluation"
   authors:
     - family-names: Wu
       given-names: Koutian
     - family-names: Zhou
       given-names: Junjie
-  doi: "10.5281/zenodo.22167102"
-  month: 8
+    - family-names: Shang
+      given-names: Ergan
+    - family-names: Wang
+      given-names: Jiayu
+    - family-names: Han
+      given-names: Pengqian
+    - family-names: Wang
+      given-names: Junkai
+    - family-names: Xu
+      given-names: Wanghan
+  doi: "10.48550/arXiv.2609.11115"
+  month: 9
   year: 2026
-  publisher:
-    name: Zenodo
-  url: "https://zenodo.org/records/22167102"
-  version: 0.9.0
+  url: "https://arxiv.org/abs/2609.11115"

--- a/README.md
+++ b/README.md
@@ -116,14 +116,14 @@ If Benchmark Radar supports your research or evaluation work, please cite the
 technical report:
 
 ```bibtex
-@misc{wu2026benchmarkradar,
-  author        = {Wu, Koutian and Zhou, Junjie and Shang, Ergan and Wang, Jiayu and Han, Pengqian and Wang, Junkai and Xu, Wanghan},
-  title         = {{Benchmark Radar: A Living Database and Search Engine for AI Benchmarks and Evaluation}},
-  year          = {2026},
-  eprint        = {2609.11115},
-  archivePrefix = {arXiv},
-  primaryClass  = {cs.AI},
-  url           = {https://arxiv.org/abs/2609.11115}
+@misc{wu2026benchmarkradarlivingdatabase,
+      title={Benchmark Radar: A Living Database and Search Engine for AI Benchmarks and Evaluation},
+      author={Koutian Wu and Junjie Zhou and Ergan Shang and Jiayu Wang and Pengqian Han and Junkai Wang and Wanghan Xu},
+      year={2026},
+      eprint={2609.11115},
+      archivePrefix={arXiv},
+      primaryClass={cs.AI},
+      url={https://arxiv.org/abs/2609.11115},
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -116,15 +116,14 @@ If Benchmark Radar supports your research or evaluation work, please cite the
 technical report:
 
 ```bibtex
-@misc{wu_2026_22167102,
-  author       = {Wu, Koutian and Zhou, Junjie},
-  title        = {Benchmark Radar v0.9.0: Technical Report},
-  month        = aug,
-  year         = {2026},
-  publisher    = {Zenodo},
-  version      = {0.9.0},
-  doi          = {10.5281/zenodo.22167102},
-  url          = {https://doi.org/10.5281/zenodo.22167102}
+@misc{wu2026benchmarkradar,
+  author        = {Wu, Koutian and Zhou, Junjie and Shang, Ergan and Wang, Jiayu and Han, Pengqian and Wang, Junkai and Xu, Wanghan},
+  title         = {{Benchmark Radar: A Living Database and Search Engine for AI Benchmarks and Evaluation}},
+  year          = {2026},
+  eprint        = {2609.11115},
+  archivePrefix = {arXiv},
+  primaryClass  = {cs.AI},
+  url           = {https://arxiv.org/abs/2609.11115}
 }
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -100,14 +100,14 @@ npx skills add ktwu01/benchmark-radar
 如果 Benchmark Radar 对你的研究或评测工作有帮助，欢迎引用这份技术报告：
 
 ```bibtex
-@misc{wu2026benchmarkradar,
-  author        = {Wu, Koutian and Zhou, Junjie and Shang, Ergan and Wang, Jiayu and Han, Pengqian and Wang, Junkai and Xu, Wanghan},
-  title         = {{Benchmark Radar: A Living Database and Search Engine for AI Benchmarks and Evaluation}},
-  year          = {2026},
-  eprint        = {2609.11115},
-  archivePrefix = {arXiv},
-  primaryClass  = {cs.AI},
-  url           = {https://arxiv.org/abs/2609.11115}
+@misc{wu2026benchmarkradarlivingdatabase,
+      title={Benchmark Radar: A Living Database and Search Engine for AI Benchmarks and Evaluation},
+      author={Koutian Wu and Junjie Zhou and Ergan Shang and Jiayu Wang and Pengqian Han and Junkai Wang and Wanghan Xu},
+      year={2026},
+      eprint={2609.11115},
+      archivePrefix={arXiv},
+      primaryClass={cs.AI},
+      url={https://arxiv.org/abs/2609.11115},
 }
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -100,15 +100,14 @@ npx skills add ktwu01/benchmark-radar
 如果 Benchmark Radar 对你的研究或评测工作有帮助，欢迎引用这份技术报告：
 
 ```bibtex
-@misc{wu_2026_22167102,
-  author       = {Wu, Koutian and Zhou, Junjie},
-  title        = {Benchmark Radar v0.9.0: Technical Report},
-  month        = aug,
-  year         = {2026},
-  publisher    = {Zenodo},
-  version      = {0.9.0},
-  doi          = {10.5281/zenodo.22167102},
-  url          = {https://doi.org/10.5281/zenodo.22167102}
+@misc{wu2026benchmarkradar,
+  author        = {Wu, Koutian and Zhou, Junjie and Shang, Ergan and Wang, Jiayu and Han, Pengqian and Wang, Junkai and Xu, Wanghan},
+  title         = {{Benchmark Radar: A Living Database and Search Engine for AI Benchmarks and Evaluation}},
+  year          = {2026},
+  eprint        = {2609.11115},
+  archivePrefix = {arXiv},
+  primaryClass  = {cs.AI},
+  url           = {https://arxiv.org/abs/2609.11115}
 }
 ```
 

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -8391,14 +8391,14 @@ const CITE_APA =
   "arXiv:2609.11115. " +
   CITE_DOI_URL;
 const CITE_BIBTEX = [
-  "@misc{wu2026benchmarkradar,",
-  "author = {Wu, Koutian and Zhou, Junjie and Shang, Ergan and Wang, Jiayu and Han, Pengqian and Wang, Junkai and Xu, Wanghan},",
-  "title = {{Benchmark Radar: A Living Database and Search Engine for AI Benchmarks and Evaluation}},",
-  "year = {2026},",
-  "eprint = {2609.11115},",
-  "archivePrefix = {arXiv},",
-  "primaryClass = {cs.AI},",
-  "url = {https://arxiv.org/abs/2609.11115}",
+  "@misc{wu2026benchmarkradarlivingdatabase,",
+  "      title={Benchmark Radar: A Living Database and Search Engine for AI Benchmarks and Evaluation},",
+  "      author={Koutian Wu and Junjie Zhou and Ergan Shang and Jiayu Wang and Pengqian Han and Junkai Wang and Wanghan Xu},",
+  "      year={2026},",
+  "      eprint={2609.11115},",
+  "      archivePrefix={arXiv},",
+  "      primaryClass={cs.AI},",
+  "      url={https://arxiv.org/abs/2609.11115},",
   "}",
 ].join("\n");
 

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -8383,18 +8383,22 @@ function openContact(updateUrl = true) {
 
 // The published technical report. Contract tests keep these copyable strings
 // aligned with CITATION.cff and the server-rendered citation route.
-const CITE_DOI_URL = "https://doi.org/10.5281/zenodo.22167102";
+const CITE_DOI_URL = "https://arxiv.org/abs/2609.11115";
 const CITE_CFF_URL = "https://github.com/ktwu01/benchmark-radar/blob/main/CITATION.cff";
 const CITE_APA =
-  "Wu, K., & Zhou, J. (2026). Benchmark Radar v0.9.0: Technical Report (Version 0.9.0). " + CITE_DOI_URL;
+  "Wu, K., Zhou, J., Shang, E., Wang, J., Han, P., Wang, J., & Xu, W. (2026). " +
+  "Benchmark Radar: A living database and search engine for AI benchmarks and evaluation. " +
+  "arXiv:2609.11115. " +
+  CITE_DOI_URL;
 const CITE_BIBTEX = [
-  "@techreport{Wu_Benchmark_Radar_v0_9_0_2026,",
-  "author = {Wu, Koutian and Zhou, Junjie},",
-  "doi = {10.5281/zenodo.22167102},",
-  "month = aug,",
-  "title = {{Benchmark Radar v0.9.0: Technical Report}},",
-  "url = {https://zenodo.org/records/22167102},",
-  "year = {2026}",
+  "@misc{wu2026benchmarkradar,",
+  "author = {Wu, Koutian and Zhou, Junjie and Shang, Ergan and Wang, Jiayu and Han, Pengqian and Wang, Junkai and Xu, Wanghan},",
+  "title = {{Benchmark Radar: A Living Database and Search Engine for AI Benchmarks and Evaluation}},",
+  "year = {2026},",
+  "eprint = {2609.11115},",
+  "archivePrefix = {arXiv},",
+  "primaryClass = {cs.AI},",
+  "url = {https://arxiv.org/abs/2609.11115}",
   "}",
 ].join("\n");
 

--- a/site/index.html
+++ b/site/index.html
@@ -188,14 +188,18 @@
 
     <!-- Machine-readable citation hints: Highwire tags are the convention
          academic indexers and reference managers look for; cite-as points at
-         the canonical thing to cite (the repo, which carries CITATION.cff
-         and the BibTeX entry in both READMEs). -->
-    <meta name="citation_title" content="Benchmark Radar">
+         the canonical thing to cite (the arXiv technical report). -->
+    <meta name="citation_title" content="Benchmark Radar: A Living Database and Search Engine for AI Benchmarks and Evaluation">
     <meta name="citation_author" content="Wu, Koutian">
     <meta name="citation_author" content="Zhou, Junjie">
+    <meta name="citation_author" content="Shang, Ergan">
+    <meta name="citation_author" content="Wang, Jiayu">
+    <meta name="citation_author" content="Han, Pengqian">
+    <meta name="citation_author" content="Wang, Junkai">
+    <meta name="citation_author" content="Xu, Wanghan">
     <meta name="citation_publication_date" content="2026">
-    <meta name="citation_dataset_url" content="https://benchmark-radar.org/data/radar.json">
-    <link rel="cite-as" href="https://github.com/ktwu01/benchmark-radar">
+    <meta name="citation_arxiv_id" content="2609.11115">
+    <link rel="cite-as" href="https://arxiv.org/abs/2609.11115">
 
     <!-- Root-absolute, not relative. This document is also served at six
          nested route paths, where "assets/app.js" would otherwise resolve

--- a/src/benchmark_radar/app_seeds.py
+++ b/src/benchmark_radar/app_seeds.py
@@ -572,18 +572,20 @@ def view_seeds(
 # These are the verbatim public values used by openCite and openCli in app.js.
 # Tests compare both renderers so a change to either copy fails instead of
 # quietly giving a crawler a different setup prompt or citation than a reader.
-CITE_DOI_URL = "https://doi.org/10.5281/zenodo.22167102"
+CITE_DOI_URL = "https://arxiv.org/abs/2609.11115"
 CITE_CFF_URL = "https://github.com/ktwu01/benchmark-radar/blob/main/CITATION.cff"
-# The site dialog and the CLI reminder share citation.py's author list and
-# version, so the APA a reader copies is the APA an agent is asked for.
+# The site dialog and the CLI reminder share citation.py's title and author
+# list, so the APA a reader copies is the APA an agent is asked for.
 CITE_APA = apa_citation()
-CITE_BIBTEX = """@techreport{Wu_Benchmark_Radar_v0_9_0_2026,
-author = {Wu, Koutian and Zhou, Junjie},
-doi = {10.5281/zenodo.22167102},
-month = aug,
-title = {{Benchmark Radar v0.9.0: Technical Report}},
-url = {https://zenodo.org/records/22167102},
-year = {2026}
+CITE_BIBTEX = """@misc{wu2026benchmarkradar,
+author = {Wu, Koutian and Zhou, Junjie and Shang, Ergan and Wang, Jiayu and
+          Han, Pengqian and Wang, Junkai and Xu, Wanghan},
+title = {{Benchmark Radar: A Living Database and Search Engine for AI Benchmarks and Evaluation}},
+year = {2026},
+eprint = {2609.11115},
+archivePrefix = {arXiv},
+primaryClass = {cs.AI},
+url = {https://arxiv.org/abs/2609.11115}
 }"""
 
 # The catalogs the score layer reads. LLM Stats asks for credit visible to

--- a/src/benchmark_radar/app_seeds.py
+++ b/src/benchmark_radar/app_seeds.py
@@ -577,15 +577,15 @@ CITE_CFF_URL = "https://github.com/ktwu01/benchmark-radar/blob/main/CITATION.cff
 # The site dialog and the CLI reminder share citation.py's title and author
 # list, so the APA a reader copies is the APA an agent is asked for.
 CITE_APA = apa_citation()
-CITE_BIBTEX = """@misc{wu2026benchmarkradar,
-author = {Wu, Koutian and Zhou, Junjie and Shang, Ergan and Wang, Jiayu and
-          Han, Pengqian and Wang, Junkai and Xu, Wanghan},
-title = {{Benchmark Radar: A Living Database and Search Engine for AI Benchmarks and Evaluation}},
-year = {2026},
-eprint = {2609.11115},
-archivePrefix = {arXiv},
-primaryClass = {cs.AI},
-url = {https://arxiv.org/abs/2609.11115}
+CITE_BIBTEX = """@misc{wu2026benchmarkradarlivingdatabase,
+      title={Benchmark Radar: A Living Database and Search Engine for AI Benchmarks and Evaluation},
+      author={Koutian Wu and Junjie Zhou and Ergan Shang and Jiayu Wang and
+              Pengqian Han and Junkai Wang and Wanghan Xu},
+      year={2026},
+      eprint={2609.11115},
+      archivePrefix={arXiv},
+      primaryClass={cs.AI},
+      url={https://arxiv.org/abs/2609.11115},
 }"""
 
 # The catalogs the score layer reads. LLM Stats asks for credit visible to

--- a/src/benchmark_radar/citation.py
+++ b/src/benchmark_radar/citation.py
@@ -1,28 +1,25 @@
 """Single source of truth for the project's self-citation (issue #483).
 
-The version comes from the ``__version__`` constant in
-``benchmark_radar/__init__.py`` (not importlib metadata), so a release
-bumps the citation without a separate edit; the year and DOI are stable
-because the technical report is deposited once. CITATION.cff and the
-site copy blocks in app_seeds.py keep the same author set, so every
-citation surface stays in step under this module's author list.
+The citation is the arXiv technical report (arXiv:2609.11115), a fixed
+paper rather than a versioned software release, so this no longer tracks
+``__version__``. CITATION.cff and the site copy blocks in app_seeds.py
+keep the same author set, so every citation surface stays in step under
+this module's title and author list.
 """
 
 from __future__ import annotations
 
-from . import __version__
-
 PUBLICATION_YEAR = "2026"
-AUTHORS_APA = "Wu, K., & Zhou, J."
-DOI = "10.5281/zenodo.22167102"
+TITLE = "Benchmark Radar: A living database and search engine for AI benchmarks and evaluation"
+AUTHORS_APA = "Wu, K., Zhou, J., Shang, E., Wang, J., Han, P., Wang, J., & Xu, W."
+ARXIV_ID = "2609.11115"
+ARXIV_URL = f"https://arxiv.org/abs/{ARXIV_ID}"
+DOI = f"10.48550/arXiv.{ARXIV_ID}"
 CITE_URL = "https://benchmark-radar.org/#cite"
 
 
 def apa_citation() -> str:
-    return (
-        f"{AUTHORS_APA} ({PUBLICATION_YEAR}). Benchmark Radar v{__version__}: Technical Report "
-        f"(Version {__version__}). https://doi.org/{DOI}"
-    )
+    return f"{AUTHORS_APA} ({PUBLICATION_YEAR}). {TITLE}. arXiv:{ARXIV_ID}. {ARXIV_URL}"
 
 
 def cite_reminder() -> str:

--- a/tests/test_app_pages.py
+++ b/tests/test_app_pages.py
@@ -350,7 +350,7 @@ def test_utility_pages_ship_the_existing_dialog_open_with_content(tmp_path):
     _write(tmp_path, _dashboard())
     expected = {
         "cli": ("Query it locally (CLI version)", "npx skills add ktwu01/benchmark-radar"),
-        "cite": ("Cite this work", "@techreport{Wu_Benchmark_Radar"),
+        "cite": ("Cite this work", "@misc{wu2026benchmarkradar"),
         "rubric": ("How priority is scored", "Priority is not benchmark quality."),
     }
     for utility, phrases in expected.items():

--- a/tests/test_app_pages.py
+++ b/tests/test_app_pages.py
@@ -350,7 +350,7 @@ def test_utility_pages_ship_the_existing_dialog_open_with_content(tmp_path):
     _write(tmp_path, _dashboard())
     expected = {
         "cli": ("Query it locally (CLI version)", "npx skills add ktwu01/benchmark-radar"),
-        "cite": ("Cite this work", "@misc{wu2026benchmarkradar"),
+        "cite": ("Cite this work", "@misc{wu2026benchmarkradarlivingdatabase"),
         "rubric": ("How priority is scored", "Priority is not benchmark quality."),
     }
     for utility, phrases in expected.items():

--- a/tests/test_query_surfaces.py
+++ b/tests/test_query_surfaces.py
@@ -9,7 +9,6 @@ from pathlib import Path
 
 import pytest
 
-from benchmark_radar import __version__
 from benchmark_radar.models import RadarItem, RadarRun, SourceHealth
 from benchmark_radar.query import QueryError, QueryPaths, QueryService
 from benchmark_radar.query_cli import run_query_cli
@@ -584,8 +583,9 @@ def test_cli_ends_human_output_with_citation_reminder(tmp_path: Path, capsys) ->
     assert exit_code == 0
     assert "please cite it" in output
     assert (
-        f"Wu, K., & Zhou, J. (2026). Benchmark Radar v{__version__}: Technical Report "
-        f"(Version {__version__}). https://doi.org/10.5281/zenodo.22167102"
+        "Wu, K., Zhou, J., Shang, E., Wang, J., Han, P., Wang, J., & Xu, W. (2026). "
+        "Benchmark Radar: A living database and search engine for AI benchmarks and evaluation. "
+        "arXiv:2609.11115. https://arxiv.org/abs/2609.11115"
     ) in output
     assert "https://benchmark-radar.org/#cite" in output
 

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -126,8 +126,8 @@ def test_citation_metadata_prefers_the_technical_report():
 
 def test_public_bibtex_names_all_report_authors():
     author = (
-        "author        = {Wu, Koutian and Zhou, Junjie and Shang, Ergan and "
-        "Wang, Jiayu and Han, Pengqian and Wang, Junkai and Xu, Wanghan}"
+        "author={Koutian Wu and Junjie Zhou and Ergan Shang and Jiayu Wang and "
+        "Pengqian Han and Junkai Wang and Wanghan Xu}"
     )
     for readme in (README, README_ZH):
         assert author in readme.read_text(encoding="utf-8")

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -16,7 +16,7 @@ from benchmark_radar.snapshots import rebuild_dashboard, records_badge, write_sn
 README = Path("README.md")
 README_ZH = Path("README.zh-CN.md")
 SKILL = Path("skills/benchmark-radar/SKILL.md")
-TECHNICAL_REPORT = "https://zenodo.org/records/22167102"
+TECHNICAL_REPORT = "https://arxiv.org/abs/2609.11115"
 REPORT_PDF = "https://github.com/ktwu01/benchmark-radar-paper/blob/main/main.pdf"
 
 
@@ -107,25 +107,28 @@ def test_chinese_readme_mirrors_the_english_one():
 
 def test_readmes_link_the_current_technical_report():
     # The badge and the resource list point at the tracked LaTeX build, which is
-    # the current report and reads directly on GitHub. The Zenodo DOI stays in
-    # the citation block, where it names the frozen deposit.
+    # the current report and reads directly on GitHub. The arXiv link stays in
+    # the citation block, where it names the preferred citation.
     for readme in (README, README_ZH):
         text = readme.read_text(encoding="utf-8")
         assert f'<a href="{REPORT_PDF}">' in text
         assert "TECH%20REPORT" in text
         assert f"({REPORT_PDF})" in text
-        assert TECHNICAL_REPORT in text or "10.5281/zenodo.22167102" in text
+        assert TECHNICAL_REPORT in text
 
 
 def test_citation_metadata_prefers_the_technical_report():
     text = Path("CITATION.cff").read_text(encoding="utf-8")
     assert "preferred-citation:" in text
-    assert 'doi: "10.5281/zenodo.22167102"' in text
+    assert 'doi: "10.48550/arXiv.2609.11115"' in text
     assert f'url: "{TECHNICAL_REPORT}"' in text
 
 
-def test_public_bibtex_names_both_report_authors():
-    author = "author       = {Wu, Koutian and Zhou, Junjie}"
+def test_public_bibtex_names_all_report_authors():
+    author = (
+        "author        = {Wu, Koutian and Zhou, Junjie and Shang, Ergan and "
+        "Wang, Jiayu and Han, Pengqian and Wang, Junkai and Xu, Wanghan}"
+    )
     for readme in (README, README_ZH):
         assert author in readme.read_text(encoding="utf-8")
 

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -162,13 +162,19 @@ def test_citation_formats_are_one_click_away_behind_a_short_link():
 
     # The rendered citations must agree with the file they claim to mirror, or
     # the site would hand out a citation the repository does not make.
-    for fragment in ("10.5281/zenodo.22167102", "Benchmark Radar v0.9.0: Technical Report"):
+    for fragment in (
+        "https://arxiv.org/abs/2609.11115",
+        "Benchmark Radar: A Living Database and Search Engine for AI Benchmarks and Evaluation",
+    ):
         assert fragment in cff
         assert fragment in script
     assert "given-names: Junjie" in cff
-    assert '"Wu, K., & Zhou, J. (2026)' in script
-    assert '"author = {Wu, Koutian and Zhou, Junjie},"' in script
-    assert html.count('name="citation_author"') == 2
+    assert '"Wu, K., Zhou, J., Shang, E., Wang, J., Han, P., Wang, J., & Xu, W. (2026). "' in script
+    assert (
+        '"author = {Wu, Koutian and Zhou, Junjie and Shang, Ergan and '
+        'Wang, Jiayu and Han, Pengqian and Wang, Junkai and Xu, Wanghan},"'
+    ) in script
+    assert html.count('name="citation_author"') == 7
     assert '<meta name="citation_author" content="Zhou, Junjie">' in html
 
 

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -171,8 +171,8 @@ def test_citation_formats_are_one_click_away_behind_a_short_link():
     assert "given-names: Junjie" in cff
     assert '"Wu, K., Zhou, J., Shang, E., Wang, J., Han, P., Wang, J., & Xu, W. (2026). "' in script
     assert (
-        '"author = {Wu, Koutian and Zhou, Junjie and Shang, Ergan and '
-        'Wang, Jiayu and Han, Pengqian and Wang, Junkai and Xu, Wanghan},"'
+        '"      author={Koutian Wu and Junjie Zhou and Ergan Shang and Jiayu Wang and '
+        'Pengqian Han and Junkai Wang and Wanghan Xu},"'
     ) in script
     assert html.count('name="citation_author"') == 7
     assert '<meta name="citation_author" content="Zhou, Junjie">' in html


### PR DESCRIPTION
## Summary
- The technical report is now on arXiv (arXiv:2609.11115, cs.AI, cross-listed cs.IR). Every citation surface previously pointed at the deliberately frozen Zenodo v0.9.0 deposit with only 2 of the paper's 7 authors listed.
- Updates `citation.py`, `app_seeds.py`, the client-side `app.js` mirror, `CITATION.cff`, both READMEs, and the homepage's Highwire citation meta tags to the arXiv identifiers (`10.48550/arXiv.2609.11115`) and the full 7-author byline (Wu, Zhou, Shang, Wang, Han, Wang, Xu).
- The frozen Zenodo v0.9.0 deposit itself (`AGENTS.md`, `zenodo-metadata.json`, the archival PDF, and its pinning test) is untouched — it remains a legitimate historical record, just no longer the preferred citation.
- APA reference-list entries list all authors up to 20 (no "et al." truncation there — that only applies to in-text citations), so all 7 authors appear in the APA and BibTeX forms.

Closes #566, #464, #541.

## Test plan
- [x] `ruff check .` / `ruff format --check .`
- [x] `pytest tests/test_readme.py tests/test_site.py tests/test_query_surfaces.py tests/test_app_pages.py tests/test_technical_report.py -q` (216 passed)
- [x] Opened `/cite/` and `/` locally in a browser to confirm the citation block renders the new APA/BibTeX content correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)