### PR TITLE
[不要自动merge] fix(site): halve the leaderboard title and anchor its info toggle

### DIFF
--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -2311,9 +2311,22 @@ td a {
 
 .leaderboard-top-heading {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 0.4rem;
   margin-bottom: 0.35rem;
+}
+
+/* Half the global h1 scale (issue #313). The old 48px uppercase line was the
+   largest object on the page and compressed the ranking it names; and because
+   the wrapped title filled its whole max-width box, the (i) beside it landed
+   hundreds of pixels away in empty space with no anchor. At this size the
+   heading fits one line, so the toggle sits immediately after its last
+   glyph, and wrap keeps that true on narrow screens by stacking instead. */
+.leaderboard-top-heading h1 {
+  margin: 0;
+  font-size: clamp(1.25rem, 2vw, 1.5rem);
+  line-height: 1.05;
 }
 
 .leaderboard-top-heading h2 {

--- a/tests/test_leaderboard_workbench.py
+++ b/tests/test_leaderboard_workbench.py
@@ -1028,3 +1028,28 @@ def test_issue_304_an_unresolved_slug_stops_naming_itself_in_the_url():
     # showing the default under the reader's own slug.
     assert "!state.benchmarkIndexLoaded" in dispatch
     assert "Could not load details for this benchmark." in dispatch
+
+
+def test_issue_313_the_title_is_half_size_and_its_info_is_anchored():
+    """The h1 was the largest object on the page and its (i) floated away.
+
+    At 48px uppercase the heading wrapped and filled its max-width box, so the
+    info toggle rendered hundreds of pixels right of the last glyph with
+    nothing to explain. Half scale fits the title on one line, which is what
+    lets flexbox anchor the toggle immediately after it; wrap keeps that true
+    by stacking on narrow screens instead of drifting.
+    """
+    styles = source("site/assets/styles.css")
+    html = source("site/index.html")
+
+    rule = styles.split(".leaderboard-top-heading h1 {", 1)[1].split("}", 1)[0]
+    assert "font-size: clamp(1.25rem, 2vw, 1.5rem);" in rule
+    assert "margin: 0;" in rule
+
+    heading = styles.split(".leaderboard-top-heading {", 1)[1].split("}", 1)[0]
+    assert "flex-wrap: wrap;" in heading
+    assert "align-items: center;" in heading
+
+    # The toggle stays a sibling of the heading inside one flex row.
+    row = html.split('class="leaderboard-top-heading"', 1)[1].split("</div>", 1)[0]
+    assert row.index('id="leaderboard-heading"') < row.index('id="leaderboard-top-info"')


### PR DESCRIPTION
Issue #313. The 48px uppercase heading was the largest object on the page and compressed the ranking it names; worse, the wrapped title filled its whole max-width box, so the blue (i) rendered hundreds of pixels away with no anchor. Half scale fits the title on one line, letting flexbox place the toggle immediately after the last glyph, and flex-wrap stacks them on narrow screens instead of drifting.