### PR TITLE
Add a model card SOP and split AGENTS.md into reference guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,19 @@ reduction to a few dozen. Missing measurements must not remove corpus records.
 Benchmark Frontier and its linked score ranking explicitly exclude records
 without numeric reported scores, as specified in `principle.md`.
 
+## Reference guides
+
+This file holds the rules that apply to every change. Detailed procedure lives
+in the guides below. Each line states when the guide is required reading, and
+the constraint that holds whether or not you open it.
+
+| Guide | Read it before | Constraint that always holds |
+| --- | --- | --- |
+| [`docs/pipeline-and-data-map.md`](docs/pipeline-and-data-map.md) | Touching a source input, a generator, a generated artifact, or the technical report | Never reconstruct the system from a report, the deployed site, or leftover generated files. Never patch a derived file to fix a source-data problem. |
+| [`docs/sop-add-model-cards.md`](docs/sop-add-model-cards.md) | Adding a model card, a benchmark, or a score | `data/model_cards.yml` and `data/benchmark_scores.yml` move together. Every value is read out of the cited document, never from memory. |
+| [`docs/query-surfaces.md`](docs/query-surfaces.md) | Changing search, detail lookup, the CLI or HTTP query surface, or the consumer Skill | `QueryService` is the single source of truth. No interface-specific ranking, and no silent network fallback. |
+| [`principle.md`](principle.md) | Changing any benchmark-facing surface | Start from the full corpus across all sources. |
+
 ## Glob rule: showcase and UI communication
 
 Applies to `README*`, `docs/**`, `.github/ISSUE_TEMPLATE/**`, `site/**`, and
@@ -87,229 +100,14 @@ Applies to `README*`, `docs/**`, `.github/ISSUE_TEMPLATE/**`, `site/**`,
   searchable in one query, and the model series tells a reviewer what produced
   the diff before they start reading it. A human opening a PR adds neither.
 
