### PR TITLE
Fix the isPartOf structured-data warning and date benchmark pages individually

### DIFF
--- a/docs/seo-indexing-guide.md
+++ b/docs/seo-indexing-guide.md
@@ -17,7 +17,7 @@ Last checked: **September 3, 2026**.
 | HTTP redirect | **Passing:** apex HTTP redirects to the HTTPS apex | Keep it |
 | `www` redirect | **Passing:** HTTPS `www` redirects to the HTTPS apex | Keep it |
 | `robots.txt` | **Current:** sitemap uses `benchmark-radar.org` | Keep it |
-| `sitemap.xml` | **Current:** all 1,225 URLs use `benchmark-radar.org` | Keep it |
+| `sitemap.xml` | **Current:** all 1,344 URLs use `benchmark-radar.org`, and each benchmark page carries the date of its own newest evidence | Keep it |
 | Page metadata | **Current:** canonical and `og:url` use the HTTPS apex | Keep it |
 
 Re-run the checks below after any DNS or Pages change. The table is a dated
@@ -152,6 +152,13 @@ query URLs are not listed in the sitemap, and neither are filter permutations:
 a second URL for a page that already has one is a duplicate, not a second page.
 The old `/#cli`, `/#cite`, and `/#rubric` links migrate the same way;
 rubric versions use `/rubric/?version=<number>`.
+
+When one schema node points at another, write the reference out in full rather
+than as a bare `@id`. An `@id` on its own only resolves on a page that also
+defines the node it names, and the `WebSite` and `Organization` nodes are
+defined on the homepage only. A bare reference to either from a benchmark page
+or a blog post points at nothing, which Search Console reports as
+`Invalid object type for field "isPartOf"`.
 
 Google references:
 

--- a/src/benchmark_radar/blog.py
+++ b/src/benchmark_radar/blog.py
@@ -43,7 +43,7 @@ from .blog_shell import (
     render_page,
 )
 from .feed import ATOM_NAMESPACE, SITE_URL
-from .site_shell import breadcrumb_schema, esc, webpage_schema
+from .site_shell import breadcrumb_schema, esc, organization_reference, webpage_schema
 
 LATEST_POST_LIMIT = 30
 
@@ -104,8 +104,13 @@ def _post_page(post: BlogPost, chrome: SiteChrome, chrome_i18n: dict[str, str]) 
         "dateModified": post.updated,
         "inLanguage": ["en", "zh-Hans"] if post.translated else "en",
         "author": {"@type": "Organization", "name": "Benchmark Radar"},
-        "publisher": {"@id": f"{SITE_URL}/#organization"},
-        "isPartOf": {"@id": SITE_URL + BLOG_PATH},
+        "publisher": organization_reference(),
+        "isPartOf": {
+            "@type": "Blog",
+            "@id": f"{SITE_URL}{BLOG_PATH}#blog",
+            "name": "Benchmark Radar blog",
+            "url": SITE_URL + BLOG_PATH,
+        },
         "citation": [url for _, _, url in post.sources],
         "keywords": list(post.tags),
     }

--- a/src/benchmark_radar/site_pages.py
+++ b/src/benchmark_radar/site_pages.py
@@ -21,8 +21,8 @@ from __future__ import annotations
 
 import html
 import json
-import re
 import shutil
+from datetime import date
 from pathlib import Path
 from typing import Any
 
@@ -33,8 +33,6 @@ DEFAULT_SHARD_DIR = Path("site/data/benchmarks")
 DEFAULT_PAGES_DIR = Path("site/benchmarks")
 
 _DESCRIPTION_LIMIT = 155
