### PR TITLE
Add a Cite entry to the top navigation bar

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -1785,6 +1785,13 @@ function syncNavState() {
     if (utility === "cli") cliNav.setAttribute("aria-current", "page");
     else cliNav.removeAttribute("aria-current");
   }
+  const citeNav = byId("cite-nav");
+  if (citeNav?.classList) {
+    citeNav.classList.toggle("nav-active", utility === "cite");
+    citeNav.setAttribute("aria-expanded", String(utility === "cite"));
+    if (utility === "cite") citeNav.setAttribute("aria-current", "page");
+    else citeNav.removeAttribute("aria-current");
+  }
   const citeOpen = byId("cite-open");
   citeOpen?.setAttribute("aria-expanded", String(utility === "cite"));
   if (utility === "cite") citeOpen?.setAttribute("aria-current", "page");
@@ -8928,6 +8935,14 @@ function bindEvents() {
   // a link to a crawler and to a reader copying it out of the context menu;
   // the handler keeps the click itself on the page.
   byId("cite-open").addEventListener("click", (event) => {
+    if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+    event.preventDefault();
+    openCite();
+  });
+  // The view bar entry is an anchor to the same short link, so /cite/ reads as
+  // a link to a crawler and can be copied out of the context menu; the
+  // handler keeps the click itself on the page.
+  byId("cite-nav").addEventListener("click", (event) => {
     if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
     event.preventDefault();
     openCite();

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -480,6 +480,20 @@ button.repo-badge svg {
   background: var(--panel);
 }
 
+/* Cite is the same kind of dialog-opener as CLI: a real page path that still
+   opens the familiar panel, so it gets the same inactive-blue treatment. */
+#cite-nav:not(.nav-active) {
+  color: var(--blue-deep);
+}
+
+#cite-nav::after {
+  content: " ⓘ";
+}
+
+#cite-nav:not(.nav-active):hover {
+  background: var(--panel);
+}
+
 main {
   min-height: calc(100vh - 210px);
 }

--- a/site/index.html
+++ b/site/index.html
@@ -243,6 +243,16 @@
                carries no data-view: app.js only intercepts clicks on elements that
                have one, and a brief has to arrive as a full page load. -->
           <a href="/blog/" data-i18n="Blog">Blog</a>
+          <a
+            href="/cite/"
+            id="cite-nav"
+            aria-haspopup="dialog"
+            aria-controls="cite-dialog"
+            aria-expanded="false"
+            data-i18n="Cite"
+          >
+            Cite
+          </a>
         </nav>
       </div>
       <div class="masthead-end" aria-label="Site utilities" data-i18n-aria="Site utilities">

--- a/src/benchmark_radar/app_pages.py
+++ b/src/benchmark_radar/app_pages.py
@@ -233,7 +233,7 @@ def _with_active_attributes(opening_tag: str) -> str:
 def _activate_navigation(document: str, page: str, *, utility: bool = False) -> str:
     """Ship an honest active navigation state before app.js runs."""
     if utility:
-        element_id = {"cli": "cli-nav", "cite": "cite-open"}[page]
+        element_id = {"cli": "cli-nav", "cite": "cite-nav"}[page]
         selector = re.compile(rf'<(?:a|button)\b(?=[^>]*\bid="{element_id}")[^>]*>')
     else:
         selector = re.compile(rf'<(?:a|button)\b(?=[^>]*\bdata-view="{page}")[^>]*>')

--- a/tests/test_app_pages.py
+++ b/tests/test_app_pages.py
@@ -267,7 +267,7 @@ def test_each_generated_page_marks_its_navigation_entry_current(tmp_path):
         "saturation": 'data-view="saturation"',
         "trends": 'data-view="trends"',
         "cli": 'id="cli-nav"',
-        "cite": 'id="cite-open"',
+        "cite": 'id="cite-nav"',
     }
     for path, identifying_attribute in ids.items():
         page = (tmp_path / path / "index.html").read_text(encoding="utf-8")

--- a/tests/test_blog.py
+++ b/tests/test_blog.py
@@ -501,6 +501,7 @@ def test_dashboard_and_blog_share_the_reduced_chrome_contract(tmp_path):
         "/saturation/",
         "/trends/",
         "/blog/",
+        "/cite/",
     ]
     for document in (DASHBOARD_HTML, page):
         assert _nav_targets(document) == expected


### PR DESCRIPTION
## Summary
- The cite dialog (APA, BibTeX, `.cff` link, score-source credit) was only reachable from a footer CTA. Adds a "Cite" link to the top nav, styled and wired the same way as the existing CLI dialog-opener link (real `/cite/` path, blue inactive color, info-glyph suffix).
- Reuses the existing `/cite/` utility page rather than inventing a separate "Publications" page for a single paper.
- `_activate_navigation`'s honest server-rendered active state for the "cite" utility now targets the new top-nav link (`cite-nav`) instead of the footer link (`cite-open`), matching how the CLI utility's active state targets its one nav entry point.

Closes #591.

## Test plan
- [x] `ruff check .` / `ruff format --check .`
- [x] `pytest -q` (1325 passed; 4 pre-existing/environmental failures deselected, unrelated to this change)
- [x] `node -c site/assets/app.js`
- [x] Opened `/` locally in a browser to confirm the "Cite" nav link renders correctly and opens the citation dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)