-## Pipeline and data map
-
-Do not reconstruct the system from a report, the deployed site, or whatever
-generated files happen to be present in a long-lived checkout. Start with the
-sources below, run the generators in order, and measure the rebuilt outputs.
-
-### Source inputs and the shared catalog
-
-1. **Daily discovery corpus.** `config.yml` defines the collection and scoring
-   configuration; connectors live under `src/benchmark_radar/`. A daily
-   `benchmark-radar` run writes its durable evidence to
-   `data/snapshots/YYYY-MM-DD.json`. Those dated snapshots are the source of
-   truth for cumulative observations, artifacts, source health, and history.
-2. **Benchmark registry snapshots.** `data/leaderboard_snapshots.yml` registers
-   immutable crawl inputs under `data/leaderboard_snapshots/`. The reviewed
-   join rules are `data/catalog/identity.yml` and
-   `data/catalog/llm_stats_identity_overrides.yml`. Cited release and first-score
-   dates missing from the crawls live in `data/catalog/benchmark_dates.yml`,
-   keyed by exact source record. Numeric first-score evidence only verifies a
-   date; it does not supply a highest score or merge records. Other JSONL and
-   validation files under `data/catalog/` are normalization products; do not hand-edit or
-   treat them as a separate corpus, even when Git currently tracks a generated
-   copy.
-3. **Model reports.** `data/model_cards.yml` registers cited model reports
-   and every benchmark they mention. `data/benchmark_scores.yml` is its matched,
-   protocol-aware score archive, and every score must cite a registry document.
-   Normalize these records, scores and citations into the same catalog contract
-   as every other source. Document type and protocol describe the evidence;
-   they do not establish a preferred corpus or a source ranking.
-
-### Adding a model card: scores are part of the change
-
-A pull request that adds a model card is not complete with the card alone. The
-mention belongs in `data/model_cards.yml`, and the numbers that card reports
-belong in `data/benchmark_scores.yml` in the same PR. A card landing without its
-scores leaves a model in the registry that the score progression and paired
-comparison readout cannot see, and nothing flags the gap later.
-
-Both blocks of the score file usually need an edit:
-
-- `benchmarks:` is metric identity, one entry per `benchmark_id` with `metric`,
-  `direction` and `unit`. A new benchmark id has no entry, so its score rows have
-  nothing to render against. Set `direction` from what the benchmark reports;
-  not every metric improves upward.
-- `results:` is one row per reported number: `benchmark_id`, `instrument`,
-  `protocol`, `model`, `organization`, `source_id`, `reported_at`, `value`,
-  `read_from`. Copy the shape of an existing block rather than inventing fields.
-
-Three fields carry the comparability contract and must not be shortcut:
-
-- `instrument` is version identity, separate from `benchmark_id`, so a task-set
-  change such as Terminal-Bench 2.0 to 2.1 never reads as model progress.
-- `protocol` is the comparability class. Record what the source said moves the
-  number (thinking budget, tool access, pass@1 against consensus@k). Silence is
-  not agreement, so do not leave it generic to make rows look joinable.
-- `source_id` must name a document registered in `data/model_cards.yml`, and
-  `read_from` must say how the value was read (`pdf_text`, `html_text`,
-  `table_image`).
-
-Score rows are per model, not per document. A card covering several variants,
-such as a Pro, Lite and Mini release, gets one row per variant instead of three
-systems collapsed into one label.
-
-Read every number out of the cited document and record it exactly as printed. If
-a table ships as an image and a value is not certain, add nothing: an absent row
-is honest, a guessed row is not. The same standard applies to any new benchmark
-entry's `url` and `caveat`. Verify the link resolves before committing, drop
-`url` when no real homepage or paper exists, and describe what the benchmark
-measures from its source rather than inferring a gloss from its name.
-
-### Generator order and outputs
-
-Run these from the repository root, in this order:
-
-1. `benchmark-radar normalize-catalog` reads the crawl registry, raw crawl
-   files, model reports, score archives, and reviewed identity rules. It writes
-   normalized intermediates under
-   `data/catalog/`, then the generated search index
-   `site/data/benchmark-index.json` and detail shards under
-   `site/data/benchmarks/`.
-2. `benchmark-radar classify` reads the dated snapshots plus the shared
-   catalog shards and model-report YAML files. It regenerates
-   `data/kw_bench_classifications.jsonl`, `site/data/radar.json`,
-   `site/data/radar-bootstrap.json`, `site/data/radar-trends.json`,
-   `site/data/models.json`, `site/feed.xml`, the daily brief blog under
-   `site/blog/`, and `site/blog/feed.xml`. The classifier currently uses
-   the deterministic null extractor in CI; it makes no external model call.
-3. `benchmark-radar build-data-release` validates the local corpus through
-   `QueryService` and writes `site/data/cli/manifest.json` plus the checksummed
-   `site/data/cli/benchmark-radar-data.zip`. The manifest is published on Pages;
-   the complete archive is uploaded to the rolling `cli-data` GitHub Release.
-4. `benchmark-radar export` writes the full-catalog documentation ranking as JSON,
-   CSV, Markdown, and badge files under `site/data/`. Pages then runs
-   `scripts/generate_og_image.py` and `scripts/build_logo_registry.py` before
-   tests and deployment.
-
-Most `site/data/` files and `data/kw_bench_classifications.jsonl` are derived
-and gitignored. Their absence in a fresh checkout is normal. Never patch them
-to fix a source-data problem; update the relevant snapshot, crawl input,
-identity rule, or report/score YAML and regenerate. Never report counts from a stale
-working tree: rebuild first and read the JSON that was just produced. A derived
-file that is tracked, such as `site/data/models.json` or current normalization
-outputs under `data/catalog/`, is still not an independent source of truth.
-
-### Which artifact answers which question
-
-- `site/data/radar.json`: cumulative daily-discovery corpus, source health,
-  findings, and report-specific historical analyses. It is not a second
-  population to append to the benchmark catalog.
-- `site/data/benchmark-index.json`: the complete benchmark catalog and common document
-  registry, one row per source record across all sources; reviewed identities do not silently collapse the
-  underlying evidence.
-- `site/data/benchmarks/<slug>.json`: benchmark detail, provenance, identity,
-  score series, observations and cited documents through one shared contract.
-- `site/data/models.json`: one model registry assembled from the catalog, with
-  named provenance sources for each model.
-- `data/snapshots/*.json`: committed historical evidence used for local radar
-  search and for rebuilding `radar.json`.
-- `site/blog/`: daily brief blog pages and full archive built from committed
-  snapshots, with an independent feed at `site/blog/feed.xml`.
-- `site/data/cli/`: distributable copy of the index, shards, and snapshots for
-  installed offline clients.
-
-The web, CLI and exported catalog use the exact same benchmark IDs from the
-freshly generated `benchmark-index.json`. Model-report records are already in
-that index, including benchmarks with no scores or citations. Never add
-`radar.json` score tracks to that total or fall back to a smaller report registry
-when the catalog fails to load. Compute records and sources from rebuilt outputs;
-1,259+ records across 4+ sources is the minimum scale to investigate against.
-
-`normalize-catalog` is the current command. `normalize-external` remains an
-alias for existing maintainer scripts. Implementation modules use `catalog_*`
-and shared data lives under `data/catalog/`; original fields in immutable crawl
-inputs retain their source spelling.
-
-### Technical report and deposit files
-
-The paper lives in `ktwu01/benchmark-radar-paper`, mounted as a Git submodule at
-`docs/technical-report/latex`. Initialize it with
-`git submodule update --init --recursive`, including in clean worktrees. Keep
-paper-only edits and PRs in the paper repository by default. Update the parent
-Benchmark Radar repository, including its submodule pointer, only when the user
-explicitly requests it. For a requested pointer update, push the reviewed paper
-commit first, then commit the pointer here. Overleaf sync changes the paper
-repository, not this pinned pointer.
-
-- Report source: `docs/technical-report/latex/main.tex`. This is the single
-  source of truth for the report. Edit it directly. Nothing generates it from
-  Python, Markdown, or the running site.
-- Built PDF: `docs/technical-report/latex/main.pdf`, tracked so the report reads
-  on GitHub in the paper repository. Rebuild and commit it with any change to
-  `main.tex`.
-- The four PDF figures have native TikZ sources under `latex/figures/`.
-  `make` builds them from the dated `latex/figure-data.tex` export. Refresh that
-  export only after auditing a clean corpus rebuild; review and commit the
-  figure PDFs and manuscript PDF together. The exporter writes no report prose.
-- Build instructions and audited inputs: `docs/technical-report/README.md`
-- Zenodo metadata: `docs/technical-report/zenodo-metadata.json`. It describes
-  the frozen v0.9.0 deposit, so its version and counts are a record of that
-  deposit rather than drift. A new deposit rewrites it in the same change.
-- Frozen deposit: `output/pdf/benchmark-radar-technical-report-v0.9.0.pdf`. This
-  is the artifact behind DOI 10.5281/zenodo.22167102. Nothing writes to that
-  path; leave it byte-for-byte unchanged.
-
-Before changing report claims or Zenodo metadata, run the clean-checkout CI
-sequence below and recompute claims from its outputs. Rebuild the PDF with `make`
-in `docs/technical-report/latex/`, inspect the rendered PDF, and commit that
-exact file. A deposit copies the reviewed PDF to a versioned name under
-`output/pdf/`. The PDF is a dated interpretation, not a data source.
-
-## Query surfaces
-
-- `benchmark_radar.query.QueryService` is the single source of truth for local
-  benchmark search, detail lookup, recent evidence, and data health.
-- CLI and HTTP query surfaces must call that service and return the same stable
-  JSON contract. Do not add interface-specific ranking, filtering, identity
-  merging, or silent network fallback.
-- Query responses must state their local data provenance and retrieval mode.
-  Missing or malformed generated artifacts fail visibly with machine-readable
-  errors; they must not be replaced with guessed metadata.
-- Lexical search is a high-recall candidate retriever for agents, not a final
-  suitability judge. Any shared query token may produce a candidate. BM25F is
-  the primary retrieval score. Exact/prefix/token-sequence name matches and
-  non-name contiguous phrases are bounded, query-IDF-scaled boosts; lexical
-  coverage is only a tie-breaker and explanation because BM25F already rewards
-  additional matched terms. Every result must expose matched and missing tokens,
-  fields, coverage, `retrieval_score`, `idf_coverage`, and score components.
-  `full_matches_found` means at least one candidate covers every query token,
-  `partial_candidates_only` preserves weaker evidence without claiming an answer,
-  and zero token overlap uses `no_lexical_candidates`. Semantic acceptance belongs
-  to the consuming Agent/Skill, which may issue focused query variants and inspect
-  `show` details before making a suitability claim.
-- Catalog records and daily discovery observations describe different things.
-  Label a discovery observation as evidence of a mention or release, and retain
-  the benchmark record it refers to. Source membership must not establish a
-  preferred trust tier or change the shared query ranking. A search result is a candidate, not a suitability claim. Agent query
-  expansion and final relevance judgment happen in the public Skill as a small
-  number of short variants and never change service-side ranking per interface.
-- Installed clients read the active version under the cross-platform
-  `.benchmark-radar` user data directory. `init` and `sync` are the only
-  consumer update paths; search must stay offline and must not hide an update
-  failure behind stale data.
-- Pages publishes the small CLI manifest, while the Pages workflow uploads the
-  complete checksummed bundle to the rolling `cli-data` GitHub Release. Sync
-  validates it before atomically switching state and removes old versions only
-  after the new version is active.
-- The public consumer Skill lives at `skills/benchmark-radar/SKILL.md`. Keep it
-  purpose-neutral and limited to routing user intent through consumer CLI
-  commands; do not make maintainer build commands part of its normal workflow.
-- Search evaluation is a manual review tool, not a CI gate while relevance labels
-  are LLM-assisted and only sparsely human-reviewed. Ranking changes should run
-  `scripts/evaluate_search.py` locally and inspect the qualitative judge cases.
-  Unlisted records are unjudged, not negative; do not report precision or NDCG
-  until result pools are completely labelled. A source refresh that changes a
-  judgement requires record review, not a mechanical fixture update.
-
 ## Before opening a pull request
 
 - Run the full CI sequence locally and get it passing before opening a PR. Do
   not open one against a red local run.
 - A PR that adds a model card must also add that card's scores to