-
-_ISO_DATE = re.compile(r"\d{4}-\d{2}-\d{2}")
 
 _DIR_DESCRIPTION = (
     "Every benchmark in the Benchmark Radar catalog, each with its own page "
@@ -379,13 +377,27 @@ def benchmark_slugs(shard_dir: Path) -> list[str]:
     return sorted(path.stem for path in shard_dir.glob("*.json"))
 
 
+def _is_calendar_date(value: str) -> bool:
+    """True only for a real `YYYY-MM-DD` day.
+
+    Shape alone is not enough: `2023-02-29` matches the pattern and would reach
+    the sitemap as an invalid `lastmod`. The round trip also rejects the forms
+    `date.fromisoformat` accepts but the sitemap spec does not, such as
+    `20230101`.
+    """
+    try:
+        return date.fromisoformat(value).isoformat() == value
+    except ValueError:
+        return False
+
+
 def _shard_lastmod(shard: dict[str, Any]) -> str | None:
     """Newest date the page's own evidence carries, or None when it carries none.
 
     A page changes when a score lands on it or when the record itself is dated,
     not when some other benchmark's snapshot arrives. Both fields are stored as
-    plain `YYYY-MM-DD`, so the newest one sorts lexically; anything else is
-    ignored rather than guessed at.
+    plain `YYYY-MM-DD`, so the newest one sorts lexically; anything a calendar
+    rejects is dropped rather than passed through to the sitemap.
     """
     dates = {
         row.get("reported_date")
@@ -393,7 +405,7 @@ def _shard_lastmod(shard: dict[str, Any]) -> str | None:
         for row in (source or {}).get("rows") or ()
     }
     dates.add((shard.get("record") or {}).get("released"))
-    dated = {value for value in dates if isinstance(value, str) and _ISO_DATE.fullmatch(value)}
+    dated = {value for value in dates if isinstance(value, str) and _is_calendar_date(value)}
     return max(dated) if dated else None
 
 

--- a/src/benchmark_radar/site_pages.py
+++ b/src/benchmark_radar/site_pages.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from typing import Any
 
 from .feed import SITE_URL
+from .site_shell import website_reference
 
 DEFAULT_SHARD_DIR = Path("site/data/benchmarks")
 DEFAULT_PAGES_DIR = Path("site/benchmarks")
@@ -160,7 +161,7 @@ def _webpage_jsonld(slug: str, name: str, description: str) -> str:
         "url": _canonical(slug),
         "description": description,
         "inLanguage": ["en", "zh-Hans"],
-        "isPartOf": {"@id": f"{SITE_URL}/#website"},
+        "isPartOf": website_reference(),
         "about": {"@type": "Thing", "name": name, "description": description},
     }
     return _json_ld(payload)
@@ -304,7 +305,7 @@ def _directory_html(entries: list[tuple[str, str]]) -> str:
         "url": canonical,
         "description": _DIR_DESCRIPTION,
         "inLanguage": ["en", "zh-Hans"],
