### PR TITLE
Mark the name as Benchmark Radar™ and add a contributors copyright line

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 </div>
 
-# Benchmark Radar
+# Benchmark Radar™
 
 <!-- The record-count badge is data-driven: it is regenerated from the corpus on
 every collection, so it states what the project actually holds rather than a
@@ -218,3 +218,5 @@ daily builder brief, [BuilderPulse](https://github.com/BuilderPulse/BuilderPulse
 </details>
 
 </details>
+
+© 2026 Koutian Wu and contributors

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,7 +4,7 @@
 
 </div>
 
-# Benchmark Radar
+# Benchmark Radar™
 
 <!-- 记录数 badge 由数据驱动：每次采集都会根据语料重新生成，因此它反映的是项目实际收集到的数据量；下方开头的来源数量是手工维护的，当 `config.yml` 增删采集 connector、first-party feed 或 Hacker News attention 来源时，需要同步更新该数字 -->
 
@@ -164,3 +164,5 @@ saturation 和趋势视图、每日 feed、可下载的证据数据，以及一�
 - [Benchmark logo 图库](https://benchmark-radar.org/logos.html)
 
 </details>
+
+© 2026 Koutian Wu and contributors

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -4250,6 +4250,10 @@ footer {
   color: var(--muted);
 }
 
+.copyright {
+  font-size: 0.72rem;
+}
+
 .footer-nav {
   display: flex;
   flex-wrap: wrap;

--- a/site/index.html
+++ b/site/index.html
@@ -219,7 +219,7 @@
           <span class="brand-mark" aria-hidden="true">
             <span></span>
           </span>
-          <strong>Benchmark Radar</strong>
+          <strong>Benchmark Radar™</strong>
         </a>
         <nav class="view-nav" aria-label="Dashboard views" data-i18n-aria="Dashboard views">
           <button type="button" class="nav-active" data-view="today" aria-controls="today-view" aria-current="page" data-i18n="Today">Today</button>
@@ -995,6 +995,7 @@
           <a href="https://privacy.microsoft.com/privacystatement">Microsoft Privacy Statement</a>.
         </p>
       </details>
+      <p class="copyright">© 2026 Koutian Wu and contributors</p>
     </footer>
   </body>
 </html>


### PR DESCRIPTION
Closes #620

Follows the issue's scope exactly: the ™ mark goes only at the first prominent uses (site wordmark, README H1, README.zh-CN H1), and the copyright line names all contributors, not just the maintainer.

- README.md: H1 → `Benchmark Radar™`; adds `© 2026 Koutian Wu and contributors` at the end
- README.zh-CN.md: same
- site/index.html: masthead wordmark → `Benchmark Radar™`; footer adds the copyright line (small, `.copyright`)
- site/assets/styles.css: small `.copyright` style

No ™ in machine-readable fields (title/OG/meta/JSON-LD/citation_title/RSS), per the issue.