-  `data/benchmark_scores.yml`. See "Adding a model card: scores are part of the
-  change" above for the required fields.
+  `data/benchmark_scores.yml`. Follow
+  [`docs/sop-add-model-cards.md`](docs/sop-add-model-cards.md); a card merged
+  without its scores leaves a model the score progression cannot see.
 - Run it against a clean checkout (`git worktree add --detach <tmp> <branch>`),
   not your working copy. Run `git submodule update --init --recursive` in that
   worktree before checks. Generated files such as `site/data/radar.json`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,11 @@ Applies to `README*`, `docs/**`, `.github/ISSUE_TEMPLATE/**`, `site/**`,
   does not authorize a merge.
 - Do not squash-merge pull requests.
 - Merge pull requests with a merge commit so Git preserves branch ancestry and recognizes the branch as merged.
+- If you are an agent, say so on every pull request you open. Post a comment on
+  the PR containing the marker `330226` and your model series (`GPT`, `Claude`,
+  `Kimi`, and so on) as an annotation. The marker makes agent-authored PRs
+  searchable in one query, and the model series tells a reviewer what produced
+  the diff before they start reading it. A human opening a PR adds neither.
 
 ## Pipeline and data map
 
@@ -111,6 +116,46 @@ sources below, run the generators in order, and measure the rebuilt outputs.
    Normalize these records, scores and citations into the same catalog contract
    as every other source. Document type and protocol describe the evidence;
    they do not establish a preferred corpus or a source ranking.
+
+### Adding a model card: scores are part of the change
+
+A pull request that adds a model card is not complete with the card alone. The
+mention belongs in `data/model_cards.yml`, and the numbers that card reports
+belong in `data/benchmark_scores.yml` in the same PR. A card landing without its
+scores leaves a model in the registry that the score progression and paired
+comparison readout cannot see, and nothing flags the gap later.
+
+Both blocks of the score file usually need an edit:
+
+- `benchmarks:` is metric identity, one entry per `benchmark_id` with `metric`,
+  `direction` and `unit`. A new benchmark id has no entry, so its score rows have
+  nothing to render against. Set `direction` from what the benchmark reports;
+  not every metric improves upward.
+- `results:` is one row per reported number: `benchmark_id`, `instrument`,
+  `protocol`, `model`, `organization`, `source_id`, `reported_at`, `value`,
+  `read_from`. Copy the shape of an existing block rather than inventing fields.
+
+Three fields carry the comparability contract and must not be shortcut:
+
+- `instrument` is version identity, separate from `benchmark_id`, so a task-set
+  change such as Terminal-Bench 2.0 to 2.1 never reads as model progress.
+- `protocol` is the comparability class. Record what the source said moves the
+  number (thinking budget, tool access, pass@1 against consensus@k). Silence is
+  not agreement, so do not leave it generic to make rows look joinable.
+- `source_id` must name a document registered in `data/model_cards.yml`, and
+  `read_from` must say how the value was read (`pdf_text`, `html_text`,
+  `table_image`).
+
+Score rows are per model, not per document. A card covering several variants,
+such as a Pro, Lite and Mini release, gets one row per variant instead of three
+systems collapsed into one label.
+
+Read every number out of the cited document and record it exactly as printed. If
+a table ships as an image and a value is not certain, add nothing: an absent row
+is honest, a guessed row is not. The same standard applies to any new benchmark
+entry's `url` and `caveat`. Verify the link resolves before committing, drop
+`url` when no real homepage or paper exists, and describe what the benchmark
+measures from its source rather than inferring a gloss from its name.
 
 ### Generator order and outputs
 