-        "isPartOf": {"@id": f"{SITE_URL}/#website"},
+        "isPartOf": website_reference(),
     }
     breadcrumb = {
         "@context": "https://schema.org",

--- a/src/benchmark_radar/site_pages.py
+++ b/src/benchmark_radar/site_pages.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import html
 import json
+import re
 import shutil
 from pathlib import Path
 from typing import Any
@@ -32,6 +33,8 @@ DEFAULT_SHARD_DIR = Path("site/data/benchmarks")
 DEFAULT_PAGES_DIR = Path("site/benchmarks")
 
 _DESCRIPTION_LIMIT = 155
+
+_ISO_DATE = re.compile(r"\d{4}-\d{2}-\d{2}")
 
 _DIR_DESCRIPTION = (
     "Every benchmark in the Benchmark Radar catalog, each with its own page "
@@ -374,6 +377,35 @@ def benchmark_slugs(shard_dir: Path) -> list[str]:
     if not shard_dir.is_dir():
         return []
     return sorted(path.stem for path in shard_dir.glob("*.json"))
+
+
+def _shard_lastmod(shard: dict[str, Any]) -> str | None:
+    """Newest date the page's own evidence carries, or None when it carries none.
+
+    A page changes when a score lands on it or when the record itself is dated,
+    not when some other benchmark's snapshot arrives. Both fields are stored as
+    plain `YYYY-MM-DD`, so the newest one sorts lexically; anything else is
+    ignored rather than guessed at.
+    """
+    dates = {
+        row.get("reported_date")
+        for source in (shard.get("scores_by_source") or {}).values()
+        for row in (source or {}).get("rows") or ()
+    }
+    dates.add((shard.get("record") or {}).get("released"))
+    dated = {value for value in dates if isinstance(value, str) and _ISO_DATE.fullmatch(value)}
+    return max(dated) if dated else None
+
+
+def benchmark_sitemap_entries(shard_dir: Path) -> list[tuple[str, str | None]]:
+    """Benchmark page paths in stable slug order, each with its own lastmod."""
+    if not shard_dir.is_dir():
+        return []
+    entries = []
+    for path in sorted(shard_dir.glob("*.json")):
+        shard = json.loads(path.read_text(encoding="utf-8"))
+        entries.append((f"/benchmarks/{path.stem}/", _shard_lastmod(shard)))
+    return entries
 
 
 def benchmark_page_urls(shard_dir: Path) -> list[str]:

--- a/src/benchmark_radar/site_seo.py
+++ b/src/benchmark_radar/site_seo.py
@@ -67,7 +67,7 @@ def _q(tag: str) -> str:
 
 def sitemap_tree(
     snapshots: list[dict[str, Any]],
-    benchmark_slugs: Sequence[str] = (),
+    benchmark_entries: Sequence[tuple[str, str | None]] = (),
     *,
     view_paths: Sequence[str] | None = None,
     blog_entries: Sequence[tuple[str, str | None]] = (),
@@ -77,11 +77,12 @@ def sitemap_tree(
     ``view_paths`` is what the build actually wrote. Passing None lists every
     view, which is what a caller that does not write pages at all wants.
 
-    ``blog_entries`` is what the blog build reported, each with its own lastmod
-    rather than the site-wide one: a brief for a day three weeks ago did not
-    change when today's snapshot landed, and telling a crawler otherwise asks
-    it to refetch the whole archive on every deploy. A build that writes no
-    blog passes nothing and lists nothing, the same rule the views follow.
+    ``benchmark_entries`` and ``blog_entries`` each carry their own lastmod
+    rather than the site-wide one: a benchmark whose newest score is two years
+    old, and a brief for a day three weeks ago, did not change when today's
+    snapshot landed, and telling a crawler otherwise asks it to refetch the
+    whole catalog on every deploy. A build that writes no blog passes nothing
+    and lists nothing, the same rule the views follow.
     """
     root = ET.Element(_q("urlset"))
     lastmod = _lastmod_date(snapshots)
@@ -90,7 +91,7 @@ def sitemap_tree(
         (path, lastmod) for _, path in INDEXABLE_VIEWS if published is None or path in published
     ]
     entries.append((BENCHMARK_DIRECTORY_PATH, lastmod))
-    entries.extend((f"/benchmarks/{slug}/", lastmod) for slug in benchmark_slugs)
+    entries.extend(benchmark_entries)
     entries.extend(blog_entries)
     seen: set[str] = set()
     for path, entry_lastmod in entries:
@@ -107,7 +108,7 @@ def sitemap_tree(
 def write_sitemap(
     snapshots: list[dict[str, Any]],
     output: Path,
-    benchmark_slugs: Sequence[str] = (),
+    benchmark_entries: Sequence[tuple[str, str | None]] = (),
     *,
     view_paths: Sequence[str] | None = None,
     blog_entries: Sequence[tuple[str, str | None]] = (),
@@ -115,7 +116,7 @@ def write_sitemap(
     """Write a deterministic UTF-8 sitemap beside the published data."""
     output.parent.mkdir(parents=True, exist_ok=True)
     tree = sitemap_tree(
-        snapshots, benchmark_slugs, view_paths=view_paths, blog_entries=blog_entries
+        snapshots, benchmark_entries, view_paths=view_paths, blog_entries=blog_entries
     )
     ET.indent(tree, space="  ")
     tree.write(output, encoding="utf-8", xml_declaration=True)

--- a/src/benchmark_radar/site_shell.py
+++ b/src/benchmark_radar/site_shell.py
@@ -18,6 +18,32 @@ def json_ld(payload: dict[str, Any]) -> str:
     return json.dumps(payload, ensure_ascii=False, sort_keys=True).replace("</", "<\\/")
 
 
+def website_reference() -> dict[str, Any]:
+    """Self-describing `WebSite` node for `isPartOf`.
+
+    A bare `{"@id": ...}` only resolves where that node is defined. Only the
+    homepage and its route copies define `#website`, so Search Console reports
+    `Invalid object type for field "isPartOf"` on every generated page that
+    links to it. Carrying the type inline makes the reference valid anywhere.
+    """
+    return {
+        "@type": "WebSite",
+        "@id": f"{SITE_URL}/#website",
+        "name": "Benchmark Radar",
+        "url": f"{SITE_URL}/",
+    }
+
+
+def organization_reference() -> dict[str, Any]:
+    """Self-describing `Organization` node, for the same reason as above."""
+    return {
+        "@type": "Organization",
+        "@id": f"{SITE_URL}/#organization",
+        "name": "Benchmark Radar",
+        "url": f"{SITE_URL}/",
+    }
+
+
 def breadcrumb_schema(*items: tuple[str, str], canonical: str) -> dict[str, Any]:
     return {
         "@context": "https://schema.org",
@@ -46,5 +72,5 @@ def webpage_schema(
         "url": canonical,
         "description": description,
         "inLanguage": list(languages),
-        "isPartOf": {"@id": f"{SITE_URL}/#website"},
+        "isPartOf": website_reference(),
     }

--- a/src/benchmark_radar/snapshots.py
+++ b/src/benchmark_radar/snapshots.py
@@ -42,7 +42,7 @@ from .rubric import (
     v3_rubric_reference,
     v4_rubric_reference,
 )
-from .site_pages import DEFAULT_SHARD_DIR, benchmark_slugs
+from .site_pages import DEFAULT_SHARD_DIR, benchmark_sitemap_entries
 from .site_seo import write_sitemap
 from .sources import GITHUB_RELEASE_PARSER_VERSION, github_release_title
 
@@ -1351,7 +1351,7 @@ def rebuild_dashboard(
         if feed_output is not None
         else output.parent / "sitemap.xml"
     )
-    slugs = benchmark_slugs(benchmark_shard_dir)
+    benchmark_entries = benchmark_sitemap_entries(benchmark_shard_dir)
     # A data-only build writes no view pages, so it has no list of published
     # ones, and None asks for every view. That is right rather than empty: this
     # sitemap describes the deployed site, not this build's output directory,
@@ -1371,7 +1371,7 @@ def rebuild_dashboard(
     write_sitemap(
         snapshots,
         sitemap_output,
-        slugs,
+        benchmark_entries,
         view_paths=view_paths,
         blog_entries=blog_entries,
     )

--- a/tests/test_blog.py
+++ b/tests/test_blog.py
@@ -321,6 +321,17 @@ def _schemas(page: str) -> list[dict]:
     ]
 
 
+def test_posting_references_name_their_type_so_they_resolve_off_the_homepage(tmp_path):
+    """A bare `@id` resolves nowhere but the page defining it, which Search Console rejects."""
+    write_blog_with_chrome([_briefed()], tmp_path)
+    page = (tmp_path / "blog" / "2026-08-30" / "index.html").read_text(encoding="utf-8")
+    posting = next(p for p in _schemas(page) if p.get("@type") == "BlogPosting")
+    assert posting["isPartOf"]["@type"] == "Blog"
+    assert posting["isPartOf"]["url"] == f"{SITE_URL}{BLOG_PATH}"
+    assert posting["publisher"]["@type"] == "Organization"
+    assert posting["publisher"]["@id"] == f"{SITE_URL}/#organization"
+
+
 def test_each_page_carries_a_breadcrumb_back_to_the_blog(tmp_path):
     write_blog_with_chrome([_briefed()], tmp_path)
     page = (tmp_path / "blog" / "2026-08-30" / "index.html").read_text(encoding="utf-8")

--- a/tests/test_site_pages.py
+++ b/tests/test_site_pages.py
@@ -303,6 +303,8 @@ def test_benchmark_lastmod_comes_from_the_pages_own_evidence(tmp_path):
                 {"reported_date": "2025-05-22"},
                 {"reported_date": "2026-01-09"},
                 {"reported_date": "not a date"},
+                # Right shape, no such day. It must not reach the sitemap.
+                {"reported_date": "2026-02-30"},
             ]
         }
     }

--- a/tests/test_site_pages.py
+++ b/tests/test_site_pages.py
@@ -156,6 +156,17 @@ def test_jsonld_blocks_are_single_objects_with_expected_types(tmp_path):
     assert crumbs == ["Benchmark Radar", "Benchmark directory", "Alpha Bench"]
 
 
+def test_node_references_carry_their_own_type_so_they_resolve_off_the_homepage(tmp_path):
+    """A bare `@id` resolves nowhere but the homepage, which Search Console rejects."""
+    output = _generated_pages(tmp_path, _shard("alpha-bench", "Alpha Bench"))
+    directory = (output / "index.html").read_text(encoding="utf-8")
+    for text in (_page_text(output, "alpha-bench"), directory):
+        part_of = _jsonld_blocks(text)[0]["isPartOf"]
+        assert part_of["@type"] == "WebSite"
+        assert part_of["@id"] == "https://benchmark-radar.org/#website"
+        assert part_of["url"] == "https://benchmark-radar.org/"
+
+
 def test_values_are_escaped_and_cannot_inject_markup(tmp_path):
     output = _generated_pages(
         tmp_path,

--- a/tests/test_site_pages.py
+++ b/tests/test_site_pages.py
@@ -14,6 +14,7 @@ import pytest
 from benchmark_radar.feed import SITE_URL
 from benchmark_radar.site_pages import (
     benchmark_page_urls,
+    benchmark_sitemap_entries,
     write_benchmark_pages,
 )
 from benchmark_radar.site_seo import sitemap_tree
@@ -254,10 +255,10 @@ def test_benchmark_page_urls_are_sorted_canonicals(tmp_path):
     assert benchmark_page_urls(tmp_path / "missing") == []
 
 
-def test_sitemap_includes_benchmark_pages_when_slugs_passed(tmp_path):
+def test_sitemap_includes_benchmark_pages_when_entries_are_passed(tmp_path):
     tree = sitemap_tree(
         [{"generated_at": "2026-08-21T02:17:00+00:00"}],
-        benchmark_slugs=["alpha-bench", "zeta-bench"],
+        [("/benchmarks/alpha-bench/", "2025-05-22"), ("/benchmarks/zeta-bench/", None)],
     )
     urls = [
         node.text
@@ -284,7 +285,34 @@ def test_sitemap_includes_benchmark_pages_when_slugs_passed(tmp_path):
             "sm:url/sm:lastmod", {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
         )
     ]
-    assert lastmods == ["2026-08-21"] * 11
+    # Nine site-wide dates, then the benchmark's own; the undated page gets none.
+    assert lastmods == ["2026-08-21"] * 9 + ["2025-05-22"]
+
+
+def test_benchmark_lastmod_comes_from_the_pages_own_evidence(tmp_path):
+    """A page is not modified by another benchmark's snapshot landing."""
+    shard_dir = _write_shards(
+        tmp_path,
+        _shard("alpha-bench", "Alpha Bench", released="2024-02-01"),
+        _shard("zeta-bench", "Zeta Bench", released=None),
+    )
+    alpha = json.loads((shard_dir / "alpha-bench.json").read_text(encoding="utf-8"))
+    alpha["scores_by_source"] = {
+        "model_reports": {
+            "rows": [
+                {"reported_date": "2025-05-22"},
+                {"reported_date": "2026-01-09"},
+                {"reported_date": "not a date"},
+            ]
+        }
+    }
+    (shard_dir / "alpha-bench.json").write_text(json.dumps(alpha), encoding="utf-8")
+
+    assert benchmark_sitemap_entries(shard_dir) == [
+        ("/benchmarks/alpha-bench/", "2026-01-09"),
+        ("/benchmarks/zeta-bench/", None),
+    ]
+    assert benchmark_sitemap_entries(tmp_path / "missing") == []
 
 
 def test_write_benchmark_pages_fails_loudly_without_shards(tmp_path):

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -386,7 +386,9 @@ def test_rebuild_writes_the_sitemap_at_the_site_root(tmp_path, site_shell):
         f"{SITE_URL}/blog/2026-07-27/",
     ]
     lastmods = [node.text for node in root.findall("sm:url/sm:lastmod", ns)]
-    assert lastmods == ["2026-07-27"] * len(urls)
+    # The two shards carry no dated evidence, so their pages claim no lastmod
+    # rather than borrowing today's snapshot date.
+    assert lastmods == ["2026-07-27"] * (len(urls) - 2)
 
 
 def test_rescore_applies_a_new_category_to_older_snapshots(tmp_path):


### PR DESCRIPTION
Two invisible SEO defects, plus the docs they are recorded in. No UI changes.

## `Invalid object type for field "isPartOf"`

Search Console reports this against the site. The value was a bare
`{"@id": "https://benchmark-radar.org/#website"}`. An `@id` on its own only
resolves on a page that also defines the node it names, and `#website` is
defined on the homepage and its route copies only, so the reference pointed at
nothing on all 1,284 benchmark pages, the benchmark directory, and every blog
post. Blog postings referenced their `publisher` and their parent blog the same
way.

All of them now emit self-describing nodes, so each reference is valid on the
page that carries it.

## Per-benchmark sitemap `lastmod`

Every benchmark URL carried the site-wide snapshot date, so 1,284 of the 1,344
listed URLs changed their `lastmod` on each deploy and invited crawlers to
refetch the whole catalog daily. The date now comes from the page's own
evidence: the newest reported score date, else the record's release date, else
no `lastmod`. Against the published catalog that is 429 distinct dates spanning
2015 to 2026, with 10 pages left undated rather than guessed at.

This mirrors how the blog already dates each brief.

## Docs

The live status table claimed 1,225 sitemap URLs; the published sitemap has
1,344. The node-reference rule is written down so the warning does not come
back.

## Verification

`pytest`: 1,332 passed. `ruff check src/ tests/`: clean. The one failing test on
this branch, `test_no_ji_zhun_in_user_facing_sources_strict`, fails identically
on `main` and is caused by the dirty `docs/technical-report/latex` submodule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)