### PR TITLE
feat(attention): collect the ranking signals behind the latest-releases leaderboard

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -589,6 +589,54 @@ attention:
       dataset: [dataset, corpus, training data, synthetic data]
       data_quality: [data quality, contamination, deduplication, provenance, leakage]
 
+# Dated, attributable counters for recently released benchmarks. The Latest
+# Releases leaderboard (issue #530) ranks a release by GitHub stars (55%),
+# Hugging Face paper upvotes (30%) and Hugging Face dataset downloads over the
+# last 30 days (15%), and reads them from the `benchmark_attention` block this
+# collector writes into each daily snapshot. Without the block every window
+# collapses to hand-reviewed registry entries with unknown signals, which is
+# what issue #589 saw as "stars 0, forks 0".
+#
+# Only exact resources are read: a dedicated GitHub repository, a Hugging
+# Face paper page, a Hugging Face dataset page. A resource the API reports as
+# gone is recorded as unavailable with no value, never as zero, and a request
+# that fails for a reason about the request writes nothing, so the ranking
+# keeps the last reading and marks it stale. Both APIs are anonymous; the
+# workflow's GITHUB_TOKEN only raises the GitHub budget.
+benchmark_attention:
+  enabled: true
+  # Releases older than this are not re-observed. The ranking's widest window
+  # is 90 days, so anything beyond it cannot appear.
+  window_days: 90
+  # Requests are spent newest release first, so the 7- and 30-day windows the
+  # leaderboard shows by default are refreshed before the 90-day tail. A
+  # resource the budget does not reach keeps its last reading, written again
+  # as stale. On the September 2026 history the 90-day cohort names about
+  # 470 dedicated repositories and 830 Hugging Face resources; the
+  # budgets leave headroom above both.
+  github:
+    # One request per dedicated repository. Authenticated calls have a
+    # 5,000-per-hour allowance; anonymous ones 60.
+    max_requests: 800
+    request_delay_seconds: 0.0
+  huggingface:
+    # One request per paper page or dataset, anonymous.
+    max_requests: 1200
+    request_delay_seconds: 0.1
+  # A source that fails this many times in a row is not asked again this run.
+  # Its unread resources keep their stale readings; a rate limit or outage
+  # answers every request alike, and waiting out the timeout for each of a
+  # thousand resources would outlive the daily workflow.
+  max_consecutive_failures: 5
+  # One attempt, so a budget above is a request count rather than a ceiling of
+  # `attempts` times that. A retry here buys little and costs a lot: a failed
+  # read already degrades to the previous reading carried forward as stale,
+  # while the retry backoff honours `Retry-After` for up to a minute and is not
+  # the injectable sleep the budget loop uses, so intermittent failures short of
+  # the consecutive-failure pause could add hours to a daily run.
+  attempts: 1
+  timeout_seconds: 15
+
 publish:
   dashboard_url: "https://benchmark-radar.org/"
   issue_title_prefix: "📡 AI Benchmark & Data Radar"