@@ -262,6 +307,9 @@ exact file. A deposit copies the reviewed PDF to a versioned name under
 
 - Run the full CI sequence locally and get it passing before opening a PR. Do
   not open one against a red local run.
+- A PR that adds a model card must also add that card's scores to
+  `data/benchmark_scores.yml`. See "Adding a model card: scores are part of the
+  change" above for the required fields.
 - Run it against a clean checkout (`git worktree add --detach <tmp> <branch>`),
   not your working copy. Run `git submodule update --init --recursive` in that
   worktree before checks. Generated files such as `site/data/radar.json`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,10 +104,13 @@ Applies to `README*`, `docs/**`, `.github/ISSUE_TEMPLATE/**`, `site/**`,
 
 - Run the full CI sequence locally and get it passing before opening a PR. Do
   not open one against a red local run.
-- A PR that adds a model card must also add that card's scores to
-  `data/benchmark_scores.yml`. Follow
-  [`docs/sop-add-model-cards.md`](docs/sop-add-model-cards.md); a card merged
-  without its scores leaves a model the score progression cannot see.
+- A PR that adds a model card must also add every numeric score that card
+  reports and that can be read with certainty to `data/benchmark_scores.yml`.
+  Follow [`docs/sop-add-model-cards.md`](docs/sop-add-model-cards.md); a card
+  merged without its readable scores leaves a model the score progression
+  cannot see. A card whose results are only qualitative, or whose table is an
+  image nobody can read with certainty, is still a valid addition with no score
+  rows.
 - Run it against a clean checkout (`git worktree add --detach <tmp> <branch>`),
   not your working copy. Run `git submodule update --init --recursive` in that
   worktree before checks. Generated files such as `site/data/radar.json`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,15 @@ benchmark from sitting near the top with no qualification. Write what would
 mislead someone comparing two reported numbers, for example a small split with
 wide variance, or a score that depends on scaffold and tool access.
 
-The full maintenance contract is documented at the top of
+If the document reports numbers you can read directly from it, add those too.
+They do not go in the adoption registry, which stores a mention and never a
+score. They go in [`data/benchmark_scores.yml`](data/benchmark_scores.yml), the
+matched score archive, where each row cites the document it was read from.
+
+The complete procedure for all of this, including the score fields and the
+checks the loader enforces, is
+[`docs/sop-add-model-cards.md`](docs/sop-add-model-cards.md). The maintenance
+contract is also documented at the top of
 [`data/model_cards.yml`](data/model_cards.yml).
 
 ## What this project will not accept

