### PR TITLE
Collapse APA and BibTeX blocks by default on the Cite dialog

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -8409,18 +8409,25 @@ const CITE_BIBTEX = [
 // sheet. The block itself is the button: a reader who came for a citation or a
 // setup prompt wants it on the clipboard, so clicking the text copies it rather
 // than making them select eight wrapped lines by hand.
-function copyBlock(label, value, hint, hideLabel = false) {
+//
+// `collapsed` starts the block showing only its hint ("Click to copy") with the
+// raw text hidden, for formats long enough that seeing every one at once turns
+// the sheet into a wall of text. The first click both copies and reveals, so
+// the reader who did not need to read it first still gets it on the clipboard
+// in one click, and the reader who wants to check it can see what they copied.
+function copyBlock(label, value, hint, hideLabel = false, collapsed = false) {
   const status = element("span", { className: "copy-status", text: t(hint) });
   const text = element("code", { className: "copy-text", text: value });
   const copy = element(
     "button",
     {
-      className: "copy-target",
+      className: collapsed ? "copy-target is-collapsed" : "copy-target",
       attrs: { type: "button", "aria-label": `${t(hint)}: ${t(label)}` },
     },
     [text, status],
   );
   copy.addEventListener("click", async () => {
+    copy.classList.remove("is-collapsed");
     try {
       await navigator.clipboard.writeText(value);
       copy.classList.add("is-copied");
@@ -8577,8 +8584,8 @@ function openCite(updateUrl = true) {
       text: t("Pick the format your paper or repository needs, then click it to copy."),
     }),
     element("div", { className: "copy-blocks" }, [
-      copyBlock("APA", CITE_APA, "Click to copy"),
-      copyBlock("BibTeX", CITE_BIBTEX, "Click to copy"),
+      copyBlock("APA", CITE_APA, "Click to copy", false, true),
+      copyBlock("BibTeX", CITE_BIBTEX, "Click to copy", false, true),
       copyBlock("Citation file (.cff)", CITE_CFF_URL, "Click to copy link"),
     ]),
     element("a", {

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -4010,6 +4010,17 @@ dialog::backdrop {
   border-color: var(--sea);
 }
 
+/* APA and BibTeX start collapsed: a reader who just wants the citation on
+   their clipboard should not have to scroll past both formats spelled out in
+   full first. The first click reveals the text at the same time it copies. */
+.copy-target.is-collapsed .copy-text {
+  display: none;
+}
+
+.copy-target.is-collapsed .copy-status {
+  margin-top: 0;
+}
+
 /* BibTeX and the agent prompt are written line by line and stay that way; APA
    and the bare URLs are single runs with no break opportunity, so they need
    `anywhere` to keep the dialog from growing wider than the viewport. */

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -140,8 +140,8 @@ def test_citation_formats_are_one_click_away_behind_a_short_link():
     assert "function openCite(" in script
 
     # Three formats, each copied by clicking the citation itself.
-    assert 'copyBlock("APA", CITE_APA, "Click to copy")' in script
-    assert 'copyBlock("BibTeX", CITE_BIBTEX, "Click to copy")' in script
+    assert 'copyBlock("APA", CITE_APA, "Click to copy", false, true)' in script
+    assert 'copyBlock("BibTeX", CITE_BIBTEX, "Click to copy", false, true)' in script
     assert 'copyBlock("Citation file (.cff)", CITE_CFF_URL, "Click to copy link")' in script
     assert "navigator.clipboard.writeText(value)" in script
     assert ".copy-target {" in styles


### PR DESCRIPTION
## Summary
- APA and BibTeX blocks in the "Cite this work" dialog now show only "Click to copy" by default, with the raw citation text hidden.
- Clicking a block both copies it to the clipboard and reveals the text, so a reader who wants to check what they copied still can.
- The citation file (`.cff`) link block is unaffected and keeps showing its link.

## Test plan
- [x] `pytest -q` (full suite, minus the 4 pre-existing environment-dependent deselects)
- [x] `ruff check .` / `ruff format --check .`
- [x] Verified in a real browser via gstack: APA/BibTeX start collapsed, clicking removes the collapsed state and reveals the citation text

🤖 Generated with [Claude Code](https://claude.com/claude-code)