--- a/src/benchmark_radar/benchmark_attention.py
+++ b/src/benchmark_radar/benchmark_attention.py
@@ -1,0 +1,483 @@
+"""Dated, attributable public counters for recently released benchmarks.
+
+The Latest Releases leaderboard (`release_leaderboard.py`) ranks a release by
+GitHub stars, Hugging Face paper upvotes and Hugging Face dataset downloads.
+It reads them from the `benchmark_attention` block of each daily snapshot,
+whose shape `snapshots.py` validates. The ranking engine, its validator and
+its tests landed for issue #530 before anything wrote that block, so every
+window collapsed to hand-reviewed registry entries carrying `unknown`
+signals, which issue #589 reports as "stars 0, forks 0". This module is the
+collector that fills the block.
+
+Each rule below prevents a specific failure:
+
+- Only an exact resource is queried: a dedicated GitHub repository, a
+  Hugging Face paper page, a Hugging Face dataset page. A repository that
+  hosts a benchmark in a subdirectory would credit the host's stars to the
+  benchmark; the validator refuses such URLs and so does the selection here.
+- A resource the API says is gone is recorded as `unavailable` with a null
+  value, never as zero. The ranking treats null as "no signal"; a zero would
+  rank a deleted repository below a live one with a single star.
+- A request that fails for a reason about the request (rate limit, outage,
+  malformed payload) produces no reading. The resource's last reading from
+  the previous snapshot is written again as `stale`, dated by the day it was
+  read, because the ranking reports whatever the newest observation says:
+  writing nothing would leave yesterday's reading reported as fresh.
+- Health is reported per (source, metric), so a paper-page outage cannot mark
+  dataset downloads stale. `ok` stays true while any request succeeded: the
+  ranking reads a failed health event at the same instant as fresh
+  observations as a reason to demote all of them to stale.
+- Requests are bounded per source and spent newest release first, so the
+  windows the leaderboard shows by default are refreshed before the 90-day
+  tail, and a budget smaller than the eligible cohort degrades to stale
+  readings on the oldest releases rather than to nothing.
+- A source that fails several times in a row is not asked again this run.
+  A rate limit or outage answers every request the same way, and a run that
+  waits out the timeout for each of a thousand resources would outlive the
+  daily workflow; the resources not asked keep their stale readings.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from urllib.parse import urlsplit
+
+from .corpus import artifact_alias_map, exact_artifact_key
+from .http import RequestError, get_json
+from .models import SourceHealth
+from .release_leaderboard import canonical_metric_key, is_exact_attention_source_url
+from .sources import ConnectorPayloadError, _github_headers, _request_options
+
+BLOCK_SCHEMA_VERSION = 1
+DEFAULT_WINDOW_DAYS = 90
+DEFAULT_MAX_REQUESTS = {"github": 800, "huggingface": 1200}
+DEFAULT_REQUEST_DELAY_SECONDS = {"github": 0.0, "huggingface": 0.1}
+DEFAULT_MAX_CONSECUTIVE_FAILURES = 5
+
+# One row per ranking signal: the snapshot source and metric names the
+# validator accepts, the counter kind the ranking expects, and the label the
+# dashboard's source-health list shows.
+SIGNALS: dict[str, dict[str, str]] = {
+    "github_stars": {
+        "source": "github",
+        "metric": "stars",
+        "value_kind": "cumulative",
+        "label": "GitHub stars",
+    },
+    "hf_paper_upvotes": {
+        "source": "huggingface",
+        "metric": "upvotes",
+        "value_kind": "cumulative",
+        "label": "Hugging Face paper upvotes",
+    },
+    "hf_dataset_downloads": {
+        "source": "huggingface",
+        "metric": "downloads_30d",
+        "value_kind": "rolling_30d",
+        "label": "Hugging Face dataset downloads",
+    },
+}
+
+# Statuses that describe the artifact rather than the request: the resource is
+# gone (or legally withheld), so the honest reading is "unavailable", not a
+# retry later.
+_MISSING_RESOURCE_STATUSES = {404, 410, 451}
+
+
+@dataclass(slots=True)
+class AttentionTarget:
+    canonical_id: str
+    released_at: datetime | None = None
+    resources: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class _SignalStats:
+    attempted: int = 0
+    observed: int = 0
+    unavailable: int = 0
+    failed: int = 0
+    skipped: int = 0
+    stale: int = 0
+    last_error: str | None = None
+
+
+def _parse_time(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=UTC)
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+
+
+def select_targets(
+    items: list[dict[str, Any]],
+    *,
+    as_of: datetime,
+    window_days: int = DEFAULT_WINDOW_DAYS,
+) -> list[AttentionTarget]:
+    """Released artifacts inside the window that name at least one exact resource.
+
+    Identity follows the ranking's own rule: occurrences are grouped by the
+    alias-mapped exact artifact key, and the release date is the earliest
+    `released` observation, so a re-announcement cannot move a benchmark back
+    into a window it has left. Resources are gathered from every occurrence,
+    since the repository URL of a paper released without one often arrives
+    later on the repository's own `updated` record. Artifacts released outside
+    the window, never released, or naming no exact resource produce no
+    target: there is nothing to observe for them, and a null observation
+    would admit them to the cohort with no signal to rank on.
+    """
+    as_of = as_of.astimezone(UTC)
+    window_start = as_of - timedelta(days=window_days)
+    aliases = artifact_alias_map(items)
+    grouped: dict[str, AttentionTarget] = {}
+    for item in items:
+        key = exact_artifact_key(item)
+        canonical_id = aliases.get(key, key)
+        target = grouped.get(canonical_id)
+        if target is None:
+            target = AttentionTarget(canonical_id=canonical_id)
+            grouped[canonical_id] = target
+        if item.get("event_kind") == "released":
+            released = _parse_time(item.get("published_at") or item.get("discovered_at"))
+            if released is not None and (
+                target.released_at is None or released < target.released_at
+            ):
+                target.released_at = released
+        urls = [item.get("url"), *(item.get("artifact_urls") or [])]
+        for url in urls:
+            if not isinstance(url, str):
+                continue
+            for signal in SIGNALS:
+                if signal not in target.resources and is_exact_attention_source_url(signal, url):
+                    target.resources[signal] = url.strip()
+    selected = [
+        target
+        for target in grouped.values()
+        if target.resources
+        and target.released_at is not None
+        and window_start <= target.released_at <= as_of
+    ]
+    selected.sort(key=lambda target: (target.released_at, target.canonical_id), reverse=True)
+    return selected
+
+
+def _http_status(error: Exception) -> int | None:
+    match = re.match(r"HTTP (\d{3}) ", str(error))
+    return int(match.group(1)) if match else None
+
+
+def _counter(payload: Any, field_name: str, *, label: str) -> int | float:
+    if not isinstance(payload, dict):
+        raise ConnectorPayloadError(f"{label} metadata was not an object")
+    raw = payload.get(field_name)
+    if raw is None or isinstance(raw, bool):
+        raise ConnectorPayloadError(f"{label} metadata is missing {field_name}")
+    try:
+        value = float(raw)
+    except (TypeError, ValueError) as error:
+        raise ConnectorPayloadError(f"{label} {field_name} is not a number") from error
+    if not math.isfinite(value) or value < 0:
+        raise ConnectorPayloadError(f"{label} {field_name} is not a non-negative number")
+    # Counters are whole numbers; keep them so in the snapshot and the
+    # dashboard rather than serialising 150 as 150.0.
+    return int(value) if value.is_integer() else value
+
+
+def _fetch_counter(
+    signal: str,
+    url: str,
+    *,
+    options: dict[str, Any],
+    get_json: Callable[..., Any],
+) -> int | float:
+    segments = [segment for segment in urlsplit(url).path.split("/") if segment]
+    if signal == "github_stars":
+        # A clone URL is an exact reference to the same repository, and the
+        # exactness rule accepts it, but api.github.com has no repository whose
+        # name ends in `.git`: the request 404s and a live repository would be
+        # recorded as `unavailable`, which is the misreading this module exists
+        # to prevent. The untouched URL is still what `source_url` reports.
+        owner, repo = segments[0], segments[1].removesuffix(".git")
+        payload = get_json(
+            f"https://api.github.com/repos/{owner}/{repo}",
+            headers=_github_headers(),
+            **options,
+        )
+        return _counter(payload, "stargazers_count", label="GitHub repository")
+    if signal == "hf_paper_upvotes":
+        payload = get_json(f"https://huggingface.co/api/papers/{segments[1]}", **options)
+        return _counter(payload, "upvotes", label="Hugging Face paper")
+    if signal == "hf_dataset_downloads":
+        # The Hub's `downloads` counter is the rolling 30-day figure the
+        # ranking weights; the all-time counter is a different measure and is
+        # only served on request.
+        payload = get_json(
+            f"https://huggingface.co/api/datasets/{segments[1]}/{segments[2]}", **options
+        )
+        return _counter(payload, "downloads", label="Hugging Face dataset")
+    raise ValueError(f"unknown attention signal {signal!r}")
+
+
+def _read_resource(
+    signal: str,
+    url: str,
+    *,
+    options: dict[str, Any],
+    get_json: Callable[..., Any],
+    stats: _SignalStats,
+) -> tuple[int | float | None, str] | None:
+    """One reading, or None when the request (not the artifact) failed.
+
+    A gone resource is a fact about the artifact and becomes an `unavailable`
+    reading. Anything else that goes wrong (a rate limit, an outage, a payload
+    that is not JSON or lacks the counter) is a fact about the request: it is
+    counted against the signal's health and produces no reading, so the
+    resource keeps its last one. No exception escapes, because one unreadable
+    resource must not abort the readings of the hundreds after it.
+    """
+    stats.attempted += 1
+    try:
+        value = _fetch_counter(signal, url, options=options, get_json=get_json)
+    except RequestError as error:
+        if _http_status(error) in _MISSING_RESOURCE_STATUSES:
+            stats.unavailable += 1
+            return (None, "unavailable")
+        stats.failed += 1
+        stats.last_error = f"{type(error).__name__}: {error}"
+        return None
+    except Exception as error:
+        stats.failed += 1
+        stats.last_error = f"{type(error).__name__}: {error}"
+        return None
+    stats.observed += 1
+    return (value, "fresh")
+
+
+def _previous_readings(block: dict[str, Any] | None) -> dict[tuple[str, str], tuple[Any, str]]:
+    """The last known value per (signal, resource URL) and the date it was read.
+
+    Keyed by resource rather than artifact: alias links can rename an
+    artifact's canonical id between runs, the URL cannot change.
+    """
+    readings: dict[tuple[str, str], tuple[Any, str]] = {}
+    if not block:
+        return readings
+    block_time = _parse_time(block.get("observed_at"))
+    for observation in block.get("observations") or []:
+        if not isinstance(observation, dict):
+            continue
+        signal = canonical_metric_key(observation.get("metric"))
+        value = observation.get("value")
+        if (
+            signal is None
+            or observation.get("status") not in {"fresh", "stale"}
+            or isinstance(value, bool)
+            or not isinstance(value, (int, float))
+        ):
+            continue
+        read_at = observation.get("last_successful_date")
+        if not read_at:
+            read_time = _parse_time(observation.get("observed_at")) or block_time
+            if read_time is None:
+                continue
+            read_at = read_time.date().isoformat()
+        readings[(signal, str(observation.get("source_url") or ""))] = (value, str(read_at))
+    return readings
+
+
+def collect_benchmark_attention(
+    config: dict[str, Any],
+    items: list[dict[str, Any]],
+    *,
+    observed_at: datetime,
+    previous_block: dict[str, Any] | None = None,
+    get_json: Callable[..., Any] = get_json,
+    sleep: Callable[[float], None] = time.sleep,
+) -> tuple[dict[str, Any] | None, list[SourceHealth]]:
+    """Observe the ranking signals for released artifacts in the window.
+
+    `previous_block` is the previous snapshot's `benchmark_attention`; its
+    readings are carried forward as `stale` for every resource this run did
+    not read. Returns the snapshot `benchmark_attention` block and one
+    `SourceHealth` row per signal for the run's attention health list, or
+    `(None, [])` when the collector is disabled.
+    """
+    if not config or not config.get("enabled", True):
+        return None, []
+    observed_at = observed_at.astimezone(UTC)
+    window_days = max(1, int(config.get("window_days", DEFAULT_WINDOW_DAYS)))
+    targets = select_targets(items, as_of=observed_at, window_days=window_days)
+    options = _request_options(config)
+    max_consecutive_failures = max(
+        1, int(config.get("max_consecutive_failures", DEFAULT_MAX_CONSECUTIVE_FAILURES))
+    )
+    budgets: dict[str, int] = {}
+    delays: dict[str, float] = {}
+    for source, default_budget in DEFAULT_MAX_REQUESTS.items():
+        source_config = config.get(source) or {}
+        budgets[source] = max(0, int(source_config.get("max_requests", default_budget)))
+        delays[source] = max(
+            0.0,
+            float(
+                source_config.get("request_delay_seconds", DEFAULT_REQUEST_DELAY_SECONDS[source])
+            ),
+        )
+
+    requests_made: dict[str, int] = dict.fromkeys(budgets, 0)
+    failure_streaks: dict[str, int] = dict.fromkeys(budgets, 0)
+    paused: dict[str, bool] = dict.fromkeys(budgets, False)
+    stats: dict[str, _SignalStats] = {signal: _SignalStats() for signal in SIGNALS}
+    previous = _previous_readings(previous_block)
+    observations: list[dict[str, Any]] = []
+    observed_iso = observed_at.isoformat()
+
+    for target in targets:
+        for signal, url in target.resources.items():
+            spec = SIGNALS[signal]
+            source = spec["source"]
+            signal_stats = stats[signal]
+            reading = None
+            if paused[source] or requests_made[source] >= budgets[source]:
+                signal_stats.skipped += 1
+            else:
+                if requests_made[source] and delays[source]:
+                    sleep(delays[source])
+                requests_made[source] += 1
+                reading = _read_resource(
+                    signal, url, options=options, get_json=get_json, stats=signal_stats
+                )
+                if reading is None:
+                    failure_streaks[source] += 1
+                    paused[source] = failure_streaks[source] >= max_consecutive_failures
+                else:
+                    failure_streaks[source] = 0
+            observation = {
+                "canonical_artifact_id": target.canonical_id,
+                "source": source,
+                "metric": spec["metric"],
+                "value_kind": spec["value_kind"],
+                "source_url": url,
+                "observed_at": observed_iso,
+            }
+            if reading is not None:
+                value, status = reading
+                observations.append({**observation, "value": value, "status": status})
+                continue
+            carried = previous.get((signal, url))
+            if carried is None:
+                continue
+            value, last_successful_date = carried
+            signal_stats.stale += 1
+            observations.append(
+                {
+                    **observation,
+                    "value": value,
+                    "status": "stale",
+                    "last_successful_date": last_successful_date,
+                }
+            )
+
+    health: list[dict[str, Any]] = []
+    source_health: list[SourceHealth] = []
+    for signal, spec in SIGNALS.items():
+        signal_stats = stats[signal]
+        source = spec["source"]
+        succeeded = signal_stats.observed + signal_stats.unavailable
+        ok = not (signal_stats.attempted and succeeded == 0)
+        notes = []
+        if signal_stats.failed:
+            notes.append(
+                f"{signal_stats.failed} of {signal_stats.attempted} requests failed; "
+                f"last: {signal_stats.last_error}"
+            )
+        if paused[source] and signal_stats.skipped:
+            notes.append(f"{source} paused after {max_consecutive_failures} consecutive failures")
+        if signal_stats.skipped:
+            notes.append(
+                f"{signal_stats.skipped} resources not read, "
+                f"{signal_stats.stale} carried forward as stale"
+            )
+        error = "; ".join(notes) or None
+        health.append(
+            {
+                "source": source,
+                "metric": spec["metric"],
+                "ok": ok,
+                "item_count": succeeded,
+                "error": error,
+            }
+        )
+        source_health.append(
+            SourceHealth(
+                source=spec["label"],
+                ok=ok,
+                item_count=succeeded,
+                error=error,
+                kind="attention",
+                method="API",
+            )
+        )
+    block = {
+        "schema_version": BLOCK_SCHEMA_VERSION,
+        "observed_at": observed_iso,
+        "observations": observations,
+        "health": health,
+    }
+    return block, source_health
+
+
+def merge_benchmark_attention(
+    existing: dict[str, Any] | None,
+    incoming: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Union two same-day blocks; the newer reading wins on a shared resource.
+
+    Same rule as evidence and social attention in `merge_snapshots`: a second
+    pass on the day must add to the day's readings, not replace them, and a
+    pass that ran out of budget must not erase counters the earlier pass
+    observed. A reading the newer pass only carried forward as `stale` does
+    not replace one the earlier pass actually made that day. Health describes
+    the newest pass, since it is the one whose failures the ranking should
+    treat as current.
+    """
+    if not existing and not incoming:
+        return None
+    if not incoming:
+        return existing
+    if not existing:
+        return incoming
+    merged: dict[tuple[str, str, str], dict[str, Any]] = {}
+    for observation in existing.get("observations") or []:
+        merged[_observation_key(observation)] = observation
+    for observation in incoming.get("observations") or []:
+        key = _observation_key(observation)
+        if observation.get("status") == "stale" and key in merged:
+            if merged[key].get("status") != "stale":
+                continue
+        merged[key] = observation
+    return {
+        "schema_version": BLOCK_SCHEMA_VERSION,
+        "observed_at": incoming.get("observed_at") or existing.get("observed_at"),
+        "observations": list(merged.values()),
+        "health": list(incoming.get("health") or []),
+    }
+
+
+def _observation_key(observation: dict[str, Any]) -> tuple[str, str, str]:
+    return (
+        str(observation.get("canonical_artifact_id")),
+        str(observation.get("metric")),
+        str(observation.get("source_url")),
+    )