--- a/docs/pipeline-and-data-map.md
+++ b/docs/pipeline-and-data-map.md
@@ -1,0 +1,132 @@
+# Pipeline and data map
+
+Do not reconstruct the system from a report, the deployed site, or whatever
+generated files happen to be present in a long-lived checkout. Start with the
+sources below, run the generators in order, and measure the rebuilt outputs.
+
+## Source inputs and the shared catalog
+
+1. **Daily discovery corpus.** `config.yml` defines the collection and scoring
+   configuration; connectors live under `src/benchmark_radar/`. A daily
+   `benchmark-radar` run writes its durable evidence to
+   `data/snapshots/YYYY-MM-DD.json`. Those dated snapshots are the source of
+   truth for cumulative observations, artifacts, source health, and history.
+2. **Benchmark registry snapshots.** `data/leaderboard_snapshots.yml` registers
+   immutable crawl inputs under `data/leaderboard_snapshots/`. The reviewed
+   join rules are `data/catalog/identity.yml` and
+   `data/catalog/llm_stats_identity_overrides.yml`. Cited release and first-score
+   dates missing from the crawls live in `data/catalog/benchmark_dates.yml`,
+   keyed by exact source record. Numeric first-score evidence only verifies a
+   date; it does not supply a highest score or merge records. Other JSONL and
+   validation files under `data/catalog/` are normalization products; do not hand-edit or
+   treat them as a separate corpus, even when Git currently tracks a generated
+   copy.
+3. **Model reports.** `data/model_cards.yml` registers cited model reports
+   and every benchmark they mention. `data/benchmark_scores.yml` is its matched,
+   protocol-aware score archive, and every score must cite a registry document.
+   Normalize these records, scores and citations into the same catalog contract
+   as every other source. Document type and protocol describe the evidence;
+   they do not establish a preferred corpus or a source ranking.
+
+Adding a document to either file is one procedure, written up in
+[`docs/sop-add-model-cards.md`](sop-add-model-cards.md).
+
+## Generator order and outputs
+
+Run these from the repository root, in this order:
+
+1. `benchmark-radar normalize-catalog` reads the crawl registry, raw crawl
+   files, model reports, score archives, and reviewed identity rules. It writes
+   normalized intermediates under
+   `data/catalog/`, then the generated search index
+   `site/data/benchmark-index.json` and detail shards under
+   `site/data/benchmarks/`.
+2. `benchmark-radar classify` reads the dated snapshots plus the shared
+   catalog shards and model-report YAML files. It regenerates
+   `data/kw_bench_classifications.jsonl`, `site/data/radar.json`,
+   `site/data/radar-bootstrap.json`, `site/data/radar-trends.json`,
+   `site/data/models.json`, `site/feed.xml`, the daily brief blog under
+   `site/blog/`, and `site/blog/feed.xml`. The classifier currently uses
+   the deterministic null extractor in CI; it makes no external model call.
+3. `benchmark-radar build-data-release` validates the local corpus through
+   `QueryService` and writes `site/data/cli/manifest.json` plus the checksummed
+   `site/data/cli/benchmark-radar-data.zip`. The manifest is published on Pages;
+   the complete archive is uploaded to the rolling `cli-data` GitHub Release.
+4. `benchmark-radar export` writes the full-catalog documentation ranking as JSON,
+   CSV, Markdown, and badge files under `site/data/`. Pages then runs
+   `scripts/generate_og_image.py` and `scripts/build_logo_registry.py` before
+   tests and deployment.
+
+Most `site/data/` files and `data/kw_bench_classifications.jsonl` are derived
+and gitignored. Their absence in a fresh checkout is normal. Never patch them
+to fix a source-data problem; update the relevant snapshot, crawl input,
+identity rule, or report/score YAML and regenerate. Never report counts from a stale
+working tree: rebuild first and read the JSON that was just produced. A derived
+file that is tracked, such as `site/data/models.json` or current normalization
+outputs under `data/catalog/`, is still not an independent source of truth.
+
+## Which artifact answers which question
+
+- `site/data/radar.json`: cumulative daily-discovery corpus, source health,
+  findings, and report-specific historical analyses. It is not a second
+  population to append to the benchmark catalog.
+- `site/data/benchmark-index.json`: the complete benchmark catalog and common document
+  registry, one row per source record across all sources; reviewed identities do not silently collapse the
+  underlying evidence.
+- `site/data/benchmarks/<slug>.json`: benchmark detail, provenance, identity,
+  score series, observations and cited documents through one shared contract.
+- `site/data/models.json`: one model registry assembled from the catalog, with
+  named provenance sources for each model.
+- `data/snapshots/*.json`: committed historical evidence used for local radar
+  search and for rebuilding `radar.json`.
+- `site/blog/`: daily brief blog pages and full archive built from committed
+  snapshots, with an independent feed at `site/blog/feed.xml`.
+- `site/data/cli/`: distributable copy of the index, shards, and snapshots for
+  installed offline clients.
+
+The web, CLI and exported catalog use the exact same benchmark IDs from the
+freshly generated `benchmark-index.json`. Model-report records are already in
+that index, including benchmarks with no scores or citations. Never add
+`radar.json` score tracks to that total or fall back to a smaller report registry
+when the catalog fails to load. Compute records and sources from rebuilt outputs;
+1,259+ records across 4+ sources is the minimum scale to investigate against.
+
+`normalize-catalog` is the current command. `normalize-external` remains an
+alias for existing maintainer scripts. Implementation modules use `catalog_*`
+and shared data lives under `data/catalog/`; original fields in immutable crawl
+inputs retain their source spelling.
+
+## Technical report and deposit files
+
+The paper lives in `ktwu01/benchmark-radar-paper`, mounted as a Git submodule at
+`docs/technical-report/latex`. Initialize it with
+`git submodule update --init --recursive`, including in clean worktrees. Keep
+paper-only edits and PRs in the paper repository by default. Update the parent
+Benchmark Radar repository, including its submodule pointer, only when the user
+explicitly requests it. For a requested pointer update, push the reviewed paper
+commit first, then commit the pointer here. Overleaf sync changes the paper
+repository, not this pinned pointer.
+
+- Report source: `docs/technical-report/latex/main.tex`. This is the single
+  source of truth for the report. Edit it directly. Nothing generates it from
+  Python, Markdown, or the running site.
+- Built PDF: `docs/technical-report/latex/main.pdf`, tracked so the report reads
+  on GitHub in the paper repository. Rebuild and commit it with any change to
+  `main.tex`.
+- The four PDF figures have native TikZ sources under `latex/figures/`.
+  `make` builds them from the dated `latex/figure-data.tex` export. Refresh that
+  export only after auditing a clean corpus rebuild; review and commit the
+  figure PDFs and manuscript PDF together. The exporter writes no report prose.
+- Build instructions and audited inputs: `docs/technical-report/README.md`
+- Zenodo metadata: `docs/technical-report/zenodo-metadata.json`. It describes
+  the frozen v0.9.0 deposit, so its version and counts are a record of that
+  deposit rather than drift. A new deposit rewrites it in the same change.
+- Frozen deposit: `output/pdf/benchmark-radar-technical-report-v0.9.0.pdf`. This
+  is the artifact behind DOI 10.5281/zenodo.22167102. Nothing writes to that
+  path; leave it byte-for-byte unchanged.
+
+Before changing report claims or Zenodo metadata, run the clean-checkout CI
+sequence in `AGENTS.md` and recompute claims from its outputs. Rebuild the PDF
+with `make` in `docs/technical-report/latex/`, inspect the rendered PDF, and
+commit that exact file. A deposit copies the reviewed PDF to a versioned name
+under `output/pdf/`. The PDF is a dated interpretation, not a data source.

