### PR TITLE
Resolve relative first-party feed links against the feed URL

### DIFF
--- a/src/benchmark_radar/sources.py
+++ b/src/benchmark_radar/sources.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime, timedelta
 from email.utils import parsedate_to_datetime
 from pathlib import Path
 from typing import Any
+from urllib.parse import urljoin
 
 from .describe import clean_card_text, github_summary, huggingface_summary
 from .http import get_json, get_text
@@ -127,7 +128,14 @@ def fetch_first_party_feeds(config: dict[str, Any], since: datetime, limit: int)
                     continue
                 if require_any and not any(keyword in haystack for keyword in require_any):
                     continue
-                url = _feed_link(entry)
+                # Some first-party feeds publish site-relative entry links.
+                # Resolving them against the feed URL keeps the item URL
+                # absolute, which the snapshot and corpus schemas both require.
+                # An absent link stays empty so the missing-field check below
+                # still catches it, which urljoin would otherwise mask by
+                # returning the feed's own URL.
+                link = _feed_link(entry)
+                url = urljoin(feed_url, link) if link else ""
                 source_id = _feed_text(entry, "id", "guid") or url
                 published = _feed_date(_feed_text(entry, "published", "pubDate", "date"))
                 updated = _feed_date(_feed_text(entry, "updated")) or published

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -63,6 +63,20 @@ FIRST_PARTY_ATOM = """\
 """
 
 
+FIRST_PARTY_ATOM_RELATIVE_LINK = """\
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <id>/model-release</id>
+    <title>Introducing a new model</title>
+    <link rel="alternate" href="/model-release/"/>
+    <published>2026-08-08T14:00:00Z</published>
+    <updated>2026-08-08T14:00:00Z</updated>
+    <summary>Evaluation results across the benchmark.</summary>
+  </entry>
+</feed>
+"""
+
+
 def test_first_party_feeds_parse_rss_and_atom_and_filter_noise(monkeypatch):
     payloads = {
         "https://lab.example/rss": FIRST_PARTY_RSS,
@@ -92,6 +106,24 @@ def test_first_party_feeds_parse_rss_and_atom_and_filter_noise(monkeypatch):
     assert items[0].source == "First-party feed"
     assert items[0].source_id == "Lab Atom:tag:lab.example,2026:leaderboard"
     assert items[0].organizations == ["Lab Atom"]
+
+
+def test_first_party_feeds_resolve_relative_entry_links(monkeypatch):
+    monkeypatch.setattr(
+        "benchmark_radar.sources.get_text",
+        lambda url, attempts=3, timeout=30: FIRST_PARTY_ATOM_RELATIVE_LINK,
+    )
+
+    items = fetch_first_party_feeds(
+        {"feeds": [{"name": "Relative Lab", "url": "https://lab.example/feed.xml"}]},
+        datetime(2026, 8, 8, 0, tzinfo=UTC),
+        10,
+    )
+
+    assert [item.url for item in items] == ["https://lab.example/model-release/"]
+    # The entry's own id still identifies the item, so resolving the link does
+    # not renumber records already recorded under the relative URL.
+    assert items[0].source_id == "Relative Lab:/model-release"
 
 
 def test_first_party_feeds_require_any_narrows_broad_publishers(monkeypatch):


### PR DESCRIPTION
The 2026-09-11 Daily Benchmark Radar run failed (run 34583211169) after 30+ consecutive green days:

```
benchmark_radar.corpus.CorpusError: artifact:url:ee8721b5599f211bb5b0: entity URL must be HTTP(S)
RuntimeError: required OpenAI briefing failed: ...
```

Root cause: the Sakana AI feed (https://sakana.ai/feed.xml) publishes site-relative entry links such as `/fugu-max-release/`. `_feed_link` returned that href verbatim, so it became the evidence item URL and then the corpus entity URL, which `validate_corpus` rejects. Confirmed by hash: `sha256("/fugu-max-release/")[:20]` is exactly `ee8721b5599f211bb5b0`, the entity in the traceback.

Why it surfaced only now: that post is dated 2026-09-11T00:00+09:00, which is 2026-09-10 15:00 UTC, after the 09-10 run (09:15 UTC). Today's run was the first to see it, and its title matches the `benchmark` keyword gate, so it passed the filter and entered the corpus. The feed's other entries have always been relative too; none had previously cleared the keyword gate inside the 48h lookback.

What changes:
- `fetch_first_party_feeds` resolves each entry link against the feed URL with `urljoin`, so a relative href becomes an absolute URL. An absent link still resolves to the empty string, so the existing missing-field check keeps catching it, which `urljoin` would otherwise mask by returning the feed's own URL.
- New regression test covers an Atom feed whose entry link is relative, asserting both the resolved absolute URL and that `source_id` is unchanged.

Scope: this is the minimum fix. The item identity does not move, because these entries carry their own `<id>`, so `source_id` stays `Sakana AI:/fugu-max-release` and no already-recorded record is renumbered. No snapshot data needs repair: `validate_snapshot` rejects non-HTTP URLs at write time, so no bad URL was ever persisted (verified by scanning all 49 committed snapshots, zero hits).

Test plan:
- `ruff check` and `ruff format --check` pass on both touched files.
- `pytest -q`: 1330 passed, 1 failed in `tests/test_i18n_benchmark_term.py`. That failure is pre-existing and unrelated: it fires only on `docs/technical-report/latex` submodule content (local checkout pins 8e64d7c vs main's 951ea96), and it reproduces identically with this change stashed. CI checks out the pinned submodule and passed this test on main today.
- Verified against the live feed: all 10 Sakana entries now resolve to absolute URLs, and `https://sakana.ai/fugu-max-release/` returns HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)