--- a/src/benchmark_radar/briefing.py
+++ b/src/benchmark_radar/briefing.py
@@ -133,6 +133,7 @@ def daily_report_run(snapshot: dict[str, Any], latest_run: RadarRun) -> RadarRun
             for item in (snapshot.get("attention") or {}).get("observations") or []
         ],
         selection=dict(snapshot.get("selection") or {}),
+        benchmark_attention=snapshot.get("benchmark_attention"),
     )
 
 

--- a/src/benchmark_radar/cli.py
+++ b/src/benchmark_radar/cli.py
@@ -729,6 +729,7 @@ def main() -> None:
     run = run_pipeline(
         config,
         previous_snapshot=snapshots[-1] if snapshots else None,
+        snapshots=snapshots,
     )
     _emit_persistent_source_warnings(run, config)
     args.output.parent.mkdir(parents=True, exist_ok=True)
@@ -864,6 +865,11 @@ def main() -> None:
                 ],
                 "producer_health": [health.to_dict() for health in run.producer_health],
                 "selection": report_run.selection,
+                **(
+                    {"benchmark_attention": report_run.benchmark_attention}
+                    if report_run.benchmark_attention
+                    else {}
+                ),
                 # Day-scoped like the evidence above: the briefing describes the
                 # whole UTC day and is shared by every pass over it. Omitted
                 # when the day has none.

--- a/src/benchmark_radar/models.py
+++ b/src/benchmark_radar/models.py
@@ -162,3 +162,8 @@ class RadarRun:
     # published numbers come from the registry rather than from model prose.
     # None when the Q&A did not run; it is opt-in and never blocks a snapshot.
     daily_questions: dict[str, Any] | None = None
+    # The ranking signals observed for released artifacts this pass, in the
+    # `benchmark_attention` shape `snapshots.validate_snapshot` enforces. None
+    # when the collector is disabled, so an absent block means "not collected"
+    # rather than "nothing had attention".
+    benchmark_attention: dict[str, Any] | None = None

--- a/src/benchmark_radar/pipeline.py
+++ b/src/benchmark_radar/pipeline.py
@@ -12,6 +12,7 @@ from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from . import rubric
 from .attention import fetch_attention_feeds
+from .benchmark_attention import collect_benchmark_attention
 from .corpus import exact_artifact_keys
 from .models import RadarItem, RadarRun, SourceHealth
 from .sources import FUTURE_TIMESTAMP_TOLERANCE, SOURCE_FETCHERS, collection_method
@@ -763,6 +764,7 @@ def run_pipeline(
     now: datetime | None = None,
     *,
     previous_snapshot: dict[str, Any] | None = None,
+    snapshots: list[dict[str, Any]] | None = None,
 ) -> RadarRun:
     now = now or datetime.now(UTC)
     settings = config["radar"]
@@ -865,6 +867,23 @@ def run_pipeline(
         previous_observations=((previous_snapshot or {}).get("attention") or {}).get("observations")
         or [],
     )
+    # Ranking signals are observed for every release still inside the
+    # leaderboard's widest window, not only today's, so the counters of a
+    # three-week-old release keep moving. The history is the committed
+    # snapshots; a caller that only has the previous day's file still gets
+    # that day's releases observed.
+    history = snapshots if snapshots is not None else [previous_snapshot or {}]
+    attention_items = [
+        *(item for snapshot in history for item in snapshot.get("evidence_items") or []),
+        *(item.to_dict() for item in published),
+    ]
+    benchmark_attention, benchmark_attention_health = collect_benchmark_attention(
+        config.get("benchmark_attention") or {},
+        attention_items,
+        observed_at=now,
+        previous_block=(previous_snapshot or {}).get("benchmark_attention"),
+    )
+    attention_health = [*attention_health, *benchmark_attention_health]
     previous_streaks = ((previous_snapshot or {}).get("discovery_state") or {}).get(
         "source_failure_streaks"
     ) or {}