--- a/docs/query-surfaces.md
+++ b/docs/query-surfaces.md
@@ -1,0 +1,48 @@
+# Query surfaces
+
+Rules for local benchmark search, detail lookup, recent evidence, and data
+health, across the CLI, the HTTP surface, and the public consumer Skill.
+
+- `benchmark_radar.query.QueryService` is the single source of truth for local
+  benchmark search, detail lookup, recent evidence, and data health.
+- CLI and HTTP query surfaces must call that service and return the same stable
+  JSON contract. Do not add interface-specific ranking, filtering, identity
+  merging, or silent network fallback.
+- Query responses must state their local data provenance and retrieval mode.
+  Missing or malformed generated artifacts fail visibly with machine-readable
+  errors; they must not be replaced with guessed metadata.
+- Lexical search is a high-recall candidate retriever for agents, not a final
+  suitability judge. Any shared query token may produce a candidate. BM25F is
+  the primary retrieval score. Exact/prefix/token-sequence name matches and
+  non-name contiguous phrases are bounded, query-IDF-scaled boosts; lexical
+  coverage is only a tie-breaker and explanation because BM25F already rewards
+  additional matched terms. Every result must expose matched and missing tokens,
+  fields, coverage, `retrieval_score`, `idf_coverage`, and score components.
+  `full_matches_found` means at least one candidate covers every query token,
+  `partial_candidates_only` preserves weaker evidence without claiming an answer,
+  and zero token overlap uses `no_lexical_candidates`. Semantic acceptance belongs
+  to the consuming Agent/Skill, which may issue focused query variants and inspect
+  `show` details before making a suitability claim.
+- Catalog records and daily discovery observations describe different things.
+  Label a discovery observation as evidence of a mention or release, and retain
+  the benchmark record it refers to. Source membership must not establish a
+  preferred trust tier or change the shared query ranking. A search result is a candidate, not a suitability claim. Agent query
+  expansion and final relevance judgment happen in the public Skill as a small
+  number of short variants and never change service-side ranking per interface.
+- Installed clients read the active version under the cross-platform
+  `.benchmark-radar` user data directory. `init` and `sync` are the only
+  consumer update paths; search must stay offline and must not hide an update
+  failure behind stale data.
+- Pages publishes the small CLI manifest, while the Pages workflow uploads the
+  complete checksummed bundle to the rolling `cli-data` GitHub Release. Sync
+  validates it before atomically switching state and removes old versions only
+  after the new version is active.
+- The public consumer Skill lives at `skills/benchmark-radar/SKILL.md`. Keep it
+  purpose-neutral and limited to routing user intent through consumer CLI
+  commands; do not make maintainer build commands part of its normal workflow.
+- Search evaluation is a manual review tool, not a CI gate while relevance labels
+  are LLM-assisted and only sparsely human-reviewed. Ranking changes should run
+  `scripts/evaluate_search.py` locally and inspect the qualitative judge cases.
+  Unlisted records are unjudged, not negative; do not report precision or NDCG
+  until result pools are completely labelled. A source refresh that changes a
+  judgement requires record review, not a mechanical fixture update.

