### PR TITLE
feat(site): open the leaderboard on the latest releases

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -1116,6 +1116,49 @@ const I18N = {
     release: "发布",
     "release date unrecorded": "未记录发布日期",
     released: "发布于",
+    // Latest releases (issue #530)
+    "Leaderboard views": "排行榜视图",
+    "Latest releases": "最新发布",
+    "Model-card adoption": "模型卡采用情况",
+    "Reported scores": "报告分数",
+    "latest.deck":
+      "近期发布的benchmark，按当前获得的关注度排序：GitHub star、Hugging Face 论文点赞以及最近 30 天的 Hugging Face 数据集下载量。",
+    "Release window": "发布时间窗口",
+    "{days} days": "{days} 天",
+    "7 days": "7 天",
+    "30 days": "30 天",
+    "90 days": "90 天",
+    "Attention score": "关注度得分",
+    "GitHub stars": "GitHub star 数",
+    "Hugging Face paper upvotes": "Hugging Face 论文点赞数",
+    "Hugging Face dataset downloads, last 30 days": "Hugging Face 数据集下载量（最近 30 天）",
+    unavailable: "资源已不可用",
+    "not observed": "未观测到",
+    "{value} · stale since {date}": "{value} · 自 {date} 起未更新",
+    "{value} · stale": "{value} · 未更新",
+    "{value} · unverified since {date}": "{value} · 自 {date} 起未经核验",
+    "{value} · unverified": "{value} · 未经核验",
+    "source ↗": "来源 ↗",
+    "Coverage {coverage}": "覆盖率 {coverage}",
+    unranked: "未排名",
+    high: "高",
+    medium: "中",
+    low: "低",
+    "limited signals: not enough fresh durable signal to rank":
+      "信号有限：缺少足够新鲜的持久信号，未纳入排名",
+    "no score": "无得分",
+    "No benchmark released in the last {days} days has a measurable attention signal yet.":
+      "最近 {days} 天内发布的benchmark尚无可测量的关注度信号。",
+    "Try {window}": "试试 {window}",
+    "See model-card adoption instead": "改看模型卡采用情况",
+    "Loading this window…": "正在加载该时间窗口…",
+    "This window could not be loaded. Refresh to try again.": "无法加载该时间窗口，请刷新重试。",
+    "The {window} window is not in this build.": "此版本未提供 {window} 的时间窗口。",
+    "The latest releases ranking is not available in this build.": "此版本未提供最新发布排行。",
+    "{ranked} of {total} releases in this window are ranked; the rest are listed with limited signals.":
+      "该时间窗口内 {total} 个发布中有 {ranked} 个进入排名；其余因信号有限仅列出。",
+    "Ranking {method}: {signals}, each normalized as log1p(value) / log1p(window maximum) and summed to a 0 to 100 score. A release is ranked only when enough of its weight comes from fresh, durable signals; the rest are listed with limited signals. Dataset downloads are a rolling 30-day figure, never a cumulative total. Stars come from the benchmark's own repository, never a parent framework. Window {start} to {end}, UTC.":
+      "排名方法 {method}：{signals}，各信号按 log1p(值) / log1p(窗口最大值) 归一化后加权求和为 0 到 100 的得分。只有当足够权重来自新鲜且持久的信号时才纳入排名，其余因信号有限仅列出。数据集下载量为滚动 30 天数字，绝非累计总量。star 数来自该benchmark自己的仓库，绝非上级框架。时间窗口 {start} 至 {end}（UTC）。",
     "scale. Every number below is read from the same definition the pipeline applies.":
       "的标尺。下面每个数字都按流程应用的同一套定义读取。",
     to: "到",
@@ -1221,6 +1264,11 @@ const state = {
   benchmarkQuery: "",
   leaderboardShowAll: false,
   leaderboardTopExpanded: false,
+  // Issue #530: the leaderboard opens on the latest releases; the cumulative
+  // adoption view is one click, or one legacy permalink, away. An empty
+  // window means "the payload's default".
+  lmode: "latest",
+  lwindow: "",
   todayResultsKey: "",
   todayRenderedDate: "",
   todayPage: 1,
@@ -1453,6 +1501,7 @@ function readUrl() {
   state.ldomain = params.get("ldomain") || "";
   state.lorg = params.get("lorg") || "";
   state.lera = params.get("lera") || "";
+  state.lwindow = LATEST_WINDOWS.includes(params.get("lwindow")) ? params.get("lwindow") : "";
   state.lscore = scoreCutoff(params.get("lscore"));
   state.lheight = ["cards", "documents"].includes(params.get("lheight")) ? "documents" : "models";
   state.benchmarkVisibleLimit = BENCHMARK_SEARCH_LIMIT;
@@ -1461,6 +1510,9 @@ function readUrl() {
   state.lfrontierExplicit = Boolean(state.lfrontier);
   // Existing benchmark permalinks follow the score history to its new tab.
   if (state.view === "leaderboard" && state.lfrontierExplicit) state.view = "saturation";
+  // Resolved after that redirect: a legacy benchmark permalink is a Saturation
+  // address, and its cutoff must not decide which leaderboard mode opens next.
+  state.lmode = leaderboardModeFromParams(params, state.view);
   const rawHash = window.location.hash.slice(1);
   const hashParams = new URLSearchParams(rawHash);
   // A first-class utility path wins over every legacy fragment. This keeps a
@@ -1525,12 +1577,20 @@ function writeUrl(mode = "replace") {
   }
   if (!utility && state.view === "map" && state.entity) params.set("entity", state.entity);
   if (!utility && state.view === "leaderboard") {
-    params.set("lscore", state.lscore);
-    if (state.lheight === "documents") params.set("lheight", state.lheight);
-    if (state.lq) params.set("lq", state.lq);
-    if (state.ldomain) params.set("ldomain", state.ldomain);
-    if (state.lorg) params.set("lorg", state.lorg);
-    if (state.lera) params.set("lera", state.lera);
+    // The adoption filters are written only in adoption mode: any of them in
+    // a URL is what readUrl takes as the reader's choice of that mode, so a
+    // latest-releases address that carried them would flip on reload, and
+    // an adoption address needs no extra marker to survive one.
+    if (state.lmode === "adoption") {
+      params.set("lscore", state.lscore);
+      if (state.lheight === "documents") params.set("lheight", state.lheight);
+      if (state.lq) params.set("lq", state.lq);
+      if (state.ldomain) params.set("ldomain", state.ldomain);
+      if (state.lorg) params.set("lorg", state.lorg);
+      if (state.lera) params.set("lera", state.lera);
+    } else if (state.lwindow && state.lwindow !== latestReleasesDefaultWindow()) {
+      params.set("lwindow", state.lwindow);
+    }
   }
   if (!utility && state.view === "saturation") {
     params.set("lscore", state.lscore);
@@ -1664,9 +1724,9 @@ const VIEW_SEO = {
     canonical: "/",
   },
   leaderboard: {
-    title: "AI benchmark frontier and rankings | Benchmark Radar",
+    title: "Latest AI benchmark releases and rankings | Benchmark Radar",
     description:
-      "Explore Benchmark Frontier by highest reported score, and compare benchmarks by recorded scores and source documents across the catalog.",
+      "Benchmarks released in the last 7, 30 or 90 days, ranked by the attention they are receiving now: GitHub stars, Hugging Face paper upvotes and dataset downloads.",
     canonical: "/leaderboard/",
   },
   saturation: {
@@ -7725,6 +7785,372 @@ function renderLeaderboardTop(board) {
   }
 }
 
+// --- Latest releases (issue #530) -------------------------------------------
+// The page opens on recently released benchmarks ranked by the attention they
+// are receiving now, printed from the pipeline's `latest_releases_leaderboard`
+// payload (release_leaderboard.py). Nothing is scored in the browser: rank,
+// components, coverage, confidence and method version arrive as published, so
+// what a reader sees is what the snapshot recorded.
+const LATEST_WINDOWS = ["7d", "30d", "90d"];
+const LATEST_WINDOW_DAYS = { "7d": 7, "30d": 30, "90d": 90 };
+// Order and wording follow the signals issue #530 names. Each component's
+// weight is read from the payload rather than restated here, so a re-weighted
+// method version prints its own numbers.
+const LATEST_SIGNALS = [
+  { key: "github_stars", label: "GitHub stars" },
+  { key: "hf_paper_upvotes", label: "Hugging Face paper upvotes" },
+  { key: "hf_dataset_downloads", label: "Hugging Face dataset downloads, last 30 days" },
+];
+// The adoption view's own filters. A permalink carrying one was written when
+// the page had no modes, and must keep opening the view it filtered.
+const LEADERBOARD_ADOPTION_PARAMS = ["lscore", "lheight", "lq", "ldomain", "lorg", "lera"];
+
+// The cutoff is shared with Saturation, whose every address carries it, so on
+// its own it marks the adoption mode only on a leaderboard address: a reader
+// coming back from /saturation/?lscore=60 has chosen no leaderboard mode. The
+// other filters are written by the adoption mode alone, wherever the address
+// was read from.
+function leaderboardModeFromParams(params, view = "leaderboard") {
+  const requested = params.get("lmode");
+  if (requested === "adoption" || requested === "latest") return requested;
+  const markers = view === "leaderboard"
+    ? LEADERBOARD_ADOPTION_PARAMS
+    : LEADERBOARD_ADOPTION_PARAMS.filter((key) => key !== "lscore");
+  return markers.some((key) => params.has(key)) ? "adoption" : "latest";
+}
+
+function latestReleasesPayload() {
+  return state.data?.latest_releases_leaderboard || null;
+}
+
+function latestReleasesDefaultWindow(payload = latestReleasesPayload()) {
+  return LATEST_WINDOWS.includes(payload?.default_window) ? payload.default_window : "30d";
+}
+
+function latestReleasesWindowKey() {
+  return LATEST_WINDOWS.includes(state.lwindow) ? state.lwindow : latestReleasesDefaultWindow();
+}
+
+function latestWindowLabel(windowKey) {
+  return t("{days} days", { days: LATEST_WINDOW_DAYS[windowKey] || windowKey });
+}
+
+// Null is "no signal", never zero. A stale reading keeps the day it was read,
+// so a run of failed collections cannot make an old counter look current; a
+// resource its source reports as gone says so instead of going quiet.
+function latestSignalText(component) {
+  const status = component?.status || "unknown";
+  const value = component?.value;
+  if (status === "unavailable") return t("unavailable");
+  if (value === null || value === undefined) return t("not observed");
+  const number = Number(value).toLocaleString();
+  if (status === "stale") {
+    return component.last_successful_date
+      ? t("{value} · stale since {date}", { value: number, date: component.last_successful_date })
+      : t("{value} · stale", { value: number });
+  }
+  // Anything the engine did not mark fresh keeps its number but says so. A
+  // connector counter reaches the payload as `unknown` carrying a real value
+  // (release_leaderboard._extract_fallback_metric), kept visible for audit and
+  // deliberately not promoted to fresh; printed bare it read as a fresh
+  // observation, which is the imputation issue #530 rules out.
+  if (status !== "fresh") {
+    return component.last_successful_date
+      ? t("{value} · unverified since {date}", {
+          value: number,
+          date: component.last_successful_date,
+        })
+      : t("{value} · unverified", { value: number });
+  }
+  return number;
+}
+
+// A window with nothing in it is a real state, not a broken page: say so and
+// point at a wider window (issue #530). A wider window the loaded payload does
+// not carry yet is still offered, since choosing it fetches the full corpus;
+// one that is loaded and empty is not, and past the widest window the
+// cumulative adoption view is the honest suggestion.
+function latestReleasesEmptyState(windowKey, payload) {
+  const wider = LATEST_WINDOWS.slice(LATEST_WINDOWS.indexOf(windowKey) + 1).filter((key) => {
+    const loaded = payload?.windows?.[key];
+    return !loaded || (loaded.entries || []).length > 0;
+  });
+  return {
+    message: t(
+      "No benchmark released in the last {days} days has a measurable attention signal yet.",
+      { days: LATEST_WINDOW_DAYS[windowKey] || windowKey },
+    ),
+    windows: wider,
+    adoption: wider.length === 0,
+  };
+}
+
+function latestReleasesWeights(entries) {
+  const weights = {};
+  for (const { key } of LATEST_SIGNALS) {
+    const published = entries.find((entry) => entry.components?.[key]?.weight !== undefined);
+    weights[key] = published ? Number(published.components[key].weight) : null;
+  }
+  return weights;
+}
+
+function latestReleasesMethodNote(payload, windowData) {
+  const weights = latestReleasesWeights(windowData.entries || []);
+  const signals = LATEST_SIGNALS.map(({ key, label }) =>
+    weights[key] === null ? t(label) : `${Math.round(weights[key] * 100)}% ${t(label)}`,
+  ).join(", ");
+  return t(
+    "Ranking {method}: {signals}, each normalized as log1p(value) / log1p(window maximum) and summed to a 0 to 100 score. A release is ranked only when enough of its weight comes from fresh, durable signals; the rest are listed with limited signals. Dataset downloads are a rolling 30-day figure, never a cumulative total. Stars come from the benchmark's own repository, never a parent framework. Window {start} to {end}, UTC.",
+    {
+      method: payload.method_version || "",
+      signals,
+      start: formatDate(windowData.window_start, { dateStyle: "medium" }),
+      end: formatDate(windowData.window_end, { dateStyle: "medium" }),
+    },
+  );
+}
+
+// One row per release: the rank line, and behind it every input the rank was
+// computed from, each with its status and a link to the resource it was read
+// from. A release the engine could not rank keeps its place in the list, with
+// the reason, rather than disappearing.
+function latestReleaseRow(entry, maxScore, open = new Set()) {
+  const ranked = entry.status === "ranked" && Boolean(entry.rank);
+  const artifact = String(entry.canonical_artifact_id || "");
+  const score = entry.score === null || entry.score === undefined ? null : Number(entry.score);
+  const confidence = String(entry.confidence || "").toLowerCase();
+  const width = score !== null && maxScore > 0 ? ((score / maxScore) * 100).toFixed(1) : "0";
+  const summary = element("summary", { className: "leaderboard-top-row latest-release-summary" }, [
+    ranked
+      ? element("span", { className: "leaderboard-top-rank", text: String(entry.rank).padStart(2, "0") })
+      : element("span", { className: "leaderboard-top-rank" }, [
+          element("span", { text: "—", attrs: { "aria-hidden": "true" } }),
+          element("span", { className: "visually-hidden", text: t("unranked") }),
+        ]),
+    element("span", { className: "leaderboard-top-name" }, [
+      element("span", { text: entry.name }),
+      entry.release_date
+        ? element("small", {
+            className: "latest-release-date",
+            text: `${t("released")} ${formatDate(entry.release_date, { dateStyle: "medium" })}`,
+          })
+        : null,
+    ]),
+    element("span", { className: "leaderboard-top-bar" }, [
+      element("span", {
+        className: `leaderboard-top-bar-fill${ranked ? "" : " latest-release-bar-limited"}`,
+        attrs: { style: `width:${width}%` },
+      }),
+    ]),
+    element("span", { className: "leaderboard-top-count" }, [
+      element("span", { text: score === null ? t("no score") : String(score) }),
+      confidence
+        ? element("span", {
+            className: `pill pill-confidence pill-confidence-${confidence}`,
+            text: t(confidence),
+          })
+        : null,
+    ]),
+  ]);
+  const signals = element(
+    "dl",
+    { className: "latest-release-signals" },
+    LATEST_SIGNALS.map(({ key, label }) => {
+      const component = entry.components?.[key] || {};
+      const url = safeHttpUrl(component.source_url);
+      return element("div", { className: "latest-release-signal" }, [
+        element("dt", { text: t(label) }),
+        element("dd", {}, [
+          element("span", { text: latestSignalText(component) }),
+          url
+            ? element("a", {
+                className: "latest-release-source",
+                text: t("source ↗"),
+                attrs: { href: url, target: "_blank", rel: "noopener noreferrer" },
+              })
+            : null,
+          component.weight !== undefined && component.weight !== null
+            ? element("small", {
+                className: "latest-release-weight",
+                text: `${t("weight")} ${Math.round(Number(component.weight) * 100)}%`,
+              })
+            : null,
+        ]),
+      ]);
+    }),
+  );
+  const meta = [
+    t("Coverage {coverage}", { coverage: Number(entry.coverage || 0).toFixed(2) }),
+    confidence ? `${t("confidence")} ${t(confidence)}` : "",
+    ranked ? "" : t("limited signals: not enough fresh durable signal to rank"),
+  ]
+    .filter(Boolean)
+    .join(" · ");
+  return element("li", { className: "latest-release" }, [
+    element("details", {
+      className: "latest-release-details",
+      attrs: { "data-artifact": artifact, open: open.has(artifact) ? "" : null },
+    }, [
+      summary,
+      element("div", { className: "latest-release-body" }, [
+        entry.purpose ? element("p", { className: "latest-release-purpose", text: entry.purpose }) : null,
+        signals,
+        element("p", { className: "latest-release-meta", text: meta }),
+      ]),
+    ]),
+  ]);
+}
+
+function renderLatestReleases() {
+  const host = byId("latest-releases-list");
+  if (!host) return;
+  const payload = latestReleasesPayload();
+  const windowKey = latestReleasesWindowKey();
+  document.querySelectorAll("[data-lwindow]").forEach((control) => {
+    if (control.hasAttribute("aria-pressed")) {
+      control.setAttribute("aria-pressed", String(control.dataset.lwindow === windowKey));
+    }
+  });
+  const windowLabel = byId("latest-releases-window");
+  if (windowLabel) windowLabel.textContent = `· ${latestWindowLabel(windowKey)}`;
+  const empty = byId("latest-releases-empty");
+  const note = byId("latest-releases-note");
+  const info = byId("latest-releases-info");
+  const windowData = payload?.windows?.[windowKey];
+  if (!windowData) {
+    // The bootstrap payload carries the default window only (snapshots.py);
+    // a wider one arrives with the full corpus. Once that has loaded, a window
+    // still missing is not coming, and the reader is told so rather than left
+    // on a loading line; a failed fetch says the same, since the refresh
+    // control re-requests the corpus for this address.
+    replaceChildren(host, []);
+    if (info) replaceChildren(info, []);
+    if (note) note.textContent = "";
+    // Matches the stateNeedsFullData guard: the adoption view never reads a
+    // release window, so fetching the whole corpus to fill a hidden section
+    // is waste the guard exists to avoid.
+    const loading =
+      Boolean(payload) && !state.fullDataLoaded && state.lmode !== "adoption";
+    if (empty) {
+      empty.hidden = false;
+      if (!payload) {
+        empty.textContent = t("The latest releases ranking is not available in this build.");
+      } else if (loading) {
+        empty.textContent = t("Loading this window…");
+      } else {
+        replaceChildren(empty, [
+          document.createTextNode(
+            `${t("The {window} window is not in this build.", { window: latestWindowLabel(windowKey) })} `,
+          ),
+          ...LATEST_WINDOWS.filter((key) => payload.windows?.[key]).map((key) =>
+            element("button", {
+              className: "latest-releases-empty-action",
+              text: t("Try {window}", { window: latestWindowLabel(key) }),
+              attrs: { type: "button", "data-lwindow": key },
+            }),
+          ),
+        ]);
+      }
+    }
+    if (loading) {
+      ensureFullData()
+        .then(() => {
+          if (state.view === "leaderboard") renderLatestReleases();
+        })
+        .catch((error) => {
+          console.error(error);
+          if (state.view !== "leaderboard" || latestReleasesWindowKey() !== windowKey) return;
+          if (empty) empty.textContent = t("This window could not be loaded. Refresh to try again.");
+        });
+    }
+    return;
+  }
+  if (info) {
+    replaceChildren(
+      info,
+      windowData.window_start ? [infoDisclosure(latestReleasesMethodNote(payload, windowData))] : [],
+    );
+  }
+  const entries = windowData.entries || [];
+  if (!entries.length) {
+    const suggestion = latestReleasesEmptyState(windowKey, payload);
+    replaceChildren(host, []);
+    if (note) note.textContent = "";
+    if (empty) {
+      empty.hidden = false;
+      replaceChildren(empty, [
+        document.createTextNode(`${suggestion.message} `),
+        ...suggestion.windows.map((key) =>
+          element("button", {
+            className: "latest-releases-empty-action",
+            text: t("Try {window}", { window: latestWindowLabel(key) }),
+            attrs: { type: "button", "data-lwindow": key },
+          }),
+        ),
+        suggestion.adoption
+          ? element("button", {
+              className: "latest-releases-empty-action",
+              text: t("See model-card adoption instead"),
+              attrs: { type: "button", "data-lmode": "adoption" },
+            })
+          : null,
+      ]);
+    }
+    return;
+  }
+  if (empty) empty.hidden = true;
+  const scores = entries.map((entry) => Number(entry.score)).filter((score) => Number.isFinite(score));
+  const maxScore = scores.length ? Math.max(...scores) : 0;
+  // A redraw (the catalog index landing, Refresh, Back) must not fold the
+  // signals a reader has just opened.
+  const open = new Set(
+    Array.from(host.querySelectorAll("details[open]"), (details) => details.dataset.artifact),
+  );
+  replaceChildren(
+    host,
+    entries.map((entry) => latestReleaseRow(entry, maxScore, open)),
+  );
+  if (note) {
+    note.textContent = t(
+      "{ranked} of {total} releases in this window are ranked; the rest are listed with limited signals.",
+      {
+        ranked: Number(windowData.ranked_count || 0).toLocaleString(),
+        total: Number(windowData.total_cohort_count || 0).toLocaleString(),
+      },
+    );
+  }
+}
+
+// The two modes are one page: the adoption view keeps its markup, ids,
+// seeds and handlers, and is shown or hidden as a block.
+function syncLeaderboardMode() {
+  const latest = state.lmode !== "adoption";
+  const latestSection = byId("latest-releases");
+  const adoption = byId("leaderboard-adoption");
+  if (latestSection) latestSection.hidden = !latest;
+  if (adoption) adoption.hidden = latest;
+  document.querySelectorAll("[data-lmode]").forEach((control) => {
+    if (control.hasAttribute("aria-pressed")) {
+      control.setAttribute("aria-pressed", String(control.dataset.lmode === state.lmode));
+    }
+  });
+}
+
+function setLeaderboardMode(mode) {
+  const next = mode === "adoption" ? "adoption" : "latest";
+  if (next === state.lmode) return;
+  state.lmode = next;
+  renderLeaderboard();
+  writeUrl("push");
+}
+
+function setLatestWindow(windowKey) {
+  if (!LATEST_WINDOWS.includes(windowKey)) return;
+  state.lwindow = windowKey;
+  renderLatestReleases();
+  writeUrl();
+}
+
 // Keep navigation available so a catalog failure can explain itself on its own page.
 function syncLeaderboardNav() {
   const navButton = document.querySelector('[data-view="leaderboard"]');
@@ -7737,6 +8163,8 @@ function renderSaturation() {
 }
 
 function renderLeaderboard() {
+  syncLeaderboardMode();
+  renderLatestReleases();
   initBenchmarkSearch();
   syncScoreFilters();
   renderBenchmarkSkyline();
@@ -8729,6 +9157,32 @@ function bindEvents() {
   // "input"-before-"change" ordering that broke the Scan date picker (issue
   // #43) cannot write a stale value back over the reader's pick here: whichever
   // event arrives first, all three values come from the DOM as it stands now.
+  // One delegated listener for the mode and window controls: the empty state
+  // renders its own "try a wider window" buttons, which a bind-time
+  // querySelectorAll would never see.
+  byId("leaderboard-view").addEventListener("click", (event) => {
+    const windowControl = event.target.closest("[data-lwindow]");
+    if (windowControl) {
+      setLatestWindow(windowControl.dataset.lwindow);
+      return;
+    }
+    const modeControl = event.target.closest("button[data-lmode]");
+    if (modeControl) {
+      setLeaderboardMode(modeControl.dataset.lmode);
+      return;
+    }
+    const scoresLink = event.target.closest('a.leaderboard-mode[href="/saturation/"]');
+    if (
+      scoresLink
+      && event.button === 0
+      && !(event.metaKey || event.ctrlKey || event.shiftKey || event.altKey)
+      && compatibleDashboard(state.data)
+    ) {
+      event.preventDefault();
+      setView("saturation");
+      renderSaturation();
+    }
+  });
   byId("leaderboard-filters").addEventListener("input", () => {
     state.lq = byId("leaderboard-search").value;
     state.ldomain = byId("leaderboard-domain").value;
@@ -9146,6 +9600,16 @@ function compatibleDashboard(data) {
 function stateNeedsFullData() {
   if (state.fullDataLoaded) return false;
   if (state.view === "map" && (byId("relationship-explorer")?.open || state.entity)) return true;
+  // The bootstrap payload carries the default release window only
+  // (snapshots.py); a leaderboard address naming another one needs the corpus.
+  const latest = latestReleasesPayload();
+  if (
+    state.view === "leaderboard"
+    && state.lmode !== "adoption"
+    && latest
+    && state.lwindow
+    && !latest.windows?.[state.lwindow]
+  ) return true;
   return state.view === "today" && Boolean(
     state.todayDate === "all" ||
     (state.todayDate && state.todayDate !== state.data?.latest_date)

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -5408,3 +5408,175 @@ dialog {
     grid-template-columns: 2rem minmax(0, 26rem) minmax(0, 1fr) 7rem;
   }
 }
+
+/* --- Leaderboard modes and latest releases (issue #530) --------------------
+   Three ways to rank one catalog on one page. The mode strip reads as a
+   choice, not a filter; the pressed mode inverts so the reader can see which
+   ranking the rows below describe without reading the heading. */
+.leaderboard-modes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin: 0 0 1rem;
+}
+
+.leaderboard-mode,
+.latest-releases-window-button {
+  padding: 0.35rem 0.8rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--panel);
+  color: var(--ink);
+  font-family: var(--utility);
+  font-size: 0.72rem;
+  letter-spacing: 0.05em;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.leaderboard-mode[aria-pressed="true"],
+.latest-releases-window-button[aria-pressed="true"] {
+  border-color: var(--ink);
+  background: var(--ink);
+  color: var(--panel);
+}
+
+.leaderboard-mode:hover,
+.leaderboard-mode:focus-visible,
+.latest-releases-window-button:hover,
+.latest-releases-window-button:focus-visible {
+  border-color: var(--blue);
+}
+
+.latest-releases-window {
+  color: var(--muted);
+  font-weight: 400;
+}
+
+.latest-releases-windows {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin: 0.4rem 0 0.7rem;
+}
+
+.latest-releases-window-button {
+  padding: 0.25rem 0.65rem;
+  font-size: 0.66rem;
+}
+
+/* Each release is a disclosure: the summary is the ranked row, the body is
+   every input behind the rank. The row keeps the top-list grid, so the four
+   columns line up with the column headings above. */
+.latest-release {
+  border-bottom: 1px solid var(--line);
+}
+
+.latest-release:last-child {
+  border-bottom: none;
+}
+
+.latest-release-summary {
+  list-style: none;
+  cursor: pointer;
+  border-bottom: none;
+}
+
+.latest-release-summary::-webkit-details-marker {
+  display: none;
+}
+
+.latest-release-date {
+  display: block;
+  color: var(--muted);
+  font-family: var(--utility);
+  font-size: 0.62rem;
+  letter-spacing: 0.04em;
+}
+
+/* A release the engine could not rank keeps its bar, muted: the score it has
+   is real, the rank it lacks is the point. */
+.latest-release-bar-limited {
+  background: var(--muted);
+  opacity: 0.45;
+}
+
+.leaderboard-top-count .pill-confidence {
+  margin-left: 0.35rem;
+}
+
+.latest-release-body {
+  padding: 0.1rem 0.85rem 0.85rem 3.6rem;
+  font-size: 0.85rem;
+}
+
+.latest-release-purpose {
+  margin: 0 0 0.4rem;
+}
+
+.latest-release-signals {
+  display: grid;
+  gap: 0.3rem;
+  margin: 0.3rem 0;
+}
+
+.latest-release-signal {
+  display: grid;
+  grid-template-columns: minmax(0, 18rem) minmax(0, 1fr);
+  gap: 0.5rem;
+  align-items: baseline;
+}
+
+.latest-release-signal dt {
+  color: var(--muted);
+  font-family: var(--utility);
+  font-size: 0.68rem;
+  letter-spacing: 0.05em;
+}
+
+.latest-release-signal dd {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: baseline;
+  margin: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.latest-release-source {
+  color: var(--blue-deep);
+}
+
+.latest-release-weight,
+.latest-release-meta {
+  color: var(--muted);
+  font-size: 0.75rem;
+}
+
+.latest-release-meta {
+  margin: 0.3rem 0 0;
+}
+
+.latest-releases-empty-action {
+  margin-left: 0.35rem;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--blue-deep);
+  font-family: var(--body);
+  font-size: inherit;
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
+  cursor: pointer;
+}
+
+@media (max-width: 640px) {
+  .latest-release-body {
+    padding-left: 0.85rem;
+  }
+
+  .latest-release-signal {
+    grid-template-columns: 1fr;
+    gap: 0.15rem;
+  }
+}

--- a/site/index.html
+++ b/site/index.html
@@ -508,6 +508,42 @@
           <h1 id="leaderboard-heading" data-i18n="Leaderboard">Leaderboard</h1>
         </div>
 
+        <!-- Three modes, one page (issue #530). Latest releases opens by
+             default: which newly released benchmarks are gaining attention
+             now. The cumulative model-card adoption view and the reported
+             score workbench keep their content, labels and permalinks. -->
+        <nav class="leaderboard-modes" aria-label="Leaderboard views" data-i18n-aria="Leaderboard views">
+          <button type="button" class="leaderboard-mode" data-lmode="latest" aria-pressed="true" data-i18n="Latest releases">Latest releases</button>
+          <button type="button" class="leaderboard-mode" data-lmode="adoption" aria-pressed="false" data-i18n="Model-card adoption">Model-card adoption</button>
+          <a class="leaderboard-mode" href="/saturation/" data-i18n="Saturation">Saturation</a>
+        </nav>
+
+        <section class="leaderboard-top latest-releases" id="latest-releases" aria-labelledby="latest-releases-heading">
+          <div class="leaderboard-top-heading">
+            <h2 id="latest-releases-heading"><span data-i18n="Latest releases">Latest releases</span> <span class="latest-releases-window" id="latest-releases-window">· 30 days</span></h2>
+            <span id="latest-releases-info"></span>
+          </div>
+          <p class="section-note latest-releases-deck" data-i18n="latest.deck">Recently released benchmarks, ranked by the attention they are receiving now: GitHub stars, Hugging Face paper upvotes and Hugging Face dataset downloads over the last 30 days.</p>
+          <div class="latest-releases-windows" role="group" aria-label="Release window" data-i18n-aria="Release window">
+            <button type="button" class="latest-releases-window-button" data-lwindow="7d" aria-pressed="false" data-i18n="7 days">7 days</button>
+            <button type="button" class="latest-releases-window-button" data-lwindow="30d" aria-pressed="true" data-i18n="30 days">30 days</button>
+            <button type="button" class="latest-releases-window-button" data-lwindow="90d" aria-pressed="false" data-i18n="90 days">90 days</button>
+          </div>
+          <div class="leaderboard-top-columns" aria-hidden="true">
+            <span class="leaderboard-top-columns-rank" data-i18n="Rank">Rank</span>
+            <span class="leaderboard-top-columns-name" data-i18n="Benchmark">Benchmark</span>
+            <span class="leaderboard-top-columns-count" data-i18n="Attention score">Attention score</span>
+          </div>
+          <ol class="leaderboard-top-list latest-releases-list" id="latest-releases-list"></ol>
+          <p class="empty-state latest-releases-empty" id="latest-releases-empty" aria-live="polite" hidden></p>
+          <p class="section-note" id="latest-releases-note" aria-live="polite"></p>
+        </section>
+
+        <!-- The adoption view, shown when the reader picks it or follows a
+             permalink that carries its filters. Hidden, not removed: its
+             seeded rows stay in the document for crawlers and readers
+             without scripts. -->
+        <div id="leaderboard-adoption" hidden>
         <section class="benchmark-skyline" id="benchmark-skyline" aria-labelledby="benchmark-skyline-heading">
           <div class="skyline-heading">
             <div>
@@ -673,6 +709,7 @@
             <div class="leaderboard-list" id="leaderboard-cards"></div>
           </div>
         </details>
+        </div>
       </section>
 
       <section class="view" id="map-view" aria-labelledby="map-heading" hidden>

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -21,7 +21,7 @@ need no JavaScript to read.
 - [About Benchmark Radar](https://benchmark-radar.org/about/): what the project collects, where the records come from, and every place it publishes. Plain prose, no JavaScript needed.
 - [Technical report](https://arxiv.org/abs/2609.11115): *Benchmark Radar: A Living Database and Search Engine for AI Benchmarks and Evaluation* (arXiv:2609.11115), the paper describing how the collection, catalog, and retrieval work. This is the preferred citation for the project.
 - [Benchmark directory](https://benchmark-radar.org/benchmarks/): every benchmark in the catalog, each with its own page covering what it tests, who published it, and which scores are on record.
-- [Model card adoption leaderboard](https://benchmark-radar.org/leaderboard/): which benchmarks frontier labs report in their own model and system cards, plus reported scores over time.
+- [Leaderboard](https://benchmark-radar.org/leaderboard/): opens on the latest releases, recently released benchmarks ranked by the attention they are receiving now (GitHub stars, Hugging Face paper upvotes and 30-day dataset downloads, each dated and linked to its source); one click away is the model card adoption ranking, which benchmarks frontier labs report in their own model and system cards.
 - [Benchmark saturation](https://benchmark-radar.org/saturation/): benchmarks ranked by their highest reported score, and each score's history over time with the source, date, and test conditions it was read from.
 - [Discovery trends](https://benchmark-radar.org/trends/): how many new benchmarks arrive by category, source, and day.
 - [Explore the connections](https://benchmark-radar.org/explore/): how benchmarks, datasets, organizations, and sources link to each other.

--- a/src/benchmark_radar/app_seeds.py
+++ b/src/benchmark_radar/app_seeds.py
@@ -18,9 +18,10 @@ one side has an obvious counterpart on the other.
 from __future__ import annotations
 
 import math
-from datetime import date
+from datetime import UTC, date, datetime
 from decimal import ROUND_HALF_UP, Decimal
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
 from .citation import apa_citation
 from .site_shell import SOURCE_LABELS, esc
@@ -67,6 +68,8 @@ LEADERBOARD_TOP_LIMIT = 5
 # below the ranking. It is the caveat that keeps a document count from being
 # read as a quality score, so a page that ships the ranking ships it too.
 LEADERBOARD_TOP_NOTE = "Open the source-document list below to trace each count to its citations."
+# The window the leaderboard opens on (issue #530), keyed as the payload keys it.
+LATEST_WINDOW_DAYS = {"7d": 7, "30d": 30, "90d": 90}
 
 
 # The slider's default position in site/index.html. The seed must render the
@@ -97,6 +100,265 @@ def _info_disclosure(text: str) -> str:
     )
 
 
+# The signals latestReleaseRow lists, in its order and with its labels.
+_LATEST_SIGNALS = (
+    ("github_stars", "GitHub stars"),
+    ("hf_paper_upvotes", "Hugging Face paper upvotes"),
+    ("hf_dataset_downloads", "Hugging Face dataset downloads, last 30 days"),
+)
+_LATEST_EMPTY_ANCHOR = (
+    '<p class="empty-state latest-releases-empty" id="latest-releases-empty" '
+    'aria-live="polite" hidden></p>'
+)
+_LATEST_NOTE_ANCHOR = '<p class="section-note" id="latest-releases-note" aria-live="polite"></p>'
+_LATEST_RANKED_NOTE = (
+    "{ranked} of {total} releases in this window are ranked; "
+    "the rest are listed with limited signals."
+)
+_LATEST_METHOD_NOTE = (
+    "Ranking {method}: {signals}, each normalized as log1p(value) / log1p(window maximum) "
+    "and summed to a 0 to 100 score. A release is ranked only when enough of its weight "
+    "comes from fresh, durable signals; the rest are listed with limited signals. Dataset "
+    "downloads are a rolling 30-day figure, never a cumulative total. Stars come from the "
+    "benchmark's own repository, never a parent framework. Window {start} to {end}, UTC."
+)
+
+
+def _utc_medium_date(value: Any) -> str:
+    """Match formatDate(value, {dateStyle: "medium"}): the UTC calendar day."""
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return _medium_date(str(value or "")[:10])
+    if parsed.tzinfo is not None:
+        parsed = parsed.astimezone(UTC)
+    return _medium_date(parsed.date().isoformat())
+
+
+def _percent(value: Any) -> str:
+    """Match Math.round(Number(value) * 100): half rounds up, never to even."""
+    scaled = Decimal(str(float(value) * 100)).quantize(Decimal("1"), rounding=ROUND_HALF_UP)
+    return f"{int(scaled)}%"
+
+
+def _js_number(value: Any) -> str:
+    """Match String(number) for the integral and plain decimal scores the engine emits."""
+    number = float(value)
+    return str(int(number)) if number.is_integer() else str(number)
+
+
+def _safe_http_url(value: Any) -> str:
+    """Mirror safeHttpUrl in app.js: the normalized href, or "" if not http(s).
+
+    The renderer builds its link from `new URL(value).href`, which lowercases
+    the scheme and host and supplies a "/" path. Prefix-testing the raw string
+    instead looked equivalent and was not: the engine accepts `HTTPS://Host/x`
+    (release_leaderboard casefolds before comparing), and for that input the
+    seed emitted no link at all while the renderer emitted one, so a crawler
+    and a reader without scripts lost the provenance link a scripted reader
+    got. That is the one thing a seed may never do.
+    """
+    parsed = urlsplit(str(value or ""))
+    if parsed.scheme.lower() not in ("http", "https") or not parsed.netloc:
+        return ""
+    return urlunsplit(
+        (
+            parsed.scheme.lower(),
+            parsed.netloc.lower(),
+            parsed.path or "/",
+            parsed.query,
+            parsed.fragment,
+        )
+    )
+
+
+def _latest_signal_text(component: dict[str, Any]) -> str:
+    """The reading latestSignalText prints for one component."""
+    status = component.get("status") or "unknown"
+    value = component.get("value")
+    if status == "unavailable":
+        return "unavailable"
+    if value is None:
+        return "not observed"
+    number = _num(value)
+    if status == "stale":
+        since = component.get("last_successful_date")
+        return f"{number} · stale since {since}" if since else f"{number} · stale"
+    if status != "fresh":
+        since = component.get("last_successful_date")
+        return f"{number} · unverified since {since}" if since else f"{number} · unverified"
+    return number
+
+
+def _latest_method_note(payload: dict[str, Any], window: dict[str, Any]) -> str:
+    """The (i) text latestReleasesMethodNote composes from the published weights."""
+    entries = window.get("entries") or []
+    parts = []
+    for key, label in _LATEST_SIGNALS:
+        weight = next(
+            (
+                entry["components"][key].get("weight")
+                for entry in entries
+                if "weight" in ((entry.get("components") or {}).get(key) or {})
+            ),
+            None,
+        )
+        parts.append(label if weight is None else f"{_percent(weight)} {label}")
+    return _LATEST_METHOD_NOTE.format(
+        method=payload.get("method_version") or "",
+        signals=", ".join(parts),
+        start=_utc_medium_date(window.get("window_start")),
+        end=_utc_medium_date(window.get("window_end")),
+    )
+
+
+def _latest_release_row(entry: dict[str, Any], top: float) -> str:
+    """One row, as latestReleaseRow draws it: the rank line and its disclosure."""
+    ranked = entry.get("status") == "ranked" and bool(entry.get("rank"))
+    score = entry.get("score")
+    confidence = str(entry.get("confidence") or "").lower()
+    width = f"{float(score) / top * 100:.1f}" if score is not None and top else "0"
+    rank = (
+        f'<span class="leaderboard-top-rank">{int(entry["rank"]):02}</span>'
+        if ranked
+        else '<span class="leaderboard-top-rank"><span aria-hidden="true">—</span>'
+        '<span class="visually-hidden">unranked</span></span>'
+    )
+    release_date = entry.get("release_date")
+    date = (
+        f'<small class="latest-release-date">released {esc(_utc_medium_date(release_date))}</small>'
+        if release_date
+        else ""
+    )
+    bar_class = "leaderboard-top-bar-fill" + ("" if ranked else " latest-release-bar-limited")
+    score_text = esc(_js_number(score)) if score is not None else "no score"
+    pill = (
+        f'<span class="pill pill-confidence pill-confidence-{esc(confidence)}">'
+        f"{esc(confidence)}</span>"
+        if confidence
+        else ""
+    )
+    signals = []
+    for key, label in _LATEST_SIGNALS:
+        component = (entry.get("components") or {}).get(key) or {}
+        url = _safe_http_url(component.get("source_url"))
+        link = (
+            f'<a class="latest-release-source" href="{esc(url)}" target="_blank" '
+            'rel="noopener noreferrer">source ↗</a>'
+            if url
+            else ""
+        )
+        weight = component.get("weight")
+        weight_text = (
+            f'<small class="latest-release-weight">weight {_percent(weight)}</small>'
+            if weight is not None
+            else ""
+        )
+        signals.append(
+            f'<div class="latest-release-signal"><dt>{esc(label)}</dt>'
+            f"<dd><span>{esc(_latest_signal_text(component))}</span>{link}{weight_text}</dd></div>"
+        )
+    meta = " · ".join(
+        part
+        for part in (
+            f"Coverage {_decimal(entry.get('coverage') or 0)}",
+            f"confidence {confidence}" if confidence else "",
+            "" if ranked else "limited signals: not enough fresh durable signal to rank",
+        )
+        if part
+    )
+    purpose = entry.get("purpose")
+    purpose_html = f'<p class="latest-release-purpose">{esc(purpose)}</p>' if purpose else ""
+    return (
+        '<li class="latest-release"><details class="latest-release-details" '
+        f'data-artifact="{esc(entry.get("canonical_artifact_id") or "")}">'
+        '<summary class="leaderboard-top-row latest-release-summary">'
+        f"{rank}"
+        f'<span class="leaderboard-top-name"><span>{esc(entry.get("name") or "")}</span>'
+        f"{date}</span>"
+        f'<span class="leaderboard-top-bar"><span class="{bar_class}" style="width:{width}%">'
+        "</span></span>"
+        f'<span class="leaderboard-top-count"><span>{score_text}</span>{pill}</span>'
+        "</summary>"
+        f'<div class="latest-release-body">{purpose_html}'
+        f'<dl class="latest-release-signals">{"".join(signals)}</dl>'
+        f'<p class="latest-release-meta">{esc(meta)}</p></div>'
+        "</details></li>"
+    )
+
+
+def _latest_releases_seed(dashboard: dict[str, Any]) -> dict[str, str]:
+    """What renderLatestReleases draws for the payload's default window.
+
+    The page opens on this ranking (issue #530), so a crawler or a reader
+    without scripts must see the rows the script would draw, each with the
+    inputs behind its rank, the method note, and, when the window holds
+    nothing, the same empty state with its way out. A build without the
+    ranking seeds nothing here and the script says so.
+    """
+    payload = dashboard.get("latest_releases_leaderboard") or {}
+    windows = payload.get("windows") or {}
+    window_key = payload.get("default_window") or "30d"
+    window = windows.get(window_key) or {}
+    if not payload or not window:
+        return {}
+    days = LATEST_WINDOW_DAYS.get(window_key, window_key)
+    seeds = {
+        '<span class="latest-releases-window" id="latest-releases-window">· 30 days</span>': (
+            '<span class="latest-releases-window" id="latest-releases-window" data-seed>'
+            f"· {days} days</span>"
+        ),
+    }
+    if window.get("window_start"):
+        seeds['<span id="latest-releases-info"></span>'] = (
+            '<span id="latest-releases-info" data-seed>'
+            f"{_info_disclosure(_latest_method_note(payload, window))}</span>"
+        )
+    entries = window.get("entries") or []
+    if not entries:
+        # latestReleasesEmptyState: wider windows are offered unless they are
+        # known to be empty too; past the widest, the adoption view.
+        keys = list(LATEST_WINDOW_DAYS)
+        wider = [
+            key
+            for key in keys[keys.index(window_key) + 1 :]
+            if key not in windows or (windows[key] or {}).get("entries")
+        ]
+        actions = [
+            '<button class="latest-releases-empty-action" type="button" '
+            f'data-lwindow="{key}">Try {LATEST_WINDOW_DAYS[key]} days</button>'
+            for key in wider
+        ]
+        if not wider:
+            actions.append(
+                '<button class="latest-releases-empty-action" type="button" '
+                'data-lmode="adoption">See model-card adoption instead</button>'
+            )
+        seeds[_LATEST_EMPTY_ANCHOR] = (
+            '<p class="empty-state latest-releases-empty" id="latest-releases-empty" '
+            'aria-live="polite" data-seed>'
+            f"No benchmark released in the last {days} days has a measurable attention "
+            f"signal yet. {''.join(actions)}</p>"
+        )
+        return seeds
+    scores = [float(entry["score"]) for entry in entries if entry.get("score") is not None]
+    top = max(scores) if scores else 0.0
+    rows = "".join(_latest_release_row(entry, top) for entry in entries)
+    seeds[
+        '<ol class="leaderboard-top-list latest-releases-list" id="latest-releases-list"></ol>'
+    ] = (
+        '<ol class="leaderboard-top-list latest-releases-list" id="latest-releases-list" '
+        f"data-seed>{rows}</ol>"
+    )
+    ranked = _num(window.get("ranked_count") or 0)
+    total = _num(window.get("total_cohort_count") or 0)
+    seeds[_LATEST_NOTE_ANCHOR] = (
+        '<p class="section-note" id="latest-releases-note" aria-live="polite" data-seed>'
+        f"{esc(_LATEST_RANKED_NOTE.format(ranked=ranked, total=total))}</p>"
+    )
+    return seeds
+
+
 def _leaderboard_seed(
     dashboard: dict[str, Any], catalog_index: list[dict[str, Any]]
 ) -> dict[str, str]:
@@ -104,7 +366,10 @@ def _leaderboard_seed(
     board = dashboard.get("model_card_leaderboard") or {}
     ranked = [entry for entry in (board.get("entries") or []) if (entry.get("card_count") or 0) > 0]
     entries = ranked[:LEADERBOARD_TOP_LIMIT]
-    ranking_seed = _score_ranking_seed(dashboard, catalog_index)
+    ranking_seed = {
+        **_latest_releases_seed(dashboard),
+        **_score_ranking_seed(dashboard, catalog_index),
+    }
     if not entries:
         return ranking_seed
     # Scaled against the top row on screen rather than the top row overall,

--- a/tests/fixtures/latest_releases.json
+++ b/tests/fixtures/latest_releases.json
@@ -1,0 +1,97 @@
+{
+  "schema_version": 1,
+  "method_version": "attention-ranking-v1",
+  "generated_at": "2026-09-10T09:00:00+00:00",
+  "default_window": "30d",
+  "windows": {
+    "7d": {
+      "window_start": "2026-09-03T09:00:00+00:00",
+      "window_end": "2026-09-10T09:00:00+00:00",
+      "window_days": 7,
+      "ranked_count": 0,
+      "total_cohort_count": 0,
+      "signal_coverage": 0.0,
+      "entries": []
+    },
+    "30d": {
+      "window_start": "2026-08-11T09:00:00+00:00",
+      "window_end": "2026-09-10T23:30:00-05:00",
+      "window_days": 30,
+      "ranked_count": 1,
+      "total_cohort_count": 2,
+      "signal_coverage": 0.5,
+      "entries": [
+        {
+          "canonical_artifact_id": "artifact:github:org/bench",
+          "name": "Bench <Agents> & \"Tools\"",
+          "purpose": "Evaluates tool-using agents on long-horizon tasks.",
+          "release_date": "2026-09-01T00:00:00+00:00",
+          "score": 87,
+          "coverage": 0.85,
+          "confidence": "High",
+          "status": "ranked",
+          "rank": 1,
+          "components": {
+            "github_stars": {
+              "value": 1204,
+              "normalized": 1.0,
+              "weight": 0.55,
+              "status": "fresh",
+              "source_url": "https://github.com/org/bench?tab=readme&x=1"
+            },
+            "hf_paper_upvotes": {
+              "value": 33,
+              "normalized": 0.9,
+              "weight": 0.3,
+              "status": "stale",
+              "source_url": "HTTPS://HuggingFace.co/papers/2609.01234",
+              "last_successful_date": "2026-09-08"
+            },
+            "hf_dataset_downloads": {
+              "value": null,
+              "normalized": null,
+              "weight": 0.15,
+              "status": "unavailable",
+              "source_url": "https://huggingface.co/datasets/org/bench-data"
+            }
+          }
+        },
+        {
+          "canonical_artifact_id": "artifact:arxiv:2609.02222",
+          "name": "Quiet",
+          "purpose": "",
+          "release_date": "2026-08-20T23:00:00-05:00",
+          "score": null,
+          "coverage": 0.0,
+          "confidence": "Low",
+          "status": "limited_signals",
+          "rank": null,
+          "components": {
+            "github_stars": {
+              "value": null,
+              "normalized": null,
+              "weight": 0.55,
+              "status": "unknown",
+              "source_url": null
+            },
+            "hf_paper_upvotes": {
+              "value": null,
+              "normalized": null,
+              "weight": 0.3,
+              "status": "unknown",
+              "source_url": "javascript:alert(1)"
+            },
+            "hf_dataset_downloads": {
+              "value": 420,
+              "normalized": null,
+              "weight": 0.15,
+              "status": "unknown",
+              "source_url": "https://huggingface.co/datasets/org/quiet",
+              "last_successful_date": "2026-08-30"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/latest_releases_harness.mjs
+++ b/tests/latest_releases_harness.mjs
@@ -1,0 +1,207 @@
+// Execute the latest-releases functions (issue #530) with small deterministic
+// inputs, without a browser: mode resolution, window fallback, signal text,
+// the empty-state suggestion, and the URL round trip.
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const source = readFileSync('site/assets/app.js', 'utf8');
+function fn(name) {
+  const start = source.indexOf(`function ${name}(`);
+  assert(start >= 0, name);
+  return source.slice(start, source.indexOf('\n}\n', start) + 2);
+}
+function section(start, end) {
+  const from = source.indexOf(start);
+  assert(from >= 0, start);
+  return source.slice(from, source.indexOf(end, from));
+}
+
+const t = (key, params) => {
+  let value = key;
+  for (const [name, replacement] of Object.entries(params || {})) {
+    value = value.replaceAll(`{${name}}`, String(replacement));
+  }
+  return value;
+};
+const formatDate = (value) => String(value).slice(0, 10);
+
+const payload = {
+  schema_version: 1,
+  method_version: 'attention-ranking-v1',
+  generated_at: '2026-09-10T09:00:00+00:00',
+  default_window: '30d',
+  windows: {
+    '7d': { window_start: '2026-09-03T09:00:00+00:00', window_end: '2026-09-10T09:00:00+00:00', ranked_count: 0, total_cohort_count: 0, entries: [] },
+    '30d': {
+      window_start: '2026-08-11T09:00:00+00:00', window_end: '2026-09-10T09:00:00+00:00',
+      ranked_count: 1, total_cohort_count: 2,
+      entries: [
+        {
+          canonical_artifact_id: 'artifact:github:org/bench', name: 'Bench', purpose: 'agents', release_date: '2026-09-01T00:00:00+00:00',
+          score: 87, coverage: 0.85, confidence: 'High', status: 'ranked', rank: 1,
+          components: {
+            github_stars: { value: 1204, normalized: 1, weight: 0.55, status: 'fresh', source_url: 'https://github.com/org/bench' },
+            hf_paper_upvotes: { value: 33, normalized: 0.9, weight: 0.3, status: 'stale', source_url: 'https://huggingface.co/papers/2609.01234', last_successful_date: '2026-09-08' },
+            hf_dataset_downloads: { value: null, normalized: null, weight: 0.15, status: 'unavailable', source_url: 'https://huggingface.co/datasets/org/bench-data' },
+          },
+        },
+        {
+          canonical_artifact_id: 'artifact:arxiv:2609.02222', name: 'Quiet', purpose: '', release_date: '2026-08-20T00:00:00+00:00',
+          score: null, coverage: 0, confidence: 'Low', status: 'limited_signals', rank: null,
+          components: {
+            github_stars: { value: null, normalized: null, weight: 0.55, status: 'unknown', source_url: null },
+            hf_paper_upvotes: { value: null, normalized: null, weight: 0.3, status: 'unknown', source_url: null },
+            hf_dataset_downloads: { value: null, normalized: null, weight: 0.15, status: 'unknown', source_url: null },
+          },
+        },
+      ],
+    },
+  },
+};
+
+const state = { data: { latest_releases_leaderboard: payload }, lwindow: '', lmode: 'latest', fullDataLoaded: false };
+const names = ['leaderboardModeFromParams', 'latestReleasesPayload', 'latestReleasesDefaultWindow', 'latestReleasesWindowKey', 'latestWindowLabel', 'latestSignalText', 'latestReleasesEmptyState', 'latestReleasesWeights', 'latestReleasesMethodNote'];
+const latest = new Function('state', 't', 'formatDate', `${section('const LATEST_WINDOWS =', 'function leaderboardModeFromParams(')}\n${names.map(fn).join('\n')}\nreturn {${names.join(',')}};`)(state, t, formatDate);
+
+// Mode: the page opens on the latest releases; a permalink carrying any of the
+// adoption view's own filters, written before the page had modes, still opens
+// the adoption view; an explicit lmode wins either way.
+assert.equal(latest.leaderboardModeFromParams(new URLSearchParams('')), 'latest');
+assert.equal(latest.leaderboardModeFromParams(new URLSearchParams('lwindow=7d')), 'latest');
+for (const legacy of ['lscore=70', 'lq=agent', 'ldomain=code', 'lorg=OpenAI', 'lera=2025', 'lheight=documents']) {
+  assert.equal(latest.leaderboardModeFromParams(new URLSearchParams(legacy)), 'adoption', legacy);
+}
+assert.equal(latest.leaderboardModeFromParams(new URLSearchParams('lmode=latest&lscore=70')), 'latest');
+assert.equal(latest.leaderboardModeFromParams(new URLSearchParams('lmode=adoption')), 'adoption');
+assert.equal(latest.leaderboardModeFromParams(new URLSearchParams('lmode=bogus')), 'latest');
+// Read from a Saturation address, whose every URL carries the shared cutoff,
+// the cutoff alone is no choice of a leaderboard mode; the adoption view's
+// own filters still are.
+assert.equal(latest.leaderboardModeFromParams(new URLSearchParams('lscore=60'), 'saturation'), 'latest');
+assert.equal(latest.leaderboardModeFromParams(new URLSearchParams('lscore=60&lq=agent'), 'saturation'), 'adoption');
+assert.equal(latest.leaderboardModeFromParams(new URLSearchParams('lmode=adoption&lscore=60'), 'saturation'), 'adoption');
+
+// Window: the payload's default unless the reader picked a valid one.
+assert.equal(latest.latestReleasesDefaultWindow(), '30d');
+assert.equal(latest.latestReleasesDefaultWindow({ default_window: '7d' }), '7d');
+assert.equal(latest.latestReleasesDefaultWindow({ default_window: '14d' }), '30d');
+assert.equal(latest.latestReleasesWindowKey(), '30d');
+state.lwindow = '90d';
+assert.equal(latest.latestReleasesWindowKey(), '90d');
+state.lwindow = '14d';
+assert.equal(latest.latestReleasesWindowKey(), '30d');
+state.lwindow = '';
+assert.equal(latest.latestWindowLabel('7d'), '7 days');
+
+// Signals: null is "no signal", never zero; a stale reading carries the day
+// it was read; a gone resource says so.
+const bench = payload.windows['30d'].entries[0].components;
+assert.equal(latest.latestSignalText(bench.github_stars), '1,204');
+assert.equal(latest.latestSignalText(bench.hf_paper_upvotes), '33 · stale since 2026-09-08');
+assert.equal(latest.latestSignalText(bench.hf_dataset_downloads), 'unavailable');
+assert.equal(latest.latestSignalText({ value: 5, status: 'stale' }), '5 · stale');
+assert.equal(latest.latestSignalText({ value: 0, status: 'fresh' }), '0');
+assert.equal(latest.latestSignalText({ value: null, status: 'unknown' }), 'not observed');
+assert.equal(latest.latestSignalText(undefined), 'not observed');
+
+// Empty state: the 7-day window is empty, so it points at the 30-day window,
+// which has entries; the 90-day window is not loaded yet and is still
+// offered. Past the widest window the suggestion is the adoption view.
+const empty7 = latest.latestReleasesEmptyState('7d', payload);
+assert.equal(empty7.message, 'No benchmark released in the last 7 days has a measurable attention signal yet.');
+assert.deepEqual(empty7.windows, ['30d', '90d']);
+assert.equal(empty7.adoption, false);
+const loadedEmpty = { ...payload, windows: { ...payload.windows, '30d': { entries: [] }, '90d': { entries: [] } } };
+assert.deepEqual(latest.latestReleasesEmptyState('7d', loadedEmpty).windows, []);
+assert.equal(latest.latestReleasesEmptyState('7d', loadedEmpty).adoption, true);
+assert.equal(latest.latestReleasesEmptyState('90d', payload).adoption, true);
+
+// Method note: weights come from the published components, not from a
+// number restated in the browser.
+assert.deepEqual(latest.latestReleasesWeights(payload.windows['30d'].entries), { github_stars: 0.55, hf_paper_upvotes: 0.3, hf_dataset_downloads: 0.15 });
+const note = latest.latestReleasesMethodNote(payload, payload.windows['30d']);
+assert(note.startsWith('Ranking attention-ranking-v1: 55% GitHub stars, 30% Hugging Face paper upvotes, 15% Hugging Face dataset downloads, last 30 days,'), note);
+assert(note.includes('never a cumulative total'));
+assert(note.includes('Window 2026-08-11 to 2026-09-10, UTC.'));
+const bare = latest.latestReleasesMethodNote({ method_version: 'v9' }, { entries: [], window_start: '2026-08-11', window_end: '2026-09-10' });
+assert(bare.startsWith('Ranking v9: GitHub stars, Hugging Face paper upvotes, Hugging Face dataset downloads, last 30 days,'), bare);
+
+// URL round trip through the real readUrl / writeUrl: the latest mode writes
+// only a non-default window; the adoption mode writes its filters and names
+// itself, so its address survives a reload in the same mode.
+const routeSource = [
+  section('const VIEW_SEO = {', '// These sheets are also indexable pages.'),
+  section('const UTILITY_SEO = {', '// One list, not two:'),
+  section('const VIEW_PATHS =', 'function applySeo('),
+  section('function scoreCutoff(', 'function matchesScoreFilter('),
+  section('const LATEST_WINDOWS =', 'function latestReleasesWindowKey('),
+  section('function readUrl()', '// `push` adds a history entry'),
+  section('function writeUrl(', '// A pushed entry changes the URL'),
+].join('\n');
+const routes = new Function('state', 'BENCHMARK_SEARCH_LIMIT', `
+  const window = { location: { origin: 'https://benchmark-radar.org', pathname: '/', search: '', hash: '' }, history: { state: null,
+    pushState(s, _t, url) { const u = new URL(url, 'https://benchmark-radar.org'); window.location.pathname = u.pathname; window.location.search = u.search; window.location.hash = u.hash; },
+    replaceState(s, _t, url) { this.pushState(s, _t, url); } } };
+  ${routeSource}
+  return {
+    install(url) { const u = new URL(url, 'https://benchmark-radar.org'); window.location.pathname = u.pathname; window.location.search = u.search; window.location.hash = u.hash; },
+    readUrl, writeUrl, current() { return window.location.pathname + window.location.search; },
+  };
+`)(state, 50);
+
+routes.install('/leaderboard/');
+routes.readUrl();
+assert.equal(state.lmode, 'latest');
+assert.equal(state.lwindow, '');
+routes.writeUrl('replace');
+assert.equal(routes.current(), '/leaderboard/', 'the default view writes a clean address');
+
+routes.install('/leaderboard/?lwindow=90d');
+routes.readUrl();
+assert.equal(state.lwindow, '90d');
+routes.writeUrl('replace');
+assert.equal(routes.current(), '/leaderboard/?lwindow=90d');
+state.lwindow = '30d';
+routes.writeUrl('replace');
+assert.equal(routes.current(), '/leaderboard/', 'the default window is not written');
+
+routes.install('/leaderboard/?lscore=70&lq=agent');
+routes.readUrl();
+assert.equal(state.lmode, 'adoption', 'a pre-mode permalink opens the view it filtered');
+assert.equal(state.lq, 'agent');
+routes.writeUrl('replace');
+assert.equal(routes.current(), '/leaderboard/?lscore=70&lq=agent', 'the address keeps its pre-mode shape');
+routes.readUrl();
+assert.equal(state.lmode, 'adoption');
+
+routes.install('/leaderboard/?lmode=adoption');
+routes.readUrl();
+state.lmode = 'latest';
+state.lwindow = '7d';
+routes.writeUrl('replace');
+assert.equal(routes.current(), '/leaderboard/?lwindow=7d', 'switching back to latest drops the adoption filters');
+
+// Back from Saturation restores an address with the shared cutoff; opening
+// the leaderboard from there must not land on a mode the reader never chose.
+routes.install('/saturation/?lscore=60');
+routes.readUrl();
+assert.equal(state.view, 'saturation');
+assert.equal(state.lmode, 'latest', 'the shared cutoff on a Saturation address is not a mode choice');
+state.view = 'leaderboard';
+routes.writeUrl('push');
+assert.equal(routes.current(), '/leaderboard/');
+// A legacy leaderboard permalink for one benchmark is a Saturation address
+// now, and its cutoff no more chooses a mode than any other.
+routes.install('/leaderboard/?lfrontier=bench-95&lscore=70');
+routes.readUrl();
+assert.equal(state.view, 'saturation');
+assert.equal(state.lmode, 'latest');
+// The adoption view's own filters, wherever they were read from, still open it.
+routes.install('/saturation/?lscore=40&lq=agent&lheight=documents');
+routes.readUrl();
+assert.equal(state.lmode, 'adoption');
+state.view = 'leaderboard';
+routes.writeUrl('push');
+assert.equal(routes.current(), '/leaderboard/?lscore=40&lheight=documents&lq=agent');
+
+console.log('latest releases harness ok');

--- a/tests/latest_releases_render_harness.mjs
+++ b/tests/latest_releases_render_harness.mjs
@@ -1,0 +1,301 @@
+// Executes the latest-releases renderer (issue #530) against the fixture the
+// seed tests share, on a minimal DOM, and prints what it drew as JSON: the
+// rows with their disclosure bodies, the method note, the empty state and its
+// way out, the loading, failed and absent-window messages, and which rows stay
+// open across a redraw. The Python test compares the rows and the note with
+// the seeds app_seeds.py writes, so the two can never disagree silently.
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+// app.js imports its brand-mark resolvers from glyphs.js; `new Function`
+// cannot take an import statement, so the module is inlined (as the other
+// render harnesses do) and the real source runs otherwise unchanged.
+const glyphs = readFileSync(join(here, "..", "site", "assets", "glyphs.js"), "utf8")
+  .replace(/^export \{[\s\S]*?\};$/m, "");
+const source =
+  glyphs +
+  readFileSync(join(here, "..", "site", "assets", "app.js"), "utf8").replace(
+    /^import \{[\s\S]*?\} from "\.\/glyphs\.js";$/m,
+    "",
+  );
+
+const allNodes = [];
+
+class StubNode {
+  constructor(tag) {
+    this.tag = tag;
+    this.className = "";
+    this.children = [];
+    this.attributes = {};
+    this._text = "";
+    this.hidden = false;
+    allNodes.push(this);
+  }
+  set textContent(value) {
+    this._text = String(value);
+    this.children = [];
+  }
+  get textContent() {
+    return this.children.length
+      ? this.children.map((child) => child.textContent).join("")
+      : this._text;
+  }
+  setAttribute(key, value) {
+    this.attributes[key] = String(value);
+  }
+  getAttribute(key) {
+    return key in this.attributes ? this.attributes[key] : null;
+  }
+  hasAttribute(key) {
+    return key in this.attributes;
+  }
+  removeAttribute(key) {
+    delete this.attributes[key];
+  }
+  get open() {
+    return "open" in this.attributes;
+  }
+  set open(value) {
+    if (value) this.attributes.open = "";
+    else delete this.attributes.open;
+  }
+  get dataset() {
+    const out = {};
+    for (const [key, value] of Object.entries(this.attributes)) {
+      if (key.startsWith("data-")) {
+        out[key.slice(5).replace(/-(\w)/g, (_m, c) => c.toUpperCase())] = value;
+      }
+    }
+    return out;
+  }
+  append(child) {
+    this.children.push(child);
+  }
+  replaceChildren(...children) {
+    this.children = children;
+    this._text = "";
+  }
+  addEventListener() {}
+  descendants() {
+    return this.children.flatMap((child) =>
+      child instanceof StubNode ? [child, ...child.descendants()] : [],
+    );
+  }
+  querySelectorAll(selector) {
+    return this.descendants().filter((node) => matches(node, selector));
+  }
+  querySelector(selector) {
+    return this.querySelectorAll(selector)[0] || null;
+  }
+  getContext() {
+    return null;
+  }
+}
+
+class StubText {
+  constructor(value) {
+    this.tag = "#text";
+    this.children = [];
+    this.attributes = {};
+    this._text = String(value);
+  }
+  get textContent() {
+    return this._text;
+  }
+}
+
+// The selectors the renderer uses: a tag, an attribute, or both.
+function matches(node, selector) {
+  const parsed = selector.match(/^([a-z]*)(?:\[([\w-]+)\])?$/);
+  if (!parsed) return false;
+  const [, tag, attribute] = parsed;
+  if (tag && node.tag !== tag) return false;
+  if (attribute && !(attribute in node.attributes)) return false;
+  return Boolean(tag || attribute);
+}
+
+const registry = new Map();
+globalThis.document = {
+  createElement: (tag) => new StubNode(tag),
+  createElementNS: (_ns, tag) => new StubNode(tag),
+  createTextNode: (value) => new StubText(value),
+  getElementById: (id) => {
+    if (!registry.has(id)) registry.set(id, new StubNode("div"));
+    return registry.get(id);
+  },
+  addEventListener: () => {},
+  querySelectorAll: (selector) => allNodes.filter((node) => matches(node, selector)),
+  querySelector: () => null,
+};
+globalThis.window = {
+  addEventListener: () => {},
+  location: { origin: "https://benchmark-radar.org", pathname: "/", search: "", hash: "" },
+  history: { state: null, pushState() {}, replaceState() {} },
+  matchMedia: () => ({ matches: false, addEventListener() {} }),
+};
+const fetchCalls = [];
+let fetchBehaviour = () => new Promise(() => {});
+globalThis.fetch = (path) => {
+  fetchCalls.push(String(path));
+  return fetchBehaviour(path);
+};
+const errors = [];
+console.error = (error) => errors.push(String(error?.message || error));
+
+// The window and mode controls the page ships; the renderer syncs their
+// pressed state through document.querySelectorAll.
+function control(attribute, value, pressed) {
+  const button = document.createElement("button");
+  button.setAttribute(attribute, value);
+  button.setAttribute("aria-pressed", String(pressed));
+  return button;
+}
+const windowControls = ["7d", "30d", "90d"].map((key) => control("data-lwindow", key, key === "30d"));
+const modeControls = ["latest", "adoption"].map((key) => control("data-lmode", key, key === "latest"));
+
+// Bootstrapping runs on load and stalls on the never-settling fetch above.
+// The export follows the source so `const state` is initialised by then.
+new Function(
+  `${source}\nglobalThis.__render = { state, renderLatestReleases, syncLeaderboardMode, stateNeedsFullData, setLang };`,
+)();
+const R = globalThis.__render;
+
+function esc(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#x27;");
+}
+// Serialized the way app_seeds.py writes markup: class first, then the
+// attributes in the order element() set them, text escaped like html.escape.
+function html(node) {
+  if (node.tag === "#text") return esc(node._text);
+  const attrs = node.className ? [` class="${esc(node.className)}"`] : [];
+  for (const [key, value] of Object.entries(node.attributes)) attrs.push(` ${key}="${esc(value)}"`);
+  const inner = node.children.length ? node.children.map(html).join("") : esc(node._text);
+  return `<${node.tag}${attrs.join("")}>${inner}</${node.tag}>`;
+}
+const inner = (node) => node.children.map(html).join("") || esc(node._text);
+const byId = (id) => document.getElementById(id);
+
+function snapshot() {
+  return {
+    list: inner(byId("latest-releases-list")),
+    info: inner(byId("latest-releases-info")),
+    empty: inner(byId("latest-releases-empty")),
+    emptyHidden: byId("latest-releases-empty").hidden,
+    note: byId("latest-releases-note").textContent,
+    window: byId("latest-releases-window").textContent,
+    pressedWindows: windowControls.filter((b) => b.getAttribute("aria-pressed") === "true").map((b) => b.dataset.lwindow),
+    pressedModes: modeControls.filter((b) => b.getAttribute("aria-pressed") === "true").map((b) => b.dataset.lmode),
+    latestHidden: byId("latest-releases").hidden,
+    adoptionHidden: byId("leaderboard-adoption").hidden,
+    fetchCalls: fetchCalls.splice(0),
+  };
+}
+const openRows = () =>
+  byId("latest-releases-list").querySelectorAll("details[open]").map((d) => d.dataset.artifact);
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+const payload = JSON.parse(readFileSync(process.argv[2], "utf8"));
+const state = R.state;
+state.view = "leaderboard";
+state.lmode = "latest";
+state.lwindow = "";
+state.fullDataLoaded = false;
+state.data = { schema_version: 2, days: [{}], latest_releases_leaderboard: payload };
+const out = {};
+
+R.syncLeaderboardMode();
+R.renderLatestReleases();
+out.default = snapshot();
+
+// Open the first row, redraw, and the same row is still open.
+byId("latest-releases-list").children[0].children[0].open = true;
+out.openBefore = openRows();
+R.renderLatestReleases();
+out.openAfter = openRows();
+
+state.lmode = "adoption";
+R.syncLeaderboardMode();
+out.adoption = { latestHidden: byId("latest-releases").hidden, adoptionHidden: byId("leaderboard-adoption").hidden, pressedModes: snapshot().pressedModes };
+state.lmode = "latest";
+R.syncLeaderboardMode();
+
+state.lwindow = "7d";
+R.renderLatestReleases();
+out.empty7d = snapshot();
+
+// A window the bootstrap did not carry: the corpus is fetched; when that
+// fails the reader is told, when it has loaded without the window too.
+out.needsFullData = {};
+state.lwindow = "90d";
+out.needsFullData.missingWindow = R.stateNeedsFullData();
+state.lmode = "adoption";
+out.needsFullData.adoption = R.stateNeedsFullData();
+state.lmode = "latest";
+state.lwindow = "30d";
+out.needsFullData.loadedWindow = R.stateNeedsFullData();
+state.lwindow = "90d";
+state.view = "today";
+out.needsFullData.otherView = R.stateNeedsFullData();
+state.view = "leaderboard";
+state.fullDataLoaded = true;
+out.needsFullData.fullLoaded = R.stateNeedsFullData();
+state.fullDataLoaded = false;
+
+fetchBehaviour = () => Promise.reject(new Error("HTTP 404"));
+R.renderLatestReleases();
+out.failed90d = { ...snapshot(), errorsBefore: errors.length };
+await tick();
+await tick();
+out.failed90d.after = snapshot().empty;
+out.failed90d.errors = errors.splice(0);
+
+state.fullDataLoaded = true;
+R.renderLatestReleases();
+out.missing90d = snapshot();
+state.fullDataLoaded = false;
+
+fetchBehaviour = () => new Promise(() => {});
+R.renderLatestReleases();
+out.loading90d = snapshot();
+await tick();
+out.loading90d.after = snapshot().empty;
+
+// Adoption mode reads no release window, and stateNeedsFullData skips the
+// corpus for it, so the renderer must not fetch it either to fill a section
+// syncLeaderboardMode has hidden.
+state.lmode = "adoption";
+state.lwindow = "90d";
+state.fullDataLoaded = false;
+// The previous scenario left a never-settling corpus request in flight, and
+// ensureFullData dedupes on it. Clearing it is what makes a fetch here
+// observable, so this probe fails when the guard is removed.
+state.fullDataPromise = null;
+fetchBehaviour = () => new Promise(() => {});
+R.syncLeaderboardMode();
+snapshot();
+R.renderLatestReleases();
+out.adoption90d = { ...snapshot(), needsFullData: R.stateNeedsFullData() };
+state.lmode = "latest";
+R.syncLeaderboardMode();
+
+state.lwindow = "";
+R.setLang("zh");
+R.renderLatestReleases();
+out.zh = snapshot();
+R.setLang("en");
+
+// The bootstrap trims a window the engine did not publish to an empty stub
+// (snapshots.py): no bounds, so no method note, and the empty state's way out.
+payload.windows["90d"] = {};
+state.lwindow = "90d";
+R.renderLatestReleases();
+out.stub90d = snapshot();
+
+console.log(JSON.stringify(out));

--- a/tests/test_latest_releases_view.py
+++ b/tests/test_latest_releases_view.py
@@ -1,0 +1,419 @@
+"""The leaderboard opens on the latest releases (issue #530).
+
+The ranking engine and its payload landed for #530 before the page read them,
+so `/leaderboard/` kept opening on the cumulative model-card adoption view.
+Each test names the failure it protects against.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from benchmark_radar.app_pages import load_view_seo
+from benchmark_radar.app_seeds import _latest_releases_seed
+
+ROOT = Path(__file__).resolve().parents[1]
+SITE = ROOT / "site"
+FIXTURE = ROOT / "tests" / "fixtures" / "latest_releases.json"
+LIST_ANCHOR = (
+    '<ol class="leaderboard-top-list latest-releases-list" id="latest-releases-list"></ol>'
+)
+WINDOW_ANCHOR = '<span class="latest-releases-window" id="latest-releases-window">· 30 days</span>'
+INFO_ANCHOR = '<span id="latest-releases-info"></span>'
+EMPTY_ANCHOR = (
+    '<p class="empty-state latest-releases-empty" id="latest-releases-empty" '
+    'aria-live="polite" hidden></p>'
+)
+NOTE_ANCHOR = '<p class="section-note" id="latest-releases-note" aria-live="polite"></p>'
+
+
+def _inner(markup: str) -> str:
+    """The content between a seeded container's opening and closing tags."""
+    return markup[markup.index(">") + 1 : markup.rindex("</")]
+
+
+def _render(payload: dict) -> dict:
+    """What the real renderer draws for the payload, on a minimal DOM (see the harness)."""
+    node = shutil.which("node")
+    assert node, "Node.js is required for the site behavior tests"
+    with open(FIXTURE.with_name("latest_releases_under_test.json"), "w", encoding="utf-8") as fh:
+        json.dump(payload, fh)
+    try:
+        result = subprocess.run(
+            [node, "tests/latest_releases_render_harness.mjs", fh.name],
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=ROOT,
+        )
+    finally:
+        Path(fh.name).unlink(missing_ok=True)
+    return json.loads(result.stdout)
+
+
+def _payload(entries: list[dict] | None = None, default_window: str = "30d") -> dict:
+    window = {
+        "window_start": "2026-08-11T09:00:00+00:00",
+        "window_end": "2026-09-10T09:00:00+00:00",
+        "window_days": 30,
+        "ranked_count": 1,
+        "total_cohort_count": 2,
+        "signal_coverage": 0.5,
+        "entries": entries
+        if entries is not None
+        else [
+            {
+                "canonical_artifact_id": "artifact:github:org/bench",
+                "name": "Bench <Agents>",
+                "purpose": "",
+                "release_date": "2026-09-01T00:00:00+00:00",
+                "score": 87,
+                "coverage": 0.85,
+                "confidence": "High",
+                "status": "ranked",
+                "rank": 1,
+                "components": {},
+            },
+            {
+                "canonical_artifact_id": "artifact:arxiv:2609.02222",
+                "name": "Quiet",
+                "purpose": "",
+                "release_date": "2026-08-20T00:00:00+00:00",
+                "score": None,
+                "coverage": 0.0,
+                "confidence": "Low",
+                "status": "limited_signals",
+                "rank": None,
+                "components": {},
+            },
+        ],
+    }
+    return {
+        "schema_version": 1,
+        "method_version": "attention-ranking-v1",
+        "generated_at": "2026-09-10T09:00:00+00:00",
+        "default_window": default_window,
+        "windows": {default_window: window},
+    }
+
+
+def _leaderboard_section(html: str) -> str:
+    start = html.index('<section class="view" id="leaderboard-view"')
+    return html[start : html.index('<section class="view" id="map-view"', start)]
+
+
+def test_the_page_opens_on_latest_releases_and_keeps_the_adoption_view():
+    # Acceptance: `/leaderboard/` defaults to Latest releases · 30d, and the
+    # existing model-card adoption and reported-score views stay reachable
+    # with their content intact.
+    html = (SITE / "index.html").read_text(encoding="utf-8")
+    section = _leaderboard_section(html)
+
+    modes = section.index('<nav class="leaderboard-modes"')
+    latest = section.index('id="latest-releases"')
+    adoption = section.index('<div id="leaderboard-adoption" hidden>')
+    assert modes < latest < adoption, "modes, then the latest ranking, then the adoption view"
+    assert 'data-lmode="latest" aria-pressed="true"' in section
+    assert 'data-lmode="adoption" aria-pressed="false"' in section
+    assert 'href="/saturation/"' in section, "the score workbench stays a separate view"
+    # One path, one reader-facing name: the nav, the heading, VIEW_LABELS and
+    # the sitemap all call /saturation/ Saturation, so a mode label of its own
+    # invention would land the reader somewhere that never uses the word they
+    # clicked.
+    assert 'href="/saturation/" data-i18n="Saturation">Saturation</a>' in section
+    # The latest section is not hidden; the adoption block is, and it still
+    # holds every element the adoption renderer writes into.
+    opening = re.search(r'<section[^>]*id="latest-releases"[^>]*>', section)
+    assert opening and 'class="leaderboard-top latest-releases"' in opening.group(0)
+    assert "hidden" not in opening.group(0)
+    for anchor in (
+        'id="benchmark-skyline"',
+        'id="leaderboard-top-list"',
+        'id="leaderboard-insights"',
+        'id="leaderboard-filters"',
+        'id="leaderboard-cards"',
+    ):
+        assert anchor in section[adoption:], anchor
+    # Three windows, the 30-day one pressed, in the order the payload keys them.
+    assert re.findall(r'data-lwindow="(\w+)"', section) == ["7d", "30d", "90d"]
+    assert 'data-lwindow="30d" aria-pressed="true"' in section
+    assert 'id="latest-releases-window">· 30 days</span>' in section
+    # The window switch rewrites the count and the empty state with no page
+    # load, so both announce themselves the way this view's other counts do.
+    assert 'id="latest-releases-empty" aria-live="polite" hidden' in section
+    assert 'id="latest-releases-note" aria-live="polite"' in section
+
+
+def test_browser_mode_window_signal_and_url_contracts():
+    node = shutil.which("node")
+    assert node, "Node.js is required for the site behavior tests"
+    subprocess.run(
+        [node, "tests/latest_releases_harness.mjs"], check=True, capture_output=True, text=True
+    )
+
+
+def test_adoption_filters_are_written_only_in_adoption_mode():
+    # A latest-releases address that carried the adoption filters would flip
+    # to the adoption view on reload, because those filters are what marks a
+    # pre-mode permalink as an adoption one.
+    script = (SITE / "assets" / "app.js").read_text(encoding="utf-8")
+    body = script.split('function writeUrl(mode = "replace")', 1)[1].split("\nfunction ", 1)[0]
+    leaderboard = body.split('if (!utility && state.view === "leaderboard")', 1)[1].split(
+        'if (!utility && state.view === "saturation")', 1
+    )[0]
+    gate = leaderboard.index('if (state.lmode === "adoption")')
+    for key in ("lscore", "lheight", "lq", "ldomain", "lorg", "lera"):
+        assert leaderboard.index(f'params.set("{key}"') > gate, key
+    assert 'params.set("lwindow"' in leaderboard
+    # The adoption filters are the mode's own marker, so the address keeps the
+    # shape pre-mode permalinks had (test_clean_route_model... holds it).
+    assert 'params.set("lmode"' not in leaderboard
+    # Resolved for the view the address names, after a legacy benchmark
+    # permalink has been redirected to Saturation, so the shared cutoff on a
+    # Saturation address cannot pick the adoption mode (harness covers it).
+    redirect = script.index('if (state.view === "leaderboard" && state.lfrontierExplicit)')
+    assert script.index("state.lmode = leaderboardModeFromParams(params, state.view);") > redirect
+    # The renderer is reached from every path that redraws the leaderboard.
+    head = "function renderLeaderboard() {\n  syncLeaderboardMode();\n  renderLatestReleases();"
+    assert head in script
+    # A mode is a different ranking, so switching is a navigation Back undoes;
+    # a window is a facet of the same one and refines the entry in place.
+    mode_switch = script.split("function setLeaderboardMode(", 1)[1].split("\n}\n", 1)[0]
+    assert 'writeUrl("push")' in mode_switch
+    window_switch = script.split("function setLatestWindow(", 1)[1].split("\n}\n", 1)[0]
+    assert "writeUrl()" in window_switch
+
+
+def test_every_visible_latest_releases_string_is_translated():
+    # Every static label the section shows and every string its renderer draws
+    # through t() has a zh entry, so the Chinese interface does not fall back
+    # to English on the page's default view.
+    html = (SITE / "index.html").read_text(encoding="utf-8")
+    script = (SITE / "assets" / "app.js").read_text(encoding="utf-8")
+    section = _leaderboard_section(html)
+    latest = section[: section.index('<div id="leaderboard-adoption" hidden>')]
+    zh = script.split("  zh: {", 1)[1].split("\n  },\n", 1)[0]
+
+    def has(key: str) -> bool:
+        quoted = json.dumps(key, ensure_ascii=False)
+        return f"{quoted}:" in zh or f"\n    {key}:" in zh
+
+    for key in re.findall(r'data-i18n(?:-aria)?="([^"]+)"', latest):
+        assert has(key), f"missing zh translation for {key!r}"
+    for key in (
+        "GitHub stars",
+        "Hugging Face paper upvotes",
+        "Hugging Face dataset downloads, last 30 days",
+        "unavailable",
+        "not observed",
+        "{value} · stale since {date}",
+        "{value} · unverified since {date}",
+        "{value} · unverified",
+        "source ↗",
+        "Coverage {coverage}",
+        "limited signals: not enough fresh durable signal to rank",
+        "No benchmark released in the last {days} days has a measurable attention signal yet.",
+        "Try {window}",
+        "See model-card adoption instead",
+        "{days} days",
+        "unranked",
+        "Loading this window…",
+        "This window could not be loaded. Refresh to try again.",
+        "The {window} window is not in this build.",
+    ):
+        assert has(key), f"missing zh translation for {key!r}"
+    # The feature adds no second entry for a key the table already had: a
+    # repeated key silently keeps only its last value.
+    for key in ("confidence", "high", "medium", "low", "unranked", "released", "weight"):
+        assert zh.count(f"\n    {key}:") + zh.count(f'\n    "{key}":') == 1, key
+
+
+def test_the_static_leaderboard_page_seeds_the_default_window():
+    # A crawler or a reader without scripts sees the same rows the script
+    # draws for the default window, in the published order, with the limited
+    # entry kept and marked rather than dropped, and the inputs behind each
+    # rank in the disclosure the script would otherwise draw.
+    seed = _latest_releases_seed({"latest_releases_leaderboard": _payload()})
+    rows = seed[LIST_ANCHOR]
+    assert "data-seed" in rows
+    assert rows.count('<li class="latest-release">') == 2
+    assert '<span class="leaderboard-top-rank">01</span>' in rows
+    assert "Bench &lt;Agents&gt;" in rows, "names are escaped"
+    assert (
+        '<span class="leaderboard-top-rank"><span aria-hidden="true">—</span>'
+        '<span class="visually-hidden">unranked</span></span>'
+    ) in rows
+    assert "latest-release-bar-limited" in rows
+    assert "<span>87</span>" in rows and "<span>no score</span>" in rows
+    assert 'class="pill pill-confidence pill-confidence-high">high</span>' in rows
+    assert 'class="latest-release-date">released Sep 1, 2026</small>' in rows
+    assert rows.count('<div class="latest-release-body">') == 2
+    assert rows.count("<dt>GitHub stars</dt><dd><span>not observed</span>") == 2
+    assert "limited signals: not enough fresh durable signal to rank" in rows
+    assert rows.index("Bench") < rows.index("Quiet"), "published order is kept"
+    assert seed[WINDOW_ANCHOR].endswith("· 30 days</span>")
+    assert "Ranking attention-ranking-v1:" in seed[INFO_ANCHOR]
+    assert EMPTY_ANCHOR not in seed, "rows leave the empty state to the script"
+    # The default window names itself, so a payload defaulting to 7 days
+    # would not open under a 30-day heading.
+    week = _latest_releases_seed({"latest_releases_leaderboard": _payload(default_window="7d")})
+    assert week[WINDOW_ANCHOR].endswith("· 7 days</span>")
+    # Nothing to rank is a real state the page must show without scripts, with
+    # the same way out the script offers; nothing published is nothing seeded.
+    empty = _latest_releases_seed({"latest_releases_leaderboard": _payload(entries=[])})
+    assert LIST_ANCHOR not in empty
+    assert empty[EMPTY_ANCHOR].startswith(
+        '<p class="empty-state latest-releases-empty" id="latest-releases-empty" '
+        'aria-live="polite" data-seed>'
+        "No benchmark released in the last 30 days has a measurable attention signal yet. "
+    )
+    assert 'data-lwindow="90d">Try 90 days</button>' in empty[EMPTY_ANCHOR]
+    assert 'data-lwindow="7d"' not in empty[EMPTY_ANCHOR], "only wider windows are offered"
+    widest = _latest_releases_seed(
+        {"latest_releases_leaderboard": _payload(entries=[], default_window="90d")}
+    )
+    assert 'data-lmode="adoption">See model-card adoption instead</button>' in widest[EMPTY_ANCHOR]
+    # A wider window known to be empty is not offered; one not published is.
+    known = _payload(entries=[], default_window="7d")
+    known["windows"]["30d"] = {**known["windows"]["7d"], "entries": []}
+    offered = _latest_releases_seed({"latest_releases_leaderboard": known})[EMPTY_ANCHOR]
+    assert 'data-lwindow="30d"' not in offered and 'data-lwindow="90d"' in offered
+    assert _latest_releases_seed({}) == {}
+    unpublished = {**_payload(), "windows": {}}
+    assert _latest_releases_seed({"latest_releases_leaderboard": unpublished}) == {}
+
+
+def test_seeds_are_what_the_renderer_draws():
+    # The rule app_seeds.py states: a seed is what the renderer would produce
+    # from the same data, in the same markup. Checked against the renderer
+    # itself rather than a description of it, on a fixture with a ranked row
+    # carrying fresh, stale and unavailable signals, a limited row, an unsafe
+    # source URL, and an empty window.
+    payload = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    drawn = _render(payload)
+    seed = _latest_releases_seed({"latest_releases_leaderboard": payload})
+    assert _inner(seed[LIST_ANCHOR]) == drawn["default"]["list"]
+    assert _inner(seed[INFO_ANCHOR]) == drawn["default"]["info"]
+    # The renderer fills the ranked-count note for a non-empty window, so the
+    # seed has to as well: without it a reader without scripts saw rows marked
+    # "limited signals" and nothing saying how many of the cohort were ranked.
+    assert _inner(seed[NOTE_ANCHOR]) == drawn["default"]["note"]
+    assert drawn["default"]["window"] == "· 30 days"
+    assert drawn["default"]["emptyHidden"] is True
+    assert drawn["default"]["note"] == (
+        "1 of 2 releases in this window are ranked; the rest are listed with limited signals."
+    )
+    assert drawn["default"]["pressedWindows"] == ["30d"]
+    assert drawn["default"]["pressedModes"] == ["latest"]
+    assert drawn["default"]["latestHidden"] is False and drawn["default"]["adoptionHidden"] is True
+    # The unsafe URL is not linked; the safe ones are, with their weights.
+    assert 'href="javascript:' not in drawn["default"]["list"]
+    assert drawn["default"]["list"].count('class="latest-release-source"') == 4
+    # A connector counter reaches the payload as a real number the engine marks
+    # `unknown` and refuses to promote. Printed bare it read exactly like a
+    # fresh observation, which is the imputation issue #530 rules out.
+    assert "420 · unverified since 2026-08-30" in drawn["default"]["list"]
+    assert "420<" not in drawn["default"]["list"]
+    week = _latest_releases_seed(
+        {"latest_releases_leaderboard": {**payload, "default_window": "7d"}}
+    )
+    assert _inner(week[EMPTY_ANCHOR]) == drawn["empty7d"]["empty"]
+    assert _inner(week[INFO_ANCHOR]) == drawn["empty7d"]["info"]
+    assert drawn["empty7d"]["list"] == "" and drawn["empty7d"]["window"] == "· 7 days"
+
+
+def test_the_renderer_keeps_open_rows_loads_wider_windows_and_reports_failure():
+    drawn = _render(json.loads(FIXTURE.read_text(encoding="utf-8")))
+    # A redraw (the catalog index landing, Refresh, Back) keeps the signals a
+    # reader opened.
+    assert drawn["openBefore"] == ["artifact:github:org/bench"]
+    assert drawn["openAfter"] == ["artifact:github:org/bench"]
+    # The adoption mode hides the latest section and shows the adoption block.
+    assert drawn["adoption"] == {
+        "latestHidden": True,
+        "adoptionHidden": False,
+        "pressedModes": ["adoption"],
+    }
+    # A window the bootstrap did not carry is a full-data route, like a
+    # historical Today URL: boot, Back and Refresh fetch the corpus for it.
+    assert drawn["needsFullData"] == {
+        "missingWindow": True,
+        "adoption": False,
+        "loadedWindow": False,
+        "otherView": False,
+        "fullLoaded": False,
+    }
+    # The renderer fetches it too, says so while waiting, and says what
+    # happened when the fetch fails instead of loading forever.
+    assert drawn["failed90d"]["empty"] == "Loading this window…"
+    assert drawn["failed90d"]["fetchCalls"] == ["/data/radar.json"]
+    assert drawn["failed90d"]["after"] == "This window could not be loaded. Refresh to try again."
+    assert drawn["failed90d"]["errors"] == ["HTTP 404"]
+    # A corpus that has loaded without the window is not going to bring it.
+    assert drawn["missing90d"]["empty"].startswith("The 90 days window is not in this build. ")
+    assert drawn["missing90d"]["empty"].count("data-lwindow=") == 2
+    assert drawn["missing90d"]["fetchCalls"] == []
+    assert drawn["loading90d"]["after"] == "Loading this window…"
+    # Adoption mode reads no release window and stateNeedsFullData skips the
+    # corpus for it, so the renderer must not fetch it either to fill a hidden
+    # section. The guard and the renderer have to agree or one of them is waste.
+    assert drawn["adoption90d"]["fetchCalls"] == []
+    assert drawn["adoption90d"]["needsFullData"] is False
+    assert drawn["adoption90d"]["latestHidden"] is True
+    # The empty stub the bootstrap keeps for an unpublished window has no
+    # bounds to print a method note for; the empty state still shows its way out.
+    assert drawn["stub90d"]["info"] == ""
+    assert drawn["stub90d"]["empty"].startswith("No benchmark released in the last 90 days")
+    assert 'data-lmode="adoption"' in drawn["stub90d"]["empty"]
+    # The Chinese interface draws the same rows in its own words.
+    assert drawn["zh"]["window"] == "· 30 天"
+    assert "发布于" in drawn["zh"]["list"] and "released" not in drawn["zh"]["list"]
+    assert "来源 ↗" in drawn["zh"]["list"]
+
+
+def test_the_leaderboard_page_describes_its_new_default():
+    seo = load_view_seo(SITE / "assets" / "app.js")["leaderboard"]
+    assert "latest" in seo["title"].lower()
+    assert "GitHub stars" in seo["description"]
+    assert seo["canonical"] == "/leaderboard/"
+    # The description is the page's meta, og and twitter description at once.
+    # Every other view sits between 126 and 166 characters; a longer one is
+    # cut off in a result snippet, and this page had run to 230.
+    assert len(seo["description"]) <= 170
+
+
+def test_written_leaderboard_page_carries_both_rankings(tmp_path):
+    # tests/ has no __init__.py, so the sibling module is imported by its own
+    # name: that resolves under the `pytest` script CI runs and under
+    # `python -m pytest` alike.
+    from test_app_pages import _dashboard, _write
+
+    dashboard = _dashboard()
+    dashboard["latest_releases_leaderboard"] = _payload()
+    _write(tmp_path, dashboard)
+    page = (tmp_path / "leaderboard" / "index.html").read_text(encoding="utf-8")
+    assert 'id="latest-releases-list" data-seed>' in page
+    assert "Bench &lt;Agents&gt;" in page
+    assert 'id="leaderboard-top-list" data-seed>' in page, "the adoption rows are still seeded"
+    assert page.index('id="latest-releases-list"') < page.index('id="leaderboard-top-list"')
+    seo = load_view_seo(tmp_path / "assets" / "app.js")
+    assert seo["leaderboard"]["canonical"] == "/leaderboard/"
+
+
+@pytest.mark.parametrize("status", ["ranked", "limited_signals"])
+def test_seed_bar_widths_scale_against_the_top_score(status):
+    entries = [
+        {"name": "Top", "score": 80, "status": "ranked", "rank": 1},
+        {"name": "Half", "score": 40, "status": status, "rank": 2 if status == "ranked" else None},
+    ]
+    rows = _latest_releases_seed({"latest_releases_leaderboard": _payload(entries=entries)})[
+        LIST_ANCHOR
+    ]
+    assert 'style="width:100.0%"' in rows
+    assert 'style="width:50.0%"' in rows

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -612,6 +612,9 @@ def test_clean_route_model_migrates_legacy_urls_and_preserves_utility_background
             section("const VIEW_PATHS =", "function applySeo("),
             # readUrl parses the score cutoff through this helper.
             section("function scoreCutoff(", "function matchesScoreFilter("),
+            # readUrl and writeUrl resolve the leaderboard mode and window
+            # (issue #530) through these.
+            section("const LATEST_WINDOWS =", "function latestReleasesWindowKey("),
             section("function readUrl()", "// `push` adds a history entry"),
             section("function writeUrl(", "// A pushed entry changes the URL"),
         )


### PR DESCRIPTION
Part of #530: the page half. Together with the collector PR for #589 it completes the issue's acceptance list; the two are independent and merge in either order.

One commit on top of upstream `main` at 5d9e378.

## What changes for a reader

- **`/leaderboard/` opens on "Latest releases · 30 days".** Recently released benchmarks ranked by the attention they are receiving now, from the `latest_releases_leaderboard` payload the pipeline already publishes. 7- and 90-day windows are one click away.
- **Model-card adoption and reported scores stay separate modes on the same address.** The adoption view keeps every element, id, seed and handler it has today, shown as a block when the reader picks it. Reported scores links to the existing `/saturation/` workbench.
- **Every rank shows its inputs.** Each row prints rank, name, release date, a bar scaled against the top score, the score and its confidence. Opening a row shows each signal with its value and status (fresh, stale since the day it was last read, unavailable, or not observed), its weight and a link to the resource it was read from, plus coverage and confidence. A release the engine could not rank stays in the list, marked as limited signals, rather than vanishing.
- **The (i) states the method.** Method version, the weights read from the published components (not restated in the browser), the log1p normalization, that downloads are a rolling 30-day figure and never cumulative, that stars come from the benchmark's own repository and never a parent framework, and the window bounds in UTC.
- **An empty window is a real state.** The page says no release in the window has a measurable signal yet and offers the wider windows; past the widest one it offers the adoption view. A window the corpus fails to load, or does not carry, says so instead of sitting on a loading line, and the refresh control re-requests the corpus for it.
- **Switching modes is one Back away.** A mode is a different ranking, so choosing one pushes a history entry; picking a window refines the entry in place. Opening a row's signals survives a redraw (the catalog index landing, a refresh, Back).
- **Chinese interface.** Every visible string has a translation.

## Acceptance criteria this covers

| Criterion | Where |
| --- | --- |
| `/leaderboard/` defaults to Latest releases · 30d | mode strip, `state.lmode`, `latestReleasesDefaultWindow` |
| Each rank exposes inputs, components, coverage, confidence, method version, source links | `latestReleaseRow`, `latestReleasesMethodNote` |
| Missing and stale metrics stay distinguishable | `latestSignalText` |
| Downloads never presented as cumulative or delta | signal label "last 30 days" and the method note |
| Existing views preserved with current trust labels | adoption block unchanged; `/saturation/` unchanged |
| Empty states suggest broader windows | `latestReleasesEmptyState` |

The cohort, dedupe, keyword and parent-framework rules are the engine's (`release_leaderboard.py`) and the collector's (the collector PR); this PR prints what they publish and computes nothing.

## Addresses

A permalink written before the page had modes carries the adoption view's own filters (`lscore`, `lq`, `ldomain`, `lorg`, `lera`, `lheight`). Any of them selects the adoption mode on read, and the mode writes them back in exactly the shape it always did, so `test_clean_route_model_migrates_legacy_urls_and_preserves_utility_backgrounds` holds unchanged. The latest mode writes only a non-default `lwindow`, so its address can never flip modes on reload. `?lmode=latest|adoption` is accepted as an explicit override.

The cutoff is shared with Saturation, whose every address carries it, so on a Saturation address `lscore` alone is not a mode choice: a reader who goes Latest releases → Saturation → Back → Forward → Leaderboard lands on Latest releases, not on a mode they never picked. The mode is resolved after the legacy benchmark permalink redirect for the same reason.

## Wiring

- `site/index.html`: the mode strip, the latest-releases section, and the adoption block wrapper (`#leaderboard-adoption`, hidden by default; its seeded rows stay in the document for crawlers).
- `site/assets/app.js`: `state.lmode` / `state.lwindow`; `readUrl` and `writeUrl`; `leaderboardModeFromParams`, `latestReleasesWindowKey`, `latestSignalText`, `latestReleasesEmptyState`, `latestReleasesMethodNote`, `latestReleaseRow`, `renderLatestReleases`, `syncLeaderboardMode`; one delegated click handler for the mode and window controls (the empty state renders its own buttons); zh strings.
- `site/assets/styles.css`: the mode and window pills, the row disclosure and its signal grid, phone layout.
- `src/benchmark_radar/app_seeds.py`: `_latest_releases_seed`, so the static `/leaderboard/` page carries what the renderer draws for the default window: the rows with their disclosure bodies (signals, statuses, weights, source links, coverage and confidence), the method note, and, for an empty window, the empty state with its way out. A test runs the real renderer on a shared fixture and compares the markup byte for byte with the seed.
- `site/llms.txt` and `VIEW_SEO.leaderboard`: the page's title, description and llms.txt entry describe the new default.
- `tests/test_site.py`: the route-model test loads the mode and window helpers `readUrl` and `writeUrl` now call.
- The bootstrap payload already carries only the default window (`snapshots.py`); a leaderboard address naming another one is a full-data route in `stateNeedsFullData`, so boot, Back and the refresh control fetch the corpus for it the way they do for a historical Today URL, and the renderer fetches it on a window click.

## Tests

`tests/test_latest_releases_view.py` (eleven tests), `tests/latest_releases_harness.mjs` and `tests/latest_releases_render_harness.mjs`, each named for the failure it protects against: the page opens on the latest ranking with the adoption block hidden and intact; mode resolution for bare, legacy, explicit and bogus addresses, and for a Saturation address with and without the adoption filters; window fallback; signal text for fresh, stale (dated and undated), unavailable, zero and null; the empty-state suggestion for a loaded-empty, unloaded and widest window; weights read from components; the method note; the URL round trip through the real `readUrl` and `writeUrl`; adoption filters written only in adoption mode, a mode switch pushed and a window switch replaced; every visible string translated and no key entered twice; the static seed (order, escaping, limited entries kept, disclosure bodies, method note, empty state, default window named, nothing seeded for nothing); the seed equal to what the real renderer draws on a shared fixture (a ranked row with fresh, stale and unavailable signals, a limited row, an unsafe source URL, an empty window); the renderer keeping open rows across a redraw, treating a missing window as a full-data route, fetching it, reporting a failed fetch and a window the corpus does not carry, and drawing the Chinese interface; the page metadata describing the new default; the written page carrying both rankings; bar widths scaled against the top score.

Twenty-two behaviours were checked by reverting each one and watching its test go red, among them: the default mode, adoption filters leaking into the latest address, Saturation's cutoff choosing a mode, the mode resolved before the legacy redirect, a missing window not counted as a full-data route, a failed fetch left on the loading line, a loaded corpus without the window left on it, open rows collapsing, a mode switch replacing history, the seed dropping the confidence pill, the disclosure body, a weight, or offering a window known to be empty, a release date formatted outside UTC, a duplicated translation key, and the method note printed for a window with no bounds.

## Verification

Clean-worktree run of the CI sequence (`git worktree add --detach`, submodule initialized): `ruff check .`, `ruff format --check .`, `normalize-catalog`, `classify` and `build-data-release` pass; `pytest -q` reports 1344 passed, 1 failed.

The one failure is `tests/test_briefing.py::test_zh_output_budget_covers_worst_case`, which downloads tiktoken's `o200k_base` table from `openaipublic.blob.core.windows.net`, a host the build sandbox's egress policy blocks. It fails identically on an untouched `main` checkout in the same sandbox and passes on GitHub's runner.

Driven in Chromium against a built payload with four synthetic entries (three ranked, one limited): the page opens on the 30-day ranking with the adoption block hidden and the unranked row announced as "unranked" to assistive technology; a row opens to its signals, with the stale upvote dated and the gone dataset marked unavailable; the 7-day window fetches the full corpus and lands on the empty state whose "Try 30 days" button restores the ranking; the 90-day window shows its five rows, and booting directly on `?lwindow=90d` loads them through the boot path; choosing the adoption mode pushes one history entry (pressing it again pushes none) and Back returns to Latest releases; an opened row stays open across the refresh control; `/saturation/?lscore=60` then the Leaderboard tab opens Latest releases, while `/saturation/?lscore=60&lq=agent` opens adoption with the search filled; "Reported scores" switches to Saturation without a page load; with `radar.json` blocked, the 90-day window reports that it could not be loaded and the refresh control brings its rows back, and booting on the 90-day address shows the error banner rather than a loading line; the Chinese interface translates the heading, modes, columns, note and signal text; at 400px the body has no horizontal scroll. No page errors.

## Not in this PR

The collector that fills the payload with real counters (the collector PR). Until it merges the live page shows the empty state, which is the honest reading of an empty payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UaUf4LgR9HogJ1DhXwjESy