@@ -899,4 +918,5 @@ def run_pipeline(
             "attention": attention_state,
             "source_failure_streaks": failure_streaks,
         },
+        benchmark_attention=benchmark_attention,
     )

--- a/src/benchmark_radar/release_leaderboard.py
+++ b/src/benchmark_radar/release_leaderboard.py
@@ -105,7 +105,14 @@ def is_dedicated_benchmark_repo(url: str | None) -> bool:
     match = re.search(r"^https?://(?:www\.)?github\.com/([^/]+)/([^/#?]+)", url, re.I)
     if not match:
         return False
-    path_suffix = url.split("github.com/", 1)[1].split("?")[0].split("#")[0].strip("/")
+    # Split the same way the match above was made: case-insensitively. A
+    # capitalised "GitHub.com/..." matched the regex and then found nothing to
+    # split on, raising IndexError. That was survivable while only the
+    # leaderboard build called this, but the attention collector now calls it
+    # inside run_pipeline, where one such link in historical evidence would
+    # abort the whole daily run.
+    path_suffix = re.split(r"github\.com/", url, maxsplit=1, flags=re.I)[1]
+    path_suffix = path_suffix.split("?")[0].split("#")[0].strip("/")
     parts = [p for p in path_suffix.split("/") if p]
     return len(parts) == 2
 

--- a/src/benchmark_radar/snapshots.py
+++ b/src/benchmark_radar/snapshots.py
@@ -12,6 +12,7 @@ from typing import Any
 from . import kw_bench
 from .app_pages import write_app_pages
 from .attention import fetch_attention_feeds
+from .benchmark_attention import merge_benchmark_attention
 from .benchmark_scores import DEFAULT_SCORES_PATH, load_scores, score_progression
 from .blog import write_blog
 from .corpus import (
@@ -106,6 +107,9 @@ def snapshot_for_run(run: RadarRun) -> dict[str, Any]:
         "producer_health": [health.to_dict() for health in run.producer_health],
         "selection": run.selection,
         "discovery_state": run.discovery_state,
+        # Present only when the collector ran, so the ranking can tell "no
+        # signals observed" from "collection disabled" (issue #530).
+        **({"benchmark_attention": run.benchmark_attention} if run.benchmark_attention else {}),
     }
 
 