--- a/docs/sop-add-model-cards.md
+++ b/docs/sop-add-model-cards.md
@@ -1,0 +1,227 @@
+# SOP: adding a model card
+
+Use this when a vendor publishes a model card, system card, technical report or
+release post and you want it in the registry. It covers the whole change: the
+document, any benchmark it introduces, and the scores it reports.
+
+`CONTRIBUTING.md` has the short version for a first contribution. This file is
+the complete procedure, including the parts the short version leaves out.
+
+Two files move together:
+
+| File | What it stores |
+| --- | --- |
+| `data/model_cards.yml` | The document, and which benchmarks it mentions. Never a number. |
+| `data/benchmark_scores.yml` | The numbers that document reports, one row each. |
+
+A card added without its scores is not a finished change. It leaves a model in
+the registry that the score progression and paired comparison readout cannot
+see, and nothing reports the gap afterwards.
+
+## Before you start
+
+You need the document itself, open in front of you. Every value below is read
+out of it. If you are working from a summary, a screenshot of a table someone
+posted, or memory of what the model scores, stop here: this dataset's only claim
+is that any row can be checked against its source.
+
+Confirm the URL loads, and that it points at the document you actually read
+rather than a landing page that links to it.
+
+## Step 1: register the document
+
+Append to the `model_cards:` block in `data/model_cards.yml`.
+
+```yaml
+  - id: acme_frontier_1_model_card
+    organization: Acme
+    model: Frontier-1
+    document_type: model_card
+    published: 2026-05-14
+    url: https://acme.example/frontier-1-model-card
+    retrieved_at: 2026-09-11
+    benchmarks:
+      - gpqa_diamond
+      - swe_bench_verified
+      - aime
+```
+
+Required: `id`, `organization`, `model`, `url`, `benchmarks`. The loader rejects
+an entry missing any of them.
+
+| Field | Notes |
+| --- | --- |
+| `id` | Unique. Score rows cite it, so treat it as a stable key. |
+| `document_type` | One of `model_card`, `system_card`, `technical_report`, `release_post`, `benchmark_leaderboard`. |
+| `published` | The document's own date, not the model's release date. ISO `YYYY-MM-DD`. |
+| `retrieved_at` | When you read it. It is not refreshed automatically. |
+| `url` | Must be HTTP(S), and one URL per document. |
+| `revised` | Optional. Only for a document that genuinely gained a benchmark after publication, such as an arXiv report at v2 or a living card the vendor edits in place. |
+| `benchmarks` | Canonical ids, each resolving against the `benchmarks:` block. |
+
+The counted unit is the document. A card reporting AIME at pass@1, at
+consensus@64, and again with a Python tool contributes exactly one adoption, so
+a long appendix cannot outvote a different vendor.
+
+A leaderboard published by the benchmark's own authors goes in
+`source_documents:` instead, which additionally requires `name` and `publisher`.
+
+## Step 2: add any benchmark the registry is missing
+
+Every id used in step 1 must already exist in the `benchmarks:` block. An
+unknown id is a hard error, because a typo would otherwise invent a phantom
+benchmark with exactly one adopter, indistinguishable from a real benchmark
+nobody adopted.
+
+```yaml
+  - id: acme_reasoning_eval
+    name: Acme Reasoning Eval
+    aliases: ["ARE", "Acme Reasoning Eval"]
+    domain: reasoning
+    url: https://arxiv.org/abs/2604.01234
+    released: 2026-03-02
+    caveat: >-
+      140 items, so run-to-run variance is wide and a single reported number
+      hides it.
+```
+
+Required: `id`, `name`, `domain`, `caveat`.
+
+`caveat` is required rather than optional. The ranking's headline risk is being
+read as a quality ordering, and the per-row caveat is what stops a saturated or
+contaminated benchmark from sitting near the top with no qualification. Write
+what would mislead someone comparing two reported numbers, for example a small
+split with wide variance, or a score that depends on scaffold and tool access.
+Do not write a generic gloss inferred from the benchmark's name.
+
+`url` must point at the benchmark's real homepage or paper, and you must open it
+to confirm. A plausible-looking guess at a GitHub path is worse than no link: it
+looks checkable and is not. When you cannot find a real one, omit `url`.
+
+`released` is the benchmark's own publication date. It lets a reader separate a
+newly adopted benchmark from a newly published one. Omit it rather than guess.
+
+## Step 3: add the scores
+
+Append to `data/benchmark_scores.yml`. Two blocks usually need an edit.
+
+**Metric identity**, once per benchmark, in the `benchmarks:` block. A benchmark
+absent here has no metric, direction or unit for its rows to render against.
+
+```yaml
+  - benchmark_id: acme_reasoning_eval
+    metric: accuracy
+    direction: higher_is_better
+    unit: percent
+```
+
+Required: `benchmark_id`, `metric`, `direction`, `unit`. `direction` is
+`higher_is_better` or `lower_is_better`, and it exists because not every metric
+improves upward. An edit-distance metric inverts the axis, and a chart that
+assumed higher-is-better would draw the progression upside down.
+
+**One row per reported number**, in the `results:` block.
+
+```yaml
+  - benchmark_id: acme_reasoning_eval
+    instrument: acme_reasoning_eval
+    protocol: thinking on, pass@1
+    model: Frontier-1
+    organization: Acme
+    source_id: acme_frontier_1_model_card
+    reported_at: 2026-05-14
+    value: 71.4
+    read_from: pdf_text
+```
+
+All nine fields are required. Three of them carry the comparability contract:
+
+- **`instrument`** is version identity, kept separate from `benchmark_id`.
+  Terminal-Bench 2.0 and 2.1 share an id and are different instruments, because
+  2.1 changed 28 of 89 tasks. Same for HumanEval against HumanEval-Mul, or GPQA
+  full against Diamond. This is what stops a task-set change from reading as
+  model progress.
+- **`protocol`** is the comparability class. Record what the source said moves
+  the number: thinking budget, tool access, pass@1 against consensus@k. Silence
+  is not agreement, so two documents that both omit tool access are not evidence
+  that their setups matched. Do not leave it generic to make rows look joinable.
+- **`source_id`** must name a document registered in `data/model_cards.yml`, and
+  that document must actually report the benchmark being scored. The loader
+  checks the pair, because an id mistyped to a different real card would
+  otherwise publish a number with false provenance.
+
+`read_from` is how you read the value: `pdf_text`, `html_text` or
+`table_image`. The interface grades evidence on this field, so it is not a
+formality.
+
+Optional:
+
+- `measurement_kind` defaults to `reported_self_score`. Use
+  `benchmark_publisher_run` only when the benchmark's own publisher ran the
+  measurement, which additionally requires the cited document to be a
+  `benchmark_leaderboard` with a named `publisher`.
+- `reported_by` marks a third-party citation, where the publisher repeated a
+  competitor's self-reported figure. That is weaker evidence, and weaker still
+  when the publisher had a stake in the comparison. The interface marks these
+  rather than mixing them in.
+
+Score rows are per model, not per document. A card covering a Pro, Lite and Mini
+release gets one row per variant. Collapsing three systems into one label makes
+the series meaningless.
+
+### Recording the value
+
+Record the number exactly as printed. Do not round it, convert it, or reconcile
+it with a figure from elsewhere.
+
+If a document publishes its table as an image and a value cannot be read with
+certainty, add nothing. An absent row is honest, a guessed row is not.
+
+A note on precision: GPQA Diamond has 198 items, so a single-run accuracy can
+only land on multiples of about 0.505 points. A reported 92.1% therefore cannot
+be a plain single-run accuracy over the full split, which is why `protocol`
+carries the run treatment when the source states it.
+
+## Step 4: rebuild and verify
+
+```bash
+benchmark-radar rebuild
+pytest -q
+```
+
+Before opening the pull request, run the full CI sequence from `AGENTS.md`
+against a clean checkout.
+
+## What the loader rejects
+
+These fail the build loudly, which is the point. A mistake should not silently
+shift the ranking.
+
+- A card or benchmark entry missing a required field.
+- A benchmark id used by a card but absent from the `benchmarks:` block.
+- A new benchmark with no `caveat`.
+- A `url` that is not HTTP(S).
+- A date that is not a real ISO calendar date.
+- A card reporting a benchmark released after the card, with no `revised` date.
+- A score row citing a `source_id` that no card or source document declares.
+- A score row citing a document that does not report that benchmark.
+- A score row for a benchmark with no metric identity entry.
+- A percent value outside 0 to 100.
+- A `read_from`, `direction` or `measurement_kind` outside its allowed set.
+- Two rows for the same model on the same instrument, under the same protocol,
+  from the same document. That is a contradiction: the chart would draw two
+  points at one position with no way to say which is the reading.
+- A `benchmark_publisher_run` row whose document is not a registered leaderboard
+  with a named publisher.
+
+## What the loader cannot catch
+
+Each of these passes validation and is still wrong, so they are on you:
+
+- A number transcribed from the wrong row or column of a table.
+- A `protocol` string that omits a condition the document stated.
+- A `caveat` that describes what the benchmark sounds like rather than what it
+  measures.
+- A `url` that resolves but points at an unrelated project with a similar name.
+- A benchmark recorded as mentioned when the document only cites it in related
+  work rather than reporting a result.

--- a/docs/sop-add-model-cards.md
+++ b/docs/sop-add-model-cards.md
@@ -14,9 +14,11 @@ Two files move together:
 | `data/model_cards.yml` | The document, and which benchmarks it mentions. Never a number. |
 | `data/benchmark_scores.yml` | The numbers that document reports, one row each. |
 