@@ -738,6 +742,12 @@ def merge_snapshots(existing: dict[str, Any], incoming: dict[str, Any]) -> dict[
     else:
         day_questions = incoming_questions or existing_questions
 
+    # Ranking signals follow the same union rule: a second pass that ran out
+    # of request budget must not erase the counters the first pass observed.
+    merged_benchmark_attention = merge_benchmark_attention(
+        existing.get("benchmark_attention"), incoming.get("benchmark_attention")
+    )
+
     merged = {
         **incoming,
         "evidence_items": evidence_items,
@@ -750,6 +760,10 @@ def merge_snapshots(existing: dict[str, Any], incoming: dict[str, Any]) -> dict[
         merged["briefing"] = briefing
     else:
         merged.pop("briefing", None)
+    if merged_benchmark_attention:
+        merged["benchmark_attention"] = merged_benchmark_attention
+    else:
+        merged.pop("benchmark_attention", None)
     if day_questions:
         merged["questions"] = day_questions
     else:

--- a/tests/test_benchmark_attention.py
+++ b/tests/test_benchmark_attention.py
@@ -1,0 +1,709 @@
+"""The collector behind the Latest Releases leaderboard's signals (issue #530).
+
+Before it existed nothing wrote `benchmark_attention`, so every window of the
+leaderboard collapsed to hand-reviewed registry entries with `unknown`
+signals (issue #589). Each test names the failure it protects against.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+from benchmark_radar.benchmark_attention import (
+    collect_benchmark_attention,
+    merge_benchmark_attention,
+    select_targets,
+)
+from benchmark_radar.briefing import daily_report_run
+from benchmark_radar.http import RequestError
+from benchmark_radar.models import RadarItem, SourceHealth
+from benchmark_radar.pipeline import run_pipeline
+from benchmark_radar.release_leaderboard import build_latest_releases_leaderboard
+from benchmark_radar.snapshots import (
+    SCHEMA_VERSION,
+    merge_snapshots,
+    snapshot_for_run,
+    validate_snapshot,
+)
+
+NOW = datetime(2026, 9, 10, 9, 0, tzinfo=UTC)
+REPO = "https://github.com/org/bench"
+PAPER = "https://huggingface.co/papers/2609.01234"
+DATASET = "https://huggingface.co/datasets/org/bench-data"
+
+CONFIG = {
+    "enabled": True,
+    "window_days": 90,
+    "github": {"max_requests": 10, "request_delay_seconds": 0.0},
+    "huggingface": {"max_requests": 10, "request_delay_seconds": 0.0},
+    "attempts": 1,
+    "timeout_seconds": 5,
+}
+
+
+def _item(url, *, days_ago, event_kind="released", artifact_urls=(), source="GitHub"):
+    published = NOW - timedelta(days=days_ago)
+    return RadarItem(
+        source=source,
+        source_id=url,
+        title=f"Bench {url}",
+        url=url,
+        published_at=published,
+        updated_at=published,
+        discovered_at=published,
+        event_kind=event_kind,
+        artifact_urls=list(artifact_urls),
+    ).to_dict()
+
+
+def _snapshot(generated_at, evidence_items=(), benchmark_attention=None):
+    snapshot = {
+        "schema_version": SCHEMA_VERSION,
+        "date": generated_at.date().isoformat(),
+        "generated_at": generated_at.isoformat(),
+        "since": (generated_at - timedelta(hours=48)).isoformat(),
+        "evidence_items": list(evidence_items),
+        "attention": {"observations": []},
+        "ingest_health": [],
+        "producer_health": [],
+        "discovery_state": {},
+        "selection": {},
+    }
+    if benchmark_attention is not None:
+        snapshot["benchmark_attention"] = benchmark_attention
+    return snapshot
+
+
+def _observation(canonical_id, value, *, url=REPO, status="fresh"):
+    return {
+        "canonical_artifact_id": canonical_id,
+        "source": "github",
+        "metric": "stars",
+        "value": value,
+        "value_kind": "cumulative",
+        "source_url": url,
+        "status": status,
+    }
+
+
+class FakeApi:
+    """Answer each resource URL with a payload or raise the configured error."""
+
+    def __init__(self, responses):
+        self.responses = responses
+        self.calls: list[str] = []
+
+    def __call__(self, url, **kwargs):
+        self.calls.append(url)
+        response = self.responses.get(url)
+        if isinstance(response, Exception):
+            raise response
+        if response is None:
+            raise RequestError(f"HTTP 404 from {url}")
+        return response
+
+
+GITHUB_API = "https://api.github.com/repos/org/bench"
+PAPER_API = "https://huggingface.co/api/papers/2609.01234"
+DATASET_API = "https://huggingface.co/api/datasets/org/bench-data"
+
+
+def test_a_clone_url_reads_the_repository_rather_than_a_404():
+    # Authors paste clone URLs into a `code` field, and the exactness rule
+    # accepts one because it names the same repository. api.github.com has no
+    # repository whose name ends in `.git`, so the unstripped path 404s and a
+    # live repository would be recorded as `unavailable` -- the misreading this
+    # module exists to prevent, made permanent because only fresh and stale
+    # readings are ever carried forward. The reported source_url stays the URL
+    # as deposited.
+    api = FakeApi({GITHUB_API: {"stargazers_count": 150}})
+    block = collect_benchmark_attention(
+        CONFIG,
+        [
+            _item(
+                "https://arxiv.org/abs/2609.01234",
+                days_ago=3,
+                artifact_urls=[f"{REPO}.git"],
+                source="arXiv",
+            )
+        ],
+        observed_at=NOW,
+        get_json=api,
+    )[0]
+
+    assert api.calls == [GITHUB_API]
+    observation = block["observations"][0]
+    assert (observation["value"], observation["status"]) == (150, "fresh")
+    assert observation["source_url"] == f"{REPO}.git"
+
+
+def test_a_capitalised_github_host_does_not_abort_the_run():
+    # The exactness predicate matched the host case-insensitively and then
+    # split the URL case-sensitively, so a capitalised link raised IndexError.
+    # The collector calls that predicate inside run_pipeline, where one such
+    # link in historical evidence would abort the whole daily run rather than
+    # skip one resource.
+    api = FakeApi({"https://api.github.com/repos/Org/Bench": {"stargazers_count": 7}})
+    block = collect_benchmark_attention(
+        CONFIG,
+        [_item("https://GitHub.com/Org/Bench", days_ago=3)],
+        observed_at=NOW,
+        get_json=api,
+    )[0]
+
+    assert [observation["value"] for observation in block["observations"]] == [7]
+
+
+def test_select_targets_groups_by_identity_and_keeps_only_exact_resources():
+    # The ranking groups occurrences by alias-mapped exact key and dates the
+    # release by its earliest `released` observation. A paper item carrying
+    # the repository URL and the repository's own item must become one target
+    # whose release date is the older of the two, or a re-announcement would
+    # move a benchmark back into a window it has left.
+    linked = "https://github.com/org/linked"
+    items = [
+        _item("https://arxiv.org/abs/2609.01234", days_ago=3, artifact_urls=[REPO], source="arXiv"),
+        _item(REPO, days_ago=5),
+        _item(DATASET, days_ago=1, source="Hugging Face"),
+        # A subdirectory of a hosting repository is not the benchmark's own
+        # repository; crediting the host's stars would be misattribution.
+        _item("https://github.com/org/monorepo/tree/main/bench", days_ago=2),
+        # Routine updates are not releases.
+        _item("https://github.com/org/updated", days_ago=1, event_kind="updated"),
+        # Outside the widest window the ranking shows.
+        _item("https://github.com/org/ancient", days_ago=120),
+        # A paper released without a repository, whose repository's own
+        # `updated` record links back to it: the update supplies the resource
+        # but must not supply the release date.
+        _item("https://arxiv.org/abs/2609.05555", days_ago=4, source="arXiv"),
+        _item(
+            linked,
+            days_ago=1,
+            event_kind="updated",
+            artifact_urls=["https://arxiv.org/abs/2609.05555"],
+        ),
+    ]
+
+    targets = select_targets(items, as_of=NOW, window_days=90)
+
+    assert [target.resources for target in targets] == [
+        {"hf_dataset_downloads": DATASET},
+        {"github_stars": linked},
+        {"github_stars": REPO},
+    ]
+    assert targets[1].released_at == NOW - timedelta(days=4)
+    assert targets[2].released_at == NOW - timedelta(days=5)
+
+
+def test_collector_writes_a_block_the_snapshot_validator_accepts():
+    api = FakeApi(
+        {
+            GITHUB_API: {"stargazers_count": 150, "forks_count": 3},
+            PAPER_API: {"upvotes": 20},
+            DATASET_API: {"downloads": 1000, "downloadsAllTime": 99999},
+        }
+    )
+    items = [
+        _item(
+            "https://arxiv.org/abs/2609.01234",
+            days_ago=3,
+            artifact_urls=[REPO, PAPER],
+            source="arXiv",
+        ),
+        _item(DATASET, days_ago=1, source="Hugging Face"),
+    ]
+
+    block, health = collect_benchmark_attention(CONFIG, items, observed_at=NOW, get_json=api)
+
+    by_metric = {observation["metric"]: observation for observation in block["observations"]}
+    assert by_metric["stars"]["value"] == 150 and by_metric["stars"]["value_kind"] == "cumulative"
+    # Counters stay whole numbers in the snapshot; 150 must not become 150.0.
+    assert all(isinstance(o["value"], int) for o in block["observations"])
+    assert by_metric["upvotes"]["value"] == 20 and by_metric["upvotes"]["source"] == "huggingface"
+    # The Hub's `downloads` is the rolling 30-day figure the ranking weights,
+    # not the all-time counter.
+    assert by_metric["downloads_30d"]["value"] == 1000
+    assert by_metric["downloads_30d"]["value_kind"] == "rolling_30d"
+    assert {observation["status"] for observation in block["observations"]} == {"fresh"}
+    assert all(row["ok"] and row["item_count"] == 1 for row in block["health"])
+    assert [row.kind for row in health] == ["attention"] * 3
+    validate_snapshot(_snapshot(NOW, benchmark_attention=block))
+
+
+def test_missing_resource_is_unavailable_not_zero():
+    # A deleted repository must not rank below a live one with a single star;
+    # the ranking treats null as "no signal", zero as a reading.
+    api = FakeApi({GITHUB_API: RequestError(f"HTTP 404 from {GITHUB_API}")})
+
+    block, health = collect_benchmark_attention(
+        CONFIG, [_item(REPO, days_ago=2)], observed_at=NOW, get_json=api
+    )
+
+    (observation,) = block["observations"]
+    assert observation["status"] == "unavailable" and observation["value"] is None
+    stars_health = next(row for row in block["health"] if row["metric"] == "stars")
+    assert stars_health["ok"] is True and stars_health["item_count"] == 1
+    validate_snapshot(_snapshot(NOW, benchmark_attention=block))
+
+
+def test_transient_failure_carries_the_last_reading_forward_as_stale():
+    # A rate limit on one repository is not a fact about that benchmark. The
+    # ranking reports whatever the newest observation says, so writing
+    # nothing would leave yesterday's reading reported as fresh: the last
+    # reading is written again as stale, dated by the day it was read. `ok`
+    # stays true, because a failed health event at the same instant as fresh
+    # observations would demote all of them to stale.
+    other = "https://github.com/org/other"
+    api = FakeApi(
+        {
+            GITHUB_API: RequestError(f"HTTP 429 from {GITHUB_API} after 3 attempts"),
+            "https://api.github.com/repos/org/other": {"stargazers_count": 7},
+        }
+    )
+    items = [_item(REPO, days_ago=1), _item(other, days_ago=2)]
+    yesterday = NOW - timedelta(days=1)
+    previous = {
+        "schema_version": 1,
+        "observed_at": yesterday.isoformat(),
+        "observations": [
+            {
+                "canonical_artifact_id": "artifact:github:org/bench",
+                "source": "github",
+                "metric": "stars",
+                "value": 140,
+                "value_kind": "cumulative",
+                "source_url": REPO,
+                "status": "fresh",
+                "observed_at": yesterday.isoformat(),
+            }
+        ],
+        "health": [],
+    }
+
+    block, health = collect_benchmark_attention(
+        CONFIG, items, observed_at=NOW, previous_block=previous, get_json=api
+    )
+
+    by_url = {observation["source_url"]: observation for observation in block["observations"]}
+    assert by_url[other]["status"] == "fresh" and by_url[other]["value"] == 7
+    assert by_url[REPO]["status"] == "stale" and by_url[REPO]["value"] == 140
+    assert by_url[REPO]["last_successful_date"] == yesterday.date().isoformat()
+    assert by_url[REPO]["observed_at"] == NOW.isoformat()
+    stars_health = next(row for row in block["health"] if row["metric"] == "stars")
+    assert stars_health["ok"] is True and stars_health["item_count"] == 1
+    assert stars_health["error"].startswith("1 of 2 requests failed; last: RequestError: HTTP 429")
+    validate_snapshot(_snapshot(NOW, benchmark_attention=block))
+
+    # Two days later the reading is still dated by the day it was read, so a
+    # chain of failures cannot make an old counter look recent.
+    later = NOW + timedelta(days=1)
+    chained, _ = collect_benchmark_attention(
+        CONFIG, items, observed_at=later, previous_block=block, get_json=api
+    )
+    carried = next(o for o in chained["observations"] if o["source_url"] == REPO)
+    assert carried["status"] == "stale"
+    assert carried["last_successful_date"] == yesterday.date().isoformat()
+
+    # With nothing to carry forward, a failure writes nothing: a null reading
+    # would admit the artifact to the cohort with no signal to rank on.
+    bare, _ = collect_benchmark_attention(CONFIG, items, observed_at=NOW, get_json=api)
+    assert [observation["source_url"] for observation in bare["observations"]] == [other]
+
+
+def test_the_ranking_reports_the_carried_reading_as_stale():
+    # End to end through `_resolve_attention_metric`: the day after a failure
+    # the leaderboard shows the old value marked stale, not fresh.
+    evidence = [_item(REPO, days_ago=5)]
+    first, _ = collect_benchmark_attention(
+        CONFIG,
+        evidence,
+        observed_at=NOW - timedelta(days=1),
+        get_json=FakeApi({GITHUB_API: {"stargazers_count": 150}}),
+    )
+    second, _ = collect_benchmark_attention(
+        CONFIG,
+        evidence,
+        observed_at=NOW,
+        previous_block=first,
+        get_json=FakeApi({GITHUB_API: RequestError(f"HTTP 503 from {GITHUB_API}")}),
+    )
+    snapshots = [
+        _snapshot(NOW - timedelta(days=1), evidence_items=evidence, benchmark_attention=first),
+        _snapshot(NOW, evidence_items=evidence, benchmark_attention=second),
+    ]
+
+    payload = build_latest_releases_leaderboard(snapshots, as_of=NOW, reviewed_benchmark_ids=set())
+
+    stars = payload["windows"]["30d"]["entries"][0]["components"]["github_stars"]
+    assert (stars["value"], stars["status"]) == (150, "stale")
+    assert stars["last_successful_date"] == (NOW - timedelta(days=1)).date().isoformat()
+
+
+def test_a_source_is_paused_after_consecutive_failures():
+    # An outage answers every request the same way; waiting out the timeout
+    # for each of a thousand resources would outlive the daily workflow. The
+    # source is not asked again this run, its unread resources keep their
+    # stale readings, and the other source is unaffected.
+    repos = [f"https://github.com/org/r{index}" for index in range(8)]
+    api = FakeApi(
+        {
+            **{
+                f"https://api.github.com/repos/org/r{index}": RequestError("HTTP 502 from x")
+                for index in range(8)
+            },
+            DATASET_API: {"downloads": 3},
+        }
+    )
+    items = [
+        *(_item(url, days_ago=index + 1) for index, url in enumerate(repos)),
+        _item(DATASET, days_ago=20, source="Hugging Face"),
+    ]
+    previous = {
+        "schema_version": 1,
+        "observed_at": (NOW - timedelta(days=1)).isoformat(),
+        "observations": [
+            {
+                "canonical_artifact_id": "artifact:github:org/r7",
+                "source": "github",
+                "metric": "stars",
+                "value": 9,
+                "value_kind": "cumulative",
+                "source_url": repos[7],
+                "status": "fresh",
+            }
+        ],
+        "health": [],
+    }
+    config = {**CONFIG, "max_consecutive_failures": 3}
+
+    block, _ = collect_benchmark_attention(
+        config, items, observed_at=NOW, previous_block=previous, get_json=api
+    )
+
+    assert len([call for call in api.calls if "api.github.com" in call]) == 3
+    assert DATASET_API in api.calls
+    by_url = {observation["source_url"]: observation for observation in block["observations"]}
+    assert set(by_url) == {repos[7], DATASET}
+    assert by_url[repos[7]]["status"] == "stale"
+    stars_health = next(row for row in block["health"] if row["metric"] == "stars")
+    assert stars_health["ok"] is False
+    assert "github paused after 3 consecutive failures" in stars_health["error"]
+    assert "5 resources not read, 1 carried forward as stale" in stars_health["error"]
+    # A success resets the streak: three failures spread across successes do
+    # not pause the source.
+    spread = FakeApi(
+        {
+            f"https://api.github.com/repos/org/r{index}": (
+                RequestError("HTTP 502 from x") if index % 2 else {"stargazers_count": 1}
+            )
+            for index in range(8)
+        }
+    )
+    collect_benchmark_attention(config, items[:-1], observed_at=NOW, get_json=spread)
+    assert len(spread.calls) == 8
+
+
+def test_every_request_failing_marks_the_signal_unhealthy():
+    api = FakeApi({GITHUB_API: RequestError(f"HTTP 403 from {GITHUB_API}")})
+
+    block, health = collect_benchmark_attention(
+        CONFIG, [_item(REPO, days_ago=1)], observed_at=NOW, get_json=api
+    )
+
+    assert block["observations"] == []
+    stars_health = next(row for row in block["health"] if row["metric"] == "stars")
+    assert stars_health["ok"] is False and stars_health["item_count"] == 0
+    assert next(row for row in health if row.source == "GitHub stars").ok is False
+    validate_snapshot(_snapshot(NOW, benchmark_attention=block))
+
+
+def test_malformed_payload_is_a_failure_not_a_reading():
+    # A payload without the counter is a parsing gap, not a benchmark with
+    # zero stars; and a response that is not JSON at all, or any other
+    # exception from one resource, must not abort the readings after it.
+    other = "https://github.com/org/other"
+    api = FakeApi(
+        {
+            GITHUB_API: {"full_name": "org/bench"},
+            "https://api.github.com/repos/org/other": json.JSONDecodeError("bad", "<html>", 0),
+            "https://api.github.com/repos/org/third": {"stargazers_count": 4},
+        }
+    )
+    items = [
+        _item(REPO, days_ago=1),
+        _item(other, days_ago=2),
+        _item("https://github.com/org/third", days_ago=3),
+    ]
+
+    block, _ = collect_benchmark_attention(CONFIG, items, observed_at=NOW, get_json=api)
+
+    assert [observation["value"] for observation in block["observations"]] == [4]
+    stars_health = next(row for row in block["health"] if row["metric"] == "stars")
+    assert stars_health["ok"] is True
+    assert stars_health["error"].startswith("2 of 3 requests failed; last: JSONDecodeError")
+
+
+def test_budget_is_spent_newest_first_and_the_unread_tail_is_carried_forward():
+    # A budget below the cohort must refresh the releases the leaderboard
+    # shows by default before the 90-day tail; a paper and the repository it
+    # names are one artifact and cost one request; and the release the budget
+    # did not reach keeps its last reading as stale instead of vanishing.
+    newest = "https://github.com/org/newest"
+    oldest = "https://github.com/org/oldest"
+    api = FakeApi(
+        {
+            "https://api.github.com/repos/org/newest": {"stargazers_count": 1},
+            GITHUB_API: {"stargazers_count": 2},
+            "https://api.github.com/repos/org/oldest": {"stargazers_count": 3},
+        }
+    )
+    items = [
+        _item(oldest, days_ago=30),
+        _item(newest, days_ago=1),
+        _item(REPO, days_ago=10),
+        _item(
+            "https://arxiv.org/abs/2609.09999", days_ago=10, artifact_urls=[REPO], source="arXiv"
+        ),
+    ]
+    config = {**CONFIG, "github": {"max_requests": 2, "request_delay_seconds": 0.0}}
+    previous = {
+        "schema_version": 1,
+        "observed_at": (NOW - timedelta(days=1)).isoformat(),
+        "observations": [
+            {
+                "canonical_artifact_id": "artifact:github:org/oldest",
+                "source": "github",
+                "metric": "stars",
+                "value": 2,
+                "value_kind": "cumulative",
+                "source_url": oldest,
+                "status": "fresh",
+            }
+        ],
+        "health": [],
+    }
+
+    block, _ = collect_benchmark_attention(
+        config, items, observed_at=NOW, previous_block=previous, get_json=api
+    )
+
+    assert api.calls == [
+        "https://api.github.com/repos/org/newest",
+        GITHUB_API,
+    ]
+    by_url = {observation["source_url"]: observation for observation in block["observations"]}
+    assert {url: o["status"] for url, o in by_url.items()} == {
+        newest: "fresh",
+        REPO: "fresh",
+        oldest: "stale",
+    }
+    assert by_url[oldest]["value"] == 2
+    stars_health = next(row for row in block["health"] if row["metric"] == "stars")
+    assert stars_health["ok"] is True
+    assert stars_health["error"] == "1 resources not read, 1 carried forward as stale"
+    validate_snapshot(_snapshot(NOW, benchmark_attention=block))
+
+
+def test_disabled_collector_writes_nothing():
+    assert collect_benchmark_attention({"enabled": False}, [], observed_at=NOW) == (None, [])
+    assert collect_benchmark_attention({}, [], observed_at=NOW) == (None, [])
+
+
+def test_merge_unions_readings_and_the_newer_pass_wins():
+    # Issue #104 rule applied to signals: a second pass that ran out of budget
+    # must not erase the counters the first pass observed.
+    first = {
+        "schema_version": 1,
+        "observed_at": "2026-09-10T03:00:00+00:00",
+        "observations": [
+            {"canonical_artifact_id": "a", "metric": "stars", "source_url": REPO, "value": 10},
+            {
+                "canonical_artifact_id": "b",
+                "metric": "stars",
+                "source_url": "https://github.com/o/b",
+                "value": 5,
+            },
+        ],
+        "health": [
+            {"source": "github", "metric": "stars", "ok": True, "item_count": 2, "error": None}
+        ],
+    }
+    second = {
+        "schema_version": 1,
+        "observed_at": "2026-09-10T15:00:00+00:00",
+        "observations": [
+            {"canonical_artifact_id": "a", "metric": "stars", "source_url": REPO, "value": 12},
+        ],
+        "health": [
+            {"source": "github", "metric": "stars", "ok": True, "item_count": 1, "error": None}
+        ],
+    }
+
+    merged = merge_benchmark_attention(first, second)
+
+    assert merged["observed_at"] == "2026-09-10T15:00:00+00:00"
+    assert {(o["canonical_artifact_id"], o["value"]) for o in merged["observations"]} == {
+        ("a", 12),
+        ("b", 5),
+    }
+    assert merged["health"] == second["health"]
+    assert merge_benchmark_attention(None, None) is None
+    assert merge_benchmark_attention(first, None) is first
+
+    # A reading the later pass only carried forward as stale must not replace
+    # the reading the earlier pass made that day.
+    carried = {
+        **second,
+        "observations": [
+            {
+                "canonical_artifact_id": "a",
+                "metric": "stars",
+                "source_url": REPO,
+                "value": 10,
+                "status": "stale",
+            }
+        ],
+    }
+    kept = {
+        o["canonical_artifact_id"]: o
+        for o in merge_benchmark_attention(first, carried)["observations"]
+    }
+    assert kept["a"]["value"] == 10 and "status" not in kept["a"]
+    assert merge_benchmark_attention(carried, second)["observations"][0]["value"] == 12
+
+    existing = _snapshot(NOW - timedelta(hours=12), benchmark_attention=first)
+    incoming = _snapshot(NOW, benchmark_attention=second)
+    assert len(merge_snapshots(existing, incoming)["benchmark_attention"]["observations"]) == 2
+    without = merge_snapshots(_snapshot(NOW - timedelta(hours=12)), _snapshot(NOW))
+    assert "benchmark_attention" not in without
+
+
+def test_pipeline_observes_releases_across_the_history_and_writes_the_block(monkeypatch):
+    # The counters of a three-week-old release keep moving, so the collector
+    # must see the committed history, not only today's items; and the block
+    # must reach the snapshot with its health rows in the attention list.
+    pipeline = __import__("benchmark_radar.pipeline", fromlist=["SOURCE_FETCHERS"])
+    today = RadarItem(
+        source="GitHub",
+        source_id="org/today",
+        title="Today Bench",
+        url="https://github.com/org/today",
+        published_at=NOW,
+        updated_at=NOW,
+        event_kind="released",
+        summary="A benchmark released today.",
+    )
+    monkeypatch.setitem(pipeline.SOURCE_FETCHERS, "github", lambda config, since, limit: [today])
+    monkeypatch.setattr(
+        pipeline,
+        "fetch_attention_feeds",
+        lambda *args, **kwargs: ([], [], [], {}),
+    )
+    seen: dict[str, object] = {}
+
+    def fake_collect(config, items, *, observed_at, previous_block=None):
+        seen["items"] = items
+        seen["previous_block"] = previous_block
+        block = {
+            "schema_version": 1,
+            "observed_at": observed_at.isoformat(),
+            "observations": [_observation("artifact:github:org/today", 1)],
+            "health": [],
+        }
+        return block, [SourceHealth(source="GitHub stars", ok=True, kind="attention")]
+
+    monkeypatch.setattr(pipeline, "collect_benchmark_attention", fake_collect)
+    yesterday_block = {
+        "schema_version": 1,
+        "observed_at": (NOW - timedelta(days=1)).isoformat(),
+        "observations": [_observation("artifact:github:org/bench", 140)],
+        "health": [],
+    }
+    history = [
+        _snapshot(NOW - timedelta(days=20), evidence_items=[_item(REPO, days_ago=20)]),
+        _snapshot(NOW - timedelta(days=1), benchmark_attention=yesterday_block),
+    ]
+    config = {
+        "radar": {
+            "lookback_hours": 48,
+            "max_items_per_source": 10,
+            "report_limit": 10,
+            "minimum_score": 0,
+        },
+        "taxonomy": {"benchmark": ["benchmark"]},
+        "sources": {"github": {"enabled": True}},
+        "benchmark_attention": {"enabled": True},
+    }
+
+    run = run_pipeline(config, NOW, previous_snapshot=history[-1], snapshots=history)
+
+    assert {item["url"] for item in seen["items"]} == {REPO, "https://github.com/org/today"}
+    # Yesterday's readings are what today's failures carry forward.
+    assert seen["previous_block"] is yesterday_block
+    assert run.benchmark_attention["schema_version"] == 1
+    assert [health.source for health in run.attention_ingest_health] == ["GitHub stars"]
+    snapshot = snapshot_for_run(run)
+    validate_snapshot(snapshot)
+    assert snapshot["benchmark_attention"] is run.benchmark_attention
+    # A day merged from two passes reports the merged block, not this pass's.
+    earlier_pass = _snapshot(
+        NOW - timedelta(hours=6),
+        benchmark_attention={
+            **yesterday_block,
+            "observations": [_observation("artifact:github:org/other", 5)],
+        },
+    )
+    merged = merge_snapshots(earlier_pass, snapshot)
+    reported = daily_report_run(merged, run).benchmark_attention
+    assert reported is not run.benchmark_attention
+    assert {o["canonical_artifact_id"] for o in reported["observations"]} == {
+        "artifact:github:org/other",
+        "artifact:github:org/today",
+    }
+
+
+def test_disabled_collector_leaves_the_snapshot_without_a_block(monkeypatch):
+    pipeline = __import__("benchmark_radar.pipeline", fromlist=["SOURCE_FETCHERS"])
+    monkeypatch.setitem(pipeline.SOURCE_FETCHERS, "github", lambda config, since, limit: [])
+    monkeypatch.setattr(pipeline, "fetch_attention_feeds", lambda *a, **k: ([], [], [], {}))
+    config = {
+        "radar": {
+            "lookback_hours": 48,
+            "max_items_per_source": 10,
+            "report_limit": 10,
+            "minimum_score": 0,
+        },
+        "taxonomy": {"benchmark": ["benchmark"]},
+        "sources": {"github": {"enabled": True}},
+    }
+
+    run = run_pipeline(config, NOW)
+
+    assert run.benchmark_attention is None
+    assert "benchmark_attention" not in snapshot_for_run(run)
+
+
+def test_leaderboard_ranks_a_release_from_the_collected_block():
+    # End to end: an unreviewed release with a dedicated repository enters the
+    # 30-day cohort only because the collector observed it, and ranks
+    # formally because GitHub stars are a durable signal above the 45% floor.
+    api = FakeApi({GITHUB_API: {"stargazers_count": 150}})
+    evidence = [_item(REPO, days_ago=5)]
+    block, _ = collect_benchmark_attention(CONFIG, evidence, observed_at=NOW, get_json=api)
+    snapshots = [_snapshot(NOW, evidence_items=evidence, benchmark_attention=block)]
+
+    payload = build_latest_releases_leaderboard(snapshots, as_of=NOW, reviewed_benchmark_ids=set())
+
+    window = payload["windows"]["30d"]
+    assert window["ranked_count"] == 1
+    entry = window["entries"][0]
+    assert entry["status"] == "ranked"
+    stars = entry["components"]["github_stars"]
+    assert (stars["value"], stars["status"], stars["source_url"]) == (150, "fresh", REPO)
+    # Without the block the same release is invisible: this is the failure
+    # issue #589 reported.
+    bare = build_latest_releases_leaderboard(
+        [_snapshot(NOW, evidence_items=evidence)], as_of=NOW, reviewed_benchmark_ids=set()
+    )
+    assert bare["windows"]["30d"]["entries"] == []


### PR DESCRIPTION
Part of #530. Closes #589.

One commit on top of upstream `main` at 5d9e378.

## What this gives the leaderboard

- **The "Latest releases" windows fill with attributable numbers.** After a clean build of today's `main`, the 30-day window holds one entry and the 7-day window none, every signal `unknown`. That is not a data problem: the ranking engine, the `benchmark_attention` validator and their tests all landed for #530, but nothing produced the block they read. This PR is that producer.
- **Every number is dated and points at its exact resource.** GitHub stars from the benchmark's own repository, Hugging Face paper upvotes from its paper page, Hugging Face 30-day dataset downloads from its dataset page, each observation carrying `observed_at` and the resource URL the validator requires.
- **No new secret, no workflow change.** Both APIs are anonymous for reads; the workflow's existing `GITHUB_TOKEN` only raises the GitHub budget from 60 to 5,000 requests an hour.
- **Cost per daily run, from the committed snapshots as of 2026-09-10:** the 30-day window has 312 releases with a dedicated repository, 30 with a paper page and 508 with a dataset page; the 90-day tail adds another 160 repositories and 291 datasets, so a full pass is about 470 GitHub and 830 Hugging Face requests. Budgets default to 800 and 1,200, spent newest release first, and a run stops asking a source after five failures in a row, so an outage costs minutes rather than the timeout times the cohort.

## The page half

`/leaderboard/` still opens on the model-card adoption view on `main`. The engine's payload is populated by this PR, and the view that reads it, opening the page on Latest releases · 30d, is the latest-releases view PR. The two are independent and merge in either order: with this one first the page gains real numbers the moment the view lands; with the view first it shows its empty state until this collector runs.

## How the collector decides, and what each rule prevents

- **Only exact resources.** A repository that hosts a benchmark in a subdirectory would credit the host's stars to the benchmark; `is_exact_attention_source_url` is the single rule, shared with the validator.
- **A gone resource is `unavailable`, never zero.** The ranking treats null as "no signal"; a zero would rank a deleted repository below a live one with a single star. HTTP 404, 410 and 451 are the only codes read as facts about the artifact.
- **A failed request carries the last reading forward as `stale`.** A rate limit or outage is a fact about the request, not the benchmark. `_resolve_attention_metric` reports whatever the newest observation says, so writing nothing would leave yesterday's reading reported as fresh; instead the previous snapshot's reading is written again with `status: stale` and `last_successful_date` set to the day it was actually read, and a chain of failures keeps that date rather than refreshing it. With nothing to carry forward, nothing is written: a null reading would admit the artifact to the cohort with no signal to rank on. No exception escapes a single resource read (an HTML error page where JSON was expected counts as a failed request), so one bad response cannot abort the hundreds after it.
- **Health per (source, metric), `ok` while anything succeeded.** The engine reads a failed health event at the same instant as fresh observations as a reason to demote all of them to stale, so one throttled repository must not flip the whole source; and a paper-page outage must not stale dataset downloads.
- **Budgets newest-first, and a pause after consecutive failures.** The 7- and 30-day windows the leaderboard shows by default are refreshed before the 90-day tail; a release the budget does not reach keeps its last reading as stale rather than dropping out. A source that fails `max_consecutive_failures` (5) times in a row is not asked again that run, because a rate limit answers every request alike and waiting out the timeout for each of a thousand resources would outlive the daily workflow. The health row says so: `github paused after 5 consecutive failures; 312 resources not read, 298 carried forward as stale`.
- **Identity follows the engine's rule.** Occurrences are grouped by alias-mapped exact artifact key and dated by their earliest `released` observation, so a re-announcement cannot move a benchmark back into a window it has left, and the observation's `canonical_artifact_id` is the id `filter_release_cohort` groups on. Resources are gathered from every occurrence, because the repository of a paper released without one often arrives later on the repository's own `updated` record; only the date is restricted to `released` records. A paper and the repository it names are one artifact and cost one request.

## Wiring

- `src/benchmark_radar/benchmark_attention.py`: `select_targets`, `collect_benchmark_attention`, `merge_benchmark_attention`.
- `pipeline.run_pipeline`: new keyword `snapshots` (the committed history), because the counters of a three-week-old release keep moving and the collector must see releases older than today's 48-hour lookback; the previous snapshot's block goes in as `previous_block` for the stale carry-forward; the collector's health rows join the attention health list.
- `models.RadarRun.benchmark_attention`; `snapshots.snapshot_for_run` writes the block only when the collector ran, so an absent block means "not collected" rather than "nothing had attention"; `merge_snapshots` unions same-day passes under the issue #104 rule (a pass that ran out of budget must not erase the first pass's readings, and a reading the later pass only carried forward as stale never replaces one the earlier pass actually made that day).
- `cli.py`: passes the history in and mirrors the block into `out/items.json`; `briefing.daily_report_run` carries the merged day's block.
- `config.yml`: `benchmark_attention` block (`window_days`, per-source `max_requests` and `request_delay_seconds`, `max_consecutive_failures`, `attempts`, `timeout_seconds`), with the rules above documented in place.

## Tests

`tests/test_benchmark_attention.py`, fourteen tests, each named for the failure it protects against: identity grouping and exact-resource selection (subdirectory URLs, out-of-window releases and never-released artifacts excluded, a repository learned from an `updated` record dated by the paper's release); a block the snapshot validator accepts with all three signals as whole numbers; a gone resource as `unavailable`; a transient failure carrying yesterday's reading forward as `stale` with the original date, across a chain of days, and writing nothing when there is nothing to carry; the leaderboard reporting that carried reading as stale end to end; a source paused after consecutive failures while the other source is unaffected, and a streak reset by a success; every request failing marking the signal unhealthy; a malformed payload and a non-JSON response as failures that do not abort later reads; budget spent newest-first with the unread tail carried forward; the disabled collector; same-day merge union with the stale-precedence rule; the pipeline passing the history and the previous block through and reporting a merged day's block; and end-to-end, `build_latest_releases_leaderboard` ranking a release from the collected block that is invisible without it (the #589 failure).

Eleven behaviours were checked by reverting each one and watching its test go red: the carry-forward, the broad exception catch, the pause and its streak reset, resources from `updated` records, the release date from `released` records only, the merge precedence and health rules, the carried date, the pipeline passing the previous block, and the integer coercion.

## Verification

Clean-worktree run of the CI sequence (`git worktree add --detach`, submodule initialized): `ruff check .`, `ruff format --check .`, `normalize-catalog`, `classify` and `build-data-release` pass; `pytest -q` reports 1343 passed, 1 failed.

The one failure is `tests/test_briefing.py::test_zh_output_budget_covers_worst_case`, which downloads tiktoken's `o200k_base` table from `openaipublic.blob.core.windows.net`, a host the build sandbox's egress policy blocks. It fails identically on an untouched `main` checkout in the same sandbox and passes on GitHub's runner.

The live GitHub and Hugging Face endpoints were not reachable from the sandbox, so the response fields (`stargazers_count`, `upvotes`, `downloads`) follow the documented payloads and the connectors in `sources.py` that already read them. The first daily run after merge is the first live exercise; the three new rows in source health will show any surprise.

## Not in this PR

The `/leaderboard/` default view (the latest-releases view PR, see above). Paper upvotes are read only where an artifact already carries a Hugging Face paper URL (30 of the 1,283 targets in the 90-day cohort); deriving a paper page from every arXiv id would cost a request per paper for mostly 404s, and is a separate decision. Fallback counters from connector `metrics` keep their existing `unknown` status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UaUf4LgR9HogJ1DhXwjESy