-A card added without its scores is not a finished change. It leaves a model in
-the registry that the score progression and paired comparison readout cannot
-see, and nothing reports the gap afterwards.
+A card that reports numbers and is added without them is not a finished change.
+It leaves a model in the registry that the score progression and paired
+comparison readout cannot see, and nothing reports the gap afterwards. A card
+whose results are only qualitative, or whose table is an image nobody can read
+with certainty, is a finished change with no score rows at all.
 
 ## Before you start
 
@@ -52,7 +54,7 @@ an entry missing any of them.
 | Field | Notes |
 | --- | --- |
 | `id` | Unique. Score rows cite it, so treat it as a stable key. |
-| `document_type` | One of `model_card`, `system_card`, `technical_report`, `release_post`, `benchmark_leaderboard`. |
+| `document_type` | One of `model_card`, `system_card`, `technical_report`, `release_post`, `benchmark_leaderboard`. Set it whenever the document is not literally a model card. The loader accepts its absence and the catalog then labels the document `model_card`, so an omitted value publishes a system card or technical report under a document type it does not have. |
 | `published` | The document's own date, not the model's release date. ISO `YYYY-MM-DD`. |
 | `retrieved_at` | When you read it. It is not refreshed automatically. |
 | `url` | Must be HTTP(S), and one URL per document. |
@@ -120,7 +122,12 @@ Required: `benchmark_id`, `metric`, `direction`, `unit`. `direction` is
 improves upward. An edit-distance metric inverts the axis, and a chart that
 assumed higher-is-better would draw the progression upside down.
 
-**One row per reported number**, in the `results:` block.
+**One row per number reported in the declared metric**, in the `results:` block.
+Rows carry no metric or unit of their own, so every row inherits the pair
+declared above. A benchmark holds exactly one metric, and a second entry for the
+same `benchmark_id` is rejected, so a card reporting the same benchmark under a
+different metric has nowhere to record it. Leave those numbers out rather than
+filing them as rows labelled with a metric they were not measured in.
 
 ```yaml
   - benchmark_id: acme_reasoning_eval
@@ -163,7 +170,13 @@ Optional:
 - `reported_by` marks a third-party citation, where the publisher repeated a
   competitor's self-reported figure. That is weaker evidence, and weaker still
   when the publisher had a stake in the comparison. The interface marks these
-  rather than mixing them in.
+  rather than mixing them in. Optional to the loader and mandatory in fact: name
+  the publishing organization whenever it differs from the one that made the
+  model being scored, which is the usual case for a number read out of a
+  comparison table. Omitting it does not fail the build. It publishes the row as
+  a self-report and credits the measurement to the scored model's own
+  organization, which gives a competitor's figure stronger provenance than it
+  has.
 
 Score rows are per model, not per document. A card covering a Pro, Lite and Mini
 release gets one row per variant. Collapsing three systems into one label makes
@@ -220,8 +233,8 @@ Each of these passes validation and is still wrong, so they are on you:
 
 - A number transcribed from the wrong row or column of a table.
 - A `protocol` string that omits a condition the document stated.
-- A `caveat` that describes what the benchmark sounds like rather than what it
-  measures.
+- A `caveat` that describes the benchmark rather than warning about what would
+  mislead someone comparing two reported numbers.
 - A `url` that resolves but points at an unrelated project with a similar name.
 - A benchmark recorded as mentioned when the document only cites it in related
   work rather than reporting a result.


### PR DESCRIPTION
## Summary

`AGENTS.md` is read in full on every task, so reference material that applies to a minority of changes was competing for attention with rules that apply to all of them. This splits the reference material out and adds the procedure that was missing.

**New: [`docs/sop-add-model-cards.md`](docs/sop-add-model-cards.md).** Adding a model card spans two files and a set of loader checks that no single place stated. A contributor had to reconstruct it from `CONTRIBUTING.md`, the header of `data/model_cards.yml`, and the header of `data/benchmark_scores.yml`, and in practice the scores got missed. The SOP walks the whole change: register the document, add any missing benchmark, add the score rows, rebuild. Field tables and enums come from the loaders (`model_cards.py`, `benchmark_scores.py`) rather than from current data, so required versus optional is accurate. It closes with what the loader rejects and, separately, what it cannot catch.

**New: [`docs/pipeline-and-data-map.md`](docs/pipeline-and-data-map.md) and [`docs/query-surfaces.md`](docs/query-surfaces.md).** Moved out of `AGENTS.md`. No rule text changed. Headings shift one level, and the technical report section now names `AGENTS.md` for the CI sequence instead of saying "below".

**`AGENTS.md` loses 176 lines of reference material and gains a 22-line routing table**, leaving it at 130 lines. Each row of that table says when a guide is required reading and which constraint holds whether or not you open it, so moving the detail out does not quietly drop the rule.

**Two contributor rules stay inline**, because they apply to every change: a model card PR must carry its scores, and an agent opening a PR self-identifies with the marker `330226` plus its model series.

**`CONTRIBUTING.md`** now points at the SOP. Its "no scores in the adoption registry" rule reads as "no scores wanted" without naming the archive that does take them.

## Test plan

Documentation only. No Python and no data files are touched.

- [x] `ruff check .` passes
- [x] `ruff format --check .` passes, 168 files already formatted
- [x] Every line removed from `AGENTS.md` is verified present in a new doc, or accounted for as an intentional rewrite: the inline subsection became the SOP, one cross-reference was retargeted, six headings shifted level
- [x] All five relative documentation links resolve
- [x] Markdown is not linted in `ci.yml`, and no markdownlint or prettier config exists
- [x] The generator sequence and `pytest` cannot be affected by a Markdown-only diff, so they were not re-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)
